### PR TITLE
fix(governance): close three OIs — plan-gate repo-root, flaky SSE test, docs ref drift

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -225,6 +225,24 @@ jobs:
             -p no:cacheprovider \
             --basetemp=/tmp/vnx_pytest_safe
 
+      - name: Docs file:line reference guard
+        run: |
+          set -euo pipefail
+          # Fail CI when a living docs/ citation (file.py:123) drifts from the
+          # tree — the lane-conformity-matrix and its peers must stay honest as
+          # code shifts. Scoped to explicit line numbers in living docs only
+          # (_archive/examples/investigations/governance-decisions are frozen
+          # point-in-time artifacts); code fences are skipped. See OI-1107.
+          python3 "$GITHUB_WORKSPACE/scripts/ci/check_docs_file_line_refs.py"
+
+      - name: Run docs file:line reference guard unit tests
+        run: |
+          set -euo pipefail
+          pytest -q \
+            "$GITHUB_WORKSPACE/tests/test_ci_check_docs_file_line_refs.py" \
+            -p no:cacheprovider \
+            --basetemp=/tmp/vnx_pytest_safe
+
   trace-token-check:
     name: Trace Token Validation
     runs-on: ubuntu-latest

--- a/scripts/check_no_file_derived_data_paths.py
+++ b/scripts/check_no_file_derived_data_paths.py
@@ -39,6 +39,23 @@ AST-based, so comments and docstrings never trip it. Two violation shapes:
    ``plan_gate_panel.py`` blocked every plan-gate fleet-wide (2026-07-31) while
    passing shape-1 detection — the gate tested the mechanism, not the input.
 
+3. REPO-ROOT resolution (OI-1145) — two new shapes for the same class one level
+   up: deriving the REPO ROOT (not just the data dir) from ``__file__``.
+   (a) a canonical repo-root resolver (``resolve_project_root``) fed a
+   ``__file__``-anchored argument, e.g. ``resolve_project_root(__file__)``; and
+   (b) a ``.git``-marker finder (``_find_repo_root`` / ``_find_project_root`` /
+   ``_find_git_root`` / ``_git_root_from``) fed a ``__file__``-anchored start
+   path, e.g. ``_find_repo_root(Path(__file__).resolve().parent)`` — the exact
+   construct that landed the plan-gate seat ledger in the fabric keystone
+   instead of the project (fixed by reversing to CWD-first; the ``__file__``
+   fallback that remains is grandfathered). Raw ``parents[N]`` upward walks
+   that do NOT carry a ``.vnx-data``/``ROADMAP.yaml`` marker stay OUT of scope:
+   the depth-to-root depends on each file's location, so a depth rule false-
+   positives on legit ``_LIB_DIR = Path(__file__).resolve().parents[2]``
+   lib-dir derivations (e.g. ``providers/provider_lanes/*``). The marker shape
+   (1) and the resolver/finder shapes (2/3) are the precise signals.
+
+
 Scope
 -----
 ``scripts/lib/`` — the shared runtime library that runs in BOTH dev and central
@@ -232,6 +249,67 @@ GRANDFATHERED_RESOLVER_ANCHORS: Dict[str, Set[str]] = {
     },
 }
 
+# OI-1145 grandfathered repo-root RESOLVER anchors (shape 3a): existing
+# resolve_project_root(__file__) sites. Each is a pre-existing repo-root
+# resolution that would resolve the fabric checkout in a central install; the
+# migration to a CWD-first / threaded-repo-root resolution belongs to follow-up
+# work, so these are grandfathered the same way the data-resolver anchors are —
+# the gate blocks NEW occurrences and any change to a grandfathered line.
+GRANDFATHERED_REPO_ROOT_ANCHORS: Dict[str, Set[str]] = {
+    "scripts/lib/envelope_govern_support.py": {
+        "resolve_project_root(__file__)",
+    },
+    "scripts/lib/dispatch_worktree_isolation.py": {
+        "resolve_project_root(__file__)",
+    },
+    "scripts/lib/plan_gate_effectiveness_probe.py": {
+        "project_root.resolve_project_root(__file__)",
+    },
+    "scripts/lib/tmux_worktree.py": {
+        "resolve_project_root(__file__)",
+    },
+    "scripts/lib/migration_inventory.py": {
+        "resolve_project_root(__file__)",
+    },
+    "scripts/lib/governance_effectiveness_probe.py": {
+        "project_root.resolve_project_root(__file__)",
+    },
+    "scripts/lib/pool_worktree_manager.py": {
+        "resolve_project_root(__file__)",
+    },
+    "scripts/lib/intelligence_backfill.py": {
+        "resolve_project_root(__file__)",
+    },
+    "scripts/lib/gate_worktree.py": {
+        "resolve_project_root(__file__)",
+    },
+}
+
+# OI-1145 grandfathered repo-root FINDER anchors (shape 3b): existing .git-marker
+# finder calls fed a __file__ anchor. plan_gate_panel's entry is the DEFENSIVE
+# FALLBACK left after the OI-1145 fix reversed the order to CWD-first (the cwd
+# leg now wins; __file__ only fires when cwd is not a project checkout). It is
+# grandfathered so the gate can pass while still blocking any NEW finder call
+# anchored on __file__.
+GRANDFATHERED_REPO_ROOT_FINDERS: Dict[str, Set[str]] = {
+    "scripts/lib/plan_gate_panel.py": {
+        "_find_repo_root(Path(__file__).resolve().parent)",
+    },
+    "scripts/lib/migration_linter.py": {
+        "_find_project_root(Path(__file__))",
+    },
+    # _git_root_from(here) where ``here`` is a __file__-anchored local: the
+    # canonical vnx_paths resolver is tried FIRST; the git-root walk only fires
+    # in the except-Exception last resort (mirrors the grandfathered data-path
+    # fallbacks above).
+    "scripts/lib/strategy/roadmap.py": {
+        "_git_root_from(here)",
+    },
+    "scripts/lib/strategy/decisions.py": {
+        "_git_root_from(here)",
+    },
+}
+
 # Canonical data/state-dir resolver entry points that must never be fed a
 # __file__-derived anchor (shape 2). Attribute form
 # (``project_root.resolve_data_dir``) and bare form (``from project_root import
@@ -242,6 +320,25 @@ RESOLVER_FN_NAMES = frozenset({
     "resolve_data_dir",
     "resolve_state_dir",
     "resolve_dispatch_dir",
+})
+
+# OI-1145 shape 3a: the canonical REPO-ROOT resolver fed a __file__ anchor.
+# Previously deliberately excluded (resolve_project_root resolves a repo root,
+# not a .vnx-data dir); the plan-gate opus-seat failure (OI-1145) showed the
+# same keystone bug applies one level up — the resolver honors caller_file
+# FIRST, so in a central install it returns the fabric checkout, not the
+# project.
+REPO_ROOT_RESOLVER_FN_NAMES = frozenset({
+    "resolve_project_root",
+})
+
+# OI-1145 shape 3b: subprocess-free .git-marker finders fed a __file__ anchor.
+# Keyed by NAME, not by the walk shape, so the same precise signal as shape 2.
+REPO_ROOT_FINDER_FN_NAMES = frozenset({
+    "_find_repo_root",
+    "_find_project_root",
+    "_find_git_root",
+    "_git_root_from",
 })
 
 
@@ -386,6 +483,30 @@ def _is_resolver_call(node: ast.AST) -> bool:
     return False
 
 
+def _is_repo_root_resolver_call(node: ast.AST) -> bool:
+    """True for calls to the canonical repo-root resolver (shape 3a)."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in REPO_ROOT_RESOLVER_FN_NAMES
+    if isinstance(func, ast.Attribute):
+        return func.attr in REPO_ROOT_RESOLVER_FN_NAMES
+    return False
+
+
+def _is_repo_root_finder_call(node: ast.AST) -> bool:
+    """True for calls to a .git-marker repo-root finder (shape 3b)."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in REPO_ROOT_FINDER_FN_NAMES
+    if isinstance(func, ast.Attribute):
+        return func.attr in REPO_ROOT_FINDER_FN_NAMES
+    return False
+
+
 def _resolver_call_args(node: ast.Call) -> List[ast.AST]:
     """All argument expressions of a call (positional + keyword values)."""
     return list(node.args) + [kw.value for kw in node.keywords]
@@ -406,6 +527,28 @@ def check_source(source: str) -> List[Tuple[int, str]]:
     for node in ast.walk(tree):
         # Shape 2 (input side): a canonical resolver fed a __file__ anchor.
         if _is_resolver_call(node):
+            if any(
+                _references_file_anchor(arg, anchored)
+                for arg in _resolver_call_args(node)
+            ):
+                key = (getattr(node, "lineno", 0), _segment(source, node))
+                if key not in seen:
+                    seen.add(key)
+                    violations.append(key)
+            continue
+        # Shape 3a (OI-1145): the canonical repo-root resolver fed a __file__ anchor.
+        if _is_repo_root_resolver_call(node):
+            if any(
+                _references_file_anchor(arg, anchored)
+                for arg in _resolver_call_args(node)
+            ):
+                key = (getattr(node, "lineno", 0), _segment(source, node))
+                if key not in seen:
+                    seen.add(key)
+                    violations.append(key)
+            continue
+        # Shape 3b (OI-1145): a .git-marker finder fed a __file__ anchor.
+        if _is_repo_root_finder_call(node):
             if any(
                 _references_file_anchor(arg, anchored)
                 for arg in _resolver_call_args(node)
@@ -470,7 +613,12 @@ def scan_dir(root: Path) -> List[Tuple[str, int, str]]:
             source = py.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        allowed = GRANDFATHERED.get(rel, set()) | GRANDFATHERED_RESOLVER_ANCHORS.get(rel, set())
+        allowed = (
+            GRANDFATHERED.get(rel, set())
+            | GRANDFATHERED_RESOLVER_ANCHORS.get(rel, set())
+            | GRANDFATHERED_REPO_ROOT_ANCHORS.get(rel, set())
+            | GRANDFATHERED_REPO_ROOT_FINDERS.get(rel, set())
+        )
         for lineno, seg in _dedup_violations(source):
             if seg in allowed:
                 continue
@@ -489,17 +637,21 @@ def main(argv: List[str] | None = None) -> int:
 
     violations = scan_dir(root)
     if not violations:
-        print("[central-mode-paths] PASS — no __file__-derived data-path literals.")
+        print(
+            "[central-mode-paths] PASS — no __file__-anchored data-path or "
+            "repo-root derivations."
+        )
         return 0
 
     print(f"[central-mode-paths] FAIL — {len(violations)} violation(s):\n")
     for rel, lineno, seg in violations:
         print(
             f"::error file={rel},line={lineno}::central-mode path bug: "
-            f"'{seg}' derives a .vnx-data/ROADMAP path from __file__.\n"
-            f"In a central install this resolves the keystone, not "
-            f"~/.vnx-data/<project>. Route through vnx_paths.resolve_data_root()/"
-            f"resolve_state_dir() (VNX_HOME + project-marker aware). See #1023.\n"
+            f"'{seg}' anchors a .vnx-data/ROADMAP path or repo root on __file__.\n"
+            f"In a central install this resolves the keystone, not the project.\n"
+            f"Route data/state through vnx_paths.resolve_* (VNX_HOME + project-marker\n"
+            f"aware) and resolve the repo root CWD-first (or thread repo_root).\n"
+            f"See #1023 and OI-1145.\n"
         )
     return 1
 

--- a/scripts/ci/check_docs_file_line_refs.py
+++ b/scripts/ci/check_docs_file_line_refs.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""CI check: fail when a ``docs/`` file:line reference drifts from the tree.
+
+The lane-conformity-matrix and the other living docs cite source locations as
+``file.py:123`` (or ``file.py:120-130``).  Every merge that moves a function a
+few lines makes those citations a little more wrong, and nobody notices.  This
+check makes the drift fail CI instead of silently rotting.
+
+Scope — deliberately narrow, so it never false-alarms on a doc edit:
+
+* **Only explicit line numbers.**  A bare filename (``file.py``) is never
+  flagged: prose mentions files constantly, and a filename alone carries no
+  line claim to drift.  The pattern matched is ``file.py:123`` (ranges and
+  comma lists allowed: ``file.py:120-130``, ``file.py:120,123``).
+* **Only living docs.**  Frozen point-in-time artifacts are skipped: they are
+  historical records, and "correcting" their line numbers to today's values
+  would falsify what they recorded.  Skipped: ``docs/_archive/``,
+  ``docs/examples/`` (illustrative), ``docs/investigations/`` (dated triage
+  reports), ``docs/governance/decisions/`` (Nygard ADRs, whose own survey cites
+  are explicitly "not re-grepped to a line number").
+* **Code fences are skipped.**  A fenced block is a literal listing or schema
+  example (``scripts/lib/foo.py:10-20`` in a JSON example is a placeholder,
+  not a citation).  Real citations live inline in backtick prose.
+
+Resolution — robust enough to read the docs as written:
+
+* ``dispatch_cli.py``        — bare basename, unique in the tree.
+* ``scripts/lib/foo.py``     — exact repo-relative path.
+* ``append_receipt_internals/payload.py`` — path relative to ``scripts/lib/``.
+
+All three resolve through one rule: the cited path must equal, or be the
+suffix of, exactly one tracked file.  Zero matches is "not found"; more than
+one is "ambiguous"; both are violations, because the doc no longer names a
+single, checkable location.
+
+Exit 0 when every living citation resolves and its line numbers are in bounds.
+Exit 1 with the drifted citations listed otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Living docs only — these subdirectories of docs/ are frozen artifacts.
+_EXEMPT_DOC_SUBDIRS = frozenset({
+    "_archive",
+    "examples",
+    "investigations",
+    "governance/decisions",
+})
+
+# Extensions we treat as "a file" in a citation.  Covering the observed set
+# (py, sh, yaml, yml, md, ts, toml) plus the obvious neighbours.
+_KNOWN_EXTENSIONS = (
+    "py|sh|yaml|yml|json|md|toml|ts|js|sql|txt|ndjson|tpl|go|rs"
+)
+
+# ``file.py:123`` / ``file.py:120-130`` / ``file.py:120,123`` — the file part
+# must look like a path (word chars, dots, slashes, dashes) and end in a known
+# extension.  A leading dot is allowed so hidden-directory citations
+# (``.github/workflows/x.yml``, ``.vnx/x.yaml``) resolve instead of being
+# misread as ``github/...``.  ``(?<![\w/])`` keeps ``https://host:8080`` and
+# ``foo.py2:3`` out.
+_REF_RE = re.compile(
+    r"(?<![\w/])"
+    r"(?P<file>[.]?[\w][\w./-]*\.(?:{ext}))"
+    r":(?P<lines>\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*)".format(ext=_KNOWN_EXTENSIONS)
+)
+
+
+def tracked_rel_paths(repo_root: Path) -> list[str]:
+    """Return every tracked file path, repo-relative and posix-separated."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def resolve_ref(ref: str, paths: list[str]) -> tuple[str, str]:
+    """Resolve a cited path against tracked files.
+
+    Returns ``(status, resolved)`` where status is one of ``ok``,
+    ``not_found``, or ``ambiguous``, and *resolved* is the matched
+    repo-relative path (empty unless status is ``ok``).
+    """
+    candidates = [p for p in paths if p == ref or p.endswith("/" + ref)]
+    if len(candidates) == 1:
+        return "ok", candidates[0]
+    if not candidates:
+        return "not_found", ""
+    return "ambiguous", ""
+
+
+def _in_bounds(linespec: str, file_lines: int) -> bool:
+    """True when every line number in *linespec* is within the file."""
+    for part in linespec.split(","):
+        if "-" in part:
+            start, _, end = part.partition("-")
+            start_n, end_n = int(start), int(end)
+            # A reversed range (``1702-1671``) is malformed, not merely shifted.
+            if start_n > end_n or end_n > file_lines:
+                return False
+        elif int(part) > file_lines:
+            return False
+    return True
+
+
+def check_ref(ref: str, linespec: str, repo_root: Path, paths: list[str]) -> str | None:
+    """Return a violation string for one citation, or None when it checks out."""
+    status, resolved = resolve_ref(ref, paths)
+    if status == "not_found":
+        return f"{ref}:{linespec} — file not found"
+    if status == "ambiguous":
+        return f"{ref}:{linespec} — ambiguous (matches {_ambiguous_count(ref, paths)} files)"
+    file_lines = _count_lines(repo_root / resolved)
+    if not _in_bounds(linespec, file_lines):
+        return f"{resolved}:{linespec} — line out of bounds (file has {file_lines} lines)"
+    return None
+
+
+def _ambiguous_count(ref: str, paths: list[str]) -> int:
+    return sum(1 for p in paths if p == ref or p.endswith("/" + ref))
+
+
+def _count_lines(path: Path) -> int:
+    return sum(1 for _ in path.open(encoding="utf-8", errors="ignore"))
+
+
+def scan_markdown(text: str) -> list[tuple[int, str, str]]:
+    """Return ``(line_no, ref, linespec)`` for inline citations only.
+
+    Lines inside fenced code blocks (````` ``` ``` ``) are skipped: a fence
+    marks a literal listing or schema example, not a prose citation.
+    """
+    citations: list[tuple[int, str, str]] = []
+    in_fence = False
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for match in _REF_RE.finditer(line):
+            citations.append((line_no, match.group("file"), match.group("lines")))
+    return citations
+
+
+def is_live_doc(doc_rel: str) -> bool:
+    """True when *doc_rel* (relative to docs/) is a living reference doc."""
+    return not any(
+        doc_rel == prefix or doc_rel.startswith(prefix + "/")
+        for prefix in _EXEMPT_DOC_SUBDIRS
+    )
+
+
+def iter_live_docs(docs_dir: Path) -> list[Path]:
+    """Return every living .md under *docs_dir*, frozen subdirs excluded."""
+    docs: list[Path] = []
+    for md in sorted(docs_dir.rglob("*.md")):
+        rel = md.relative_to(docs_dir).as_posix()
+        if is_live_doc(rel):
+            docs.append(md)
+    return docs
+
+
+def check_docs(docs_dir: Path, repo_root: Path, paths: list[str]) -> list[str]:
+    """Return violation strings for every drifted citation in living docs."""
+    violations: list[str] = []
+    for md in iter_live_docs(docs_dir):
+        text = md.read_text(encoding="utf-8", errors="ignore")
+        for line_no, ref, linespec in scan_markdown(text):
+            violation = check_ref(ref, linespec, repo_root, paths)
+            if violation is not None:
+                rel = md.relative_to(repo_root).as_posix()
+                violations.append(f"  {rel}:{line_no} — {violation}")
+    return violations
+
+
+def resolve_repo_root(argv: list[str]) -> Path:
+    """Return the repo root from ``--root`` or ``git rev-parse``."""
+    if "--root" in argv:
+        return Path(argv[argv.index("--root") + 1]).resolve()
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip()).resolve()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    repo_root = resolve_repo_root(args)
+    docs_dir = repo_root / "docs"
+    if not docs_dir.is_dir():
+        print(f"ERROR: docs/ not found under {repo_root}")
+        return 1
+
+    paths = tracked_rel_paths(repo_root)
+    violations = check_docs(docs_dir, repo_root, paths)
+
+    if not violations:
+        print("OK: every docs/ file:line reference resolves and is in bounds.")
+        return 0
+
+    print("ERROR: drifted docs/ file:line references:\n")
+    for line in violations:
+        print(line)
+    print()
+    print("Fix the citation to match the current tree (or drop the line number")
+    print("if the reference is meant to be illustrative rather than exact).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -1189,10 +1189,17 @@ def _resolve_seat_ledger_path(data_dir: Optional[str]) -> Optional[Path]:
     ``.vnx-attest/``. A caller with no ``data_dir`` (e.g. a test injecting a
     dispatcher) gets ``None`` and skips persistence unless it passes
     ``seat_ledger_path`` explicitly (OI-888).
+
+    Resolution order is CWD-first (OI-1145): the panel runs with the governed
+    project as its working directory, so ``Path.cwd()`` is the project root. A
+    ``__file__``-first walk anchors on this file's own checkout instead — the
+    fabric keystone in a central install — and lands the seat ledger in the
+    read-only version tree, never the project. ``__file__`` remains only as the
+    fallback for callers not running inside a project checkout.
     """
     if not data_dir:
         return None
-    root = _find_repo_root(Path(__file__).resolve().parent) or _find_repo_root(Path.cwd())
+    root = _find_repo_root(Path.cwd()) or _find_repo_root(Path(__file__).resolve().parent)
     if root is None:
         return None
     return root / SEAT_LEDGER_RELPATH

--- a/tests/test_central_mode_path_gate.py
+++ b/tests/test_central_mode_path_gate.py
@@ -23,6 +23,8 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 from check_no_file_derived_data_paths import (  # noqa: E402
     GRANDFATHERED,
+    GRANDFATHERED_REPO_ROOT_ANCHORS,
+    GRANDFATHERED_REPO_ROOT_FINDERS,
     GRANDFATHERED_RESOLVER_ANCHORS,
     check_source,
     scan_dir,
@@ -209,13 +211,70 @@ def test_resolver_without_file_anchor_not_flagged() -> None:
 
 
 def test_resolver_anchor_only_flags_data_resolvers() -> None:
-    # resolve_project_root resolves a REPO root (worktree/provenance semantics),
-    # not a .vnx-data dir — deliberately out of this gate's shape-2 set.
+    # OI-1145 broadened the gate: resolve_project_root now IS flagged when fed a
+    # __file__ anchor (shape 3a) — the same keystone bug one level up. The old
+    # deliberate exclusion ("resolve_project_root resolves a REPO root, not a
+    # .vnx-data dir") was reversed by the plan-gate opus-seat failure.
     src = (
         "from project_root import resolve_project_root\n"
         "p = resolve_project_root(__file__)\n"
     )
+    violations = check_source(src)
+    assert len(violations) >= 1
+    assert any("resolve_project_root(__file__)" in seg for _, seg in violations)
+
+
+def test_resolver_without_file_anchor_not_flagged_repo_root() -> None:
+    # The fix pattern for the repo-root resolver: no __file__ anchor (no args,
+    # or a runtime/env-derived argument) must not trip shape 3a.
+    src = (
+        "import os\n"
+        "from project_root import resolve_project_root\n"
+        "a = resolve_project_root()\n"
+        "b = resolve_project_root(os.environ['X'])\n"
+        "def f(repo_root):\n"
+        "    return resolve_project_root(caller_file=repo_root)\n"
+    )
     assert check_source(src) == []
+
+
+def test_repo_root_finder_fed_file_anchor_flagged() -> None:
+    # OI-1145 shape 3b: the exact plan_gate_panel construct that landed the seat
+    # ledger in the keystone — a .git-marker finder fed a __file__-anchored start.
+    src = (
+        "from pathlib import Path\n"
+        "def _find_repo_root(start):\n"
+        "    return start\n"
+        "def bad():\n"
+        "    return _find_repo_root(Path(__file__).resolve().parent)\n"
+    )
+    violations = check_source(src)
+    assert len(violations) >= 1
+    assert any("_find_repo_root(Path(__file__).resolve().parent)" in seg for _, seg in violations)
+
+
+def test_repo_root_finder_fed_cwd_not_flagged() -> None:
+    # The OI-1145 fix pattern: the finder is fed CWD (not __file__), so it must
+    # not trip shape 3b.
+    src = (
+        "from pathlib import Path\n"
+        "def _find_repo_root(start):\n"
+        "    return start\n"
+        "def ok():\n"
+        "    return _find_repo_root(Path.cwd())\n"
+    )
+    assert check_source(src) == []
+
+
+def test_repo_root_resolver_attr_form_flagged() -> None:
+    # Shape 3a attribute form (project_root.resolve_project_root) is caught too.
+    src = (
+        "import project_root\n"
+        "p = project_root.resolve_project_root(__file__)\n"
+    )
+    violations = check_source(src)
+    assert len(violations) >= 1
+    assert any("project_root.resolve_project_root(__file__)" in seg for _, seg in violations)
 
 
 def test_planted_resolver_anchor_in_lib_fails(tmp_path: Path) -> None:
@@ -327,6 +386,10 @@ def test_grandfather_keys_reference_real_files() -> None:
         assert (VNX_ROOT / rel).is_file(), f"grandfathered path missing: {rel}"
     for rel in GRANDFATHERED_RESOLVER_ANCHORS:
         assert (VNX_ROOT / rel).is_file(), f"grandfathered resolver-anchor path missing: {rel}"
+    for rel in GRANDFATHERED_REPO_ROOT_ANCHORS:
+        assert (VNX_ROOT / rel).is_file(), f"grandfathered repo-root anchor path missing: {rel}"
+    for rel in GRANDFATHERED_REPO_ROOT_FINDERS:
+        assert (VNX_ROOT / rel).is_file(), f"grandfathered repo-root finder path missing: {rel}"
 
 
 def test_grandfathered_resolver_anchors_still_present_in_tree() -> None:
@@ -349,5 +412,35 @@ def test_grandfathered_resolver_anchors_still_present_in_tree() -> None:
     }
     assert found == expected, (
         "stale or missing resolver-anchor grandfather entries:\n"
+        + "\n".join(sorted(f"  {rel}: {seg}" for rel, seg in expected - found))
+    )
+
+
+def test_grandfathered_repo_root_anchors_still_present_in_tree() -> None:
+    # OI-1145: the repo-root resolver + finder grandfather entries must still
+    # exist verbatim — a migrated site must drop its entry, not rot silently.
+    import check_no_file_derived_data_paths as gate
+
+    found = set()
+    for py in (VNX_ROOT / "scripts" / "lib").rglob("*.py"):
+        rel = py.relative_to(VNX_ROOT).as_posix()
+        allowed = (
+            GRANDFATHERED_REPO_ROOT_ANCHORS.get(rel, set())
+            | GRANDFATHERED_REPO_ROOT_FINDERS.get(rel, set())
+        )
+        if not allowed:
+            continue
+        for _, seg in gate._dedup_violations(py.read_text(encoding="utf-8")):
+            if seg in allowed:
+                found.add((rel, seg))
+    expected = {
+        (rel, seg)
+        for rel, segs in (
+            {**GRANDFATHERED_REPO_ROOT_ANCHORS, **GRANDFATHERED_REPO_ROOT_FINDERS}
+        ).items()
+        for seg in segs
+    }
+    assert found == expected, (
+        "stale or missing repo-root grandfather entries:\n"
         + "\n".join(sorted(f"  {rel}: {seg}" for rel, seg in expected - found))
     )

--- a/tests/test_ci_check_docs_file_line_refs.py
+++ b/tests/test_ci_check_docs_file_line_refs.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Tests for scripts/ci/check_docs_file_line_refs.py (OI-1107).
+
+The check fails CI when a ``docs/`` ``file.py:123`` citation drifts from the
+tree.  These tests pin the three behaviours that make it safe to run on every
+merge: (1) it resolves the three citation forms the docs actually use, (2) it
+ignores bare filenames and code-fence placeholders, and (3) it scopes itself
+to living docs so frozen point-in-time artifacts never false-alarm.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "ci"))
+
+import check_docs_file_line_refs as check  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# resolve_ref — the three citation forms docs use
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_ref_exact_path() -> None:
+    paths = ["scripts/lib/foo.py", "scripts/lib/bar.py"]
+    status, resolved = check.resolve_ref("scripts/lib/foo.py", paths)
+    assert status == "ok"
+    assert resolved == "scripts/lib/foo.py"
+
+
+def test_resolve_ref_basename_unique() -> None:
+    paths = ["scripts/lib/foo.py", "tests/test_foo.py"]
+    status, resolved = check.resolve_ref("foo.py", paths)
+    assert status == "ok"
+    assert resolved == "scripts/lib/foo.py"
+
+
+def test_resolve_ref_suffix_path() -> None:
+    # Cited relative to scripts/lib/ (e.g. append_receipt_internals/payload.py).
+    paths = ["scripts/lib/append_receipt_internals/payload.py"]
+    status, resolved = check.resolve_ref("append_receipt_internals/payload.py", paths)
+    assert status == "ok"
+    assert resolved == "scripts/lib/append_receipt_internals/payload.py"
+
+
+def test_resolve_ref_not_found() -> None:
+    status, _ = check.resolve_ref("missing.py", ["scripts/lib/real.py"])
+    assert status == "not_found"
+
+
+def test_resolve_ref_ambiguous() -> None:
+    paths = ["a/foo.py", "b/foo.py"]
+    status, _ = check.resolve_ref("foo.py", paths)
+    assert status == "ambiguous"
+
+
+def test_resolve_ref_hidden_dir_path() -> None:
+    # A leading-dot citation resolves exactly, and does not collide with the
+    # same-named template under templates/init/.
+    paths = [".github/workflows/attestation-gate.yml", "templates/init/attestation-gate.yml"]
+    status, resolved = check.resolve_ref(".github/workflows/attestation-gate.yml", paths)
+    assert status == "ok"
+    assert resolved == ".github/workflows/attestation-gate.yml"
+
+
+# ---------------------------------------------------------------------------
+# scan_markdown — what is a citation, and what is not
+# ---------------------------------------------------------------------------
+
+
+def test_scan_markdown_finds_inline_refs() -> None:
+    text = "see `dispatch_cli.py:1700` and `foo.py:120-130`"
+    cites = [(f, l) for _, f, l in check.scan_markdown(text)]
+    assert ("dispatch_cli.py", "1700") in cites
+    assert ("foo.py", "120-130") in cites
+
+
+def test_scan_markdown_skips_fenced_blocks() -> None:
+    # A schema example inside a code fence is a placeholder, not a citation.
+    text = (
+        "```json\n"
+        '{"ref": "scripts/lib/foo.py:10-20"}\n'
+        "```\n"
+        "real `scripts/lib/bar.py:5`\n"
+    )
+    cites = [(f, l) for _, f, l in check.scan_markdown(text)]
+    assert cites == [("scripts/lib/bar.py", "5")]
+
+
+def test_scan_markdown_ignores_bare_filename() -> None:
+    text = "open `scripts/lib/foo.py` first"
+    assert check.scan_markdown(text) == []
+
+
+def test_scan_markdown_hidden_dir_citation() -> None:
+    text = "see `.github/workflows/attestation-gate.yml:55-67`"
+    files = [f for _, f, _ in check.scan_markdown(text)]
+    assert ".github/workflows/attestation-gate.yml" in files
+    # The leading dot must be preserved, not misread as a dot-less path.
+    assert "github/workflows/attestation-gate.yml" not in files
+
+
+# ---------------------------------------------------------------------------
+# is_live_doc — the frozen-doc carve-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rel", "expected"),
+    [
+        ("lane-conformity-matrix.md", True),
+        ("governance/ATTESTATION_ENFORCEMENT.md", True),
+        ("core/DISPATCH_RULES.md", True),
+        ("_archive/old.md", False),
+        ("examples/example_headless_research.md", False),
+        ("investigations/20260801-oi-triage.md", False),
+        ("governance/decisions/ADR-035.md", False),
+    ],
+)
+def test_is_live_doc(rel: str, expected: bool) -> None:
+    assert check.is_live_doc(rel) is expected
+
+
+# ---------------------------------------------------------------------------
+# check_ref / check_docs — drift detection
+# ---------------------------------------------------------------------------
+
+
+def test_check_ref_out_of_bounds(tmp_path: Path) -> None:
+    (tmp_path / "x.py").write_text("a\nb\nc\n", encoding="utf-8")
+    violation = check.check_ref("x.py", "10", tmp_path, ["x.py"])
+    assert violation is not None
+    assert "out of bounds" in violation
+
+
+def test_check_ref_in_bounds(tmp_path: Path) -> None:
+    (tmp_path / "x.py").write_text("a\nb\nc\n", encoding="utf-8")
+    assert check.check_ref("x.py", "2-3", tmp_path, ["x.py"]) is None
+
+
+def test_check_ref_reversed_range_flagged(tmp_path: Path) -> None:
+    (tmp_path / "x.py").write_text("a\nb\nc\n", encoding="utf-8")
+    violation = check.check_ref("x.py", "3-1", tmp_path, ["x.py"])
+    assert violation is not None
+
+
+def test_check_docs_planted_drift_fails(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "living.md").write_text("see `x.py:999`\n", encoding="utf-8")
+    (tmp_path / "x.py").write_text("a\n", encoding="utf-8")
+    violations = check.check_docs(docs, tmp_path, ["x.py"])
+    assert any("out of bounds" in v for v in violations)
+
+
+def test_check_docs_skips_frozen_dirs(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    (docs / "investigations").mkdir(parents=True)
+    (docs / "investigations" / "frozen.md").write_text("see `x.py:999`\n", encoding="utf-8")
+    (tmp_path / "x.py").write_text("a\n", encoding="utf-8")
+    assert check.check_docs(docs, tmp_path, ["x.py"]) == []
+
+
+# ---------------------------------------------------------------------------
+# integration — the live tree is clean (and the check actually runs it)
+# ---------------------------------------------------------------------------
+
+
+def test_current_tree_passes() -> None:
+    rc = check.main(["--root", str(VNX_ROOT)])
+    assert rc == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -341,7 +341,8 @@ class TestSSEEndpoint(unittest.TestCase):
             mock_handler = MagicMock()
             mock_handler.wfile = FakeWfile()
 
-            # Create the events file empty, then write an event after a delay
+            # Create the events file empty, then write an event after the stream
+            # has actually started tailing.
             events_file.write_text("")
 
             import api_intelligence
@@ -352,13 +353,31 @@ class TestSSEEndpoint(unittest.TestCase):
 
             api_intelligence._sd = mock_sd_fn
 
-            # Run handle_events_stream in a thread with a very short poll,
-            # inject a line, then break connection after first keepalive
+            # OI-1181: coordinate on the stream's first poll instead of a fixed
+            # sleep. handle_events_stream reaches time.sleep() only after it has
+            # opened the events file and seeked to end, so the injector waits for
+            # that signal before appending the event — eliminating the race where
+            # a slow CI image seeks past an already-written line and the stream
+            # emits only keepalives. The injector then waits (own 5s timeout) for
+            # the first data frame before breaking the connection, so the
+            # assertion below is deterministic.
+            stream_polling = threading.Event()
+            real_sleep = api_intelligence.time.sleep
+
+            def signaling_sleep(secs):
+                stream_polling.set()
+                return real_sleep(secs)
+
             def write_event_and_break():
-                time.sleep(0.1)
+                if not stream_polling.wait(timeout=5.0):
+                    return
                 with open(events_file, "a") as fh:
                     fh.write(test_event + "\n")
-                time.sleep(0.2)
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    if any(b"data:" in c for c in written_chunks if isinstance(c, bytes)):
+                        break
+                    time.sleep(0.01)
                 # Simulate disconnect
                 mock_handler.wfile.write = lambda d: (_ for _ in ()).throw(BrokenPipeError())
 
@@ -368,7 +387,10 @@ class TestSSEEndpoint(unittest.TestCase):
             try:
                 with patch("api_intelligence._SSE_POLL_INTERVAL", 0.05):
                     with patch("api_intelligence._SSE_KEEPALIVE_INTERVAL", 0.05):
-                        handle_events_stream(mock_handler, "T1")
+                        with patch.object(
+                            api_intelligence.time, "sleep", side_effect=signaling_sleep
+                        ):
+                            handle_events_stream(mock_handler, "T1")
             finally:
                 api_intelligence._sd = original_sd_fn
                 thread.join(timeout=2.0)

--- a/tests/test_plan_gate_seat_ledger.py
+++ b/tests/test_plan_gate_seat_ledger.py
@@ -150,6 +150,46 @@ def test_resolve_seat_ledger_path_none_without_data_dir():
     assert pgp._resolve_seat_ledger_path(None) is None
 
 
+def test_resolve_seat_ledger_path_prefers_cwd_over_file(monkeypatch, tmp_path):
+    """OI-1145: the governed project (cwd) wins over the package checkout.
+
+    In a central install ``__file__`` sits inside the fabric version-tree, so a
+    ``__file__``-first walk lands the seat ledger in the read-only keystone. The
+    resolver must consult ``Path.cwd()`` first and short-circuit before ever
+    touching ``__file__``.
+    """
+    calls = []
+    cwd_root = tmp_path / "project-root"
+
+    def _fake_find(start):
+        calls.append(start)
+        if start.resolve() == Path.cwd().resolve():
+            return cwd_root
+        return tmp_path / "keystone"
+
+    monkeypatch.setattr(pgp, "_find_repo_root", _fake_find)
+    ledger = pgp._resolve_seat_ledger_path("/some/data_dir")
+
+    assert ledger == cwd_root / pgp.SEAT_LEDGER_RELPATH
+    assert len(calls) == 1  # cwd short-circuits; __file__ is never consulted
+    assert calls[0].resolve() == Path.cwd().resolve()
+
+
+def test_resolve_seat_ledger_path_falls_back_to_file(monkeypatch, tmp_path):
+    """__file__ remains the fallback when cwd is not inside a project checkout."""
+    file_root = tmp_path / "fabric"
+
+    def _fake_find(start):
+        if start.resolve() == Path.cwd().resolve():
+            return None
+        return file_root
+
+    monkeypatch.setattr(pgp, "_find_repo_root", _fake_find)
+    ledger = pgp._resolve_seat_ledger_path("/some/data_dir")
+
+    assert ledger == file_root / pgp.SEAT_LEDGER_RELPATH
+
+
 def test_find_repo_root_walks_to_git_marker(tmp_path):
     (tmp_path / ".git").mkdir()
     nested = tmp_path / "a" / "b" / "c"

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -838,12 +838,14 @@ def _check_ledger_health(data_root: Path) -> Check:
 
 
 def _check_embedded_path_assumptions() -> Check:
-    """WARN when scripts/lib contains __file__-anchored .vnx-data/ROADMAP.yaml derivations.
+    """WARN on __file__-anchored .vnx-data/ROADMAP.yaml AND repo-root derivations.
 
-    Central-mode-path-correctness (#1023/#1024): a bare ``Path(__file__)….parent…``
-    walk that builds a ``.vnx-data``/``ROADMAP.yaml`` path resolves the KEYSTONE
-    (``~/.vnx-system/versions/<v>/.vnx-data``) instead of the project's
-    ``~/.vnx-data/<project>`` in a central install. Delegates to the AST-based
+    Central-mode-path-correctness (#1023/#1024) plus OI-1145: a bare
+    ``Path(__file__)….parent…`` walk that builds a ``.vnx-data``/``ROADMAP.yaml``
+    path, OR that resolves the REPO ROOT (``resolve_project_root(__file__)`` /
+    a ``.git``-marker finder fed ``__file__``), resolves the KEYSTONE
+    (``~/.vnx-system/versions/<v>/``) instead of the project in a central
+    install. Delegates to the AST-based
     ``scripts/check_no_file_derived_data_paths.py`` detector — which carries a
     grandfathered allowlist for already-migrated last-resort fallbacks and traces
     module-level marker constants (e.g. ``_DEFAULT_RELATIVE_PATH = Path(".vnx-data/x")``
@@ -881,16 +883,20 @@ def _check_embedded_path_assumptions() -> Check:
             name="paths:embedded-assumptions",
             status=WARN,
             detail=(
-                f"{len(violations)} __file__-anchored .vnx-data/ROADMAP.yaml path "
-                f"derivation(s) in scripts/lib — resolves the keystone, not the "
-                f"project, in a central install. Route through vnx_paths.resolve_paths() "
-                f"instead: {shown}{more}"
+                f"{len(violations)} __file__-anchored .vnx-data/ROADMAP.yaml or "
+                f"repo-root derivation(s) in scripts/lib — resolves the keystone, not "
+                f"the project, in a central install. Route data/state through "
+                f"vnx_paths.resolve_paths() and resolve the repo root CWD-first "
+                f"(OI-1145): {shown}{more}"
             ),
         )
     return Check(
         name="paths:embedded-assumptions",
         status=PASS,
-        detail="no __file__-anchored .vnx-data/ROADMAP.yaml path derivations in scripts/lib",
+        detail=(
+            "no __file__-anchored .vnx-data/ROADMAP.yaml or repo-root "
+            "derivations in scripts/lib"
+        ),
     )
 
 


### PR DESCRIPTION
Closes three open items from dispatch `20260815-nn-w14-drie-open-items`.

## OI-1145 — plan-gate opus-seat falls over fleet-wide
`_resolve_seat_ledger_path` in `scripts/lib/plan_gate_panel.py` anchored its repo-root walk on `__file__` first, so a central-install panel resolved the fabric keystone (`~/.vnx-system/versions/<v>/`) instead of the governed project. Reversed to CWD-first with `__file__` as fallback. Broadened the central-mode path gate (`check_no_file_derived_data_paths.py`) + doctor `paths:embedded-assumptions` to flag repo-root resolver/finder calls fed a `__file__` anchor: 13 sites detected (9 `resolve_project_root` + 4 `.git`-marker finder), grandfathered so only new occurrences block.

## OI-1181 — flaky SSE test
`test_sse_endpoint_streams_events` used a fixed sleep/wait and got only keepalives on slow CI. Now signals the stream's first poll via `threading.Event`; the injector waits for that before appending the event, so the first data frame is deterministic.

## OI-1107 — lane-conformity-matrix drift
Added `scripts/ci/check_docs_file_line_refs.py`: fails CI when a living `docs/` `file.py:123` citation drifts. Scoped to explicit line numbers in living docs (frozen `_archive`/`examples`/`investigations`/`governance/decisions` and code fences excluded). Measured 0 drifted citations in the living tree; the matrix itself has 96 refs, all in bounds. Wired into `vnx-ci.yml` profile-a with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)