### PR TITLE
feat(gate): add objective/track set-goal to repair too-thin track goals (OI-1230)

### DIFF
--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -81,6 +81,26 @@ class InvalidTransitionError(ValueError):
     pass
 
 
+class GoalTooThinError(ValueError):
+    """A track goal below the plan-gate's minimum meaningful length was refused.
+
+    Mirrors ``planning_cli.PlanRefusal``'s refusal form (measured length +
+    threshold) so a set-goal refusal reads the same as the gate's own, but the
+    remediation points at setting a longer goal rather than at ``--doc``. Carries
+    the measured length and the threshold so callers can render the refusal
+    without recomputing either.
+    """
+
+    def __init__(self, length: int, threshold: int) -> None:
+        self.length = length
+        self.threshold = threshold
+        super().__init__(
+            f"set-goal refused: goal too thin to be a plan "
+            f"(measured {length} meaningful chars, threshold {threshold}). "
+            f"Provide a goal of at least {threshold} meaningful characters."
+        )
+
+
 def _now_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
 
@@ -380,6 +400,71 @@ def update_authored_fields(
                 (*updates.values(), track_id, project_id),
             )
             conn.commit()
+
+        updated = conn.execute(
+            "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        return dict(updated)
+    finally:
+        conn.close()
+
+
+def set_goal(
+    state_dir: str | Path,
+    track_id: str,
+    project_id: str,
+    goal: str,
+    *,
+    min_goal_chars: int,
+    actor: str = "operator",
+) -> dict[str, Any]:
+    """Set a track's ``goal_state``, validated against the plan-gate threshold.
+
+    The only operator-facing way to repair a too-thin goal after creation:
+    ``objective add`` / ``track new --goal`` set the goal once, and no other verb
+    updates it. The threshold is supplied by the caller from the plan-gate's own
+    source (``plan_gate_panel.load_goal_min_chars``) so the two can never drift
+    apart; the length is measured the same way the gate measures it (after
+    whitespace-stripping).
+
+    Refuses (``GoalTooThinError``) when the new goal is below ``min_goal_chars``
+    meaningful characters. Never touches ``phase``, ``derived_status``,
+    ``phase_changed_at``, or ``completed_at`` — filling in a goal is not
+    progress. Emits a ``track_goal_set`` audit event carrying the old and new
+    goal values so a silent overwrite of the queue is impossible to hide.
+
+    Raises ``TrackNotFoundError`` when the track does not exist.
+    """
+    if actor not in ("operator", "T0", "system"):
+        raise ValueError(f"Invalid actor: {actor!r}. Must be 'operator', 'T0', or 'system'")
+    if not isinstance(goal, str):
+        raise GoalTooThinError(length=0, threshold=min_goal_chars)
+
+    measured = len(goal.strip())
+    if measured < min_goal_chars:
+        raise GoalTooThinError(length=measured, threshold=min_goal_chars)
+
+    conn = _get_conn(state_dir)
+    try:
+        row = conn.execute(
+            "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        if not row:
+            raise TrackNotFoundError(f"Track not found: ({track_id!r}, {project_id!r})")
+
+        old_goal = row["goal_state"]
+
+        _emit_track_event(
+            state_dir, "track_goal_set", track_id, project_id, actor,
+            {"old_goal": old_goal, "new_goal": goal},
+        )
+        conn.execute(
+            "UPDATE tracks SET goal_state = ? WHERE track_id = ? AND project_id = ?",
+            (goal, track_id, project_id),
+        )
+        conn.commit()
 
         updated = conn.execute(
             "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2043,6 +2043,47 @@ def cmd_objective_set_lane_hint(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_objective_set_goal(args: argparse.Namespace) -> int:
+    """Set a track's ``goal_state``, validated against the plan-gate threshold.
+
+    The only operator-facing repair for a too-thin goal after creation: the
+    plan-first gate refuses a goal under ``goal_min_chars`` meaningful characters,
+    and before this verb no command could raise it without an operator-attest
+    (which books the track as done) or a forbidden direct DB write. Reads the
+    threshold from the plan-gate's own source (``plan_gate_panel.load_goal_min_chars``)
+    so the two never drift apart. Writes via ``tracks_lib.set_goal``, the
+    single-writer; never touches ``phase`` or ``derived_status``.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    import plan_gate_panel  # noqa: PLC0415
+    min_goal_chars = plan_gate_panel.load_goal_min_chars()
+
+    try:
+        track = tracks_lib.set_goal(
+            state_dir, track_id, project_id, args.goal,
+            min_goal_chars=min_goal_chars, actor="operator",
+        )
+    except tracks_lib.GoalTooThinError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except tracks_lib.TrackNotFoundError as exc:
+        print(
+            f"objective set-goal: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"Set goal_state on {track_id} [{project_id}] "
+        f"({len(args.goal.strip())} meaningful chars)"
+    )
+    return 0
+
+
 def cmd_deliverable_add(args: argparse.Namespace) -> int:
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
@@ -4155,6 +4196,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="descriptive dispatch-routing hint (governed|direct|unset); default unset",
     )
     p_add.set_defaults(func=cmd_objective_add)
+
+    p_set_goal = obj_sub.add_parser(
+        "set-goal",
+        help="repair a too-thin track goal: set goal_state on an existing track "
+             "(validated against the plan-gate's goal_min_chars threshold)",
+    )
+    _common(p_set_goal)
+    p_set_goal.add_argument("track_id")
+    p_set_goal.add_argument(
+        "goal",
+        help="what 'done' looks like for this track (>= goal_min_chars meaningful chars)",
+    )
+    p_set_goal.set_defaults(func=cmd_objective_set_goal)
 
     p_lane_hint = obj_sub.add_parser(
         "set-lane-hint",

--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -345,7 +345,7 @@ def test_horizon_help_lists_full_surface(monkeypatch, capsys):
     for verb in (
         "add", "list", "show", "sync", "drift", "reconcile",
         "reconcile-review", "reconcile-streak", "close", "reopen",
-        "link-pr", "set-lane-hint",
+        "link-pr", "set-lane-hint", "set-goal",
         "deliverable", "plan-gate",
     ):
         assert verb in out, f"missing verb in `vnx horizon --help`: {verb}"
@@ -357,7 +357,7 @@ def test_objective_and_deliverable_alias_help(monkeypatch, capsys):
     for verb in (
         "add", "list", "show", "sync", "drift", "reconcile",
         "reconcile-review", "reconcile-streak", "close", "reopen",
-        "link-pr", "set-lane-hint",
+        "link-pr", "set-lane-hint", "set-goal",
     ):
         assert verb in out
     # objective is the OBJECTIVE-domain alias only — deliverable/plan-gate stay

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -320,6 +320,7 @@ _OBJECTIVE_ARGV = {
     "reopen": ["delegate-track"],
     "link-pr": ["delegate-track", "#1234", "#1235", "--delivery", "complete"],
     "set-lane-hint": ["delegate-track", "governed"],
+    "set-goal": ["delegate-track", "Delegate goal state"],
 }
 _DELIVERABLE_ARGV = {
     "add": ["--objective", "delegate-track", "--output-kind", "doc", "--title", "Delegate deliverable"],

--- a/tests/test_objective_set_goal.py
+++ b/tests/test_objective_set_goal.py
@@ -1,0 +1,299 @@
+"""tests/test_objective_set_goal.py — `vnx objective set-goal` / `vnx track set-goal`.
+
+Punt 16 + OI-1230: a too-thin track goal was only settable at creation time
+(`objective add` / `track new --goal`). The plan-first gate refuses a goal under
+``goal_min_chars`` meaningful characters, and no verb could raise it afterwards
+without an operator-attest (which books the track as done) or a forbidden direct
+DB write.
+
+Verifies the repair command end to end, against a temporary database:
+
+- a too-thin goal is refused with the measured length and the threshold
+- a sufficient goal is written and read back from DISK (fresh connection), with
+  ``phase`` and ``derived_status`` untouched
+- the ``track_goal_set`` audit event carries the old and the new goal value
+- an unknown track_id fails loudly
+- both surfaces (`objective set-goal`, `track set-goal`) share the same writer
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+for p in (_LIB, _SCRIPTS, _ROOT):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+import planning_cli  # noqa: E402
+import plan_gate_panel  # noqa: E402
+
+
+THRESHOLD = 200
+
+
+def _bootstrap(tmp_path: Path) -> Path:
+    """Create a temporary state dir with the track schema (migrations 0022-0028)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS dispatches (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL DEFAULT 'vnx-dev', "
+        "state TEXT NOT NULL DEFAULT 'queued', terminal_id TEXT, track TEXT, "
+        "priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT, "
+        "attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT, "
+        "created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "expires_after TEXT, metadata_json TEXT DEFAULT '{}', "
+        "UNIQUE(dispatch_id, project_id))"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS coordination_events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "event_id TEXT, event_type TEXT, entity_type TEXT, entity_id TEXT, from_state TEXT, "
+        "to_state TEXT, actor TEXT, reason TEXT, metadata_json TEXT, occurred_at TEXT, project_id TEXT)"
+    )
+    conn.commit()
+    for version, filename in [
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _read_row(state_dir: Path, track_id: str, project_id: str) -> dict:
+    """Read a track row from DISK via a fresh connection (not the in-memory DAL)."""
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def _read_events(state_dir: Path) -> list[dict]:
+    path = state_dir.parent / "events" / "track_events.ndjson"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _add_args(state_dir: Path, **over) -> argparse.Namespace:
+    base = dict(
+        track_id="feat-goal-001", goal="x" * 250,
+        project_id="vnx-dev", state_dir=str(state_dir), json=False,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# DAL: tracks.set_goal
+# ---------------------------------------------------------------------------
+
+def test_set_goal_thin_goal_refused_with_length_and_threshold(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal")
+
+    with pytest.raises(tracks_lib.GoalTooThinError) as exc_info:
+        tracks_lib.set_goal(
+            state_dir, "feat-goal-001", "vnx-dev", "too thin",
+            min_goal_chars=THRESHOLD,
+        )
+
+    assert exc_info.value.length == len("too thin")
+    assert exc_info.value.threshold == THRESHOLD
+    msg = str(exc_info.value)
+    assert "measured 8 meaningful chars" in msg
+    assert f"threshold {THRESHOLD}" in msg
+    # refused: nothing was written
+    assert _read_row(state_dir, "feat-goal-001", "vnx-dev")["goal_state"] == "old goal"
+
+
+def test_set_goal_measures_whitespace_stripped_length(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal")
+
+    # 300 spaces -> 0 meaningful chars, refused.
+    with pytest.raises(tracks_lib.GoalTooThinError) as exc_info:
+        tracks_lib.set_goal(
+            state_dir, "feat-goal-001", "vnx-dev", " " * 300,
+            min_goal_chars=THRESHOLD,
+        )
+    assert exc_info.value.length == 0
+
+
+def test_set_goal_sufficient_goal_written_and_phase_preserved(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(
+        state_dir, "feat-goal-001", "vnx-dev", "T", "old goal", phase="active",
+    )
+    # plant a non-default derived_status to prove set_goal does not touch it
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE tracks SET derived_status = 'blocked' WHERE track_id = ? AND project_id = ?",
+        ("feat-goal-001", "vnx-dev"),
+    )
+    conn.commit()
+    before = _read_row(state_dir, "feat-goal-001", "vnx-dev")
+
+    new_goal = "ship " + "x" * 240
+    result = tracks_lib.set_goal(
+        state_dir, "feat-goal-001", "vnx-dev", new_goal,
+        min_goal_chars=THRESHOLD,
+    )
+
+    assert result["goal_state"] == new_goal
+    # read back from disk (fresh connection), not the returned dict
+    after = _read_row(state_dir, "feat-goal-001", "vnx-dev")
+    assert after["goal_state"] == new_goal
+    assert after["phase"] == "active"
+    assert after["derived_status"] == "blocked"
+    assert after["phase_changed_at"] == before["phase_changed_at"]
+
+
+def test_set_goal_audit_event_contains_old_and_new(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal")
+
+    new_goal = "ship " + "x" * 240
+    tracks_lib.set_goal(
+        state_dir, "feat-goal-001", "vnx-dev", new_goal,
+        min_goal_chars=THRESHOLD, actor="operator",
+    )
+
+    events = [e for e in _read_events(state_dir) if e["event_type"] == "track_goal_set"]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["details"]["old_goal"] == "old goal"
+    assert ev["details"]["new_goal"] == new_goal
+    assert ev["track_id"] == "feat-goal-001"
+    assert ev["project_id"] == "vnx-dev"
+    assert ev["actor"] == "operator"
+    assert ev["timestamp"]
+
+
+def test_set_goal_unknown_track_raises(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    with pytest.raises(tracks_lib.TrackNotFoundError):
+        tracks_lib.set_goal(
+            state_dir, "does-not-exist", "vnx-dev", "x" * 250,
+            min_goal_chars=THRESHOLD,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI: objective set-goal (planning_cli)
+# ---------------------------------------------------------------------------
+
+def test_objective_set_goal_cmd_thin_refused(tmp_path, capsys):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal")
+
+    rc = planning_cli.cmd_objective_set_goal(_add_args(state_dir, goal="too thin"))
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "measured 8 meaningful chars" in err
+    assert f"threshold {plan_gate_panel.load_goal_min_chars()}" in err
+    # refused: nothing written
+    assert _read_row(state_dir, "feat-goal-001", "vnx-dev")["goal_state"] == "old goal"
+
+
+def test_objective_set_goal_cmd_sufficient_written(tmp_path, capsys):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal", phase="active")
+
+    new_goal = "ship " + "x" * 240
+    rc = planning_cli.cmd_objective_set_goal(_add_args(state_dir, goal=new_goal))
+    assert rc == 0
+    assert "Set goal_state" in capsys.readouterr().out
+
+    after = _read_row(state_dir, "feat-goal-001", "vnx-dev")
+    assert after["goal_state"] == new_goal
+    assert after["phase"] == "active"
+
+
+def test_objective_set_goal_cmd_unknown_track_fails(tmp_path, capsys):
+    state_dir = _bootstrap(tmp_path)
+    rc = planning_cli.cmd_objective_set_goal(
+        _add_args(state_dir, track_id="does-not-exist", goal="x" * 250)
+    )
+    assert rc == 2
+    assert "track not found" in capsys.readouterr().err
+
+
+def test_objective_set_goal_cli_end_to_end(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal")
+
+    new_goal = "ship " + "x" * 240
+    rc = planning_cli.main([
+        "objective", "set-goal", "feat-goal-001", new_goal,
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    assert _read_row(state_dir, "feat-goal-001", "vnx-dev")["goal_state"] == new_goal
+
+
+# ---------------------------------------------------------------------------
+# CLI: vnx track set-goal alias
+# ---------------------------------------------------------------------------
+
+def test_track_set_goal_alias_writes(tmp_path, monkeypatch, capsys):
+    # Pin the data root to the temp dir so the alias's _resolve_state_dir never
+    # falls through to the real central store (~/.vnx-data/<id>).
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal")
+
+    from vnx_cli.commands import track as track_cmd
+
+    args = argparse.Namespace(
+        track_id="feat-goal-001", goal="ship " + "x" * 240,
+        project_id="vnx-dev", project_dir=str(tmp_path),
+    )
+    rc = track_cmd._cmd_set_goal(args)
+    assert rc == 0
+    assert "Set goal_state" in capsys.readouterr().out
+
+    assert _read_row(state_dir, "feat-goal-001", "vnx-dev")["goal_state"] == "ship " + "x" * 240
+
+
+def test_track_set_goal_alias_thin_refused(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-goal-001", "vnx-dev", "T", "old goal")
+
+    from vnx_cli.commands import track as track_cmd
+
+    args = argparse.Namespace(
+        track_id="feat-goal-001", goal="too thin",
+        project_id="vnx-dev", project_dir=str(tmp_path),
+    )
+    rc = track_cmd._cmd_set_goal(args)
+    assert rc == 2
+    assert "measured 8 meaningful chars" in capsys.readouterr().err

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -195,6 +195,12 @@ def _cmd_set_lane_hint(args: Any) -> int:
     return pc.cmd_objective_set_lane_hint(args)
 
 
+def _cmd_set_goal(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_set_goal(args)
+
+
 _VERB_DISPATCH: dict[str, Callable[[Any], int]] = {
     "add": _cmd_add,
     "list": _cmd_list,
@@ -208,6 +214,7 @@ _VERB_DISPATCH: dict[str, Callable[[Any], int]] = {
     "reopen": _cmd_reopen,
     "link-pr": _cmd_link_pr,
     "set-lane-hint": _cmd_set_lane_hint,
+    "set-goal": _cmd_set_goal,
 }
 
 

--- a/vnx_cli/commands/track.py
+++ b/vnx_cli/commands/track.py
@@ -283,6 +283,41 @@ def _cmd_show(args) -> int:
     return 0
 
 
+def _cmd_set_goal(args) -> int:
+    """Repair a too-thin track goal (alias for `vnx objective set-goal`).
+
+    ``goal_state`` is set only at creation time (``new --goal`` / ``objective add``),
+    and ``vnx track show`` is the surface that displays it — so the track group is
+    where a track operator looks to repair a goal the plan-gate refuses. Delegates
+    to the same ``tracks_lib.set_goal`` single-writer as the objective verb; the
+    threshold comes from the plan-gate's own source so the two never drift.
+    """
+    project_id = args.project_id
+    state_dir = _resolve_state_dir(args.project_dir)
+    tracks_lib = _require_tracks_lib(state_dir)
+
+    import plan_gate_panel
+    min_goal_chars = plan_gate_panel.load_goal_min_chars()
+
+    try:
+        track = tracks_lib.set_goal(
+            state_dir, args.track_id, project_id, args.goal,
+            min_goal_chars=min_goal_chars, actor="operator",
+        )
+    except tracks_lib.GoalTooThinError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except tracks_lib.TrackNotFoundError as exc:
+        print(f"  Error: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        f"  Set goal_state on {track['track_id']} [{project_id}] "
+        f"({len(args.goal.strip())} meaningful chars)"
+    )
+    return 0
+
+
 def vnx_track(args) -> int:
     sub = getattr(args, "track_subcommand", None)
     if sub == "new":
@@ -299,6 +334,8 @@ def vnx_track(args) -> int:
         return _cmd_oi_close(args)
     elif sub == "dispatch":
         return _cmd_dispatch(args)
+    elif sub == "set-goal":
+        return _cmd_set_goal(args)
     elif sub == "list":
         return _cmd_list(args)
     elif sub == "show":

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -441,7 +441,7 @@ def _register_dispatch_agent_subparser(subparsers: argparse.Action) -> None:
 def _register_track_subparser(subparsers: argparse.Action) -> None:
     track_parser = subparsers.add_parser(
         "track",
-        help="manage feature-tracks (new/activate/park/unpark/done/oi-close/dispatch/list/show)",
+        help="manage feature-tracks (new/activate/park/unpark/done/oi-close/dispatch/set-goal/list/show)",
     )
     track_parser.add_argument(
         "--project-dir",
@@ -523,6 +523,15 @@ def _register_track_subparser(subparsers: argparse.Action) -> None:
     toic_parser.add_argument("--reason", required=True, metavar="REASON",
                              help="resolution reason (required; recorded in audit trail)")
     toic_parser.add_argument("--project-dir", default=".", metavar="DIR")
+
+    tsg_parser = track_subs.add_parser(
+        "set-goal", help="set a track's goal_state (repair a too-thin goal)")
+    tsg_parser.add_argument("track_id", metavar="TRACK_ID")
+    tsg_parser.add_argument("goal", metavar="GOAL",
+                            help="what 'done' looks like (>= goal_min_chars meaningful chars)")
+    tsg_parser.add_argument("--project-id", required=True, metavar="PROJECT_ID",
+                            help="project_id for this track (required; ADR-007)")
+    tsg_parser.add_argument("--project-dir", default=".", metavar="DIR")
 
 
 _HORIZON_CHOICES = ("now", "next", "later")
@@ -704,6 +713,18 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
     p_lane_hint.add_argument(
         "lane_hint", choices=_LANE_HINT_CHOICES, metavar="LANE_HINT",
         help="descriptive dispatch-routing hint (governed|direct|unset)",
+    )
+
+    p_set_goal = subs.add_parser(
+        "set-goal",
+        help="repair a too-thin track goal (validated against the "
+             "goal_min_chars threshold)",
+    )
+    _common_horizon_args(p_set_goal)
+    p_set_goal.add_argument("track_id", metavar="TRACK_ID")
+    p_set_goal.add_argument(
+        "goal", metavar="GOAL",
+        help="what 'done' looks like (>= goal_min_chars meaningful chars)",
     )
 
 


### PR DESCRIPTION
## Wat

Een te dun track-goal (`goal_state` onder de plan-gate drempel) kon alleen bij aanmaak worden gezet. Daarna was er geen reparatiepad zonder operator-attest of een verboden directe DB-write (Punt 16 / OI-1230).

Deze PR voegt een governed repair-pad toe:

- `vnx objective set-goal <track_id> <goal>`
- `vnx track set-goal <track_id> <goal>` (alias; het track-commando is waar een operator kijkt om een goal te repareren)

## Hoe

- `tracks.set_goal`: single-writer. Valideert tegen dezelfde drempel als de plan-gate, gelezen uit `plan_gate_panel.load_goal_min_chars()` (niet opnieuw hardcoded). Weigert luid met gemeten lengte + drempel. Schrijft een `track_goal_set` audit-event (old/new). Raakt alleen `goal_state`; `phase` en `derived_status` blijven onaangeraakt.
- `vnx objective set-goal` via `planning_cli.cmd_objective_set_goal` + horizon delegate; `vnx track set-goal` via het track-commando. Beide delegeren naar dezelfde writer.
- `project_id` loopt door (ADR-007); geen stille `vnx-dev`.

## Testbewijs

- `tests/test_objective_set_goal.py`: 11 tests. Dun goal geweigerd (lengte + drempel), whitespace-stripped meting, voldoende goal geschreven + terugleesbaar, phase/derived_status ongewijzigd, audit old+new, onbekend track_id faalt luid, CLI end-to-end, track-alias schrijft + weigert.
- Rebase op `origin/main` schoon; `test_horizon_parity.py` + `test_horizon_cli.py` bijgewerkt voor het nieuwe verb.
- 138/138 groen op de geraakte testbestanden (incl. de 2 horizon-files die het nieuwe verb dekken).

Pre-existing failures (niet door deze PR, bevestigd op schone HEAD via `git stash`): `test_track_cli.py`, `test_plan_gate_panel.py`, `test_planning_cli_objective.py`, `test_track_v23_cli.py` falen op schema-drift (`no such column: output_ref` e.d.) in deze worktree.

Dispatch-ID: 20260815-nn-w15-objective-set-goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)