### PR TITLE
fix(gate): treat empty/dropped tiebreaker lanes as no-answer, not parse failure

### DIFF
--- a/scripts/lib/plan_gate_tiebreaker.py
+++ b/scripts/lib/plan_gate_tiebreaker.py
@@ -130,9 +130,18 @@ class TiebreakerNoAnswerError(Exception):
     answer but the answer failed the strict contract. This means there was no
     answer to parse at all — the lane timed out / errored / never authored a
     report, so the governance layer fabricated the body (which carries
-    ``SYNTHESIZED_REPORT_MARKER``). Carries the lane ``status`` (timeout / error
-    / unknown) so the caller names the actual state instead of blaming the
-    parser. Both keep the track blocked; only the reported reason differs.
+    ``SYNTHESIZED_REPORT_MARKER``). Carries the lane ``status`` so the caller
+    names the actual state instead of blaming the parser:
+
+      - ``timeout``    — a synthesized report whose Status line names a timeout,
+        or a hung lane subprocess (``subprocess.TimeoutExpired``);
+      - ``error``      — a synthesized report whose Status line names an error;
+      - ``empty``      — an empty completion (zero tokens / whitespace-only);
+      - ``no-output``  — the lane dropped without authoring a report file (the
+        dispatcher raised instead of returning text);
+      - ``unknown``    — a synthesized report with no readable Status line.
+
+    Both keep the track blocked; only the reported reason differs.
     """
 
     def __init__(self, status: str = "unknown", *, raw: str = "") -> None:
@@ -156,6 +165,24 @@ def _extract_synthesized_status(report_text: str) -> str:
     if match:
         return match.group(1).strip() or "unknown"
     return "unknown"
+
+
+def _raised_lane_status(exc: BaseException) -> str:
+    """The no-answer status for a dispatcher that RAISED instead of returning a report.
+
+    The real dispatcher (``_make_default_dispatcher``) raises when the lane never
+    delivered a report: a hung lane subprocess surfaces as
+    ``subprocess.TimeoutExpired`` (a timeout); anything else (e.g. ``RuntimeError``
+    "no report for ..." when ``_read_report`` found no report file) means the lane
+    dropped without authoring a report at all. Both are the "proces dat wegvalt
+    zonder uitvoer" no-answer form — the reason names the lane state, never the
+    parser and never a decision.
+    """
+    import subprocess  # noqa: PLC0415
+
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return "timeout"
+    return "no-output"
 
 
 # ---------------------------------------------------------------------------
@@ -690,9 +717,12 @@ def run_tiebreaker(
     the strict contract (no fence, wrong outcome, a findings list, more than one
     change) — the caller treats that as a loud failure, never silently filling
     in a decision. Raises ``TiebreakerNoAnswerError`` when the lane delivered no
-    answer at all (a governance-synthesized report: timeout / error / no report
-    file) — a distinct loud failure from a parse failure, which stays reserved
-    for an answer that exists but fails the contract.
+    answer at all — a governance-synthesized report (timeout / error), an EMPTY
+    completion (zero tokens), or a raised lane that dropped without authoring a
+    report file — a distinct loud failure from a parse failure, which stays
+    reserved for an answer that exists but fails the contract. A no-answer is
+    NEVER a decision: there is no ``TiebreakerResult``, so it can never read as
+    START/STOP (and hence never as a PASS or REVISE).
     """
     import uuid  # noqa: PLC0415
 
@@ -722,7 +752,19 @@ def run_tiebreaker(
         last_round_findings=list(last_round_findings or []),
     )
     did = f"plan-tiebreak-{track_id}-{uuid.uuid4().hex[:8]}"
-    report_text = disp(dispatch_provider, resolved_model, instruction, did)
+    try:
+        report_text = disp(dispatch_provider, resolved_model, instruction, did)
+    except Exception as exc:  # vnx-silent-except: a raised lane is a NO-ANSWER, not a crash
+        # Punt 17 — "proces dat wegvalt zonder uitvoer": the lane dropped without
+        # authoring a report (the real dispatcher raises RuntimeError when
+        # _read_report finds no report file, or TimeoutExpired when the lane
+        # subprocess hangs). There is nothing to parse, so this must read as a
+        # NO-ANSWER (lane state), never as a parse failure and never as a
+        # decision. The status names the lane state so the caller reports the
+        # cause, not the parser.
+        raise TiebreakerNoAnswerError(
+            status=_raised_lane_status(exc), raw=str(exc),
+        ) from exc
     # OI-1219: a synthesized report is by definition NOT a model answer — the
     # lane never delivered a verdict, so the governance layer fabricated the
     # body (SYNTHESIZED_REPORT_MARKER). Detect the marker BEFORE parse_tiebreaker
@@ -735,6 +777,13 @@ def run_tiebreaker(
         raise TiebreakerNoAnswerError(
             status=_extract_synthesized_status(report_text), raw=report_text,
         )
+    # Punt 17 — an EMPTY completion (zero tokens) is a NO-ANSWER, not a parse
+    # failure. parse_tiebreaker("") would raise TiebreakerParseError("empty
+    # tiebreaker report"), which conflates "the model said nothing" with "the
+    # model said something malformed". Intercept the empty completion BEFORE the
+    # parser so the two distinct failures read distinctly.
+    if not (report_text or "").strip():
+        raise TiebreakerNoAnswerError(status="empty", raw=report_text or "")
     result = parse_tiebreaker(report_text)
     # Stamp the model + round the parser cannot know.
     result.model = resolved_model

--- a/tests/test_plan_gate_tiebreaker.py
+++ b/tests/test_plan_gate_tiebreaker.py
@@ -351,6 +351,124 @@ def test_run_tiebreaker_real_answer_still_parse_failure():
 
 
 # --------------------------------------------------------------------------
+# Punt 17 — the "geen antwoord" branch: all three silent-lane forms
+# --------------------------------------------------------------------------
+#
+# The tiebreaker has two failure branches: a REAL answer that fails the strict
+# contract (TiebreakerParseError), and NO answer at all (TiebreakerNoAnswerError).
+# The second branch had only ever been proven for the synthesized-report form
+# (which the probe hit by luck); the empty-completion and dropped-process forms
+# were never driven. These tests drive all three forms and assert each reads as
+# a DISTINCT no-answer, never as a decision and never as a parse failure.
+
+def test_run_tiebreaker_empty_completion_is_no_answer_not_parse_error():
+    """An EMPTY completion (zero tokens) is a NO-ANSWER, not a parse failure.
+
+    ``parse_tiebreaker("")`` raises ``TiebreakerParseError("empty tiebreaker
+    report")``, which conflates "the model said nothing" with "the model said
+    something malformed". ``run_tiebreaker`` must intercept the empty completion
+    BEFORE the parser and raise ``TiebreakerNoAnswerError`` instead.
+    """
+    def _empty_dispatcher(provider, model_arg, instruction, dispatch_id):
+        return ""
+
+    with pytest.raises(pgt.TiebreakerNoAnswerError) as excinfo:
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n## Approach\n",
+            track_id="trk-empty", project_id="p1", round_number=3,
+            model_arg="deepseek-v4-pro", dispatcher=_empty_dispatcher,
+        )
+    assert excinfo.value.status == "empty"
+
+
+def test_run_tiebreaker_whitespace_completion_is_no_answer():
+    """Whitespace-only output (a lane that emitted nothing but blanks) is also a
+    no-answer, not a parse failure."""
+    def _ws_dispatcher(provider, model_arg, instruction, dispatch_id):
+        return "   \n\t\n"
+
+    with pytest.raises(pgt.TiebreakerNoAnswerError) as excinfo:
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n", track_id="t", project_id="p1",
+            round_number=3, model_arg="deepseek-v4-pro", dispatcher=_ws_dispatcher,
+        )
+    assert excinfo.value.status == "empty"
+
+
+def test_run_tiebreaker_process_drop_no_output_is_no_answer_not_generic():
+    """A lane that drops without output surfaces as a RAISED dispatcher (the real
+    dispatcher raises ``RuntimeError`` when ``_read_report`` finds no report
+    file). That must read as NO-ANSWER (status "no-output"), not as a generic
+    exception leaking out of ``run_tiebreaker``."""
+    def _drop_dispatcher(provider, model_arg, instruction, dispatch_id):
+        raise RuntimeError("no report for plan-tiebreak-x (rc=1): ...")
+
+    with pytest.raises(pgt.TiebreakerNoAnswerError) as excinfo:
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n", track_id="t", project_id="p1",
+            round_number=3, model_arg="deepseek-v4-pro", dispatcher=_drop_dispatcher,
+        )
+    assert excinfo.value.status == "no-output"
+
+
+def test_run_tiebreaker_lane_subprocess_timeout_is_no_answer_timeout_status():
+    """A hung lane subprocess (``subprocess.TimeoutExpired``) reads as no-answer
+    with status "timeout", distinct from the drop-without-output form."""
+    import subprocess
+
+    def _hang_dispatcher(provider, model_arg, instruction, dispatch_id):
+        raise subprocess.TimeoutExpired(cmd=["claude"], timeout=900)
+
+    with pytest.raises(pgt.TiebreakerNoAnswerError) as excinfo:
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n", track_id="t", project_id="p1",
+            round_number=3, model_arg="deepseek-v4-pro", dispatcher=_hang_dispatcher,
+        )
+    assert excinfo.value.status == "timeout"
+
+
+def test_empty_answer_is_never_a_decision():
+    """An empty completion must never come back as a START/STOP decision: the
+    call RAISES, so there is no ``TiebreakerResult`` and no outcome to misread
+    as a PASS (START) or REVISE (STOP)."""
+    def _empty_dispatcher(provider, model_arg, instruction, dispatch_id):
+        return ""
+
+    with pytest.raises(pgt.TiebreakerNoAnswerError):
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n", track_id="t", project_id="p1",
+            round_number=3, model_arg="deepseek-v4-pro", dispatcher=_empty_dispatcher,
+        )
+
+
+def test_no_answer_is_distinct_from_parse_failure_for_all_three_forms():
+    """Each silent-lane form raises ``TiebreakerNoAnswerError`` and NONE raises
+    ``TiebreakerParseError``: a no-answer is a lane failure, a parse failure is a
+    contract failure, and the two must never be conflated."""
+    def _empty(provider, model_arg, instruction, dispatch_id):
+        return ""
+
+    def _drop(provider, model_arg, instruction, dispatch_id):
+        raise RuntimeError("no report")
+
+    def _synth_timeout(provider, model_arg, instruction, dispatch_id):
+        return _synthesized_report("timeout")
+
+    for dispatcher, expected_status in [
+        (_empty, "empty"),
+        (_drop, "no-output"),
+        (_synth_timeout, "timeout"),
+    ]:
+        with pytest.raises(pgt.TiebreakerNoAnswerError) as excinfo:
+            pgt.run_tiebreaker(
+                doc_text="## Problem\n", track_id="t", project_id="p1",
+                round_number=3, model_arg="deepseek-v4-pro", dispatcher=dispatcher,
+            )
+        assert excinfo.value.status == expected_status
+        assert not isinstance(excinfo.value, pgt.TiebreakerParseError)
+
+
+# --------------------------------------------------------------------------
 # Punt 8 — model identity from the registry (ADR-036)
 # --------------------------------------------------------------------------
 
@@ -749,6 +867,39 @@ def test_cmd_plan_gate_run_synthesized_tiebreaker_stays_blocked_no_answer_reason
     assert "parse failure" not in captured.err
     # The blocker is unresolved: no resolution_reason written.
     assert _resolution_reason(state_dir, "feat-synth", "p1") == ""
+
+
+def test_cmd_plan_gate_run_empty_completion_stays_blocked_not_pass_or_revise(
+    tmp_path, monkeypatch, capsys,
+):
+    """An empty completion keeps the track blocked with the NO-ANSWER reason —
+    NOT a PASS (exit 0) and NOT a REVISE (exit 2). End-to-end: the REAL
+    run_tiebreaker runs against an injected empty dispatcher, so the
+    empty-completion detection is measured, not mocked."""
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-empty", "p1", "t", "shipped", phase="queued")
+    planning_cli._seed_plan_blocker(state_dir, "feat-empty", "p1")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+    ledger = _isolate_seat_ledger(monkeypatch, tmp_path)
+    pgt.record_round(ledger, track_id="feat-empty", project_id="p1", round_number=1, outcome="panel")
+    pgt.record_round(ledger, track_id="feat-empty", project_id="p1", round_number=2, outcome="panel")
+
+    def _empty_factory(data_dir, timeout_seconds):
+        def _disp(provider, model_arg, instruction, dispatch_id):
+            return ""
+        return _disp
+
+    monkeypatch.setattr(pgt, "_default_tiebreaker_dispatcher", _empty_factory)
+    rc = planning_cli.cmd_plan_gate_run(_gate_args(state_dir, doc, track_id="feat-empty"))
+    captured = capsys.readouterr()
+    assert rc == 1  # loud failure — not PASS (0), not REVISE (2)
+    assert "no answer" in captured.err
+    assert "status=empty" in captured.err
+    assert "parse failure" not in captured.err
+    # The blocker is unresolved: no resolution_reason written.
+    assert _resolution_reason(state_dir, "feat-empty", "p1") == ""
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Wat dit fixt

De plan-gate tiebreaker had twee faaltakken, maar alleen de synthesized-report-vorm was ooit live bewezen. Twee van de drie "stille lane"-vormen pakten verkeerd uit:

| Vorm | Oud | Nieuw |
|---|---|---|
| Lege completion (nul tokens) | `TiebreakerParseError("empty tiebreaker report")` | `TiebreakerNoAnswerError(status="empty")` |
| Proces weggevallen zonder uitvoer | generieke `RuntimeError` lekte uit | `TiebreakerNoAnswerError(status="no-output")` |
| Lane subprocess hangt | generieke `TimeoutExpired` lekte uit | `TiebreakerNoAnswerError(status="timeout")` |
| Timeout (synthesized report) | `TiebreakerNoAnswerError(status="timeout")` | ongewijzigd (was al goed) |

Een no-answer mag nooit als een beslissing (START/STOP -> PASS/REVISE) of als een parse-fout binnenkomen. De checks lopen nu vóór `parse_tiebreaker`, dus de parser kan het onderscheid niet meer platgooien.

## Wat er gemeten is

- 7 nieuwe tests in `tests/test_plan_gate_tiebreaker.py` drijven de drie stiltel-vormen en dwingen de onderscheidende uitkomst af.
- Rood-op-oud: 6 failed tegen HEAD. Groen-op-nieuw: 39 passed.
- Een leeg antwoord houdt de track geblokkeerd met exit 1 (niet PASS 0, niet REVISE 2), zonder `resolution_reason` — end-to-end gemeten via `cmd_plan_gate_run`.
- Geen echt panel gedraaid, geen zetels verbruikt; alles gestubd via de injecteerbare dispatcher.

## Bestanden

- `scripts/lib/plan_gate_tiebreaker.py` — marker-detectie (was er), plus nieuwe opvang voor lege completion en een geworpen lane.
- `tests/test_plan_gate_tiebreaker.py` — de drie stiltel-vormen + distinctiveness + cmd-level stay-blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)