### PR TITLE
fix(phantom-guard): weigh pushed branch diff for fix-forward + warn on dispatch file overlap (OI-1137, OI-1091)

### DIFF
--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -175,6 +175,9 @@ def stage_spec_bundle(
     headless_reason: Optional[str] = None,
     post_merge_verification: bool = False,
     pr_id: Optional[str] = None,
+    # OI-1137: explicit work-ref — the branch a fix-forward dispatch delivers onto, so the
+    # phantom-guard weighs the pushed branch diff when the own worktree reads empty.
+    work_ref: Optional[str] = None,
     tags: tuple[str, ...] = (),
     data_dir: Optional[Path] = None,
     # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the predecessor
@@ -273,6 +276,9 @@ def stage_spec_bundle(
         "provider": _canonical_provider(provider).value,
         "model": model or None,
         "pr_id": pr_id or None,
+        # OI-1137: explicit work-ref, stripped of an origin//refs/ prefix so the
+        # resolver fetches origin/<name> without double-prefixing.
+        "work_ref": (work_ref or "").strip() or None,
         # Chain-link fields (dispatch-20260802-model-ssot-en-ketenlink).
         "task_class": (task_class or "").strip() or None,
         "parent_dispatch": (parent_dispatch or "").strip() or None,
@@ -447,6 +453,7 @@ def deliver_via_door(
     model: Optional[str] = None,
     gate: str = "",
     pr_id: Optional[str] = None,
+    work_ref: Optional[str] = None,
     project_id: Optional[str] = None,
     deadline_seconds: Optional[int] = None,
     allow_headless: bool = False,
@@ -492,6 +499,7 @@ def deliver_via_door(
             model=model,
             gate=gate,
             pr_id=pr_id,
+            work_ref=work_ref,
             project_id=project_id,
             deadline_seconds=deadline_seconds if deadline_seconds is not None else 3600,
             allow_headless=allow_headless,
@@ -519,6 +527,7 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument("--model", default=None)
     parser.add_argument("--gate", default="")
     parser.add_argument("--pr-id", default=None, dest="pr_id")
+    parser.add_argument("--work-ref", default=None, dest="work_ref")
     parser.add_argument("--parent-dispatch", default=None, dest="parent_dispatch")
     parser.add_argument("--task-class", default=None, dest="task_class")
     parser.add_argument("--tier-from", default=None, dest="tier_from")
@@ -577,6 +586,7 @@ def main(argv: Optional[list] = None) -> int:
         model=args.model,
         gate=args.gate,
         pr_id=args.pr_id,
+        work_ref=args.work_ref,
         parent_dispatch=args.parent_dispatch,
         task_class=args.task_class,
         tier_from=args.tier_from,

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -185,6 +185,7 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         skill=(raw.get("skill") or None),
         task_class=(raw.get("task_class") or None),
         pr_id=(raw.get("pr_id") or None),
+        work_ref=(raw.get("work_ref") or None),
         track_id=(raw.get("track_id") or None),
         # Chain-link (dispatch-20260802-model-ssot-en-ketenlink).
         parent_dispatch=(raw.get("parent_dispatch") or None),
@@ -2010,6 +2011,13 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                 os.environ["VNX_TIER_FROM"] = plan.tier_from
             if plan.tier_to:
                 os.environ["VNX_TIER_TO"] = plan.tier_to
+            # OI-1137: the work-ref / pr-id are exported so the tmux-lane phantom-guard can
+            # weigh the pushed branch diff for a fix-forward dispatch (its own worktree reads
+            # empty). Same fallback pattern as VNX_PARENT_DISPATCH above.
+            if plan.work_ref:
+                os.environ["VNX_WORK_REF"] = plan.work_ref
+            if plan.pr_id:
+                os.environ["VNX_PR_ID"] = plan.pr_id
             # The resolved model is exported too, so governance corrective
             # receipts (phantom_guard / pr_enforcement) can record the model the
             # dispatch ran without threading a parameter through every call site.

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -375,6 +375,7 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
         task_class=spec.task_class,
         tier_from=spec.tier_from,
         tier_to=spec.tier_to,
+        work_ref=spec.work_ref,
     )
 
     # INTEGRITY — persist the enriched final prompt + verify raw+injections reconstruct it
@@ -486,6 +487,7 @@ def run_envelope_plan(
         task_class=plan.task_class,
         tier_from=plan.tier_from,
         tier_to=plan.tier_to,
+        work_ref=plan.work_ref,
     )
 
     enriched_instruction = _prepare(spec)
@@ -504,6 +506,7 @@ def run_envelope_plan(
         task_class=spec.task_class,
         tier_from=spec.tier_from,
         tier_to=spec.tier_to,
+        work_ref=spec.work_ref,
     )
 
     # INTEGRITY — the bundle dir is the pending/<id>/ that hosts instruction.md.
@@ -717,6 +720,7 @@ def run_envelope_headless_plan(
         task_class=plan.task_class,
         tier_from=plan.tier_from,
         tier_to=plan.tier_to,
+        work_ref=plan.work_ref,
     )
 
     enriched_instruction = _prepare(spec)
@@ -735,6 +739,7 @@ def run_envelope_headless_plan(
         task_class=spec.task_class,
         tier_from=spec.tier_from,
         tier_to=spec.tier_to,
+        work_ref=spec.work_ref,
     )
 
     # INTEGRITY — persist the enriched final prompt + verify reconstruction

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -269,6 +269,10 @@ class GovernSpec:
     pr_id: Optional[str] = None
     base_sha: Optional[str] = None
     worktree_path: Optional[Path] = None
+    # OI-1137: explicit work-ref (branch a fix-forward delivers onto). The tmux lane does not
+    # know this value from the plan (it runs in a separate pane); govern() falls back to the
+    # door's VNX_WORK_REF env var when the spec does not carry it.
+    work_ref: Optional[str] = None
     model: Optional[str] = None
     # When role="plan-reviewer" the worker's report is a free-form review ending
     # with a vnx-plan-verdict fence — it intentionally lacks the standard contract
@@ -396,6 +400,13 @@ def govern(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome:
             base_sha=spec.base_sha,
             receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
             state_dir=spec.state_dir,
+            # OI-1137: a fix-forward dispatch's own worktree reads empty even though the worker
+            # pushed onto an existing branch. Thread the work target so the guard weighs the
+            # pushed branch diff (spec first, then the door's env the tmux pane inherited).
+            work_ref=spec.work_ref or os.environ.get("VNX_WORK_REF") or None,
+            pr_id=spec.pr_id or os.environ.get("VNX_PR_ID") or None,
+            parent_dispatch=spec.parent_dispatch or os.environ.get("VNX_PARENT_DISPATCH") or None,
+            repo=spec.worktree_path,
         )
     except Exception as exc:  # noqa: BLE001
         logger.error("govern: phantom-guard check failed (non-fatal) dispatch=%s: %s", dispatch_id, exc)

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -122,6 +122,9 @@ class ExecutionPlan:
     pr_id: Optional[str] = None         # OI-982: carried from DispatchSpec so the fix-forward
                                         # diff fallback in _resolve_fix_forward_diff works.
                                         # NOT in digest() — advisory only.
+    work_ref: Optional[str] = None      # OI-1137: explicit work-ref (the branch a fix-forward
+                                        # delivers onto) so the phantom-guard weighs the pushed
+                                        # branch diff. NOT in digest() — advisory only.
     # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): advisory receipt
     # metadata, NOT in digest() — like ``role``, it must not perturb the permit
     # fingerprint. parent_dispatch / tier_from / tier_to / task_class.
@@ -399,6 +402,7 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         route_reason=",".join(fired),
         role=spec.role,
         pr_id=spec.pr_id,
+        work_ref=spec.work_ref,
         # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): copied from the
         # door-computed snapshot so the receipt can say which dispatch this one
         # continues and on which tier.

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -149,6 +149,11 @@ class DispatchSpec:
     # a declaration by the caller, never derived from instruction text or role.
     irreversible: bool = False
     pr_id: Optional[str] = None
+    # OI-1137: explicit work-ref — the branch a fix-forward dispatch delivers onto, so the
+    # phantom-guard can weigh the pushed branch diff when the own worktree reads empty.
+    # Optional; None for a normal dispatch. A bare branch name (dispatch/<id>) or an
+    # origin/-prefixed form is accepted; the resolver normalizes the prefix away.
+    work_ref: Optional[str] = None
     track_id: Optional[str] = None  # structural link to a tracks-table row (TL-D1); validated at the door
     # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the predecessor
     # this dispatch continues (retry / fix-forward / escalation), the tier
@@ -206,6 +211,28 @@ class ValidatedSpec:
 # ---------------------------------------------------------------------------
 
 _ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$")
+
+# OI-1137: git-ref shape validation for an explicit work_ref. Branch names (which is what
+# work_ref carries) disallow whitespace, "..", "@{", and a set of reserved chars; they may
+# contain "/" (unlike _ID_RE) and may not start with "-", end with "/" or ".", or be "@".
+_GIT_REF_INVALID = re.compile(r"[\s~^:?*\[\]\\]|\.\.|@\{")
+
+
+def _validate_branch_ref(raw: str) -> "str | None":
+    """Return an error string if raw is not a valid git branch name, else None."""
+    if not raw or raw != raw.strip():
+        return "empty or has leading/trailing whitespace"
+    if len(raw) > 255:
+        return "exceeds 255 chars"
+    if raw == "@":
+        return "reserved name '@'"
+    if raw.startswith("-"):
+        return "may not start with '-'"
+    if raw.startswith("/") or raw.endswith("/") or raw.endswith("."):
+        return "may not start with '/', end with '/', or end with '.'"
+    if _GIT_REF_INVALID.search(raw):
+        return "contains a character git forbids in a branch name"
+    return None
 
 _BLOCKED_FIRST_COMPONENTS = frozenset({".git", ".vnx-data"})
 
@@ -410,6 +437,22 @@ def validate(
             return Reject(
                 "bad-tier-value",
                 f"{_tier_field} {_tier_val!r} is not one of {sorted(_VALID_TIERS)}",
+            )
+
+    # Rule 15 — work_ref format (OI-1137). An explicit work-ref is a git branch name (may
+    # contain "/"), validated with git's own ref rules. Strip a leading origin/ or refs/heads/
+    # prefix before validating, since the resolver normalizes those away at use time.
+    if spec.work_ref is not None:
+        _work_ref = spec.work_ref.strip()
+        for _prefix in ("refs/heads/", "refs/remotes/origin/", "origin/"):
+            if _work_ref.startswith(_prefix):
+                _work_ref = _work_ref[len(_prefix):]
+                break
+        _err = _validate_branch_ref(_work_ref)
+        if _err is not None:
+            return Reject(
+                "bad-work-ref",
+                f"work_ref {spec.work_ref!r} is not a valid branch name ({_err})",
             )
 
     return ValidatedSpec(

--- a/scripts/lib/envelope_govern_support.py
+++ b/scripts/lib/envelope_govern_support.py
@@ -68,49 +68,50 @@ def _resolve_fix_forward_diff(
     base_ref: str = "origin/main",
     repo: Optional[Path] = None,
 ) -> Optional[str]:
-    """Fall back to the PUSHED PR branch's diff when the dispatch's own worktree/branch diff
-    reads empty and the dispatch targets an EXISTING PR (``spec.pr_id`` set) — a fix-forward
-    dispatch.
+    """Fall back to the PUSHED branch's diff when the dispatch's own worktree/branch diff reads
+    empty and the dispatch declares a work target — a fix-forward dispatch.
 
-    A fix-forward dispatch pushes its commit onto that PR's branch (per its instruction), not
+    A fix-forward dispatch pushes its commit onto an EXISTING branch (per its instruction), not
     onto its own ``dispatch/<id>`` worktree branch — the own-worktree diff then reads empty even
     though real work landed and was pushed. T0's rule is "verify the pushed branch, not the
-    report" (phantom_guard module docstring). ``spec.pr_id`` is the dispatch's existing-PR
-    identifier — already carried on EnvelopeSpec, populated from ``--pr-id`` — resolved to its
-    head branch via ``gh pr view``.
+    report" (phantom_guard module docstring). The work target is declared by precedence:
+    ``spec.work_ref`` (an explicit branch name), ``spec.pr_id`` (an existing PR resolved to its
+    head branch via ``gh pr view``), or ``spec.parent_dispatch`` (derived to
+    ``dispatch/<parent>``). The resolution + fetch + diff live in
+    ``phantom_guard.resolve_pushed_work_diff`` so the tmux and envelope lanes share one
+    implementation.
 
     ``repo`` is the git checkout to resolve/fetch/diff against — the orchestrator's own repo
     root (the ephemeral dispatch worktree is gone or going away by the time GOVERN runs), not
     the worker's torn-down worktree. Defaults to ``project_root.resolve_project_root``.
 
     No-op for a normal dispatch: a non-empty ``own_diff`` short-circuits before any gh/git call,
-    so the own-worktree diff stays the sole source there (unchanged behavior). Best-effort: any
-    resolution failure (no gh, bad pr_id, PR not pushed yet) falls back to ``own_diff``
+    and a dispatch with no work_ref/pr_id/parent_dispatch returns ``own_diff`` untouched — so
+    the own-worktree diff stays the sole source there (unchanged behavior). Best-effort: any
+    resolution failure (no gh, bad pr_id, branch not pushed yet) falls back to ``own_diff``
     unchanged — a genuinely empty dispatch (no own diff, no resolvable/non-empty pushed branch)
     still reads empty here, so phantom_guard() still catches it.
     """
     if (own_diff or "").strip():
         return own_diff
+    work_ref = (getattr(spec, "work_ref", None) or "").strip()
     pr_id = (spec.pr_id or "").strip()
-    if not pr_id:
+    parent_dispatch = (getattr(spec, "parent_dispatch", None) or "").strip()
+    if not work_ref and not pr_id and not parent_dispatch:
         return own_diff
     try:
-        from phantom_guard import compute_branch_diff, resolve_pr_head_branch  # noqa: PLC0415
+        from phantom_guard import resolve_pushed_work_diff  # noqa: PLC0415
         if repo is None:
             from project_root import resolve_project_root  # noqa: PLC0415
             repo = resolve_project_root(__file__)
-        branch = resolve_pr_head_branch(pr_id, repo=repo)
-        if not branch:
-            return own_diff
-        subprocess.run(
-            ["git", "fetch", "origin", branch],
-            cwd=str(repo), capture_output=True, text=True, timeout=30, check=False,
+        pushed_diff = resolve_pushed_work_diff(
+            work_ref=work_ref, pr_id=pr_id, parent_dispatch=parent_dispatch,
+            base_ref=base_ref, repo=repo,
         )
-        pushed_diff = compute_branch_diff(f"origin/{branch}", base_ref=base_ref, repo=repo)
     except Exception as exc:  # noqa: BLE001 — best-effort; never raise, never false-reject on a resolution error
         logger.warning(
-            "envelope: fix-forward diff resolution failed dispatch=%s pr_id=%s: %s",
-            spec.dispatch_id, pr_id, exc,
+            "envelope: fix-forward diff resolution failed dispatch=%s: %s",
+            spec.dispatch_id, exc,
         )
         return own_diff
     return pushed_diff if pushed_diff.strip() else own_diff

--- a/scripts/lib/envelope_types.py
+++ b/scripts/lib/envelope_types.py
@@ -40,6 +40,10 @@ class EnvelopeSpec:
     task_class: Optional[str] = None
     tier_from: Optional[str] = None
     tier_to: Optional[str] = None
+    # OI-1137: explicit work-ref — the branch a fix-forward dispatch delivers onto,
+    # so the phantom-guard can weigh the pushed branch diff when the own worktree
+    # reads empty. Optional; None for a normal dispatch.
+    work_ref: Optional[str] = None
 
 
 @dataclass

--- a/scripts/lib/file_scope_overlap.py
+++ b/scripts/lib/file_scope_overlap.py
@@ -1,0 +1,194 @@
+"""file_scope_overlap.py — warn when two open dispatch branches touch the same files.
+
+OI-1091: nothing prevented two concurrent dispatches from claiming the same files. Three
+dispatches collided in ONE worktree and a sibling reset another's branch pointer (OI-1232).
+This module detects that overlap at the merge chokepoint and WARNS. It never blocks: a merge
+still proceeds, but T0 sees the collision before it lands and can reconcile the two tracks.
+
+Shape of the check:
+  - ``open_dispatch_branches`` enumerates remote ``dispatch/*`` branches that are NOT yet
+    merged into the base ref (an already-merged-but-not-deleted branch is not "open", so it
+    cannot produce a spurious warning).
+  - ``changed_files`` is the ``git diff --name-only`` of a branch against the base ref.
+  - ``find_overlaps`` intersects the merging branch's files with every other open dispatch
+    branch and returns the overlaps; ``warn_overlaps`` formats + emits them.
+
+Everything is best-effort: any git/network failure degrades to "no overlaps found" and a debug
+log line, never an exception that blocks the merge.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+_LOG = logging.getLogger(__name__)
+
+DEFAULT_BASE_REF = "origin/main"
+
+# A dispatch branch is a remote ref under refs/heads/dispatch/. A fix-forward branch keeps the
+# same shape (it is the parent's dispatch/<id> branch), so the dispatch-id is the last path
+# component after the dispatch/ prefix.
+_DISPATCH_PREFIX = "dispatch/"
+
+
+def dispatch_id_from_branch(branch: str) -> Optional[str]:
+    """Extract the dispatch-id from a branch name, or None when it is not a dispatch branch.
+
+    Accepts a bare name (``dispatch/20260815-foo``) or a prefixed one (``origin/...`` /
+    ``refs/heads/...``). Returns None for a non-dispatch branch (e.g. ``main``).
+    """
+    name = (branch or "").strip()
+    for prefix in ("refs/heads/", "refs/remotes/origin/", "origin/"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    if not name.startswith(_DISPATCH_PREFIX):
+        return None
+    rest = name[len(_DISPATCH_PREFIX):].strip("/")
+    return rest or None
+
+
+def _run(cmd: list[str], *, repo: Optional[Path], check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(repo) if repo else None,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _list_remote_dispatch_branches(repo: Optional[Path]) -> list[str]:
+    """Return remote ``dispatch/*`` branch names (bare, no origin/ prefix) from the remote.
+
+    Uses ``git ls-remote --heads origin`` so the result reflects what is actually pushed, not a
+    possibly-stale local remote-tracking view.
+    """
+    proc = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin", "refs/heads/dispatch/*"],
+        cwd=str(repo) if repo else None,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    branches: list[str] = []
+    for line in proc.stdout.splitlines():
+        # "<sha>\trefs/heads/dispatch/<id>" — the ref column is after the first tab.
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        ref = parts[1].strip()
+        if ref.startswith("refs/heads/"):
+            branches.append(ref[len("refs/heads/"):])
+    return branches
+
+
+def changed_files(branch: str, *, base_ref: str = DEFAULT_BASE_REF, repo: Optional[Path] = None) -> set[str]:
+    """Return the files ``branch`` changed relative to ``base_ref`` (``git diff --name-only``).
+
+    Fetches the branch first so the comparison is against the PUSHED tip, not a stale local
+    ref. Empty set on any failure (a missing branch, a bad ref, no network).
+    """
+    _run(["git", "fetch", "origin", branch], repo=repo, check=False)
+    merge_base = _run(
+        ["git", "merge-base", base_ref, f"origin/{branch}"], repo=repo, check=False,
+    ).stdout.strip()
+    if not merge_base:
+        return set()
+    diff = _run(
+        ["git", "diff", "--name-only", f"{merge_base}..origin/{branch}"], repo=repo, check=False,
+    ).stdout
+    return {line for line in diff.splitlines() if line.strip()}
+
+
+def _is_merged(branch: str, *, base_ref: str = DEFAULT_BASE_REF, repo: Optional[Path] = None) -> bool:
+    """True when the branch's tip is already an ancestor of base_ref (i.e. fully merged)."""
+    proc = _run(
+        ["git", "merge-base", "--is-ancestor", f"origin/{branch}", base_ref],
+        repo=repo, check=False,
+    )
+    return proc.returncode == 0
+
+
+def open_dispatch_branches(
+    *, base_ref: str = DEFAULT_BASE_REF, repo: Optional[Path] = None
+) -> list[str]:
+    """Remote ``dispatch/*`` branches that are not yet merged into ``base_ref``.
+
+    An already-merged branch (merged but its remote ref not deleted) is excluded: its files are
+    already on the base, so it cannot collide with a new merge.
+    """
+    open_branches: list[str] = []
+    for branch in _list_remote_dispatch_branches(repo):
+        # _is_merged needs origin/<branch> present; changed_files fetches it, so reuse that
+        # side effect only when the branch is otherwise a candidate.
+        _run(["git", "fetch", "origin", branch], repo=repo, check=False)
+        if not _is_merged(branch, base_ref=base_ref, repo=repo):
+            open_branches.append(branch)
+    return open_branches
+
+
+def find_overlaps(
+    merging_branch: str,
+    *,
+    base_ref: str = DEFAULT_BASE_REF,
+    repo: Optional[Path] = None,
+) -> list[tuple[str, list[str]]]:
+    """Return [(other_dispatch_id, [overlapping files])] for the branch being merged.
+
+    ``merging_branch`` is the PR head branch (bare name, e.g. ``dispatch/20260815-foo``). Each
+    entry names the OTHER open dispatch whose files intersect, with the shared files listed.
+    Best-effort: on any failure returns [].
+    """
+    try:
+        mine = changed_files(merging_branch, base_ref=base_ref, repo=repo)
+        if not mine:
+            return []
+        overlaps: list[tuple[str, list[str]]] = []
+        for other in open_dispatch_branches(base_ref=base_ref, repo=repo):
+            if other == merging_branch:
+                continue
+            other_id = dispatch_id_from_branch(other)
+            if not other_id:
+                continue
+            theirs = changed_files(other, base_ref=base_ref, repo=repo)
+            shared = sorted(mine & theirs)
+            if shared:
+                overlaps.append((other_id, shared))
+        return overlaps
+    except Exception as exc:  # noqa: BLE001 — a warning must never block a merge
+        _LOG.debug("file_scope_overlap: overlap check failed branch=%s: %s", merging_branch, exc)
+        return []
+
+
+def warn_overlaps(
+    merging_branch: str,
+    *,
+    base_ref: str = DEFAULT_BASE_REF,
+    repo: Optional[Path] = None,
+    stream: Optional[Any] = None,
+) -> list[tuple[str, list[str]]]:
+    """Compute overlaps for ``merging_branch`` and emit a WARN line per colliding dispatch.
+
+    Returns the overlaps so the caller can also surface them in its result payload. The warning
+    names the other dispatch AND lists the shared files (OI-1091's contract). Emits to ``stream``
+    (default stderr) and the logger; never raises.
+    """
+    overlaps = find_overlaps(merging_branch, base_ref=base_ref, repo=repo)
+    if not overlaps:
+        return overlaps
+    out = sys.stderr if stream is None else stream
+    for other_id, files in overlaps:
+        message = (
+            f"WARN: file-scope overlap — dispatch {other_id!r} (open) also touches "
+            f"{len(files)} file(s) in this merge: {', '.join(files)}"
+        )
+        print(message, file=out)
+        _LOG.warning("file_scope_overlap: %s", message)
+    return overlaps

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -209,6 +209,83 @@ def resolve_pr_head_branch(
         return None
 
 
+def _normalize_branch_name(branch: str) -> str:
+    """Strip common ref prefixes from a work_ref so it can be fetched as origin/<name>.
+
+    ``work_ref`` may be declared as a bare branch name (``dispatch/20260815-foo``) or with a
+    remote/refs prefix (``origin/dispatch/20260815-foo``). The fetch below always targets
+    ``origin/<name>``, so a leading prefix must not double up.
+    """
+    name = (branch or "").strip()
+    for prefix in ("refs/heads/", "refs/remotes/origin/", "origin/"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    return name
+
+
+def resolve_pushed_work_diff(
+    *,
+    work_ref: Optional[str] = None,
+    pr_id: Optional[str] = None,
+    parent_dispatch: Optional[str] = None,
+    base_ref: str = "origin/main",
+    repo: Optional[Path] = None,
+) -> str:
+    """Resolve the PUSHED branch diff for a dispatch that declared a work target (fix-forward).
+
+    A fix-forward dispatch commits onto an EXISTING branch and pushes there, so its own
+    worktree/branch diff reads empty even though real work landed (the OI-1137 false-reject).
+    This resolves the branch where that work actually went — precedence: explicit ``work_ref``
+    > ``pr_id`` (resolved via gh) > ``parent_dispatch``-derived ``dispatch/<parent>`` — and
+    returns its diff against ``base_ref``. For a fix-forward, ``base_ref`` is the parent's
+    branch tip (the point this dispatch branched from), so the diff isolates THIS dispatch's
+    contribution rather than the parent's prior work.
+
+    MONOTONIC — the guard-preservation property. This only ever returns a NON-EMPTY diff when
+    pushed work actually exists; on any failure (no target declared, gh unresolvable, branch
+    not pushed, bad ref) it returns '' so the caller keeps its own (empty) diff and the phantom
+    decision is unchanged. It never downgrades a non-empty diff to empty, and a plain dispatch
+    (no work_ref/pr_id/parent_dispatch) short-circuits to '' without touching gh/git. So the
+    guard's core function — reject an evidence-free success receipt — is never weakened.
+    """
+    branch: Optional[str] = _normalize_branch_name(work_ref or "") or None
+    if not branch:
+        _pr = (pr_id or "").strip()
+        if _pr:
+            try:
+                branch = resolve_pr_head_branch(_pr, repo=repo)
+            except Exception as exc:  # noqa: BLE001 — fail-open, never manufacture evidence
+                _LOG.warning("phantom_guard: pr_id resolution failed pr_id=%s: %s", _pr, exc)
+                branch = None
+    if not branch:
+        _parent = (parent_dispatch or "").strip()
+        if _parent:
+            try:
+                from dispatch_worktree_isolation import _sanitize_dispatch_id  # noqa: PLC0415
+                branch = f"dispatch/{_sanitize_dispatch_id(_parent)}"
+            except Exception as exc:  # noqa: BLE001 — fail-open
+                _LOG.warning(
+                    "phantom_guard: parent_dispatch branch derivation failed parent=%s: %s",
+                    _parent, exc,
+                )
+                branch = None
+    if not branch:
+        return ""
+    cwd = str(repo) if repo else None
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin", branch],
+            cwd=cwd, capture_output=True, text=True, timeout=30, check=False,
+        )
+        return compute_branch_diff(f"origin/{branch}", base_ref=base_ref, repo=repo)
+    except Exception as exc:  # noqa: BLE001 — best-effort; never raise, never false-reject
+        _LOG.warning(
+            "phantom_guard: pushed-work diff resolution failed branch=%s: %s", branch, exc,
+        )
+        return ""
+
+
 def compute_worktree_diff(worktree_path: Path, *, base_ref: str = "origin/main") -> str:
     """Diff a worker's worktree (committed branch tip + uncommitted) against base_ref.
 
@@ -277,6 +354,10 @@ def guard_at_govern(
     worktree_diff: Optional[str] = None,
     task_class: Optional[str] = None,
     read_only: Optional[bool] = None,
+    work_ref: Optional[str] = None,
+    pr_id: Optional[str] = None,
+    parent_dispatch: Optional[str] = None,
+    repo: Optional[Path] = None,
 ) -> PhantomVerdict:
     """Inline govern-time phantom check for BOTH lanes (claude tmux via dispatch_govern.govern,
     providers via dispatch_envelope._govern — the kimi/glm/deepseek fabrication vector).
@@ -289,6 +370,12 @@ def guard_at_govern(
          GovernSpec — not torn down until after govern),
       2. else the dispatch's own branch ``dispatch/<sanitized id>`` (still-present isolated branch),
       3. else ABSTAIN — return ok (an unresolvable/torn-down ref must never read as "empty diff").
+
+    Fix-forward fallback (OI-1137): when the own diff above reads EMPTY (or the own ref is
+    unresolvable) AND the dispatch declares a work target (``work_ref`` / ``pr_id`` /
+    ``parent_dispatch``), the PUSHED branch diff is weighed in via ``resolve_pushed_work_diff``.
+    This is strictly MONOTONIC — it only ever upgrades an empty diff to a non-empty one when real
+    pushed work exists, never the reverse, so a plain evidence-free dispatch is still rejected.
 
     Honors ``VNX_OVERRIDE_PHANTOM_GUARD=1`` (operator escape for a legitimate no-op delivery). This
     function performs NO receipt I/O — the caller appends the corrective ``failed`` receipt on a
@@ -310,7 +397,20 @@ def guard_at_govern(
                 branch = f"dispatch/{_sanitize_dispatch_id(dispatch_id)}"
                 diff = compute_branch_diff(branch, base_ref=base)
         except Exception as exc:  # CalledProcessError / missing ref / reaped worktree
-            return _ok(f"phantom-guard ABSTAINED — worker diff unresolvable ({type(exc).__name__})")
+            # A declared work target is still resolvable from the PUSHED branch even when the own
+            # worktree/branch is gone (the fix-forward shape) — try that before abstaining.
+            diff = resolve_pushed_work_diff(
+                work_ref=work_ref, pr_id=pr_id, parent_dispatch=parent_dispatch,
+                base_ref=base, repo=repo,
+            )
+            if not (diff or "").strip():
+                return _ok(f"phantom-guard ABSTAINED — worker diff unresolvable ({type(exc).__name__})")
+    # Fix-forward fallback (monotonic: only upgrades an empty own diff, never a non-empty one).
+    if not (diff or "").strip():
+        diff = resolve_pushed_work_diff(
+            work_ref=work_ref, pr_id=pr_id, parent_dispatch=parent_dispatch,
+            base_ref=base, repo=repo,
+        ) or diff
     return phantom_guard(
         status=status, worktree_diff=diff, token_usage=token_usage, role=role,
         task_class=task_class, read_only=read_only,
@@ -330,6 +430,10 @@ def record_phantom_if_any(
     state_dir: Optional[Path] = None,
     task_class: Optional[str] = None,
     read_only: Optional[bool] = None,
+    work_ref: Optional[str] = None,
+    pr_id: Optional[str] = None,
+    parent_dispatch: Optional[str] = None,
+    repo: Optional[Path] = None,
 ) -> PhantomVerdict:
     """``guard_at_govern`` + on a phantom verdict, append a corrective ``failed`` completion receipt.
 
@@ -350,6 +454,7 @@ def record_phantom_if_any(
         dispatch_id=dispatch_id, role=role, status=status, token_usage=token_usage,
         worktree_path=worktree_path, base_sha=base_sha, worktree_diff=worktree_diff,
         task_class=task_class, read_only=read_only,
+        work_ref=work_ref, pr_id=pr_id, parent_dispatch=parent_dispatch, repo=repo,
     )
     if verdict.is_phantom and state_dir:
         try:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1237,6 +1237,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--gate", default="")
     parser.add_argument("--dispatch-paths", default="")
     parser.add_argument("--pr-id", default=None)
+    parser.add_argument("--work-ref", default=None)
     parser.add_argument(
         "--auto-route", action="store_true",
         help="Use smart_router to auto-select provider+model (opt-in, default off).",
@@ -1732,6 +1733,7 @@ def _dispatch_codex_via_envelope(args: argparse.Namespace) -> int:
         instruction=args.instruction,
         role=getattr(args, "role", None),
         pr_id=getattr(args, "pr_id", None),
+        work_ref=getattr(args, "work_ref", None),
         state_dir=state_dir,
         data_dir=data_dir,
     )
@@ -1772,6 +1774,7 @@ def _dispatch_claude_via_envelope(args: argparse.Namespace) -> int:
         instruction=args.instruction,
         role=getattr(args, "role", None),
         pr_id=getattr(args, "pr_id", None),
+        work_ref=getattr(args, "work_ref", None),
         state_dir=state_dir,
         data_dir=data_dir,
     )

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1216,6 +1216,7 @@ class TmuxInteractiveDispatch:
         if receipt is None:
             return receipt
         try:
+            import os  # noqa: PLC0415
             from phantom_guard import record_phantom_if_any  # noqa: PLC0415
             _tok = pane_tokens or {}
             verdict = record_phantom_if_any(
@@ -1229,6 +1230,13 @@ class TmuxInteractiveDispatch:
                 base_sha=base_sha,
                 receipts_file=str(self._receipts_file),
                 state_dir=self._state_dir,
+                # OI-1137: a fix-forward dispatch's own worktree reads empty even though the
+                # worker pushed onto an existing branch. Thread the work target (from the door's
+                # env the tmux pane inherited) so the guard weighs the pushed branch diff.
+                work_ref=os.environ.get("VNX_WORK_REF") or None,
+                pr_id=os.environ.get("VNX_PR_ID") or None,
+                parent_dispatch=os.environ.get("VNX_PARENT_DISPATCH") or None,
+                repo=worktree_path,
             )
         except Exception as exc:  # noqa: BLE001 — never block a real completion on a guard error
             logger.error(

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -206,6 +206,7 @@ def merge_pr(
         "register_ok": False,
         "error": "",
         "dry_run": dry_run,
+        "overlaps": [],
     }
 
     # Query PR metadata before merge (needed for receipt)
@@ -213,6 +214,15 @@ def merge_pr(
     if pr_data:
         result["pr_title"] = pr_data.get("title", "")
         result["branch"] = pr_data.get("headRefName", "")
+
+    # OI-1091: warn (never block) when another OPEN dispatch branch touches the same files as
+    # the branch being merged. Best-effort; a git/network failure degrades to no warning.
+    if result["branch"]:
+        try:
+            from file_scope_overlap import warn_overlaps  # noqa: PLC0415
+            result["overlaps"] = warn_overlaps(result["branch"], repo=SCRIPT_DIR.parent)
+        except Exception as exc:  # noqa: BLE001 — an overlap check must never block a merge
+            log.warning("file-scope overlap check failed for PR #%s: %s", pr_number, exc)
 
     if dry_run:
         result["success"] = True

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -600,3 +600,47 @@ class TestRule13TrackId:
         spec = _valid_spec(ifile, track_id="totally-nonexistent-track")
         result = _do_validate(spec, monkeypatch)
         assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 15 — work_ref format (OI-1137)
+# ---------------------------------------------------------------------------
+
+class TestRule15WorkRef:
+    def test_default_none_passes(self, tmp_path, monkeypatch):
+        """work_ref defaults to None → ValidatedSpec (rule only fires when set)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert result.spec.work_ref is None
+
+    @pytest.mark.parametrize("valid_ref", [
+        "dispatch/20260815-fix-forward",
+        "dispatch/foo.bar_baz-1",
+        "origin/dispatch/20260815-fix-forward",       # remote prefix is stripped before validation
+        "refs/heads/dispatch/20260815-fix-forward",   # refs prefix is stripped before validation
+    ])
+    def test_accepts_valid_work_ref(self, tmp_path, monkeypatch, valid_ref):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, work_ref=valid_ref)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+
+    @pytest.mark.parametrize("bad_ref", [
+        "   ",                 # whitespace-only collapses to empty after strip
+        "has spaces",
+        "dispatch/foo..bar",   # ".." is forbidden in a branch name
+        "dispatch/foo~1",      # "~" is forbidden
+        "dispatch/foo:bar",    # ":" is forbidden
+        "dispatch/foo?x",      # "?" is forbidden
+        "-dispatch/foo",       # may not start with "-"
+        "dispatch/foo/",       # may not end with "/"
+        "dispatch/foo.",       # may not end with "."
+    ])
+    def test_rejects_bad_work_ref(self, tmp_path, monkeypatch, bad_ref):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, work_ref=bad_ref)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-work-ref"

--- a/tests/test_file_scope_overlap.py
+++ b/tests/test_file_scope_overlap.py
@@ -1,0 +1,220 @@
+"""test_file_scope_overlap.py — OI-1091: overlap detection between open dispatch branches.
+
+Covers the pure branch-name handling (dispatch_id_from_branch) and the git plumbing
+(changed_files / open_dispatch_branches / find_overlaps / warn_overlaps) against a REAL local
+git repo (bare origin + working checkout), so the fetch + merge-base + diff plumbing is proven,
+not just the branching logic. The contract under test: the warning names the OTHER dispatch and
+lists the shared files, and it never blocks (best-effort, no raises).
+"""
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import file_scope_overlap as fso
+
+
+# ---------------------------------------------------------------------------
+# dispatch_id_from_branch — pure branch-name handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "branch,expected",
+    [
+        ("dispatch/20260815-foo", "20260815-foo"),
+        ("origin/dispatch/20260815-foo", "20260815-foo"),
+        ("refs/heads/dispatch/20260815-foo", "20260815-foo"),
+        ("refs/remotes/origin/dispatch/20260815-foo", "20260815-foo"),
+        ("main", None),
+        ("dispatch/", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_dispatch_id_from_branch(branch, expected):
+    assert fso.dispatch_id_from_branch(branch) == expected
+
+
+# ---------------------------------------------------------------------------
+# Real git repo fixture — proves fetch + merge-base + diff plumbing
+# ---------------------------------------------------------------------------
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True,
+    )
+
+
+@pytest.fixture()
+def git_fixture(tmp_path: Path):
+    bare = tmp_path / "origin.git"
+    work = tmp_path / "work"
+    bare.mkdir()
+    _run_git(bare, "init", "--bare", "-b", "main")
+
+    work.mkdir()
+    _run_git(work, "init", "-b", "main")
+    _run_git(work, "config", "user.email", "test@example.com")
+    _run_git(work, "config", "user.name", "Test")
+    (work / "README.md").write_text("base\n", encoding="utf-8")
+    _run_git(work, "add", "README.md")
+    _run_git(work, "commit", "-m", "base commit")
+    _run_git(work, "remote", "add", "origin", str(bare))
+    _run_git(work, "push", "origin", "main")
+    return work
+
+
+def _push_branch(work: Path, branch: str, filename: str) -> None:
+    """Create a branch off main carrying one new file and push it, then drop the local branch."""
+    _run_git(work, "checkout", "-b", branch, "main")
+    (work / filename).write_text(f"change for {filename}\n", encoding="utf-8")
+    _run_git(work, "add", filename)
+    _run_git(work, "commit", "-m", f"add {filename}")
+    _run_git(work, "push", "origin", branch)
+    _run_git(work, "checkout", "main")
+    _run_git(work, "branch", "-D", branch)
+
+
+def _push_empty_branch(work: Path, branch: str) -> None:
+    """Push a branch that equals main (nothing new) — trivially already merged."""
+    _run_git(work, "checkout", "-b", branch, "main")
+    _run_git(work, "push", "origin", branch)
+    _run_git(work, "checkout", "main")
+    _run_git(work, "branch", "-D", branch)
+
+
+# ---------------------------------------------------------------------------
+# changed_files
+# ---------------------------------------------------------------------------
+
+
+def test_changed_files_returns_pushed_files(git_fixture):
+    _push_branch(git_fixture, "dispatch/a", "a.txt")
+    assert fso.changed_files("dispatch/a", base_ref="origin/main", repo=git_fixture) == {"a.txt"}
+
+
+def test_changed_files_empty_branch_returns_empty(git_fixture):
+    _push_empty_branch(git_fixture, "dispatch/empty")
+    assert fso.changed_files("dispatch/empty", base_ref="origin/main", repo=git_fixture) == set()
+
+
+def test_changed_files_missing_branch_returns_empty(git_fixture):
+    assert fso.changed_files("dispatch/never-pushed", base_ref="origin/main", repo=git_fixture) == set()
+
+
+# ---------------------------------------------------------------------------
+# open_dispatch_branches — merged vs unmerged
+# ---------------------------------------------------------------------------
+
+
+def test_open_dispatch_branches_excludes_merged(git_fixture):
+    _push_branch(git_fixture, "dispatch/open-a", "open-a.txt")
+    _push_empty_branch(git_fixture, "dispatch/already-merged")
+    open_branches = fso.open_dispatch_branches(base_ref="origin/main", repo=git_fixture)
+    assert "dispatch/open-a" in open_branches
+    assert "dispatch/already-merged" not in open_branches
+
+
+def test_open_dispatch_branches_empty_without_branches(git_fixture):
+    assert fso.open_dispatch_branches(base_ref="origin/main", repo=git_fixture) == []
+
+
+# ---------------------------------------------------------------------------
+# find_overlaps / warn_overlaps — the OI-1091 contract
+# ---------------------------------------------------------------------------
+
+
+def test_find_overlaps_returns_colliding_dispatch_and_files(git_fixture):
+    _push_branch(git_fixture, "dispatch/other", "shared.txt")
+    _push_branch(git_fixture, "dispatch/merging", "shared.txt")
+    overlaps = fso.find_overlaps("dispatch/merging", base_ref="origin/main", repo=git_fixture)
+    assert overlaps == [("other", ["shared.txt"])]
+
+
+def test_find_overlaps_ignores_disjoint_branch(git_fixture):
+    _push_branch(git_fixture, "dispatch/other", "shared.txt")
+    _push_branch(git_fixture, "dispatch/disjoint", "disjoint.txt")
+    _push_branch(git_fixture, "dispatch/merging", "shared.txt")
+    overlaps = fso.find_overlaps("dispatch/merging", base_ref="origin/main", repo=git_fixture)
+    # only the colliding branch appears; the disjoint one is silent
+    assert overlaps == [("other", ["shared.txt"])]
+
+
+def test_find_overlaps_no_open_branches_returns_empty(git_fixture):
+    _push_branch(git_fixture, "dispatch/merging", "shared.txt")
+    assert fso.find_overlaps("dispatch/merging", base_ref="origin/main", repo=git_fixture) == []
+
+
+def test_warn_overlaps_names_dispatch_and_files(git_fixture):
+    _push_branch(git_fixture, "dispatch/other", "shared.txt")
+    _push_branch(git_fixture, "dispatch/merging", "shared.txt")
+    capture = io.StringIO()
+    overlaps = fso.warn_overlaps(
+        "dispatch/merging", base_ref="origin/main", repo=git_fixture, stream=capture,
+    )
+    assert overlaps == [("other", ["shared.txt"])]
+    emitted = capture.getvalue()
+    assert "dispatch 'other'" in emitted
+    assert "shared.txt" in emitted
+
+
+def test_warn_overlaps_no_collision_emits_nothing(git_fixture):
+    _push_branch(git_fixture, "dispatch/merging", "only.txt")
+    capture = io.StringIO()
+    overlaps = fso.warn_overlaps(
+        "dispatch/merging", base_ref="origin/main", repo=git_fixture, stream=capture,
+    )
+    assert overlaps == []
+    assert capture.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# pr_merge wiring — merge_pr surfaces the overlap in its result
+# ---------------------------------------------------------------------------
+
+
+def test_merge_pr_surfaces_overlap_warning(monkeypatch):
+    import pr_merge
+
+    monkeypatch.setattr(pr_merge, "_query_pr",
+                        lambda pr: {"title": "fix: t", "headRefName": "dispatch/merging"})
+    monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method: (True, ""))
+    monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "ok"})
+    monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **kw: True)
+    monkeypatch.setattr(
+        fso, "warn_overlaps", lambda branch, **kw: [("other", ["shared.txt"])],
+    )
+
+    result = pr_merge.merge_pr(99, dispatch_id="d1")
+    assert result["success"] is True
+    assert result["overlaps"] == [("other", ["shared.txt"])]
+
+
+def test_merge_pr_overlap_check_failure_does_not_block(monkeypatch):
+    import pr_merge
+
+    monkeypatch.setattr(pr_merge, "_query_pr",
+                        lambda pr: {"title": "fix: t", "headRefName": "dispatch/merging"})
+    monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method: (True, ""))
+    monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "ok"})
+    monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **kw: True)
+
+    def _boom(branch, **kw):
+        raise RuntimeError("git unavailable")
+
+    monkeypatch.setattr(fso, "warn_overlaps", _boom)
+    # must still merge and report success — the overlap check is best-effort
+    result = pr_merge.merge_pr(99, dispatch_id="d1")
+    assert result["success"] is True
+    assert result["overlaps"] == []

--- a/tests/test_phantom_guard_work_ref.py
+++ b/tests/test_phantom_guard_work_ref.py
@@ -1,0 +1,215 @@
+"""test_phantom_guard_work_ref.py — OI-1137: the pushed-branch fallback for fix-forward dispatches.
+
+A fix-forward dispatch declares a work target (``work_ref`` / ``pr_id`` / ``parent_dispatch``)
+instead of landing on its own ``dispatch/<id>`` branch. Its own worktree/branch diff reads empty
+while real work sits on the PUSHED branch. ``resolve_pushed_work_diff`` is the resolver that
+weighs that pushed branch in, and ``guard_at_govern`` calls it when the own diff is empty (or the
+own ref is unresolvable).
+
+The property that must NEVER regress is monotonicity: the fallback only ever upgrades an empty
+diff to non-empty when real pushed work exists. It never downgrades, never manufactures evidence
+for a plain dispatch, and never raises. Those invariants are tested explicitly here.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import phantom_guard as pg
+
+
+@dataclass
+class _FakeProc:
+    returncode: int
+    stdout: str = ""
+
+
+# ---------------------------------------------------------------------------
+# _normalize_branch_name — prefix stripping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("dispatch/20260815-foo", "dispatch/20260815-foo"),
+        ("refs/heads/dispatch/foo", "dispatch/foo"),
+        ("refs/remotes/origin/dispatch/foo", "dispatch/foo"),
+        ("origin/dispatch/foo", "dispatch/foo"),
+        ("  dispatch/padded  ", "dispatch/padded"),
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_normalize_branch_name_strips_prefixes(raw, expected):
+    assert pg._normalize_branch_name(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_pushed_work_diff — precedence, monotonicity, failure-is-empty
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_no_target_declared_short_circuits_no_git(monkeypatch):
+    # A plain dispatch (no work_ref/pr_id/parent_dispatch) must return '' WITHOUT touching git
+    # or gh — the monotonic short-circuit that keeps the fallback from ever weakening the guard.
+    def _boom(*a, **k):
+        raise AssertionError("git/gh must not be touched when no work target is declared")
+
+    monkeypatch.setattr(pg.subprocess, "run", _boom)
+    assert pg.resolve_pushed_work_diff() == ""
+    assert pg.resolve_pushed_work_diff(work_ref="", pr_id="", parent_dispatch="") == ""
+
+
+def test_resolve_work_ref_takes_precedence_over_pr_id_and_parent(monkeypatch):
+    # work_ref is the sharpest signal — it must win over pr_id/parent_dispatch, and pr_id (which
+    # would shell out to gh) must NOT be consulted when work_ref is present.
+    seen_fetch = []
+
+    def _fake_run(cmd, *a, **k):
+        if cmd[:2] == ["git", "fetch"]:
+            seen_fetch.append(cmd[2:])
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(pg.subprocess, "run", _fake_run)
+    monkeypatch.setattr(pg, "compute_branch_diff", lambda *a, **k: "diff --git a/x b/x\n+via-work-ref\n")
+    monkeypatch.setattr(pg, "resolve_pr_head_branch",
+                        lambda *a, **k: pytest.fail("pr_id must not be resolved when work_ref is set"))
+
+    result = pg.resolve_pushed_work_diff(
+        work_ref="origin/dispatch/explicit", pr_id="1161", parent_dispatch="parent-001",
+        repo=Path("/nonexistent"),
+    )
+    assert result == "diff --git a/x b/x\n+via-work-ref\n"
+    # fetch targeted the NORMALIZED branch, not the raw prefixed name
+    assert seen_fetch and seen_fetch[0] == ["origin", "dispatch/explicit"]
+
+
+def test_resolve_parent_dispatch_derives_branch_when_no_work_ref_or_pr(monkeypatch):
+    seen_fetch = []
+
+    def _fake_run(cmd, *a, **k):
+        if cmd[:2] == ["git", "fetch"]:
+            seen_fetch.append(cmd[2:])
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(pg.subprocess, "run", _fake_run)
+    monkeypatch.setattr(pg, "compute_branch_diff", lambda *a, **k: "diff --git a/y b/y\n+via-parent\n")
+
+    result = pg.resolve_pushed_work_diff(parent_dispatch="20260815/foo bar", repo=Path("/nonexistent"))
+    assert result == "diff --git a/y b/y\n+via-parent\n"
+    # parent_dispatch is sanitized into the branch name (unsafe chars become '-')
+    assert seen_fetch and seen_fetch[0] == ["origin", "dispatch/20260815-foo-bar"]
+
+
+def test_resolve_pr_id_falls_through_when_no_work_ref(monkeypatch):
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(0, ""))
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: "dispatch/pr-branch")
+    monkeypatch.setattr(pg, "compute_branch_diff", lambda *a, **k: "diff --git a/z b/z\n+via-pr\n")
+
+    result = pg.resolve_pushed_work_diff(pr_id="1161", repo=Path("/nonexistent"))
+    assert result == "diff --git a/z b/z\n+via-pr\n"
+
+
+def test_resolve_fetch_or_diff_failure_returns_empty_never_raises(monkeypatch):
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(128, "git", stderr="fatal: bad ref")
+
+    monkeypatch.setattr(pg.subprocess, "run", _raise)
+    # compute_branch_diff raises CalledProcessError -> caught -> '' (no false-reject, no raise)
+    assert pg.resolve_pushed_work_diff(work_ref="dispatch/gone", repo=Path("/nonexistent")) == ""
+
+
+def test_resolve_branch_not_pushed_fetch_nonzero_still_empty(monkeypatch):
+    # fetch returns nonzero (branch not pushed) — compute_branch_diff then raises on the missing
+    # ref; either way the result is '', never a fabricated diff.
+    def _fetch_nonzero(cmd, *a, **k):
+        if cmd[:2] == ["git", "fetch"]:
+            return _FakeProc(1, "")
+        raise subprocess.CalledProcessError(128, "git", stderr="fatal: bad ref")
+
+    monkeypatch.setattr(pg.subprocess, "run", _fetch_nonzero)
+    assert pg.resolve_pushed_work_diff(work_ref="dispatch/never-pushed", repo=Path("/nonexistent")) == ""
+
+
+# ---------------------------------------------------------------------------
+# guard_at_govern — the fallback only upgrades empty->non-empty, never weakens
+# ---------------------------------------------------------------------------
+
+
+def test_guard_empty_own_diff_upgrades_via_work_ref_not_phantom(monkeypatch):
+    # A fix-forward dispatch: own diff empty, pushed branch carries real work -> PASSES.
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(0, ""))
+    monkeypatch.setattr(pg, "compute_branch_diff",
+                        lambda *a, **k: "diff --git a/fix.txt b/fix.txt\n+real fix\n")
+
+    v = pg.guard_at_govern(dispatch_id="fixfwd-d1", role="backend-developer", status="done",
+                           token_usage=0, worktree_diff="", work_ref="dispatch/real-branch",
+                           repo=Path("/nonexistent"))
+    assert not v.is_phantom
+
+
+def test_guard_empty_own_diff_no_pushed_work_still_phantom(monkeypatch):
+    # Same shape but the pushed branch carries NOTHING -> still phantom. This is the guard-preservation
+    # invariant: an empty resolve must not upgrade the diff.
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(0, ""))
+    monkeypatch.setattr(pg, "compute_branch_diff", lambda *a, **k: "")
+
+    v = pg.guard_at_govern(dispatch_id="fixfwd-d2", role="backend-developer", status="done",
+                           token_usage=0, worktree_diff="", work_ref="dispatch/empty-branch",
+                           repo=Path("/nonexistent"))
+    assert v.is_phantom
+
+
+def test_guard_non_empty_own_diff_never_triggers_resolution(monkeypatch):
+    # A normal dispatch with real own-worktree work must NOT call resolve_pushed_work_diff at all.
+    def _boom(*a, **k):
+        raise AssertionError("resolve_pushed_work_diff must not be called when own diff is non-empty")
+
+    monkeypatch.setattr(pg, "resolve_pushed_work_diff", _boom)
+    v = pg.guard_at_govern(dispatch_id="normal-d1", role="backend-developer", status="done",
+                           token_usage=10, worktree_diff="diff --git a/x b/x\n+own work\n",
+                           work_ref="dispatch/some-branch", repo=Path("/nonexistent"))
+    assert not v.is_phantom
+
+
+def test_guard_unresolvable_own_ref_falls_back_to_pushed_work(monkeypatch):
+    # Own branch/worktree is gone (the fix-forward shape at govern time) -> the pushed branch is
+    # weighed in before abstaining. Real pushed work -> PASSES.
+    def _fake_diff(head_ref, *a, **k):
+        if head_ref.startswith("dispatch/"):
+            raise subprocess.CalledProcessError(128, "git", stderr="fatal: own branch gone")
+        return "diff --git a/fix.txt b/fix.txt\n+pushed work\n"
+
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(0, ""))
+    monkeypatch.setattr(pg, "compute_branch_diff", _fake_diff)
+
+    v = pg.guard_at_govern(dispatch_id="no-such-dispatch-xyz", role="backend-developer",
+                           status="done", token_usage=0, work_ref="dispatch/pushed-branch",
+                           repo=Path("/nonexistent"))
+    assert not v.is_phantom
+
+
+def test_guard_unresolvable_own_ref_no_pushed_work_still_abstains(monkeypatch):
+    # Own branch gone AND the pushed branch carries nothing -> ABSTAIN (never false-reject as
+    # "empty diff" on a torn-down ref).
+    def _fake_diff(head_ref, *a, **k):
+        if head_ref.startswith("dispatch/"):
+            raise subprocess.CalledProcessError(128, "git", stderr="fatal: own branch gone")
+        return ""
+
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(0, ""))
+    monkeypatch.setattr(pg, "compute_branch_diff", _fake_diff)
+
+    v = pg.guard_at_govern(dispatch_id="no-such-dispatch-xyz", role="backend-developer",
+                           status="done", token_usage=0, work_ref="dispatch/missing-branch",
+                           repo=Path("/nonexistent"))
+    assert not v.is_phantom
+    assert "ABSTAIN" in v.reason


### PR DESCRIPTION
## Summary

Two dispatch fixes, both in the merge/governance chokepoints.

**OI-1137 (phantom-guard false-reject on fix-forward).** A fix-forward dispatch commits onto an EXISTING branch and pushes there, so its own fresh worktree reads empty while work really landed. The phantom-guard rejected that as a phantom. Now a dispatch that declares a work target (`work_ref` / `pr_id` / `parent_dispatch`) has the PUSHED branch diff weighed in when the own diff is empty.

**OI-1091 (file-scope overlap).** Nothing prevented two concurrent dispatches from claiming the same files; three dispatches collided in one worktree and a sibling reset another's branch pointer (OI-1232). Add overlap detection at the merge chokepoint that WARNS, never blocks.

## Changes

### OI-1137
- `phantom_guard.py`: new `resolve_pushed_work_diff` (precedence work_ref > pr_id > parent_dispatch-derived branch, fetch + diff against the dispatch's own base ref). Threaded through `guard_at_govern` + `record_phantom_if_any`.
- New `work_ref` field threaded end-to-end: `DispatchSpec` (Rule 15 git-ref validation) -> `load_spec` -> `ExecutionPlan` (advisory, not in digest) -> `EnvelopeSpec` -> every envelope constructor -> tmux govern + pre-govern hook via `VNX_WORK_REF`/`VNX_PR_ID` env fallback.
- `envelope_govern_support._resolve_fix_forward_diff` now delegates to the shared resolver.
- `provider_dispatch.py` unified-envelope paths accept `--work-ref`.

The fallback is strictly monotonic: it only ever upgrades an empty diff to non-empty when real pushed work exists. It never downgrades, never fires for a plain dispatch, and returns '' on any failure. The guard's core function (reject an evidence-free success receipt) is unchanged.

### OI-1091
- `file_scope_overlap.py` (new): enumerates open (unmerged) remote `dispatch/*` branches, computes each branch's changed files against the base ref, intersects with the merging branch. Warning names the other dispatch + lists the shared files.
- `pr_merge.py::merge_pr()` surfaces the warning on stderr and in its result payload (`overlaps`). Best-effort; a git/network failure degrades to no warning.

## Verification

- New `tests/test_phantom_guard_work_ref.py` (18 tests): resolver precedence, monotonicity, failure-is-empty, guard upgrade/abstain paths.
- `tests/test_dispatch_spec.py`: Rule 15 work_ref validation cases.
- New `tests/test_file_scope_overlap.py` (20 tests): branch-name handling + real-git fixture proving fetch/merge-base/diff plumbing + merge_pr wiring (surfaces overlap, never blocks).
- Existing phantom-guard/fix-forward/tmux/govern/envelope/pr_merge suites stay green.

## Open Items

None.