### PR TITLE
feat(doctor,release): t0_state freshness, report-contract docs, current-flip pin warning

### DIFF
--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -112,6 +112,22 @@ These recur — observed, not hypothetical. A dispatch that "did nothing" or "bi
 | DeepSeek (bare) | `provider_dispatch.py --provider litellm:deepseek` | Chat-only, NO tools. Baseline only. |
 | local gemma | `provider_dispatch.py --provider local-gemma` | Free, local; mechanical / cutoff-resilient checks. |
 
+**Report contract (applies to every lane in this table).** A dispatch is invisible to governance without a receipt, and there is no receipt without a report. Every lane worker must write a unified report carrying the four mandatory headings: `## Summary` (≥50 chars), `## Changes`, `## Verification`, `## Open Items`, plus its `Dispatch-ID` and a real `Model`/`Provider` identity pair. Full contract in §9 and `scripts/lib/report_body_contract.py`.
+
+The fail-closed model check makes this stricter than the four headings: a dispatch-lane report without a real `Model` value is REFUSED at receipt-write time (`scripts/lib/append_receipt_internals/validation.py::_validate_model_present`), even when the report otherwise passes the contract. A report that "looks complete" can still never land a receipt.
+
+Whether a provider emits the four headings on its own, or needs them named in the instruction, was measured against the most recent unified reports in `$VNX_DATA_DIR/unified_reports/` (1500 most-recent, not assumed):
+
+| Provider (lane) | Delivers the 4 headings natively? | Measured (reports with all four) |
+|---|---|---|
+| claude (tmux + headless, subscription) | Yes | 262/262 |
+| codex | No (needs an instruction-foot) | 24/260 |
+| deepseek-harness | No (needs an instruction-foot) | 69/231 |
+| glm-harness | No (needs an instruction-foot) | 10/168 |
+| kimi | No (needs an instruction-foot) | 7/139 |
+
+For the harness/provider lanes (codex, kimi, glm, deepseek), always append the four headings to the instruction. A deepseek worker does not emit `## Summary` / `## Changes` / `## Verification` / `## Open Items` on its own, and without them there is no receipt (OI-1180). The claude lane delivers them without prompting.
+
 ## 9. Manager-block contract
 
 Every dispatch: `[[TARGET:A|B|C]]` … `[[DONE]]`, headers `Role/Track/Terminal/PR-ID/Priority/Cognition/Dispatch-ID/Parent-Dispatch/Reason`, `Workflow` + `Context`, explicit success criteria. A headless-gate dispatch must name the expected report path + receipt/result linkage. Report contract (every worker): `## Summary` (≥50 chars) / `## Changes` / `## Verification` / `## Open Items`, with the `Dispatch-ID`. Validate roles: `python3 scripts/validate_skill.py --list`.

--- a/scripts/lib/t0_state_health.py
+++ b/scripts/lib/t0_state_health.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""t0_state_health — assess t0_state.json freshness and its refresh hook (OI-1058).
+
+Read-only, no side effects. Returns raw facts plus rendered findings so the two
+``vnx doctor`` surfaces (``scripts/vnx_doctor.py`` and
+``vnx_cli/commands/doctor.py``) can surface one consistent warning without each
+reimplementing the staleness logic.
+
+The failure mode this detects: a project whose ``t0_state.json`` stops being
+refreshed (the SessionStart hook that rebuilds it was never registered, or was
+removed/renamed) while the project keeps producing dispatches. The T0 role
+reads that projection at SessionStart, so it silently plans against
+months-old open items, tracks, and escalations — nothing else complains.
+
+Detected conditions (each is its own finding):
+  1. ``t0_state.json`` is older than ``STALE_AFTER_DAYS`` while a dispatch was
+     created after the state was built — the state went stale *and* the project
+     kept working, so the refresh chain is broken rather than merely idle.
+  2. ``t0_state.json`` exists but no ``SessionStart`` hook registers
+     ``build_t0_state_hook.sh`` — the projection will never refresh, so T0
+     reads whatever was last built.
+
+``STALE_AFTER_DAYS = 7`` is deliberate. The builder runs on every SessionStart
+(``build_t0_state_hook.sh``), so a working chain leaves the state younger than
+one session. Seven days gives a project that went quiet for a week a clean
+re-entry (its first session refreshes the state, so no warning), while any
+project that had a session in the past week but carries a state older than a
+week has a broken chain worth surfacing. It also matches the weekly work cadence
+and is far tighter than the 52-day mission-control example, so the condition
+fires well before state turns visibly months-old.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+T0_STATE_FILENAME = "t0_state.json"
+STALE_AFTER_DAYS = 7
+
+# The SessionStart command that rebuilds the projection. Detected by substring:
+# a consumer's command may wrap the path in ``${VNX_HOME}`` or ``bash -c``, so
+# matching on the hook's basename is the robust check across install modes.
+_REFRESH_HOOK_MARKER = "build_t0_state_hook"
+
+
+def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-8601 UTC timestamp (``Z`` or ``+00:00``) to aware UTC.
+
+    Returns ``None`` on missing/unparseable input rather than raising — this is
+    an advisory read and must never crash ``vnx doctor``.
+    """
+    if not ts or not isinstance(ts, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.strip().replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _human_age(age_days: float) -> str:
+    """Render a fractional day count as a short human age (``52 days``)."""
+    if age_days < 1:
+        hours = int(round(age_days * 24))
+        return f"{hours} hour{'s' if hours != 1 else ''}"
+    days = int(round(age_days))
+    return f"{days} day{'s' if days != 1 else ''}"
+
+
+def _state_build_time(state_dir: Path) -> Optional[datetime]:
+    """Return the build time of t0_state.json.
+
+    Prefers the ``generated_at`` build stamp written by ``build_t0_state.py``
+    (the semantic "when was this content built"), falling back to the file
+    mtime so a pre-``generated_at`` state file (the exact mission-control case)
+    is still aged. Returns ``None`` when neither is available.
+    """
+    path = state_dir / T0_STATE_FILENAME
+    if not path.exists():
+        return None
+    generated_at: Optional[str] = None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            generated_at = str(data.get("generated_at") or data.get("timestamp") or "")
+    except (json.JSONDecodeError, OSError):
+        generated_at = None
+    ts = _parse_iso(generated_at)
+    if ts is not None:
+        return ts
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return None
+
+
+def _most_recent_dispatch(state_dir: Path) -> Optional[datetime]:
+    """Return the most recent dispatch ``created_at``, or ``None``.
+
+    ``runtime_coordination.db`` may be absent (project never dispatched) or
+    under a schema this checker has not seen — both degrade to ``None``, which
+    simply means "no evidence of activity since the build" and suppresses the
+    staleness finding rather than firing it on a guess.
+    """
+    db_path = state_dir / "runtime_coordination.db"
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = conn.execute("SELECT MAX(created_at) FROM dispatches").fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    if not row or not row[0]:
+        return None
+    return _parse_iso(str(row[0]))
+
+
+def _has_t0_refresh_hook(project_root: Path) -> bool:
+    """True when ``.claude/settings.json`` registers a SessionStart hook that
+    rebuilds the t0_state projection (``build_t0_state_hook.sh``)."""
+    settings = project_root / ".claude" / "settings.json"
+    if not settings.is_file():
+        return False
+    try:
+        data = json.loads(settings.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    hooks = data.get("hooks", {}) if isinstance(data, dict) else {}
+    for entry in hooks.get("SessionStart", []):
+        if not isinstance(entry, dict):
+            continue
+        for hook in entry.get("hooks", []):
+            if not isinstance(hook, dict):
+                continue
+            command = str(hook.get("command") or "")
+            if _REFRESH_HOOK_MARKER in command:
+                return True
+    return False
+
+
+def assess_t0_state_health(
+    state_dir: Path,
+    project_root: Path,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Assess t0_state.json freshness and return raw facts + rendered findings.
+
+    ``state_dir`` is the resolved ``VNX_STATE_DIR``; ``project_root`` is the
+    project dir whose ``.claude/settings.json`` registers the refresh hook.
+
+    Returns a dict with:
+      * ``exists``            — whether t0_state.json is present
+      * ``age_days``          — fractional days since build (None if unknown)
+      * ``age_human``         — human age string ("never built", "52 days", …)
+      * ``has_refresh_hook``  — whether a SessionStart hook rebuilds the state
+      * ``most_recent_dispatch`` — ISO string of the newest dispatch, or None
+      * ``findings``          — list of ``{"kind", "message", "remediation"}``
+                                (empty when healthy); ``kind`` is one of
+                                ``stale_while_active`` / ``missing_hook``
+    """
+    now = now if now is not None else datetime.now(timezone.utc)
+    state_path = state_dir / T0_STATE_FILENAME
+    exists = state_path.exists()
+
+    build_ts = _state_build_time(state_dir)
+    age_days: Optional[float] = None
+    age_human = "never built"
+    if exists and build_ts is not None:
+        age_days = max(0.0, (now - build_ts).total_seconds() / 86400.0)
+        age_human = _human_age(age_days)
+    elif exists:
+        age_human = "age unknown"
+
+    has_refresh_hook = _has_t0_refresh_hook(project_root)
+    most_recent = _most_recent_dispatch(state_dir)
+
+    activity_after_build = False
+    if build_ts is not None and most_recent is not None:
+        activity_after_build = most_recent > build_ts
+
+    stale_while_active = (
+        exists
+        and age_days is not None
+        and age_days > STALE_AFTER_DAYS
+        and activity_after_build
+    )
+
+    findings: List[Dict[str, str]] = []
+
+    if exists and not has_refresh_hook:
+        findings.append({
+            "kind": "missing_hook",
+            "message": (
+                "t0_state.json exists but no SessionStart hook registers "
+                "build_t0_state_hook.sh: the projection never refreshes, so the "
+                "T0 role reads whatever state was last built and does not see "
+                "new open items, tracks, or escalations"
+            ),
+            "remediation": (
+                "Run `vnx regen-settings --full` (or `vnx init`) to register the "
+                "SessionStart hook in .claude/settings.json"
+            ),
+        })
+
+    if stale_while_active:
+        latest = ""
+        if most_recent is not None:
+            latest = f" (latest dispatch {most_recent.strftime('%Y-%m-%d')})"
+        findings.append({
+            "kind": "stale_while_active",
+            "message": (
+                f"t0_state.json is {age_human} old but dispatches were created "
+                f"after it{latest}: the T0 role is reading stale state"
+            ),
+            "remediation": (
+                "Open a T0 terminal so the SessionStart hook rebuilds the "
+                "projection, or verify the build_t0_state_hook.sh SessionStart "
+                "hook is registered in .claude/settings.json"
+            ),
+        })
+
+    return {
+        "exists": exists,
+        "age_days": age_days,
+        "age_human": age_human,
+        "has_refresh_hook": has_refresh_hook,
+        "most_recent_dispatch": most_recent.isoformat() if most_recent else None,
+        "findings": findings,
+    }

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -895,6 +895,46 @@ def check_dream_cycle(paths: Dict[str, str]) -> List[CheckResult]:
 
 
 # ---------------------------------------------------------------------------
+# Check: t0_state.json freshness + SessionStart refresh hook (OI-1058)
+# ---------------------------------------------------------------------------
+
+def check_t0_state_freshness(paths: Dict[str, str]) -> List[CheckResult]:
+    """Warn when the t0_state projection is stale while sessions continued, or
+    when the SessionStart hook that rebuilds it is missing.
+
+    OI-1058: a project with no SessionStart hook leaves its ``t0_state.json``
+    frozen (mission-control's has sat still since 24 June). A role that reads
+    that state then plans against months-old open items without anything
+    complaining. The two trigger conditions live in
+    ``scripts/lib/t0_state_health.assess_t0_state_health`` — this function only
+    renders its findings into the doctor result model. Absent ``t0_state.json``
+    means the projection was never set up here, so there is nothing to warn on.
+    """
+    state_dir = Path(paths["VNX_STATE_DIR"])
+    project_root = Path(paths["PROJECT_ROOT"])
+    try:
+        from t0_state_health import assess_t0_state_health
+    except ImportError:
+        return [CheckResult("t0_state", WARN, "t0_state_health module not importable; skipped")]
+
+    assessment = assess_t0_state_health(state_dir, project_root)
+    if not assessment["exists"]:
+        return []
+
+    results = [
+        CheckResult("t0_state", WARN, finding["message"], finding["remediation"])
+        for finding in assessment["findings"]
+    ]
+    if results:
+        return results
+
+    return [CheckResult(
+        "t0_state", PASS,
+        f"t0_state.json is fresh ({assessment['age_human']}) and the refresh hook is wired",
+    )]
+
+
+# ---------------------------------------------------------------------------
 # Runtime checks (delegates to vnx_doctor_runtime.py)
 # ---------------------------------------------------------------------------
 
@@ -957,6 +997,7 @@ def run_doctor(paths: Dict[str, str], *,
     results.extend(check_contamination(paths))
     results.extend(check_state_root_location(paths))
     results.extend(check_dream_cycle(paths))
+    results.extend(check_t0_state_freshness(paths))
 
     if package_check:
         vnx_home = Path(paths["VNX_HOME"])

--- a/tests/test_t0_state_health.py
+++ b/tests/test_t0_state_health.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""tests/test_t0_state_health.py — OI-1058: t0_state.json staleness + refresh hook.
+
+Tests the shared ``scripts/lib/t0_state_health`` assessment directly (real code,
+no reimplementation) and the ``check_t0_state_freshness`` render in
+``scripts/vnx_doctor.py``. The failure mode under test: a project whose
+``t0_state.json`` stops refreshing while dispatches keep being created, so the
+T0 role silently plans against months-old state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from t0_state_health import (  # noqa: E402
+    STALE_AFTER_DAYS,
+    assess_t0_state_health,
+)
+
+NOW = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _write_t0_state(state_dir: Path, generated_at: str) -> Path:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "t0_state.json"
+    path.write_text(json.dumps({"generated_at": generated_at, "schema_version": "2.2"}))
+    return path
+
+
+def _age_t0_state_file(path: Path, days: float) -> None:
+    """Backdate the file's mtime so the mtime fallback path is exercised."""
+    ts = (NOW - timedelta(days=days)).timestamp()
+    os.utime(path, (ts, ts))
+
+
+def _write_dispatch(state_dir: Path, created_at: datetime) -> None:
+    """Create a minimal runtime_coordination.db with one dispatch."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("CREATE TABLE IF NOT EXISTS dispatches (dispatch_id TEXT, created_at TEXT)")
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, created_at) VALUES (?, ?)",
+        ("d-1", _iso(created_at)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _write_settings(project_root: Path, with_hook: bool) -> None:
+    (project_root / ".claude").mkdir(parents=True, exist_ok=True)
+    session_start = []
+    if with_hook:
+        session_start = [{
+            "matcher": "terminals/T0",
+            "hooks": [{
+                "type": "command",
+                "command": "bash -c 'exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"'",
+            }],
+        }]
+    (project_root / ".claude" / "settings.json").write_text(
+        json.dumps({"hooks": {"SessionStart": session_start}, "permissions": {}})
+    )
+
+
+def _assess(tmp_path: Path, *, with_hook: bool = True):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    return assess_t0_state_health(state_dir, project_root, now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# Freshness facts
+# ---------------------------------------------------------------------------
+
+def test_no_state_file_is_clean(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["exists"] is False
+    assert assessment["findings"] == []
+
+
+def test_fresh_state_with_hook_passes(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True)
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["exists"] is True
+    assert assessment["has_refresh_hook"] is True
+    assert assessment["age_human"] == "1 hour"
+    assert assessment["findings"] == []
+
+
+def test_stale_state_with_recent_dispatch_warns(tmp_path):
+    """The production shape: state 52 days old, dispatches created 3 days ago.
+
+    The message must name the consequence (the role reads stale state), not
+    just the fact of staleness.
+    """
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(days=52)))
+    _write_settings(project_root, with_hook=True)
+    _write_dispatch(state_dir, NOW - timedelta(days=3))
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    kinds = [f["kind"] for f in assessment["findings"]]
+    assert "stale_while_active" in kinds
+    stale = next(f for f in assessment["findings"] if f["kind"] == "stale_while_active")
+    assert "52 days old" in stale["message"]
+    assert "stale state" in stale["message"]  # consequence, not just the fact
+    assert "2026-08-12" in stale["message"]  # the latest-dispatch date is named
+
+
+def test_stale_state_without_recent_dispatch_does_not_warn(tmp_path):
+    """An idle project (state and last dispatch both 52 days old) is not broken:
+    its first session will refresh the state. No stale finding."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(days=52)))
+    _write_settings(project_root, with_hook=True)
+    _write_dispatch(state_dir, NOW - timedelta(days=60))  # before the build
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["findings"] == []
+
+
+def test_missing_hook_warns_even_when_fresh(tmp_path):
+    """The hook being gone is its own finding, independent of staleness: a
+    fresh state with no refresh hook will still go stale on the next session."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=False)
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    kinds = [f["kind"] for f in assessment["findings"]]
+    assert kinds == ["missing_hook"]
+    assert "build_t0_state_hook" in assessment["findings"][0]["message"]
+
+
+def test_missing_hook_and_stale_both_findings(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(days=52)))
+    _write_settings(project_root, with_hook=False)
+    _write_dispatch(state_dir, NOW - timedelta(days=3))
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    kinds = sorted(f["kind"] for f in assessment["findings"])
+    assert kinds == ["missing_hook", "stale_while_active"]
+
+
+def test_stale_threshold_is_deliberate():
+    """N must be a consciously-chosen constant, not a magic inline number."""
+    assert STALE_AFTER_DAYS == 7
+
+
+# ---------------------------------------------------------------------------
+# Defensive reads (negative paths)
+# ---------------------------------------------------------------------------
+
+def test_unparseable_generated_at_falls_back_to_mtime(tmp_path):
+    """A state file whose generated_at is garbage (or absent) still ages via
+    mtime — the exact mission-control shape: a pre-generated_at file."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    path = _write_t0_state(state_dir, "not-a-valid-iso")
+    _age_t0_state_file(path, days=52)
+    _write_settings(project_root, with_hook=True)
+    _write_dispatch(state_dir, NOW - timedelta(days=3))
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert any(f["kind"] == "stale_while_active" for f in assessment["findings"])
+
+
+def test_no_generated_at_uses_mtime(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    path = state_dir / "t0_state.json"
+    state_dir.mkdir(parents=True)
+    path.write_text(json.dumps({"schema_version": "2.2"}), encoding="utf-8")
+    _age_t0_state_file(path, days=52)
+    _write_settings(project_root, with_hook=True)
+    _write_dispatch(state_dir, NOW - timedelta(days=3))
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert any(f["kind"] == "stale_while_active" for f in assessment["findings"])
+
+
+def test_malformed_t0_state_json_does_not_crash(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / "t0_state.json").write_text("{not-json", encoding="utf-8")
+    _write_settings(project_root, with_hook=True)
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["exists"] is True
+    # Unparseable body falls back to mtime (the file was just written), so the
+    # age is read from mtime rather than crashing or claiming "never built".
+    assert assessment["age_human"] == "0 hours"
+    assert assessment["findings"] == []
+
+
+def test_no_runtime_db_suppresses_stale_finding(tmp_path):
+    """Without a coordination DB there is no evidence of activity since the
+    build, so a stale state alone must not warn (would cry wolf on idle)."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(days=52)))
+    _write_settings(project_root, with_hook=True)
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["most_recent_dispatch"] is None
+    assert assessment["findings"] == []
+
+
+def test_malformed_settings_json_does_not_crash(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    (project_root / ".claude").mkdir(parents=True)
+    (project_root / ".claude" / "settings.json").write_text("{broken", encoding="utf-8")
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["has_refresh_hook"] is False
+    assert any(f["kind"] == "missing_hook" for f in assessment["findings"])
+
+
+def test_missing_settings_file_means_no_hook(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    # no .claude/settings.json at all
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["has_refresh_hook"] is False
+    assert any(f["kind"] == "missing_hook" for f in assessment["findings"])
+
+
+# ---------------------------------------------------------------------------
+# Render through scripts/vnx_doctor.py (the bin/vnx doctor surface)
+# ---------------------------------------------------------------------------
+
+def test_doctor_render_warns_on_stale_and_active(tmp_path):
+    from vnx_doctor import WARN, check_t0_state_freshness
+
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(days=52)))
+    _write_settings(project_root, with_hook=True)
+    _write_dispatch(state_dir, NOW - timedelta(days=3))
+
+    paths = {
+        "PROJECT_ROOT": str(project_root),
+        "VNX_STATE_DIR": str(state_dir),
+    }
+    results = check_t0_state_freshness(paths)
+    assert len(results) == 1
+    assert results[0].status == WARN
+    assert results[0].name == "t0_state"
+    assert "stale state" in results[0].message
+    assert results[0].remediation
+
+
+def test_doctor_render_empty_when_no_state(tmp_path):
+    from vnx_doctor import check_t0_state_freshness
+
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    paths = {
+        "PROJECT_ROOT": str(project_root),
+        "VNX_STATE_DIR": str(state_dir),
+    }
+    assert check_t0_state_freshness(paths) == []
+
+
+def test_doctor_render_pass_when_fresh_and_hooked(tmp_path):
+    from vnx_doctor import PASS, check_t0_state_freshness
+
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True)
+
+    paths = {
+        "PROJECT_ROOT": str(project_root),
+        "VNX_STATE_DIR": str(state_dir),
+    }
+    results = check_t0_state_freshness(paths)
+    assert len(results) == 1
+    assert results[0].status == PASS
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_vnx_release_publish.py
+++ b/tests/test_vnx_release_publish.py
@@ -270,6 +270,65 @@ def test_publish_set_current_flips_atomically(
     )
 
 
+# ---------------------------------------------------------------------------
+# OI-1183: a publish that moves `current` must name the pin-update consequence
+# ---------------------------------------------------------------------------
+
+def test_publish_set_current_emits_release_notes_hint(
+    tmp_path, central_root, stub_install_central
+):
+    """A `current`-moving publish emits a paste-ready release-notes block that
+    states the pin-update consequence for consumers on a tracked pin."""
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo), set_current=True))
+
+    assert rc == 0
+    assert "Release notes (add to CHANGELOG.md under [v1.3.1])" in out
+    assert ".vnx-version" in out
+    assert "must update their pin to v1.3.1" in out
+
+
+def test_publish_set_current_warns_pinned_consumers(
+    tmp_path, central_root, stub_install_central, capsys
+):
+    """The active warning lands on stderr when `current` is flipped, naming the
+    pin that must be updated instead of silently assuming every consumer moved."""
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    rc = vnx_release_publish(_publish_args(repo=str(repo), set_current=True))
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "WARNING: `current` now points at v1.3.1" in captured.err
+    assert ".vnx-version" in captured.err
+    assert "do not follow `current`" in captured.err
+
+
+def test_publish_without_set_current_does_not_warn(
+    tmp_path, central_root, stub_install_central, capsys
+):
+    """Publish-without-cutover does not move `current`, so it must not emit the
+    pin-update warning (that would be noise about a flip that never happened)."""
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    rc = vnx_release_publish(_publish_args(repo=str(repo), set_current=False))
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "WARNING: `current` now points" not in captured.err
+
+
+def test_dry_run_set_current_previews_pin_warning(
+    tmp_path, central_root, stub_install_central
+):
+    """Dry-run surfaces the pin-update consequence before the flip is committed."""
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo), dry_run=True, set_current=True))
+
+    assert rc == 0
+    assert "Would warn" in out
+    assert ".vnx-version" in out
+    assert not (central_root / "current").exists()
+
+
 def test_publish_second_run_refused_after_first_publish(
     tmp_path, central_root, stub_install_central, capsys
 ):

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -894,6 +894,38 @@ def _check_embedded_path_assumptions() -> Check:
     )
 
 
+def _check_t0_state_freshness(project_dir: Path, data_root: Path) -> list[Check]:
+    """Warn when t0_state.json is stale while sessions continued, or when the
+    SessionStart refresh hook is missing (OI-1058).
+
+    Renders the findings from the shared ``scripts/lib/t0_state_health`` module
+    into this CLI's Check model, so the pip ``vnx doctor`` and the repo
+    ``scripts/vnx_doctor.py`` surface agree on the message instead of drifting.
+    """
+    state_dir = data_root / "state"
+    try:
+        _engine.ensure_engine_on_path()
+        from t0_state_health import assess_t0_state_health
+    except Exception as exc:
+        return [Check("t0_state", WARN, f"could not load t0_state_health module: {exc}")]
+
+    assessment = assess_t0_state_health(state_dir, project_dir)
+    if not assessment["exists"]:
+        return []
+
+    findings = assessment["findings"]
+    if not findings:
+        return [Check(
+            "t0_state",
+            PASS,
+            f"t0_state.json is fresh ({assessment['age_human']}) and the refresh hook is wired",
+        )]
+    return [
+        Check("t0_state", WARN, f"{f['message']} — {f['remediation']}")
+        for f in findings
+    ]
+
+
 def vnx_doctor(args) -> int:
     project_dir = Path(args.project_dir).resolve()
     emit_json = getattr(args, "json", False)
@@ -919,6 +951,7 @@ def vnx_doctor(args) -> int:
     checks.append(_check_hook_paths(project_dir))
     checks.append(_check_ledger_health(data_root))
     checks.append(_check_embedded_path_assumptions())
+    checks.extend(_check_t0_state_freshness(project_dir, data_root))
 
     passed = sum(1 for c in checks if c.status == PASS)
     warned = sum(1 for c in checks if c.status == WARN)

--- a/vnx_cli/commands/release.py
+++ b/vnx_cli/commands/release.py
@@ -144,6 +144,38 @@ def _materialize_from_tag(root: Path, repo: str, tag: str) -> Path:
     return target_dir
 
 
+def _release_notes_hint(tag: str) -> str:
+    """Release-note fragment for a release that moved ``current`` (OI-1183).
+
+    Release notes are written by hand into ``CHANGELOG.md`` (keep-a-changelog);
+    there is no automated generator. A publish that flips ``current`` is a
+    release that moves ``current``, so it must state the pin consequence in its
+    release notes instead of letting operators assume every consumer followed.
+    Returns a paste-ready block naming the mandatory pin-update line.
+    """
+    return (
+        f"Release notes (add to CHANGELOG.md under [{tag}]):\n"
+        f"  - {tag} is now the active `current`.\n"
+        f"  - Consumers with a tracked `.vnx-version` pin are NOT moved by this "
+        f"flip and must update their pin to {tag} explicitly:\n"
+        f"      echo '{tag}' > <project>/.vnx-version\n"
+    )
+
+
+def _current_flip_warning(tag: str) -> str:
+    """Active warning emitted to stderr when a publish flips ``current``.
+
+    A project pinned via ``.vnx-version`` keeps resolving its pin after the
+    flip, so the flip alone does not move it. Silently flipping ``current``
+    would leave operators assuming every consumer is now on ``tag`` (OI-1183).
+    """
+    return (
+        f"WARNING: `current` now points at {tag}. Consumers with a tracked "
+        f"`.vnx-version` pin do not follow `current` and must update their pin "
+        f"to {tag} (echo '{tag}' > <project>/.vnx-version)."
+    )
+
+
 def vnx_release_publish(args) -> int:
     tag: "str | None" = getattr(args, "tag", None)
     dry_run: bool = getattr(args, "dry_run", False)
@@ -228,6 +260,11 @@ def vnx_release_publish(args) -> int:
                 f"[dry-run] Would flip current ({current_name}) -> {tag} "
                 "(--set-current passed)"
             )
+            print(
+                f"[dry-run] Would warn: consumers with a tracked .vnx-version "
+                f"pin must update their pin to {tag} (the pin does not follow "
+                f"`current`)"
+            )
         else:
             print("[dry-run] current NOT flipped (publish only; pass --set-current to cut over)")
         return 0
@@ -252,6 +289,8 @@ def vnx_release_publish(args) -> int:
 
     if set_current:
         _atomic_symlink_flip(root, target_dir, dry_run=False)
+        print(_release_notes_hint(tag))
+        print(_current_flip_warning(tag), file=sys.stderr)
     else:
         print("current NOT flipped (publish only; pass --set-current to cut over).")
 


### PR DESCRIPTION
Closes three open items from the w17 sweep. Dispatch-ID: 20260815-nn-w17-drie-open-items-b.

## OI-1058: `vnx doctor` warns on a stale t0_state.json or a missing refresh hook

New shared module `scripts/lib/t0_state_health.py` (read-only, stdlib-only) assesses two conditions, consumed by both `vnx doctor` surfaces so the message cannot drift:

- `t0_state.json` older than 7 days while a dispatch was created after it (the refresh chain is broken, not merely idle). The warning names the consequence: "the T0 role is reading stale state".
- `t0_state.json` exists but no `SessionStart` hook registers `build_t0_state_hook.sh` (the projection never refreshes).

`STALE_AFTER_DAYS = 7` is deliberate: the builder runs every SessionStart, so a working chain is always younger than one session; 7 days gives a quiet project a clean re-entry while catching a broken chain within a week.

## OI-1180: report contract named at the §8 lane table

`docs/core/DISPATCH_RULES.md` §8 now names the four-heading contract, the Dispatch-ID + Model/Provider identity pair, and the fail-closed model check (`_validate_model_present`) that refuses a dispatch-lane report without a real `Model` at receipt-write time.

Per-provider heading delivery was measured over the 1500 most-recent unified reports (not assumed):

| Provider | Delivers the 4 headings natively | Measured |
|---|---|---|
| claude | Yes | 262/262 |
| codex | No | 24/260 |
| deepseek-harness | No | 69/231 |
| glm-harness | No | 10/168 |
| kimi | No | 7/139 |

Harness/provider lanes must append the four headings to the instruction.

## OI-1183: pin-update consequence on a `current`-moving release

Release notes are written by hand into `CHANGELOG.md` (there is no automated generator). `current` is moved in `vnx_cli/commands/update.py::_atomic_symlink_flip`, reached by `vnx update --to`, `vnx update --rollback`, and `vnx release publish --set-current`.

`vnx release publish --set-current` now:

- emits a paste-ready release-notes block naming the mandatory pin-update line, and
- prints an active stderr warning that consumers on a tracked `.vnx-version` pin do not follow the flip and must update their pin.

`--dry-run --set-current` previews the same consequence before the flip.

## Verification

Targeted tests only (touched files + direct neighbors), per dispatch rules:

- `tests/test_t0_state_health.py` + `tests/test_vnx_release_publish.py`: 45 passed
- `tests/test_vnx_doctor.py` + runtime + strict: 116 passed
- `tests/unit/vnx_cli/commands/test_doctor.py` + `test_vnx_cli.py` + `test_cli_init.py`: 66 passed