### PR TITLE
docs(dispatch): correct stale billing + enforcement-default claims (OI-1223, OI-1225)

### DIFF
--- a/docs/core/110_SMART_ROUTER_DESIGN.md
+++ b/docs/core/110_SMART_ROUTER_DESIGN.md
@@ -120,12 +120,11 @@ This means a cheap-and-strong model beats an expensive-and-stronger one, but a c
 
 ### 3.3 How cost gets labeled per lane
 
-Cost accounting is lane-dependent, not model-dependent, and is decided by the dispatch door's D2 rule (`dispatch_plan.py`), independent of the router's own `cost_usd_per_call` estimates:
+Cost accounting is decided by the dispatch door's D2 rule (`dispatch_plan.py`), independent of the router's own `cost_usd_per_call` estimates. For the `claude` lane the label is **auth-derived**, not lane-derived (OI-1156): the door computes `claude_auth_is_api_metered(env)` — the presence of an own `ANTHROPIC_API_KEY` or `ANTHROPIC_BASE_URL` (key-auth / redirect) is what makes the label `api_metered`. Without either, both the tmux and headless lanes bill as `subscription`.
 
 | Lane | `billing` label | Why |
 |---|---|---|
-| `claude` (tmux subscription) | `subscription` | OAuth subscription seat, not metered per call |
-| `claude` headless (`allow_headless=true`) | `api_metered` | Explicit opt-in to API-key billing |
+| `claude` (tmux or headless) | auth-derived | `api_metered` with an own `ANTHROPIC_API_KEY`/`ANTHROPIC_BASE_URL`; `subscription` otherwise |
 | `kimi` | `subscription` | CLI OAuth lane (`kimi-via-cli-only`), flat — never metered per call |
 | `local-gemma` | `local` | On-device inference, zero API cost |
 | everything else (`glm-harness`, `deepseek-harness`, `litellm:*`, `codex`, `gemini`) | `provider_metered` | Real per-token API billing |

--- a/docs/operations/WORKER_PERMISSIONS.md
+++ b/docs/operations/WORKER_PERMISSIONS.md
@@ -265,11 +265,12 @@ if working_tree_only and not (
         ...
         failure_reason=(
             "working_tree_only requires a scoped detached spawn "
-            "(both the scoped posture and ADR-012 enforcement default ON; "
-            "refusing the full opt-out path — VNX_WORKER_BLANKET_SKIP=1 / "
+            "(the commit/push deny binds only when either the scoped "
+            "posture or ADR-012 enforcement is active; refusing the full "
+            "opt-out path — VNX_WORKER_BLANKET_SKIP=1 / "
             "falsy VNX_WORKER_SCOPED AND VNX_WORKER_ENFORCEMENT_SKIP=1 / "
-            "falsy VNX_ENFORCE_WORKER_PERMISSIONS — where the commit/push "
-            "deny would not bind)"
+            "falsy VNX_ENFORCE_WORKER_PERMISSIONS — where the deny would "
+            "not bind)"
         ),
     )
 ```

--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -211,7 +211,10 @@ Single-entry gate (the default lane). Staged forms route through the door:
                                Does NOT kill the holder — use the printed pid if needed.
   VNX_DISPATCH_LEGACY=1        Force legacy path even when gate is on
 
-Headless (api_metered) lane: set allow_headless=true + headless_reason in dispatch-spec.json.
+Headless lane: set allow_headless=true + headless_reason in dispatch-spec.json.
+  Billing is auth-derived, not lane-derived (dispatch_plan.claude_auth_is_api_metered):
+  without an own ANTHROPIC_API_KEY/ANTHROPIC_BASE_URL a headless dispatch bills as
+  "subscription", not "api_metered".
   The --adapter subprocess / VNX_ADAPTER / VNX_AUTO_ROUTE flags are LEGACY-ONLY
   (cmd_dispatch path when VNX_SINGLE_ENTRY_DISPATCH is unset) and have no effect here.
 HELP

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1622,7 +1622,11 @@ def _execute_claude_headless(
     data_dir: Path,
     role: Optional[str] = None,
 ) -> int:
-    """Execute a validated claude_headless plan via ClaudeSubprocessAdapter (headless api_metered).
+    """Execute a validated claude_headless plan via ClaudeSubprocessAdapter.
+
+    Billing is auth-derived, not lane-derived (OI-1156): without an own
+    ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL this bills as ``subscription``, not
+    ``api_metered`` — see dispatch_plan.claude_auth_is_api_metered.
 
     Delegates all permit verification, TOCTOU check, and GOVERN to
     run_envelope_headless_plan — same security contract as the provider lane.

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -645,7 +645,12 @@ def run_envelope_headless_plan(
     data_dir: Path,
     role: Optional[str] = None,
 ) -> EnvelopeResult:
-    """Execute a validated ExecutionPlan for the claude_headless lane (api_metered billing).
+    """Execute a validated ExecutionPlan for the claude_headless lane.
+
+    Billing is auth-derived, not lane-derived (OI-1156): a headless dispatch
+    without an own ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL bills as
+    ``subscription``, not ``api_metered`` — see
+    dispatch_plan.claude_auth_is_api_metered.
 
     Headless lane routes to ClaudeSubprocessAdapter (spawn_claude, claude -p) with the
     same require_permit + instruction-sha256 TOCTOU verify + fail-closed GOVERN as the

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -392,7 +392,10 @@ def _sanitize_session_name(raw: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Worker-scope PreToolUse enforcement hook wiring (spike E1/E2; default ON since 15-08)
+# Worker-scope PreToolUse enforcement hook wiring (spike E1/E2). Whether
+# enforcement is ON or OFF is decided by
+# worker_permissions.worker_permission_enforcement_enabled() — that resolver
+# is the single source of truth for the default; do not restate it here.
 # ---------------------------------------------------------------------------
 
 # Command anchors the hook at the FABRIC install root, never the worktree or
@@ -527,9 +530,11 @@ def _write_worker_scope_hook_settings(
     the git-tracked ``.claude/settings.json``, so the worktree's git status stays
     clean and the worker can never accidentally commit the registration.
 
-    The hook itself is gated on ``VNX_ENFORCE_WORKER_PERMISSIONS`` (default ON
-    since 15-08), so registering it unconditionally binds on every scoped spawn
-    unless the dispatch explicitly opts out.
+    The hook itself is gated on ``VNX_ENFORCE_WORKER_PERMISSIONS`` via
+    ``worker_permissions.worker_permission_enforcement_enabled()`` (that
+    resolver is the single source of truth for the default). Registering the
+    hook unconditionally is safe because the hook is a no-op when enforcement
+    is off.
 
     Idempotent: an identical hook command is never registered twice. Existing
     unrelated keys and hook entries in the file are preserved.
@@ -2607,13 +2612,15 @@ class TmuxInteractiveDispatch:
 
         # D2.2 scoping precondition (fail-closed): a working-tree-only dispatch's
         # commit/push deny only binds in the scoped detached spawn (the path where
-        # _wp_build_claude_scope_args is invoked). Both the scoped posture and the
-        # ADR-012 enforcement default ON (14-08 and 15-08 respectively), and either
-        # predicate alone forces the scoped spawn that carries the deny — so only
-        # opting out of BOTH (VNX_WORKER_BLANKET_SKIP=1 / falsy VNX_WORKER_SCOPED
-        # AND VNX_WORKER_ENFORCEMENT_SKIP=1 / falsy VNX_ENFORCE_WORKER_PERMISSIONS)
-        # — or an attached session — leaves the worker unscoped; reject those so an
-        # unscoped working-tree-only worker can never silently reach git commit/push.
+        # _wp_build_claude_scope_args is invoked). The scoped posture defaults ON
+        # (worker_scoped_enabled); ADR-012 enforcement's default lives in
+        # worker_permissions.worker_permission_enforcement_enabled() (single source
+        # of truth). Either predicate alone forces the scoped spawn that carries
+        # the deny — so only opting out of BOTH (VNX_WORKER_BLANKET_SKIP=1 / falsy
+        # VNX_WORKER_SCOPED AND VNX_WORKER_ENFORCEMENT_SKIP=1 / falsy
+        # VNX_ENFORCE_WORKER_PERMISSIONS) — or an attached session — leaves the
+        # worker unscoped; reject those so an unscoped working-tree-only worker can
+        # never silently reach git commit/push.
         if working_tree_only and not (
             skip_permissions
             and (worker_scoped_enabled() or worker_permission_enforcement_enabled())
@@ -2623,11 +2630,12 @@ class TmuxInteractiveDispatch:
                 dispatch_id=dispatch_id,
                 failure_reason=(
                     "working_tree_only requires a scoped detached spawn "
-                    "(both the scoped posture and ADR-012 enforcement default ON; "
-                    "refusing the full opt-out path — VNX_WORKER_BLANKET_SKIP=1 / "
+                    "(the commit/push deny binds only when either the scoped "
+                    "posture or ADR-012 enforcement is active; refusing the full "
+                    "opt-out path — VNX_WORKER_BLANKET_SKIP=1 / "
                     "falsy VNX_WORKER_SCOPED AND VNX_WORKER_ENFORCEMENT_SKIP=1 / "
-                    "falsy VNX_ENFORCE_WORKER_PERMISSIONS — where the commit/push "
-                    "deny would not bind)"
+                    "falsy VNX_ENFORCE_WORKER_PERMISSIONS — where the deny would "
+                    "not bind)"
                 ),
             )
 
@@ -2717,7 +2725,8 @@ class TmuxInteractiveDispatch:
 
             if worktree_handle is not None:
                 # Worker-scope PreToolUse enforcement hook (gated by
-                # VNX_ENFORCE_WORKER_PERMISSIONS, default ON since 15-08;
+                # VNX_ENFORCE_WORKER_PERMISSIONS via
+                # worker_permissions.worker_permission_enforcement_enabled();
                 # spike E1/E2): register the hook in the fresh worktree BEFORE
                 # the tmux session spawns so cwd-based settings discovery has it
                 # from the first tool call. Best-effort: the hook is fail-open

--- a/tests/test_doc_claim_drift_guard.py
+++ b/tests/test_doc_claim_drift_guard.py
@@ -1,0 +1,81 @@
+"""Doc-claim drift guards for OI-1223 / OI-1225.
+
+Two cases where a comment or docstring asserted a default that the resolver
+contradicts:
+
+  * OI-1223 — the claude headless billing label was documented as
+    ``api_metered``. Billing is auth-derived, not lane-derived: without an own
+    ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_BASE_URL`` a headless dispatch bills as
+    ``subscription``. Resolver: ``dispatch_plan.claude_auth_is_api_metered``.
+  * OI-1225 — three sites in ``tmux_interactive_dispatch.py`` (plus a doc code
+    block) claimed ADR-012 enforcement was "default ON since 15-08". That flip
+    was reverted; the resolver
+    ``worker_permissions.worker_permission_enforcement_enabled`` returns False
+    by default.
+
+Each guard first anchors on the resolver's actual value (so a future
+legitimate change fails the anchor loudly and forces the guard to be revisited)
+and then asserts the stale claim string is absent from every site that used to
+carry it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_LIB = REPO_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from dispatch_plan import claude_auth_is_api_metered  # noqa: E402
+from worker_permissions import worker_permission_enforcement_enabled  # noqa: E402
+
+
+def _read(*parts: str) -> str:
+    return (REPO_ROOT.joinpath(*parts)).read_text(encoding="utf-8")
+
+
+def test_headless_billing_is_auth_derived_not_lane_derived():
+    # Resolver anchor: no own key, no redirect -> the claude lane (headless or
+    # tmux) bills as "subscription", never "api_metered".
+    assert claude_auth_is_api_metered({}) is False
+
+    sites = {
+        "scripts/lib/dispatch_envelope.py": ("api_metered billing",),
+        "scripts/lib/dispatch_cli.py": ("headless api_metered",),
+        "scripts/commands/dispatch.sh": ("Headless (api_metered)",),
+        "docs/core/110_SMART_ROUTER_DESIGN.md": (
+            "Explicit opt-in to API-key billing",
+        ),
+    }
+    for rel, forbidden in sites.items():
+        text = _read(*rel.split("/"))
+        for claim in forbidden:
+            assert claim not in text, (
+                f"{rel}: {claim!r} hardcodes a lane-derived billing label; "
+                "billing is auth-derived (dispatch_plan.claude_auth_is_api_metered)"
+            )
+
+
+def test_enforcement_default_claim_matches_resolver(monkeypatch):
+    monkeypatch.delenv("VNX_ENFORCE_WORKER_PERMISSIONS", raising=False)
+    monkeypatch.delenv("VNX_WORKER_ENFORCEMENT_SKIP", raising=False)
+    # Resolver anchor: the 15-08 flip was reverted, so the default is OFF. If a
+    # future remeasurement re-flips this to ON, this assertion fails first and
+    # forces the stale-claim guard below to be revisited instead of drifting.
+    assert worker_permission_enforcement_enabled() is False
+
+    for rel in (
+        "scripts/lib/tmux_interactive_dispatch.py",
+        "docs/operations/WORKER_PERMISSIONS.md",
+    ):
+        text = _read(*rel.split("/"))
+        assert "default ON since 15-08" not in text, (
+            f"{rel}: 'default ON since 15-08' contradicts the resolver "
+            "(worker_permission_enforcement_enabled default OFF)"
+        )
+        assert "ADR-012 enforcement default ON" not in text, (
+            f"{rel}: 'ADR-012 enforcement default ON' contradicts the resolver "
+            "(worker_permission_enforcement_enabled default OFF)"
+        )


### PR DESCRIPTION
## What

Two doc claims contradicted their own resolver. No behavior change — only text.

### OI-1223 — headless billing was documented as `api_metered`

PR #1531 made the claude billing label auth-derived (`dispatch_plan.claude_auth_is_api_metered`): without an own `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`, a headless dispatch bills as `subscription`, not `api_metered`.

Fixed the three stale sites (all verified line numbers first):
- `scripts/lib/dispatch_envelope.py` — `run_envelope_headless_plan` docstring
- `scripts/lib/dispatch_cli.py` — `_execute_claude_headless` docstring
- `scripts/commands/dispatch.sh` — `--help` text
- `docs/core/110_SMART_ROUTER_DESIGN.md` — §3.3 cost-label table (also caught by grep)

### OI-1225 — ADR-012 enforcement claimed "default ON since 15-08"

`worker_permission_enforcement_enabled()` returns `False` (the 15-08 flip was reverted). Three sites in `tmux_interactive_dispatch.py` (plus the mirrored code block in `docs/operations/WORKER_PERMISSIONS.md`) claimed the opposite. Removed the hardcoded default and pointed each at `worker_permission_enforcement_enabled` as the single source. The *why* stays in `worker_permissions.py`, not duplicated.

## Test

Added `tests/test_doc_claim_drift_guard.py` — anchors each claim to its resolver and fails if a stale default reappears.

## Verification

- `pytest tests/test_doc_claim_drift_guard.py tests/test_dispatch_cli.py tests/test_dispatch_envelope.py tests/test_dispatch_envelope_characterization.py tests/test_dispatch_sh_contract.py tests/test_dispatch_plan.py tests/test_worker_permission_enforcement_flag.py` — 397 passed
- `pytest tests/test_working_tree_only.py tests/test_worker_permissions.py tests/test_worker_scoped_default.py tests/test_worker_capability_scoping.py` — 134 passed
- `bash -n scripts/commands/dispatch.sh` — OK

Pre-existing failures (confirmed on clean HEAD, unchanged by this PR): 3 timing/liveness tests in `test_tmux_interactive_dispatch.py` (`name 'model' is not defined` in the worker_process_gone report path) and 5 `test_plan_gate_panel.py` tests (`no such column: output_ref` schema drift in `track_reconciler.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)