### PR TITLE
fix(event-store): rotate oversize stream at threshold instead of warning

### DIFF
--- a/scripts/lib/event_store.py
+++ b/scripts/lib/event_store.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
+import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,14 +25,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Size warning threshold (10 MB per contract)
-_SIZE_WARNING_BYTES = 10 * 1024 * 1024
+# Size-rotation threshold (10 MB). Once the live stream exceeds this it is
+# archived to the per-dispatch archive dir and truncated to 0 — a size-based
+# rotation, not a log-only warning. Configurable per instance via the
+# ``rotation_threshold_bytes`` ctor arg or the VNX_EVENT_STREAM_MAX_BYTES env
+# var; this module constant is the default and stays patchable for tests.
+_SIZE_ROTATION_BYTES = 10 * 1024 * 1024
+_SIZE_ROTATION_ENV = "VNX_EVENT_STREAM_MAX_BYTES"
 # Hard upper bound (50 MB): auto-truncate with emergency archive to prevent
-# lane blockage when teardown never runs. Deliberately higher than the warning
-# threshold so the warning fires first and gives operators time to react.
+# lane blockage when the size rotation keeps failing. Deliberately higher than
+# the rotation threshold so rotation handles the normal case first.
 _SIZE_HARD_LIMIT_BYTES = 50 * 1024 * 1024
-# Flag file written alongside the oversize NDJSON to make the condition visible
-# to the dispatcher and the operator dashboard (ADR-005 observability).
+# Flag file written alongside the oversize NDJSON when a size rotation FAILS,
+# keeping the still-oversize condition visible to the dispatcher and the
+# operator dashboard (ADR-005 observability).
 _OVERSIZE_FLAG_SUFFIX = ".oversize"
 
 
@@ -63,8 +70,15 @@ def _events_dir() -> Path:
 class EventStore:
     """NDJSON event store with per-terminal files and file locking."""
 
-    def __init__(self, events_dir: Optional[Path] = None) -> None:
+    def __init__(
+        self,
+        events_dir: Optional[Path] = None,
+        rotation_threshold_bytes: Optional[int] = None,
+    ) -> None:
         self._events_dir = events_dir or _events_dir()
+        # None means "resolve at write time" so the module default stays
+        # patchable in tests even after the store is constructed.
+        self._rotation_threshold_bytes = rotation_threshold_bytes
         self._sequences: Dict[str, int] = {}
         # Last dispatch_id appended per terminal (OI-878). Used to detect a
         # dispatch boundary on the write side so a live file that still holds a
@@ -79,6 +93,132 @@ class EventStore:
         seq = self._sequences.get(terminal, 0) + 1
         self._sequences[terminal] = seq
         return seq
+
+    def _rotation_threshold(self) -> int:
+        """Resolve the size-rotation threshold.
+
+        Precedence: explicit ctor arg > VNX_EVENT_STREAM_MAX_BYTES env var >
+        module default (_SIZE_ROTATION_BYTES). The module default stays
+        patchable so tests can construct a store without an explicit value and
+        still lower the threshold.
+        """
+        if self._rotation_threshold_bytes is not None:
+            return int(self._rotation_threshold_bytes)
+        env = os.environ.get(_SIZE_ROTATION_ENV)
+        if env:
+            try:
+                return int(env)
+            except ValueError:
+                logger.warning(
+                    "event_store: invalid %s=%r — using default %d bytes",
+                    _SIZE_ROTATION_ENV,
+                    env,
+                    _SIZE_ROTATION_BYTES,
+                )
+        return _SIZE_ROTATION_BYTES
+
+    def _oversize_flag_path(self, terminal: str) -> Path:
+        return self._terminal_path(terminal).with_suffix(_OVERSIZE_FLAG_SUFFIX)
+
+    def _write_oversize_flag(self, terminal: str) -> None:
+        """Persist the still-oversize marker after a failed rotation."""
+        try:
+            self._oversize_flag_path(terminal).write_text(
+                f"oversize:{terminal}:rotation-failed:"
+                f"{datetime.now(timezone.utc).isoformat()}\n"
+            )
+        except OSError:
+            pass
+
+    def _remove_oversize_flag(self, terminal: str) -> None:
+        try:
+            self._oversize_flag_path(terminal).unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _size_rotation_archive_id() -> str:
+        """Unique archive id for a size rotation.
+
+        Uses a timestamp namespace (like the existing ``emergency-*`` backstop)
+        so it never collides with the per-dispatch teardown archive
+        ``{dispatch_id}.ndjson`` — the teardown writes that same filename later
+        and would otherwise overwrite the rotation's events.
+        """
+        return "size-rotation-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+    def _rotate_on_size(self, terminal: str) -> None:
+        """Rotate the live stream once it exceeds the size threshold.
+
+        Archives the current content to
+        ``events/archive/{terminal}/size-rotation-{ts}.ndjson`` (the existing
+        per-dispatch archive layout, not a second schema) and truncates the live
+        file to 0 bytes. The copy and the truncate happen under a single
+        LOCK_EX on the live file, so a concurrent appender that is blocked on
+        the lock writes into the fresh file afterwards — it can never lose an
+        event to a truncate that lands between the archive read and the clear.
+
+        Never raises: a failed rotation logs ERROR (visible) and leaves the
+        live file in place, so a broken log rotation never blocks the dispatch.
+        The hard-limit backstop still bounds worst-case growth.
+        """
+        path = self._terminal_path(terminal)
+        if not path.exists():
+            return
+        threshold = self._rotation_threshold()
+        rotated_size: Optional[int] = None
+        tmp: Optional[Path] = None
+        try:
+            with open(path, "ab+") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    # Double-checked under the lock: another process may have
+                    # rotated while we waited, dropping the size back below the
+                    # threshold.
+                    size = os.fstat(f.fileno()).st_size
+                    if size <= threshold:
+                        return
+                    dest = (
+                        self.archive_dir(terminal)
+                        / f"{self._size_rotation_archive_id()}.ndjson"
+                    )
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    tmp = dest.with_name(dest.name + ".tmp")
+                    f.seek(0)
+                    with open(tmp, "wb") as tmp_f:
+                        shutil.copyfileobj(f, tmp_f)
+                    os.replace(tmp, dest)
+                    tmp = None
+                    f.seek(0)
+                    f.truncate(0)
+                    f.flush()
+                    rotated_size = size
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        except Exception as exc:  # vnx-silent-except: a broken rotation must never block the dispatch — fail visibly and continue
+            logger.error(
+                "event_store: size rotation failed for %s (threshold %d bytes): %s",
+                path,
+                threshold,
+                exc,
+                exc_info=True,
+            )
+            self._write_oversize_flag(terminal)
+            if tmp is not None:
+                try:
+                    tmp.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            return
+
+        self._sequences.pop(terminal, None)
+        self._remove_oversize_flag(terminal)
+        logger.info(
+            "event_store: rotated %s (%d bytes) over %d-byte threshold",
+            path,
+            rotated_size,
+            threshold,
+        )
 
     def _rotate_at_dispatch_boundary(self, terminal: str, new_dispatch_id: str) -> None:
         """Enforce the per-dispatch ring buffer on the write side (OI-878).
@@ -216,36 +356,12 @@ class EventStore:
             finally:
                 fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
-        # Size warning + oversize flag file so the condition is visible to the
-        # dispatcher dashboard (not just the log stream). Previously 36 warnings
-        # fired without any consumer (OI-858, Cluster E1).
-        #
-        # OI-1095: the warning must fire ONCE per threshold crossing, not once
-        # per write action. A long-running provider-lane worker produces events
-        # at high frequency — six identical warnings in a six-line tail is noise,
-        # not an alarm.  The oversize flag file doubles as the "already warned"
-        # guard: it is written alongside the first warning and removed on
-        # clear(). Subsequent writes update the flag (so it always reflects the
-        # current size) but skip the log warning until the next dispatch cycle.
-        try:
-            st = path.stat()
-            if st.st_size > _SIZE_WARNING_BYTES:
-                flag_path = path.with_suffix(_OVERSIZE_FLAG_SUFFIX)
-                already_warned = flag_path.exists()
-                if not already_warned:
-                    logger.warning(
-                        "event_store: %s exceeds %d bytes — operator intervention recommended",
-                        path,
-                        _SIZE_WARNING_BYTES,
-                    )
-                # Write/update the flag file so the dispatcher can surface this
-                # without tailing the log. The flag is terminal-scoped and lives
-                # next to the NDJSON file so it is visible in `vnx pool status`.
-                flag_path.write_text(
-                    f"oversize:{terminal}:{st.st_size}:{datetime.now(timezone.utc).isoformat()}\n"
-                )
-        except OSError:
-            pass
+        # Size-based rotation: once the live stream exceeds the rotation
+        # threshold, archive it to the per-dispatch archive dir and truncate to
+        # 0 so the file can never grow unbounded. This replaces the old log-only
+        # "operator intervention recommended" warning (OI-858) that fired every
+        # dispatch and changed nothing.
+        self._rotate_on_size(terminal)
 
         # Hard upper bound: if the file has grown past the hard limit (50 MB),
         # auto-truncate with an emergency archive so the lane doesn't block.
@@ -370,10 +486,11 @@ class EventStore:
     def oversize_flags(self) -> list[Path]:
         """Return paths to all oversize flag files currently present.
 
-        Each flag file indicates a terminal whose event file has exceeded the
-        soft warning threshold and has NOT been cleared since.  The dispatcher
-        can call this to surface the condition in ``vnx pool status`` without
-        tailing the log stream (OI-858 consumer).
+        Each flag file marks a terminal whose event file exceeded the size-
+        rotation threshold but whose rotation FAILED — i.e. the live file is
+        still oversize and needs manual attention. A successful rotation removes
+        the flag. The dispatcher can call this to surface the condition in
+        ``vnx pool status`` without tailing the log stream (OI-858 consumer).
         """
         if not self._events_dir.exists():
             return []

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -282,80 +282,162 @@ class TestLastEvent:
 
 
 # ---------------------------------------------------------------------------
-# OI-1095: size warning fires once per threshold crossing, not per write
+# Size-based rotation: the live stream is archived + truncated at the threshold
+# (replaces the old log-only "operator intervention recommended" warning)
 # ---------------------------------------------------------------------------
 
 
-class TestSizeWarning:
-    def test_warning_fires_once_per_crossing(self, store, tmp_events_dir, caplog):
-        """OI-1095: the oversize warning must fire ONCE when the threshold is
-        crossed, not on every subsequent write. The flag file doubles as the
-        "already warned" guard and is removed on clear()."""
-        import logging
-        from event_store import _OVERSIZE_FLAG_SUFFIX
+def _ndjson_lines(path: Path):
+    if not path.exists():
+        return []
+    return [line for line in path.read_text().strip().split("\n") if line]
 
-        caplog.set_level(logging.WARNING, logger="event_store")
 
-        # Write a single event that is itself above the 10MB threshold.
-        # We patch _SIZE_WARNING_BYTES to a small value so we don't need 10MB.
-        import event_store as es_mod
-
-        original_threshold = es_mod._SIZE_WARNING_BYTES
-        try:
-            es_mod._SIZE_WARNING_BYTES = 50  # tiny threshold — every write crosses it
-            # First write -> should warn
-            store.append("T1", {"type": "text", "data": {"text": "first"}})
-            # Second write -> should NOT warn (flag file exists)
-            store.append("T1", {"type": "text", "data": {"text": "second"}})
-            # Third write -> still no warning
-            store.append("T1", {"type": "text", "data": {"text": "third"}})
-        finally:
-            es_mod._SIZE_WARNING_BYTES = original_threshold
-
-        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-        oversize_warnings = [
-            r for r in warnings if "operator intervention recommended" in r.message
-        ]
-        assert len(oversize_warnings) == 1, (
-            f"warning must fire exactly once per crossing, got {len(oversize_warnings)}: "
-            f"{[r.message for r in oversize_warnings]}"
+class TestSizeRotation:
+    def test_no_rotation_below_threshold(self, tmp_events_dir):
+        store = EventStore(events_dir=tmp_events_dir, rotation_threshold_bytes=10_000_000)
+        for i in range(3):
+            store.append("T1", {"type": "text", "data": {"i": i}}, dispatch_id="d-rot-below")
+        assert store.event_count("T1") == 3
+        assert not (tmp_events_dir / "archive" / "T1").exists(), (
+            "below threshold there must be no archive and no rotation"
         )
 
-        # Flag file must exist.
-        flag_path = (tmp_events_dir / "T1.ndjson").with_suffix(_OVERSIZE_FLAG_SUFFIX)
-        assert flag_path.exists()
+    def test_rotation_above_threshold(self, tmp_events_dir):
+        store = EventStore(events_dir=tmp_events_dir, rotation_threshold_bytes=500)
+        payload = "x" * 200
+        for i in range(20):
+            store.append(
+                "T1",
+                {"type": "text", "data": {"i": i, "padding": payload}},
+                dispatch_id="d-rot-above",
+            )
+        # Live file is bounded well under the ~4KB written; rotation fired.
+        live = tmp_events_dir / "T1.ndjson"
+        assert live.stat().st_size <= 500 + 1000
+        archives = list((tmp_events_dir / "archive" / "T1").glob("size-rotation-*.ndjson"))
+        assert len(archives) >= 1, "rotation must archive the oversize stream"
 
-        # After clear, the flag is removed — next dispatch gets a fresh warning.
-        store.clear("T1")
-        assert not flag_path.exists()
+    def test_rotated_archive_contains_old_content(self, tmp_events_dir):
+        store = EventStore(events_dir=tmp_events_dir, rotation_threshold_bytes=500)
+        payload = "y" * 300
+        for i in range(20):
+            store.append(
+                "T1",
+                {"type": "text", "data": {"i": i, "padding": payload}},
+                dispatch_id="d-rot-content",
+            )
+        archived_lines = []
+        for arc in (tmp_events_dir / "archive" / "T1").glob("size-rotation-*.ndjson"):
+            archived_lines.extend(_ndjson_lines(arc))
+        assert archived_lines, "the rotated file must contain the pre-rotation events"
+        for line in archived_lines:
+            event = json.loads(line)
+            assert event["dispatch_id"] == "d-rot-content"
+            assert event["type"] == "text"
+        # No event is lost: archive + live == everything written.
+        live_lines = _ndjson_lines(tmp_events_dir / "T1.ndjson")
+        assert len(archived_lines) + len(live_lines) == 20
 
-    def test_warning_fires_again_after_clear(self, store, tmp_events_dir, caplog):
-        """After clear() removes the flag file, the warning must fire again on
-        the NEXT dispatch's threshold crossing — the warn-once guard resets."""
+    def test_live_file_empty_and_writable_after_rotation(self, tmp_events_dir):
+        # First event is big enough to cross the threshold and trigger rotation.
+        # The follow-up event is small enough to stay below it.
+        store = EventStore(events_dir=tmp_events_dir, rotation_threshold_bytes=300)
+        store.append(
+            "T1",
+            {"type": "text", "data": {"padding": "z" * 400}},
+            dispatch_id="d-rot-writable",
+        )
+        assert store.event_count("T1") == 0, "live file must be empty after rotation"
+        store.append("T1", {"type": "result", "data": {}}, dispatch_id="d-rot-writable")
+        events = list(store.tail("T1"))
+        assert len(events) == 1
+        assert events[0]["sequence"] == 1
+        assert events[0]["type"] == "result"
+
+    def test_concurrent_writer_loses_nothing(self, tmp_events_dir):
+        store = EventStore(events_dir=tmp_events_dir, rotation_threshold_bytes=2000)
+        n_threads = 4
+        n_events = 40
+        payload = "p" * 120  # ~150B/event -> ~24KB total, many rotations
+        errors = []
+
+        def writer(tid):
+            try:
+                for i in range(n_events):
+                    store.append(
+                        "T1",
+                        {"type": "text", "data": {"t": tid, "i": i, "padding": payload}},
+                        dispatch_id="d-rot-concurrent",
+                    )
+            except Exception as exc:  # vnx-silent-except: collect and assert, don't let a thread die silently
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"thread errors: {errors}"
+
+        total = len(_ndjson_lines(tmp_events_dir / "T1.ndjson"))
+        archive_dir = tmp_events_dir / "archive" / "T1"
+        if archive_dir.exists():
+            for arc in archive_dir.glob("*.ndjson"):
+                total += len(_ndjson_lines(arc))
+        assert total == n_threads * n_events, (
+            f"a concurrent writer lost events: expected {n_threads * n_events}, got {total}"
+        )
+
+    def test_rotation_failure_logs_error_and_does_not_block(self, tmp_events_dir, caplog):
         import logging
-        import event_store as es_mod
 
-        caplog.set_level(logging.WARNING, logger="event_store")
-        original_threshold = es_mod._SIZE_WARNING_BYTES
-        try:
-            es_mod._SIZE_WARNING_BYTES = 50
-            # First dispatch cycle
-            store.append("T1", {"type": "text", "data": {"text": "d1"}})
-            store.append("T1", {"type": "text", "data": {"text": "d1b"}})
-            store.clear("T1")
+        store = EventStore(events_dir=tmp_events_dir, rotation_threshold_bytes=100)
+        # Make the archive dir un-creatable: archive/T1 is a regular file.
+        archive_dir = tmp_events_dir / "archive"
+        archive_dir.mkdir()
+        (archive_dir / "T1").write_text("not a directory")
 
-            caplog.clear()
+        caplog.set_level(logging.ERROR, logger="event_store")
 
-            # Second dispatch cycle — fresh warning expected
-            store.append("T1", {"type": "text", "data": {"text": "d2"}})
-            store.append("T1", {"type": "text", "data": {"text": "d2b"}})
-        finally:
-            es_mod._SIZE_WARNING_BYTES = original_threshold
+        payload = "f" * 200
+        for i in range(5):
+            store.append(
+                "T1",
+                {"type": "text", "data": {"i": i, "padding": payload}},
+                dispatch_id="d-rot-fail",
+            )
 
-        oversize_warnings = [
+        # The dispatch must keep going: append does not raise, live file intact.
+        assert store.event_count("T1") == 5
+        errors = [
             r for r in caplog.records
-            if r.levelno == logging.WARNING and "operator intervention recommended" in r.message
+            if r.levelno == logging.ERROR and "size rotation failed" in r.message
         ]
-        assert len(oversize_warnings) == 1, (
-            "after clear, next dispatch cycle must get a fresh warning"
-        )
+        assert len(errors) >= 1, "a failed rotation must log a visible ERROR"
+        assert store.oversize_flags() != [], "a failed rotation must write the oversize flag"
+
+
+class TestSizeRotationConfig:
+    def test_default_threshold_is_10mb(self, tmp_events_dir):
+        store = EventStore(events_dir=tmp_events_dir)
+        assert store._rotation_threshold() == 10 * 1024 * 1024
+
+    def test_env_var_overrides_default(self, tmp_events_dir, monkeypatch):
+        monkeypatch.setenv("VNX_EVENT_STREAM_MAX_BYTES", "1234")
+        store = EventStore(events_dir=tmp_events_dir)
+        assert store._rotation_threshold() == 1234
+
+    def test_ctor_arg_overrides_env(self, tmp_events_dir, monkeypatch):
+        monkeypatch.setenv("VNX_EVENT_STREAM_MAX_BYTES", "1234")
+        store = EventStore(events_dir=tmp_events_dir, rotation_threshold_bytes=99)
+        assert store._rotation_threshold() == 99
+
+    def test_invalid_env_falls_back_to_default(self, tmp_events_dir, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("VNX_EVENT_STREAM_MAX_BYTES", "not-a-number")
+        caplog.set_level(logging.WARNING, logger="event_store")
+        store = EventStore(events_dir=tmp_events_dir)
+        assert store._rotation_threshold() == 10 * 1024 * 1024

--- a/tests/test_ringbuffer_truncate_oi858.py
+++ b/tests/test_ringbuffer_truncate_oi858.py
@@ -209,69 +209,89 @@ class TestWorktreeFailureSafetyNet:
 
 
 class TestOversizeConsumer:
-    """On origin/main, the oversize warning at event_store.py:150 only logs a
-    warning. It fired 36 times without any consumer. The fix adds a persistent
-    flag file that the dispatcher can surface without tailing the log."""
+    """On origin/main, the oversize warning at event_store.py only logs a
+    warning (36 times, no consumer). The fix replaces that warning with a
+    size-based rotation: archive + truncate, so the file self-heals. The
+    .oversize flag is now a persistent marker written only when a rotation
+    FAILS."""
 
-    def test_oversize_writes_flag_file(self, tmp_path, tmp_events):
+    def test_oversize_rotates_instead_of_warns(self, tmp_path, tmp_events):
         if not _HAS_OI858_CONSTANTS:
             pytest.fail(
                 "GAP 3: _OVERSIZE_FLAG_SUFFIX does not exist on origin/main. "
                 "The oversize flag file mechanism was never implemented."
             )
 
-        store = EventStore(events_dir=tmp_events)
+        store = EventStore(events_dir=tmp_events, rotation_threshold_bytes=500)
         terminal = "T1"
 
-        payload = "x" * 100000  # 100KB per event
-        for i in range(200):  # 200 * ~100KB = ~20MB > 10MB warning threshold
+        payload = "x" * 200  # ~250B/event -> ~12KB total, well over the 500B threshold
+        for i in range(50):
             store.append(terminal, {
                 "type": "text",
                 "data": {"msg": f"event-{i}", "padding": payload},
-                "dispatch_id": "oi858-oversize-test",
-            }, dispatch_id="oi858-oversize-test")
+                "dispatch_id": "oi858-rotate-test",
+            }, dispatch_id="oi858-rotate-test")
 
-        flag_path = tmp_events / f"{terminal}{_OVERSIZE_FLAG_SUFFIX}"
-        assert flag_path.exists(), (
-            "GAP 3: oversize flag file was not created. "
-            f"Expected {flag_path} to exist. On origin/main, the warning "
-            "was log-only and fired 36 times without any consumer."
+        live = tmp_events / f"{terminal}.ndjson"
+        assert live.stat().st_size <= 500 + 1000, (
+            "GAP 3: live file grew unbounded. On origin/main the oversize "
+            "condition was log-only; the fix must rotate (archive+truncate) so "
+            "the live file stays bounded."
+        )
+        archives = list(
+            (tmp_events / "archive" / terminal).glob("size-rotation-*.ndjson")
+        )
+        assert len(archives) > 0, (
+            "GAP 3: rotation must archive the oversize stream under the "
+            "per-dispatch archive dir."
+        )
+        assert store.oversize_flags() == [], (
+            "GAP 3: a successful rotation leaves no oversize flag behind."
         )
 
-    def test_oversize_flag_cleared_on_teardown(self, tmp_path, tmp_events):
+    def test_oversize_flag_written_only_on_rotation_failure(self, tmp_path, tmp_events):
         if not _HAS_OI858_CONSTANTS:
             pytest.fail("GAP 3: oversize flag constants not available on origin/main.")
 
-        store = EventStore(events_dir=tmp_events)
+        store = EventStore(events_dir=tmp_events, rotation_threshold_bytes=500)
         terminal = "T1"
 
-        payload = "x" * 100000
-        for i in range(200):
+        # Block the archive dir so rotation fails: archive/T1 is a regular file.
+        archive_dir = tmp_events / "archive"
+        archive_dir.mkdir()
+        (archive_dir / terminal).write_text("block")
+
+        payload = "x" * 200
+        for i in range(50):
             store.append(terminal, {
                 "type": "text",
                 "data": {"msg": f"event-{i}", "padding": payload},
-                "dispatch_id": "oi858-clear-flag",
-            }, dispatch_id="oi858-clear-flag")
+                "dispatch_id": "oi858-rotate-fail",
+            }, dispatch_id="oi858-rotate-fail")
 
         flag_path = tmp_events / f"{terminal}{_OVERSIZE_FLAG_SUFFIX}"
-        assert flag_path.exists(), "Flag must be created by oversize condition"
-
-        store.clear(terminal, archive_dispatch_id="oi858-clear-flag")
-        assert not flag_path.exists(), (
-            "Flag file must be removed on clear() — stale flags would cause false alarms"
+        assert flag_path.exists(), (
+            "GAP 3: when rotation fails, the .oversize flag must be written so "
+            "the still-oversize condition stays visible to the operator."
         )
 
     def test_oversize_flags_method(self, tmp_path, tmp_events):
         if not _HAS_OI858_CONSTANTS:
             pytest.fail("GAP 3: oversize_flags() method does not exist on origin/main.")
 
-        store = EventStore(events_dir=tmp_events)
+        store = EventStore(events_dir=tmp_events, rotation_threshold_bytes=500)
         terminal = "T1"
 
         assert store.oversize_flags() == [], "No flags initially"
 
-        payload = "x" * 100000
-        for i in range(200):
+        # Block the archive dir so rotation fails and writes a flag.
+        archive_dir = tmp_events / "archive"
+        archive_dir.mkdir()
+        (archive_dir / terminal).write_text("block")
+
+        payload = "x" * 200
+        for i in range(50):
             store.append(terminal, {
                 "type": "text",
                 "data": {"msg": f"event-{i}", "padding": payload},
@@ -279,9 +299,9 @@ class TestOversizeConsumer:
             }, dispatch_id="oi858-flags-method")
 
         flags = store.oversize_flags()
-        assert len(flags) > 0, "oversize_flags() must return flag files"
+        assert len(flags) > 0, "oversize_flags() must return flag files after a failed rotation"
 
-        store.clear(terminal, archive_dispatch_id="oi858-flags-method")
+        store.clear(terminal)
         assert store.oversize_flags() == [], "oversize_flags() must be empty after clear"
 
 


### PR DESCRIPTION
## Wat

Op 2026-08-15 gemeten in de centrale store `~/.vnx-data/vnx-dev/events/`: `T3.ndjson` stond op 15 MB. Bij elke dispatch die T3 raakt logde de event-store:

```
event_store: .../events/T3.ndjson exceeds 10485760 bytes — operator intervention recommended
```

Die aanbeveling voert niemand uit. Het bestand groeit gewoon door en de melding traint de lezer om hem te negeren.

## Wat er verandert

`scripts/lib/event_store.py` vervangt de log-only waarschuwing door een echte **grootte-rotatie**:

- Bij overschrijding van de drempel wordt het bestand gearchiveerd naar de bestaande archiefstructuur `events/archive/{terminal}/size-rotation-{ts}.ndjson` en begint de live-file leeg.
- De drempel is configureerbaar (`rotation_threshold_bytes` ctor-arg of env `VNX_EVENT_STREAM_MAX_BYTES`) en default blijft **10 MB** (de oude waarschuwingswaarde).
- Roteert op grootte, niet op leeftijd.

## Gelijktijdigheid

De rotatie leest + archiveert + truncate de live-file onder **één** `LOCK_EX` op diezelfde file. Appenders schrijven onder dezelfde lock. Daardoor kan een schrijvende dispatch nooit een event kwijtraken: een appender die geblokkeerd is op de lock schrijft ná de truncate in de verse file (append-mode schrijft op end-of-file = 0). De drempel wordt onder de lock opnieuw gecheckt (double-checked), zodat twee rotaties niet dubbel draaien.

## Falen is zichtbaar, blokkeert niet

Een mislukte rotatie logt `ERROR`, laat de live-file staan en schrijft de `.oversize` flag (nu een marker "rotatie faalde"). De dispatch gaat door. De 50 MB hard-limit blijft als backstop.

## Tests

- Onder de drempel: geen rotatie, geen archief.
- Boven de drempel: rotatie, live-file bounded, archief `size-rotation-*.ndjson` bestaat.
- Geroteerd bestand bevat de oude inhoud (dispatch_id + type kloppen, geen event verloren).
- Live-file is leeg én beschrijfbaar ná rotatie (sequence reset naar 1).
- Gelijktijdige schrijvers verliezen niets (4 threads x 40 events, totaal bewaard).
- Mislukte rotatie logt ERROR, blokkeert append niet, schrijft flag.
- Config: default 10 MB, env-override, ctor-override, invalid-env fallback.

94 tests groen over de touched files + directe buren.

Dispatch-ID: 20260815-nn-w12-ndjson-rotatie

🤖 Generated with [Claude Code](https://claude.com/claude-code)