### PR TITLE
feat(dispatch): complete cost ladder + wire escalation into spec receipt (OI-1229, OI-1221)

### DIFF
--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -294,6 +294,75 @@ def stage_spec_bundle(
     return spec_file
 
 
+def stage_escalation_bundle(
+    *,
+    rejected_dispatch_id: str,
+    tier_from: str,
+    instruction_text: str,
+    dispatch_id: str,
+    role: str,
+    target_slot: str,
+    project_id: Optional[str] = None,
+    gate: str = "",
+    dispatch_paths: tuple[dict, ...] = (),
+    deadline_seconds: int = 3600,
+    base_ref: str = "origin/main",
+    task_class: Optional[str] = None,
+    env: Optional[dict] = None,
+    state_dir: Optional[Path] = None,
+    now: Optional[float] = None,
+    data_dir: Optional[Path] = None,
+) -> Path:
+    """Stage a QUALITY-escalation followup bundle (OI-1221, wired OI-1229).
+
+    This is the CALLER that was missing: ``escalate_tier``/``next_tier`` already
+    computed the climb (tier_to = tier_from + 1, parent_dispatch = the rejected
+    attempt) but no call site ever fired a followup, so ``tier_from``/``tier_to``
+    stayed empty on 0 of 761 filled specs. Here the climb is resolved
+    deterministically from the cost ladder, the target rung's route is resolved
+    through ``resolve_tier_route`` (so the followup actually runs on the
+    escalated model, not re-classified back to the same cheap tier), and the
+    three chain-link fields are written into the staged ``dispatch-spec.json`` —
+    the same bytes the door carries onto the receipt.
+
+    This STAGES ONLY; it never fires the dispatch (no automatic re-dispatch
+    loop). The operator promotes the returned bundle through the single-entry
+    door, so escalation stays human-in-the-loop.
+    """
+    from providers.smart_router.tier_routing import (  # noqa: PLC0415
+        escalate_tier,
+        resolve_tier_route,
+    )
+
+    escalation = escalate_tier(tier_from, parent_dispatch=rejected_dispatch_id)
+    if escalation.tier_to is None:
+        raise ValueError(
+            f"cannot escalate: {tier_from!r} is already the top rung of the "
+            "cost ladder (no rung above it)"
+        )
+    route = resolve_tier_route(
+        escalation.tier_to, env=env, state_dir=state_dir, now=now,
+    )
+    return stage_spec_bundle(
+        instruction_text=instruction_text,
+        dispatch_id=dispatch_id,
+        role=role,
+        target_slot=target_slot,
+        project_id=project_id,
+        provider=route.provider,
+        model=route.model,
+        gate=gate,
+        dispatch_paths=dispatch_paths,
+        deadline_seconds=deadline_seconds,
+        base_ref=base_ref,
+        data_dir=data_dir,
+        parent_dispatch=escalation.parent_dispatch,
+        task_class=task_class,
+        tier_from=escalation.tier_from,
+        tier_to=escalation.tier_to,
+    )
+
+
 def bridge_dispatch(*, dry_run: bool = False, **stage_kwargs) -> int:
     """Stage a spec bundle, then drive it through the ONLY door (run_dispatch).
 

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -211,9 +211,21 @@ _BLOCKED_FIRST_COMPONENTS = frozenset({".git", ".vnx-data"})
 
 _VALID_TARGET_SLOTS = frozenset({"T0", "T1", "T2", "T3"})
 
-# Cost-tier vocabulary (mirrors providers.smart_router.cost_tier) — the
-# escalation signal on receipts must come from this closed set.
-_VALID_TIERS = frozenset({"tier-zero", "tier-low", "tier-mid", "tier-high"})
+# Cost-tier vocabulary — the escalation signal on receipts must come from this
+# closed set. It spans the four classifier scope buckets (mirrors
+# providers.smart_router.cost_tier) PLUS the three escalation-only rungs of the
+# cost ladder (OI-1229): a model-named rung is reachable only by climbing, never
+# by classification, but it is a legal tier_from/tier_to value on an escalation
+# dispatch, so it must pass the door's Rule 14 tier check.
+_VALID_TIERS = frozenset({
+    "tier-zero",
+    "tier-low",
+    "tier-mid",
+    "tier-high",
+    "kimi-k3",
+    "gpt-5.5",
+    "fable-5",
+})
 
 
 def _validate_dispatch_path(dp: DispatchPath) -> Optional[str]:

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -331,14 +331,34 @@ providers:
 # RegistryLookupError (naming what+where) on anything this registry does not
 # know.
 #
-# COST LADDER (OI-1221): the four tiers form an ordered ladder over the
-# dispatchable models, cheapest first. A tier higher is demonstrably more
-# expensive AND more capable, so a quality escalation actually climbs:
+# COST LADDER (OI-1221, extended OI-1229): seven rungs, cheapest first — the
+# seven dispatchable (provider, model) pairs in ascending output cost. A tier
+# higher is demonstrably more expensive AND more capable, so a quality
+# escalation actually climbs:
 #
 #   tier-zero  deepseek-v4-flash  $0.28/Mtok out
 #   tier-low   deepseek-v4-pro    $0.87/Mtok out   (the daily workhorse)
+#   kimi-k3    kimi-k3            $2.50/Mtok out
+#   gpt-5.5    gpt-5.5           $10.00/Mtok out
 #   tier-mid   sonnet-5          $15.00/Mtok out
 #   tier-high  opus-5            $25.00/Mtok out
+#   fable-5    fable-5           $50.00/Mtok out
+#
+# NOT on the ladder (measured 2026-08-15 over wave7_models.yaml):
+#   * glm-5.2 ($2.42/Mtok out) — the `zai` section carries NO `dispatch_enum`
+#     (its route runs via `litellm:zai`/OpenRouter, not a dispatch Provider), so
+#     it is not a dispatchable model and is correctly excluded. gemini-2.5-pro
+#     (`google`) is excluded the same way — no `dispatch_enum` either.
+#   * local-gemma — local-only inference, kept off the map (disabled via the
+#     availability layer, LOCAL_GEMMA_DISABLED_REASON).
+#   * alternate/older models under a lane's section (haiku, gpt-5.4, opus /
+#     opus-4.x, kimi-k2-7, deepseek-v4-pro-default) are not their own rungs:
+#     each rung pins one (provider, model) pair.
+#
+# The four tier-zero/low/mid/high rungs are ALSO the classifier's scope buckets
+# (cost_tier.classify_dispatch): a NEW dispatch enters the ladder at one of them.
+# The three model-named rungs (kimi-k3, gpt-5.5, fable-5) are escalation
+# destinations only — reachable by climbing, never by classification.
 #
 # Two mechanisms, opposite in intent, are deliberately kept apart:
 #   * AVAILABILITY fallback (the `fallback` list below) — an unavailable lane is
@@ -376,6 +396,18 @@ routing:
         - provider: openai
           model: gpt-5.5
           lane: provider
+    kimi-k3:
+      provider: kimi_cli
+      model: kimi-k3
+      lane: kimi_cli
+      fallback:
+        - provider: openai
+          model: gpt-5.5
+          lane: provider
+    gpt-5.5:
+      provider: openai
+      model: gpt-5.5
+      lane: provider
     tier-mid:
       provider: anthropic
       model: sonnet-5
@@ -383,4 +415,8 @@ routing:
     tier-high:
       provider: anthropic
       model: opus-5
+      lane: tmux_interactive
+    fable-5:
+      provider: anthropic
+      model: fable-5
       lane: tmux_interactive

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -42,6 +42,21 @@ def _force_kimi(monkeypatch, present: bool):
     )
 
 
+# The full cost ladder (OI-1229): every dispatchable model, cheapest first. The
+# four scope buckets (TIER_*) are the classifier's entry rungs; the three
+# model-named rungs are escalation destinations only — reachable by climbing,
+# never by classification.
+LADDER_ORDER = [
+    TIER_ZERO,
+    TIER_LOW,
+    "kimi-k3",
+    "gpt-5.5",
+    TIER_MID,
+    TIER_HIGH,
+    "fable-5",
+]
+
+
 # ---------------------------------------------------------------------------
 # Ladder invariants — derived from the registry
 # ---------------------------------------------------------------------------
@@ -72,11 +87,20 @@ def test_ladder_tier_zero_and_low_are_distinct():
 def test_ladder_order_is_cheapest_first():
     """The authored tier order climbs from the cheapest to the most expensive."""
     ladder = load_tier_ladder()
-    assert [rung.tier for rung in ladder] == [
-        TIER_ZERO,
-        TIER_LOW,
-        TIER_MID,
-        TIER_HIGH,
+    assert [rung.tier for rung in ladder] == LADDER_ORDER
+
+
+def test_ladder_covers_every_dispatchable_model():
+    """Seven rungs — one per dispatchable model — in strict cost order (OI-1229)."""
+    ladder = load_tier_ladder()
+    assert [(r.tier, r.model, r.output_cost_per_mtok) for r in ladder] == [
+        (TIER_ZERO, "deepseek-v4-flash", 0.28),
+        (TIER_LOW, "deepseek-v4-pro", 0.87),
+        ("kimi-k3", "kimi-k3", 2.50),
+        ("gpt-5.5", "gpt-5.5", 10.00),
+        (TIER_MID, "sonnet-5", 15.00),
+        (TIER_HIGH, "opus-5", 25.00),
+        ("fable-5", "fable-5", 50.00),
     ]
 
 
@@ -171,7 +195,7 @@ def test_load_tier_ladder_fails_on_non_monotonic_cost(tmp_path):
 def test_escalate_rejected_result_climbs_one_tier():
     esc = escalate_tier(TIER_LOW, "20260815-rejected-attempt")
     assert esc.tier_from == TIER_LOW
-    assert esc.tier_to == TIER_MID
+    assert esc.tier_to == "kimi-k3"
     assert esc.parent_dispatch == "20260815-rejected-attempt"
 
 
@@ -184,18 +208,29 @@ def test_escalate_from_mid_to_high():
 
 
 def test_escalate_at_top_returns_none():
-    assert escalate_tier(TIER_HIGH, "d-top").tier_to is None
+    assert escalate_tier("fable-5", "d-top").tier_to is None
 
 
 def test_escalate_unknown_tier_returns_none():
     assert escalate_tier("tier-unknown", "d-unknown").tier_to is None
 
 
+def test_escalate_model_named_rungs_climb_in_cost_order():
+    """The three escalation-only rungs slot into the climb at their cost position."""
+    assert escalate_tier("kimi-k3", "d1").tier_to == "gpt-5.5"
+    assert escalate_tier("gpt-5.5", "d2").tier_to == TIER_MID
+    assert escalate_tier(TIER_HIGH, "d3").tier_to == "fable-5"
+    assert escalate_tier("fable-5", "d4").tier_to is None
+
+
 def test_next_tier_matches_escalate_tier():
     assert next_tier(TIER_ZERO) == TIER_LOW
-    assert next_tier(TIER_LOW) == TIER_MID
+    assert next_tier(TIER_LOW) == "kimi-k3"
+    assert next_tier("kimi-k3") == "gpt-5.5"
+    assert next_tier("gpt-5.5") == TIER_MID
     assert next_tier(TIER_MID) == TIER_HIGH
-    assert next_tier(TIER_HIGH) is None
+    assert next_tier(TIER_HIGH) == "fable-5"
+    assert next_tier("fable-5") is None
 
 
 # ---------------------------------------------------------------------------
@@ -218,5 +253,5 @@ def test_quality_escalation_climbs_where_fallback_stays(monkeypatch):
 
     esc = escalate_tier(TIER_LOW, "d-rejected")
     assert esc.tier_from == TIER_LOW
-    assert esc.tier_to == TIER_MID
+    assert esc.tier_to == "kimi-k3"
     assert esc.parent_dispatch == "d-rejected"

--- a/tests/test_dispatch_bridge_escalation.py
+++ b/tests/test_dispatch_bridge_escalation.py
@@ -1,0 +1,136 @@
+"""tests/test_dispatch_bridge_escalation.py — the escalation CALLER's write path (OI-1221).
+
+``escalate_tier``/``next_tier`` already computed the climb (tier_to = tier_from + 1,
+parent_dispatch = the rejected attempt), but no caller ever fired a followup, so
+``tier_from``/``tier_to`` stayed empty on 0 of 761 filled specs. ``stage_escalation_bundle``
+is that caller: it resolves the climb from the cost ladder, resolves the target rung's
+route, and writes a genuinely-staged ``dispatch-spec.json`` carrying the three chain-link
+fields.
+
+These tests pin the WRITE PATH, not a dataclass: every assertion reads the spec back
+from disk. A dataclass test proves nothing about the receipt — the bytes the door reads
+are the bytes the receipt processor copies.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import dispatch_bridge  # noqa: E402
+
+_REJECTED_ID = "20260815-094500-rejected-attempt"
+_FOLLOWUP_ID = "20260815-100000-escalated-followup"
+
+
+def _force_kimi(monkeypatch, present: bool = True):
+    """Deterministically set kimi CLI presence (kimi-via-cli-only gate)."""
+    import shutil as _shutil
+
+    monkeypatch.setattr(
+        _shutil,
+        "which",
+        (lambda name: "/usr/local/bin/kimi") if present else (lambda name: None),
+    )
+
+
+def _stage_escalation(tmp_path, **over):
+    base = dict(
+        rejected_dispatch_id=_REJECTED_ID,
+        tier_from="tier-low",
+        instruction_text="escalate: the cheap attempt was rejected",
+        dispatch_id=_FOLLOWUP_ID,
+        role="dev",
+        target_slot="T1",
+        project_id="p1",
+        data_dir=tmp_path,
+        env={},
+        state_dir=tmp_path / "state",
+        now=0.0,
+    )
+    base.update(over)
+    return dispatch_bridge.stage_escalation_bundle(**base)
+
+
+def _read_payload(spec_file: Path) -> dict:
+    return json.loads(spec_file.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# The escalation followup carries the three chain-link fields — on disk
+# ---------------------------------------------------------------------------
+
+def test_escalation_bundle_writes_chain_link_fields_to_disk(tmp_path, monkeypatch):
+    """A REAL write: the staged spec carries tier_from/tier_to/parent_dispatch filled."""
+    _force_kimi(monkeypatch, present=True)
+    spec_file = _stage_escalation(tmp_path)
+    payload = _read_payload(spec_file)
+
+    assert payload["tier_from"] == "tier-low"
+    assert payload["tier_to"] == "kimi-k3"
+    assert payload["parent_dispatch"] == _REJECTED_ID
+    assert payload["dispatch_id"] == _FOLLOWUP_ID
+
+
+def test_escalation_followup_runs_on_the_escalated_model(tmp_path, monkeypatch):
+    """The followup resolves the TARGET rung's route — not re-classified to the
+    cheap tier it climbed out of (tier-low's deepseek primary)."""
+    _force_kimi(monkeypatch, present=True)
+    payload = _read_payload(_stage_escalation(tmp_path))
+
+    assert payload["provider"] == "kimi"
+    assert payload["model"] == "kimi-k3"
+
+
+def test_escalation_at_top_rung_refuses_to_stage(tmp_path, monkeypatch):
+    """fable-5 is the top rung: escalation has nowhere to climb and fails loud."""
+    _force_kimi(monkeypatch, present=True)
+    with pytest.raises(ValueError, match="top rung"):
+        _stage_escalation(tmp_path, tier_from="fable-5")
+
+
+# ---------------------------------------------------------------------------
+# A normal dispatch keeps the fields empty — the distinction stays countable
+# ---------------------------------------------------------------------------
+
+def test_normal_bundle_keeps_chain_link_fields_empty(tmp_path):
+    """A non-escalated dispatch stages with all three chain-link fields unset, so
+    the escalation signal on receipts remains a countable property (293 of 761
+    specs already carry the empty keys — this is the write-path half of that)."""
+    spec_file = dispatch_bridge.stage_spec_bundle(
+        instruction_text="normal work",
+        dispatch_id="20260815-110000-normal",
+        role="dev",
+        target_slot="T1",
+        project_id="p1",
+        data_dir=tmp_path,
+    )
+    payload = _read_payload(spec_file)
+
+    assert payload["tier_from"] is None
+    assert payload["tier_to"] is None
+    assert payload["parent_dispatch"] is None
+
+
+# ---------------------------------------------------------------------------
+# Regression: the fields must survive the write path, not just the kwargs
+# ---------------------------------------------------------------------------
+
+def test_escalation_fields_are_written_not_just_passed(tmp_path, monkeypatch):
+    """Fails if the chain-link fields fall OUT of stage_spec_bundle's spec_payload:
+    stage_escalation_bundle passes them as kwargs, but a payload that drops the
+    keys (or writes them empty) must be caught here — the receipt reads the file,
+    not the call."""
+    _force_kimi(monkeypatch, present=True)
+    payload = _read_payload(_stage_escalation(tmp_path))
+
+    # Non-empty STRINGS in the written file — the exact bytes the door → receipt
+    # chain copies. A missing key would raise KeyError; a None would fail these.
+    for field in ("tier_from", "tier_to", "parent_dispatch"):
+        assert isinstance(payload[field], str) and payload[field].strip(), field


### PR DESCRIPTION
## Summary

Completes the two halves of the cost-ladder work that PR #1540 left half-done.

**Deel A (OI-1229) — the ladder covered 4 of 7 dispatchable models.** `load_tier_map()` had 4 rungs while 7 dispatchable models exist. This extends the ladder to 7 rungs in cost order, adding `kimi-k3` (2.50/Mtok), `gpt-5.5` (10), and `fable-5` (50). `glm-5.2` (2.42) carries no `dispatch_enum`, so it is correctly excluded — now documented with the reason in the registry comment.

**Deel B (OI-1221) — escalation never landed in a receipt.** `escalate_tier`/`next_tier` computed the climb but no caller ever fired a followup, so `tier_from`/`tier_to` stayed empty on 0 of 761 filled specs. `stage_escalation_bundle` is that caller: it resolves the climb from the ladder, resolves the target rung's route, and stages a `dispatch-spec.json` carrying `tier_from`/`tier_to`/`parent_dispatch`. It stages only — it never fires the dispatch, so escalation stays human-in-the-loop.

## Changes

- `scripts/lib/providers/wave7_models.yaml` — `routing.tier_map` grows from 4 to 7 rungs (adds `kimi-k3`, `gpt-5.5`, `fable-5`); registry comment documents the ladder, the glm-5.2 exclusion, and the classifier-entry vs escalation-only rung split.
- `scripts/lib/dispatch_spec.py` — `_VALID_TIERS` widened to the full 7-rung vocabulary so escalation tier values pass the door's Rule 14 tier check.
- `scripts/lib/dispatch_bridge.py` — new `stage_escalation_bundle()`: the missing escalation caller (real spec write, never fires).
- `tests/smart_router/test_cost_ladder.py` — ladder-order and coverage pins updated for 7 rungs; escalation tests climb the full chain.
- `tests/test_dispatch_bridge_escalation.py` — new: disk-read tests proving the 3 chain-link fields land in the written spec on escalation, stay empty on a normal dispatch, and fail if the fields fall out of the write path.

## Verification

- Targeted + neighbor suite: **244 passed** (`test_dispatch_bridge_escalation`, `test_dispatch_bridge_staging`, `test_dispatch_spec`, `test_cost_ladder`, `test_model_ssot_and_chainlink`, `test_dispatch_envelope_field_propagation`, `test_t0_escalations_log`).
- `test_adr_003_no_sdk_imports.py`: 23 passed (no Anthropic SDK import).

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)