### PR TITLE
fix(ci): scope docs line-ref guard to tracked docs; freeze internal plan/intelligence notes

### DIFF
--- a/scripts/ci/check_docs_file_line_refs.py
+++ b/scripts/ci/check_docs_file_line_refs.py
@@ -17,7 +17,14 @@ Scope — deliberately narrow, so it never false-alarms on a doc edit:
   would falsify what they recorded.  Skipped: ``docs/_archive/``,
   ``docs/examples/`` (illustrative), ``docs/investigations/`` (dated triage
   reports), ``docs/governance/decisions/`` (Nygard ADRs, whose own survey cites
-  are explicitly "not re-grepped to a line number").
+  are explicitly "not re-grepped to a line number"), and
+  ``docs/internal/{plans,intelligence}/`` (historical proposals that cite an
+  architecture that no longer exists).
+* **Only tracked docs.**  Gitignored trees (``docs/internal/``,
+  ``docs/orchestration/``) live on the maintainer's checkout but never ship,
+  and their citations point at a local-only architecture CI has never seen.
+  Scanning them made the check fail locally while CI stayed green.  They are
+  not living repo docs, so untracked files are skipped outright.
 * **Code fences are skipped.**  A fenced block is a literal listing or schema
   example (``scripts/lib/foo.py:10-20`` in a JSON example is a placeholder,
   not a citation).  Real citations live inline in backtick prose.
@@ -50,6 +57,14 @@ _EXEMPT_DOC_SUBDIRS = frozenset({
     "examples",
     "investigations",
     "governance/decisions",
+    # Historical proposals and design notes (docs/internal/{plans,intelligence})
+    # that cite an architecture that no longer exists (dispatcher_v8_minimal.sh,
+    # unified_state_manager_v2.py, receipt_processor_v4.sh, ...).  "Correcting"
+    # their line numbers to today's values would falsify what they recorded.
+    # They are also gitignored, so they never ship; keep them carved out here so
+    # the check never false-alarms if one is ever re-added to the tree.
+    "internal/plans",
+    "internal/intelligence",
 })
 
 # Extensions we treat as "a file" in a citation.  Covering the observed set
@@ -160,11 +175,23 @@ def is_live_doc(doc_rel: str) -> bool:
     )
 
 
-def iter_live_docs(docs_dir: Path) -> list[Path]:
-    """Return every living .md under *docs_dir*, frozen subdirs excluded."""
+def iter_live_docs(docs_dir: Path, paths: list[str] | None = None) -> list[Path]:
+    """Return every living .md under *docs_dir*, untracked and frozen subdirs excluded.
+
+    *paths* is the tracked-file list (repo-relative posix paths) when known.
+    When provided, a doc is scanned only if it is tracked: gitignored trees such
+    as ``docs/internal/`` and ``docs/orchestration/`` live on the maintainer's
+    checkout but never ship, and their line numbers describe a local-only
+    architecture that CI has never seen.
+    """
+    tracked = None
+    if paths is not None:
+        tracked = {p for p in paths if p.startswith("docs/") and p.endswith(".md")}
     docs: list[Path] = []
     for md in sorted(docs_dir.rglob("*.md")):
         rel = md.relative_to(docs_dir).as_posix()
+        if tracked is not None and "docs/" + rel not in tracked:
+            continue
         if is_live_doc(rel):
             docs.append(md)
     return docs
@@ -173,7 +200,7 @@ def iter_live_docs(docs_dir: Path) -> list[Path]:
 def check_docs(docs_dir: Path, repo_root: Path, paths: list[str]) -> list[str]:
     """Return violation strings for every drifted citation in living docs."""
     violations: list[str] = []
-    for md in iter_live_docs(docs_dir):
+    for md in iter_live_docs(docs_dir, paths):
         text = md.read_text(encoding="utf-8", errors="ignore")
         for line_no, ref, linespec in scan_markdown(text):
             violation = check_ref(ref, linespec, repo_root, paths)

--- a/tests/test_ci_check_docs_file_line_refs.py
+++ b/tests/test_ci_check_docs_file_line_refs.py
@@ -122,6 +122,9 @@ def test_scan_markdown_hidden_dir_citation() -> None:
         ("examples/example_headless_research.md", False),
         ("investigations/20260801-oi-triage.md", False),
         ("governance/decisions/ADR-035.md", False),
+        # Historical proposals/design notes citing a dead architecture — frozen.
+        ("internal/plans/VNX_STATE_SIMPLIFICATION_PROPOSAL.md", False),
+        ("internal/intelligence/INTELLIGENCE_INJECTION_V1.1.md", False),
     ],
 )
 def test_is_live_doc(rel: str, expected: bool) -> None:
@@ -156,7 +159,7 @@ def test_check_docs_planted_drift_fails(tmp_path: Path) -> None:
     docs.mkdir()
     (docs / "living.md").write_text("see `x.py:999`\n", encoding="utf-8")
     (tmp_path / "x.py").write_text("a\n", encoding="utf-8")
-    violations = check.check_docs(docs, tmp_path, ["x.py"])
+    violations = check.check_docs(docs, tmp_path, ["x.py", "docs/living.md"])
     assert any("out of bounds" in v for v in violations)
 
 
@@ -164,6 +167,17 @@ def test_check_docs_skips_frozen_dirs(tmp_path: Path) -> None:
     docs = tmp_path / "docs"
     (docs / "investigations").mkdir(parents=True)
     (docs / "investigations" / "frozen.md").write_text("see `x.py:999`\n", encoding="utf-8")
+    (tmp_path / "x.py").write_text("a\n", encoding="utf-8")
+    # The frozen dir is tracked, but still skipped: is_live_doc carves it out.
+    assert check.check_docs(docs, tmp_path, ["x.py", "docs/investigations/frozen.md"]) == []
+
+
+def test_check_docs_skips_untracked_docs(tmp_path: Path) -> None:
+    # A gitignored local-only doc (absent from the tracked list) must not be
+    # scanned: it never ships, and its citations describe a local architecture.
+    docs = tmp_path / "docs"
+    (docs / "internal").mkdir(parents=True)
+    (docs / "internal" / "local-only.md").write_text("see `x.py:999`\n", encoding="utf-8")
     (tmp_path / "x.py").write_text("a\n", encoding="utf-8")
     assert check.check_docs(docs, tmp_path, ["x.py"]) == []
 


### PR DESCRIPTION
## What

The docs-drift check (`scripts/ci/check_docs_file_line_refs.py`, added in #1548) scanned every `.md` under `docs/` via `rglob`, including gitignored local-only trees (`docs/internal/`, `docs/orchestration/`). Those never ship, so CI stayed green while a maintainer checkout with the internal docs present failed the check with exit 1.

## Changes

- Scope the scan to **tracked** files (`iter_live_docs` now filters against `git ls-files`), so gitignored internal docs are skipped outright.
- Add `docs/internal/plans` and `docs/internal/intelligence` to the frozen scope, as historical proposals citing a dead architecture (`dispatcher_v8_minimal.sh`, `unified_state_manager_v2.py`, `receipt_processor_v4.sh`, ...).
- Update and add tests: pin the two new frozen dirs, pin the untracked-skip behavior.

## Measurement (local main checkout, before fix)

83 drifted citations across 3 gitignored files, all untracked:

| file | refs |
|---|---|
| `docs/internal/intelligence/INTELLIGENCE_INJECTION_V1.1.md` | 5 |
| `docs/internal/plans/VNX_STATE_SIMPLIFICATION_PROPOSAL.md` | 24 |
| `docs/orchestration/AI_scrutiny_report.md` | 54 |

No tracked living doc drifted — CI was never red.

## Verification

- `python3 scripts/ci/check_docs_file_line_refs.py` → exit 0 (worktree and against the main checkout with internal docs present).
- `pytest tests/test_ci_check_docs_file_line_refs.py -q` → 26 passed (was 23).
- The gate is not empty: it still validates **295 inline citations across 102 tracked living docs**, and a planted drift in a tracked doc still fails the check (probed end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)