### PR TITLE
fix(paths): preserve explicit VNX_STATE_DIR pin in VNX_HOME cross-project guard (OI-1160)

### DIFF
--- a/scripts/ci/test_exclusions.txt
+++ b/scripts/ci/test_exclusions.txt
@@ -77,6 +77,16 @@
 # The fix lives in vnx_paths.sh + the subprocess env pinning, not in these files.
 # Full write-up: claudedocs/test-quarantaine-verklaring-20260815.md.
 #
+# 2026-08-15 OI-1160 de-quarantine: the two receipt-processor entries
+# (test_receipt_processor_autopr_rejected_mirror.py, test_receipt_processor_bootstrap.py)
+# are removed below. The vnx_paths.sh cross-project guard now preserves an explicit
+# VNX_STATE_DIR pin alongside VNX_DATA_DIR, so a mismatched inherited VNX_HOME no
+# longer clobbers it back to $VNX_DATA_DIR/state. Both files green solo (16/16) and
+# with their neighbours (test_init_migrate_bootstrap.py, test_mc_v4_columns.py,
+# test_vnx_paths_shell_worktree.py, test_state_root_lockstep.py,
+# test_cross_project_isolation.py, and the receipt_processor siblings). 16 test
+# functions return to Profile A.
+#
 tests/integration/test_gemini_streaming_gated.py
 tests/migrations/test_auto_apply.py
 tests/pool/test_pool_lease_e2e.py
@@ -169,8 +179,6 @@ tests/test_queue_reconciliation_certification.py
 tests/test_quickstart_validation.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_receipt_classifier.py
 tests/test_receipt_instruction_hash.py
-tests/test_receipt_processor_autopr_rejected_mirror.py  # OI-1133 group-check: 6/6 failed in PR#1458 Profile A sweep (outcome_status resolves None). Not OI-1213 (2026-08-15): VNX_HOME guard clobbers the explicit VNX_STATE_DIR pin (vnx_paths.sh:221-228) -> shell-lane DB update lands in $VNX_DATA_DIR/state; see header
-tests/test_receipt_processor_bootstrap.py  # OI-1133 group-check: 6/10 failed in PR#1458 Profile A sweep (bootstrap returns rc=1). Not OI-1213 (2026-08-15): VNX_HOME guard clobbers VNX_STATE_DIR -> PROCESSING_LOG falls back to $VNX_DATA_DIR/state -> tee fails rc=1; see header
 tests/test_receipt_t0_view_filter.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_receipt_v2_pr4_wiring.py  # OI-948: receipt v2 PR4/PR5: NoneType has no attribute status, red on main too
 tests/test_receipt_v2_pr5_schema_cutover.py  # OI-948: receipt v2 PR4/PR5: NoneType has no attribute status, red on main too

--- a/scripts/lib/vnx_paths.sh
+++ b/scripts/lib/vnx_paths.sh
@@ -219,15 +219,23 @@ unset _VNX_HOME_GIT_ROOT
 # If inherited VNX_HOME points to a different project tree than VNX_HOME_DEFAULT
 # (computed from this script's location), reset it and all derived paths.
 if [ -n "${VNX_HOME:-}" ] && [ "$VNX_HOME" != "$VNX_HOME_DEFAULT" ]; then
-  # Preserve explicit VNX_DATA_DIR override (worktree isolation)
+  # Preserve explicit VNX_DATA_DIR + VNX_STATE_DIR overrides (worktree isolation).
+  # The guard's job is to derive an unset state dir from VNX_HOME, not to overrule
+  # an explicitly pinned one: an explicit VNX_STATE_DIR must win (OI-1160: the old
+  # unset-only path silently clobbered it back to $VNX_DATA_DIR/state, which breaks
+  # the receipt-processor shell lane under a mismatched inherited VNX_HOME).
   _vnx_saved_data_dir="${VNX_DATA_DIR:-}"
+  _vnx_saved_state_dir="${VNX_STATE_DIR:-}"
   unset VNX_HOME PROJECT_ROOT VNX_CANONICAL_ROOT VNX_INTELLIGENCE_DIR VNX_STATE_DIR VNX_DISPATCH_DIR VNX_LOGS_DIR VNX_PIDS_DIR VNX_LOCKS_DIR VNX_REPORTS_DIR VNX_HEADLESS_REPORTS_DIR VNX_DB_DIR
   if [ -n "$_vnx_saved_data_dir" ]; then
     VNX_DATA_DIR="$_vnx_saved_data_dir"
   else
     unset VNX_DATA_DIR
   fi
-  unset _vnx_saved_data_dir
+  if [ -n "$_vnx_saved_state_dir" ]; then
+    VNX_STATE_DIR="$_vnx_saved_state_dir"
+  fi
+  unset _vnx_saved_data_dir _vnx_saved_state_dir
 fi
 export VNX_HOME="${VNX_HOME:-$VNX_HOME_DEFAULT}"
 


### PR DESCRIPTION
## Summary

OI-1160 de-quarantine of two receipt-processor test files. The `vnx_paths.sh` cross-project guard unsets `VNX_STATE_DIR` when an inherited `VNX_HOME` points to a different project tree, silently clobbering an explicitly pinned state dir back to `$VNX_DATA_DIR/state`. An explicit pin must win; the guard's job is to derive an *unset* state dir, not overrule a set one.

## Changes

- `scripts/lib/vnx_paths.sh`: the cross-project guard now saves and restores an explicit `VNX_STATE_DIR` alongside `VNX_DATA_DIR`. When `VNX_STATE_DIR` is unset, derivation from `VNX_DATA_DIR` is unchanged.
- `scripts/ci/test_exclusions.txt`: removes `test_receipt_processor_bootstrap.py` (10 tests) and `test_receipt_processor_autopr_rejected_mirror.py` (6 tests). 16 test functions return to Profile A.

## Verification

Measured the clobber directly before and after:

```
# before: VNX_STATE_DIR (incoming) /tmp/explicit-state-dir -> after source /tmp/explicit-data-dir/state
# after:  VNX_STATE_DIR (incoming) /tmp/explicit-state-dir -> after source /tmp/explicit-state-dir
```

Control (unset `VNX_STATE_DIR`): still derives to `$VNX_DATA_DIR/state`.

- Solo, both files: 16 passed.
- With `test_init_migrate_bootstrap.py` (order-dependent `VNX_HOME` injector): 48 passed.
- With shell-resolver neighbours (`test_vnx_paths_shell_worktree.py`, `test_state_root_lockstep.py`, `test_cross_project_isolation.py`, `test_mc_v4_columns.py`): 69 passed.
- With receipt_processor siblings (`deadletter`, `lease_release`, `sc1091`, `sc2154_sc2155`, `sc2155`, `sc2181`): 37 passed.
- `shellcheck scripts/lib/vnx_paths.sh`: clean.

## Open Items

The four remaining OI-1133 group-check quarantines (`test_init_migrate_bootstrap.py`, `test_quality_advisory_pipeline.py`, `test_t0_decision_log.py`, `test_t0_escalations_log.py`) are untouched; they have no declared cause yet.