### PR TITLE
fix(role): ignore generated AGENTS.md/GEMINI.md mirrors in terminals/T0 (OI-1228)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,10 +143,16 @@ scripts/benchmark/field-tests/tasks.local.yaml
 .vnx-attest/
 .vnx/config.yml
 
-# Tri-file rolbestanden in de repo-root: door `vnx role sync --apply` gegenereerd
-# uit de canonieke rol, niet met de hand geschreven.
+# Tri-file rolbestanden (AGENTS.md / GEMINI.md): gegenereerde mirrors van de
+# canonieke rol, niet met de hand geschreven. `vnx role sync --apply` spiegelt
+# de rol naar .claude/terminals/T0/ (Codex/Gemini/Kimi-orchestrator); de
+# repo-root-versies schrijft patch-agent-files. Alleen de authored bron
+# (role-orchestrator.md) hoort in git — een verse sync mag de git-status niet
+# vervuilen (OI-1228: merge_preflight Check 1 blokkeert dan op untracked files).
 /AGENTS.md
 /GEMINI.md
+.claude/terminals/T0/AGENTS.md
+.claude/terminals/T0/GEMINI.md
 
 # Sessie-logs: eigen inhoud, maar met dagbedragen aan AI-kosten en klantcontext.
 # Deze repo is publiek, dus die gaan er niet in. Backup staat buiten git in de

--- a/tests/test_role_sync.py
+++ b/tests/test_role_sync.py
@@ -611,5 +611,90 @@ class TestDualCliParity:
         assert "not found" in (r.stdout + r.stderr).lower()
 
 
+# ---------------------------------------------------------------------------
+# OI-1228: sync-vervuiling. `vnx role sync --apply` mirrors the canonical role
+# into .claude/terminals/T0/AGENTS.md (Codex) and GEMINI.md (Gemini/Kimi).
+# Disposition: IGNORE — they are generated mirrors of the tracked
+# role-orchestrator.md, so a git copy would be redundant and would drift.
+# Without the ignore rule, every fresh sync leaves two untracked files and
+# merge_preflight.sh Check 1 (git cleanliness) blocks the merge.
+# ---------------------------------------------------------------------------
+
+TERMINAL_PROVIDER_MIRRORS = (
+    ".claude/terminals/T0/AGENTS.md",
+    ".claude/terminals/T0/GEMINI.md",
+)
+
+
+class TestSyncGitCleanliness:
+    def test_repo_gitignore_ignores_terminals_provider_mirrors(self):
+        """This repo's own .gitignore must cover the two provider mirrors, or a
+        dev checkout of vnx-orchestration re-pollutes its working copy on every
+        sync. Pins the IGNORE disposition at its source (the repo .gitignore,
+        not a global excludesfile)."""
+        for rel in TERMINAL_PROVIDER_MIRRORS:
+            r = subprocess.run(
+                ["git", "check-ignore", "-v", "--no-index", rel],
+                capture_output=True, text=True, cwd=str(REPO),
+            )
+            assert r.returncode == 0, f"{rel} is not git-ignored (OI-1228)"
+            assert rel in r.stdout
+            assert ".gitignore" in r.stdout, (
+                f"{rel} ignored by {r.stdout.strip()!r}, not this repo's .gitignore"
+            )
+
+    def test_apply_leaves_working_tree_clean_when_source_is_tracked(self, tmp_path):
+        """End-to-end, faithful to the real repo: the authored source
+        (CLAUDE.md + role-orchestrator.md) is committed first, so a fresh
+        `vnx role sync --apply` that materializes the provider mirrors must
+        leave `git status --porcelain` empty — the exact signal
+        merge_preflight.sh Check 1 reads. With the mirrors untracked they would
+        appear here as `?? .claude/terminals/T0/AGENTS.md` (see the negative
+        control below)."""
+        project = _make_project(tmp_path, "consumer")
+        _init_git(project)
+        (project / ".gitignore").write_text((REPO / ".gitignore").read_text())
+
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "role-orchestrator.md").write_text(SHIPPED_ROLE.read_text())
+        subprocess.run(["git", "add", ".claude", ".gitignore"], cwd=str(project), check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "track authored source"], cwd=str(project), check=True)
+
+        r = _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+
+        assert (t0 / "AGENTS.md").exists()
+        assert (t0 / "GEMINI.md").exists()
+
+        status = subprocess.run(
+            ["git", "status", "--porcelain"], capture_output=True, text=True, cwd=str(project),
+        ).stdout
+        assert status == ""
+
+    def test_without_ignore_rule_the_mirrors_do_pollute(self, tmp_path):
+        """Negative control: the same sync against a project whose .gitignore
+        does NOT ignore the mirrors leaves them untracked. Proves the clean
+        assertion above is produced by the ignore rule, not by a vacuous pass
+        (git collapses an all-untracked directory, so a project with no tracked
+        source would mask the pollution)."""
+        project = _make_project(tmp_path, "consumer")
+        _init_git(project)
+        # Deliberately no .gitignore.
+
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "role-orchestrator.md").write_text(SHIPPED_ROLE.read_text())
+        subprocess.run(["git", "add", ".claude"], cwd=str(project), check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "track authored source"], cwd=str(project), check=True)
+
+        r = _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+
+        status = subprocess.run(
+            ["git", "status", "--porcelain"], capture_output=True, text=True, cwd=str(project),
+        ).stdout
+        assert ".claude/terminals/T0/AGENTS.md" in status
+        assert ".claude/terminals/T0/GEMINI.md" in status
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Wat

`vnx role sync --apply` spiegelt de canonieke rol naar `.claude/terminals/T0/AGENTS.md` (Codex) en `GEMINI.md` (Gemini/Kimi). Die twee waren noch getrackt, noch genegeerd. Na elke sync stond de werkkopie dus op twee untracked bestanden, en `merge_preflight.sh` Check 1 (git cleanliness) blokkeerde de merge.

## Dispositie: negeren

Ze zijn gegenereerde mirrors van de al getrackte `role-orchestrator.md`. Een kopie in git is redundant en kan verouderen. Dit is dezelfde dispositie als de bestaande repo-root tri-file (`/AGENTS.md`, `/GEMINI.md`), die al genegeerd wordt. Hand-aanpassingen die moeten blijven horen in de getrackte bron (`role-orchestrator.md`) of in de project-`CLAUDE.md` (de enige gesanctioneerde per-project afwijking); een hand-edit aan een genegeerd bestand is machine-lokaal en kan weg bij `git clean`/worktree-reap.

## Test

Drie tests in `TestSyncGitCleanliness` (tests/test_role_sync.py):
1. de repo `.gitignore` dekt beide paden (`git check-ignore -v`),
2. een verse sync laat een schone tree achter als de bron getrackt is (`git status --porcelain` leeg),
3. negatieve controle: zonder ignore-regel vervuilen de mirrors wél de status.

## Verificatie

- `pytest tests/test_role_sync.py` — 32 passed
- `pytest tests/test_t0_role_audit_static.py tests/test_role_orchestrator_sentinel.py` — 28 passed