### PR TITLE
feat(planning): add `vnx deliverable close` to afboeken ready deliverables (OI-1151)

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -9,9 +9,12 @@ Delegated from `bin/vnx`:
   vnx deliverable add --objective <track_id> --output-kind <kind> --title "..."
   vnx deliverable list [--objective <track_id>] [--json]
   vnx deliverable promote <dispatch_id>
+  vnx deliverable close <dispatch_id> --evidence <pr>
 
 NO-NODE model: a deliverable is a proposed dispatch row with output_kind.
 `vnx deliverable promote` is the human gate (proposed -> ready).
+`vnx deliverable close` closes the loop (ready -> completed) on an
+operator-attested delivering PR.
 `vnx promote` (top-level) is the PR-queue command — NOT the same.
 
 Planning turn-on (auto-seed + advisory drift):
@@ -1720,11 +1723,13 @@ def _append_coordination_event(
     actor: str,
     reason: Optional[str] = None,
     project_id: str = "vnx-dev",
+    metadata: Optional[dict] = None,
 ) -> None:
     if not _has_table(conn, "coordination_events"):
         return
     event_id = str(uuid.uuid4()).replace("-", "")[:16]
     ts = _now_utc()
+    metadata_json = json.dumps(metadata or {}, default=str)
     has_pid = _has_col(conn, "coordination_events", "project_id")
     if has_pid:
         conn.execute(
@@ -1732,10 +1737,10 @@ def _append_coordination_event(
             INSERT INTO coordination_events
                 (event_id, event_type, entity_type, entity_id,
                  from_state, to_state, actor, reason, metadata_json, occurred_at, project_id)
-            VALUES (?, ?, 'dispatch', ?, ?, ?, ?, ?, '{}', ?, ?)
+            VALUES (?, ?, 'dispatch', ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (event_id, event_type, dispatch_id,
-             from_state, to_state, actor, reason, ts, project_id),
+             from_state, to_state, actor, reason, metadata_json, ts, project_id),
         )
     else:
         conn.execute(
@@ -1743,10 +1748,10 @@ def _append_coordination_event(
             INSERT INTO coordination_events
                 (event_id, event_type, entity_type, entity_id,
                  from_state, to_state, actor, reason, metadata_json, occurred_at)
-            VALUES (?, ?, 'dispatch', ?, ?, ?, ?, ?, '{}', ?)
+            VALUES (?, ?, 'dispatch', ?, ?, ?, ?, ?, ?, ?)
             """,
             (event_id, event_type, dispatch_id,
-             from_state, to_state, actor, reason, ts),
+             from_state, to_state, actor, reason, metadata_json, ts),
         )
 
 
@@ -2325,6 +2330,141 @@ def cmd_deliverable_promote(args: argparse.Namespace) -> int:
         conn.close()
 
     print(f"Promoted {dispatch_id}: proposed -> ready")
+    return 0
+
+
+def cmd_deliverable_close(args: argparse.Namespace) -> int:
+    """Close (afboeken) a deliverable: ready -> completed, operator-attested.
+
+    The missing half of the deliverable lifecycle: ``promote`` gates
+    proposed -> ready, but nothing moves a ready deliverable to a terminal
+    state once its work lands via a burn-PR. Ready deliverables would otherwise
+    stay ready forever. This verb closes that loop.
+
+    Human-gated by construction: ``--evidence <pr>`` is REQUIRED (a PR number,
+    not a bare flag) and must normalize via ``_normalize_pr_ref`` to ``#NNN``.
+    The evidence is an OPERATOR ATTESTATION: VNX records it structurally (who,
+    when, what) but does NOT verify the PR's merge state at close time. That is
+    deliberate. The deliverable plane is the lightweight NO-NODE model — a
+    single dispatch row, not a track with a reconciler — so there is no merge
+    evidence gather to reuse, and bolting live ``gh`` verification onto it would
+    make close fail whenever gh is unreachable (the exact degradation the
+    objective-close path already struggles with). The operator signed at
+    promote; the operator signs again here, and the attestation is named as
+    such in the audit event so it is never mistaken for a verified merge.
+
+    ADR-007: the lookup AND the audit event both carry the resolved project_id.
+    No silent 'vnx-dev' fallback — an empty project_id is refused with exit 2.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = (args.project_id or "").strip()
+    dispatch_id = args.dispatch_id
+
+    if not project_id:
+        print(
+            "deliverable close: --project-id is required (ADR-007): no project_id "
+            "was supplied and none could be resolved. No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    raw_evidence = getattr(args, "evidence", None)
+    pr_ref = _normalize_pr_ref(raw_evidence) if raw_evidence else None
+    if pr_ref is None:
+        print(
+            "deliverable close: --evidence <pr> is REQUIRED (the delivering PR, "
+            "as #NNN or NNN). It records an operator attestation of what delivered "
+            "the work — not just a bare flag. No change made.",
+            file=sys.stderr,
+        )
+        return 2
+    evidence_number = int(pr_ref.lstrip("#"))
+
+    conn = _db_conn(state_dir)
+    try:
+        row = conn.execute(
+            "SELECT * FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+            (dispatch_id, project_id),
+        ).fetchone()
+
+        if row is None:
+            print(
+                f"deliverable close: deliverable not found: {dispatch_id!r} "
+                f"(project {project_id!r}). No change made.",
+                file=sys.stderr,
+            )
+            return 1
+
+        current_state = row["state"]
+
+        if current_state == "completed":
+            if args.json:
+                print(json.dumps({
+                    "deliverable": dispatch_id,
+                    "project_id": project_id,
+                    "action": "noop_already_closed",
+                    "applied": False,
+                }, indent=2, default=str))
+            else:
+                print(f"\nvnx deliverable close — {dispatch_id} (project '{project_id}')\n")
+                print(f"  already closed (state={current_state}).\n")
+            return 0
+
+        if current_state != "ready":
+            hint = (
+                "Promote it first with `vnx deliverable promote "
+                f"{dispatch_id}`." if current_state == "proposed" else ""
+            )
+            print(
+                f"deliverable close: cannot close {dispatch_id!r}: expected state "
+                f"'ready', found {current_state!r}. {hint}No change made.".strip(),
+                file=sys.stderr,
+            )
+            return 2
+
+        now = _now_utc()
+        conn.execute(
+            """
+            UPDATE dispatches
+            SET state = 'completed', pr_ref = ?, updated_at = ?
+            WHERE dispatch_id = ? AND project_id = ? AND state = 'ready'
+            """,
+            (pr_ref, now, dispatch_id, project_id),
+        )
+        _append_coordination_event(
+            conn,
+            event_type="deliverable_completed",
+            dispatch_id=dispatch_id,
+            from_state="ready",
+            to_state="completed",
+            actor="operator",
+            reason=f"deliverable close: PR {pr_ref} (operator attestation)",
+            project_id=project_id,
+            metadata={
+                "evidence_pr": evidence_number,
+                "pr_ref": pr_ref,
+                "attestation": "operator",
+            },
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps({
+            "deliverable": dispatch_id,
+            "project_id": project_id,
+            "from_state": "ready",
+            "to_state": "completed",
+            "evidence_pr": evidence_number,
+            "pr_ref": pr_ref,
+            "attestation": "operator",
+            "action": "closed",
+            "applied": True,
+        }, indent=2, default=str))
+    else:
+        print(f"\nvnx deliverable close — {dispatch_id} (project '{project_id}')\n")
+        print(f"  ready -> completed (operator attestation: PR {pr_ref})\n")
     return 0
 
 
@@ -4268,6 +4408,21 @@ def _build_parser() -> argparse.ArgumentParser:
     _common(p_dpromote)
     p_dpromote.add_argument("dispatch_id")
     p_dpromote.set_defaults(func=cmd_deliverable_promote)
+
+    p_dclose = dlv_sub.add_parser(
+        "close",
+        help="afboeken (done): close a ready deliverable -> completed "
+             "(operator-attested PR evidence)",
+    )
+    _common(p_dclose)
+    p_dclose.add_argument("dispatch_id")
+    p_dclose.add_argument(
+        "--evidence", required=True, metavar="PR",
+        help="delivering PR as #NNN or NNN (REQUIRED). Records an operator "
+             "attestation of what delivered the work; VNX does not verify the "
+             "merge state at close time.",
+    )
+    p_dclose.set_defaults(func=cmd_deliverable_close)
 
     # ------------------------------------------------------------------
     # plan-gate subcommand (PM plan-first gate)

--- a/tests/test_deliverable_close.py
+++ b/tests/test_deliverable_close.py
@@ -1,0 +1,378 @@
+"""tests/test_deliverable_close.py — `vnx deliverable close` (OI-1151).
+
+The missing half of the deliverable lifecycle: `promote` gates
+proposed -> ready, but nothing moved a ready deliverable to a terminal state
+once its work landed via a burn-PR. This suite verifies the afboeken verb:
+
+- close WITH evidence succeeds: ready -> completed, pr_ref stamped, and the
+  audit event (who/when/what) is readable back from disk
+- close WITHOUT evidence fails (argparse required + invalid-value guard)
+- close on an UNKNOWN deliverable id fails loud (exit 1), nothing written
+- the state of a NOT-closed deliverable is left untouched when another closes
+- a proposed deliverable (not yet promoted) refuses close with a hint
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import planning_cli  # noqa: E402
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
+PROJECT_ID = "test-proj"
+
+
+def _build_db(tmp_path: Path) -> Path:
+    """Return a state_dir with migrations 0022 + 0024 + 0027 applied."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch',
+            entity_id TEXT NOT NULL,
+            from_state TEXT,
+            to_state TEXT,
+            actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+
+    for ver, fname in (
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    ensure_dispatches_columns(conn)
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    schema_migration.apply_script_if_below(
+        conn,
+        27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+@pytest.fixture()
+def state_with_track(tmp_path: Path) -> tuple[Path, str]:
+    state_dir = _build_db(tmp_path)
+    track_id = "feat-alpha"
+    tracks_lib.create_track(
+        state_dir,
+        track_id,
+        PROJECT_ID,
+        title="Feature Alpha",
+        goal_state="ship Feature Alpha",
+        phase="queued",
+        horizon="now",
+    )
+    return state_dir, track_id
+
+
+def _dispatch_ids(state_dir: Path, state: str) -> list[str]:
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    rows = conn.execute(
+        "SELECT dispatch_id FROM dispatches WHERE project_id = ? AND state = ? ORDER BY id",
+        (PROJECT_ID, state),
+    ).fetchall()
+    conn.close()
+    return [r[0] for r in rows]
+
+
+def _dispatch_row(state_dir: Path, dispatch_id: str) -> dict:
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+        (dispatch_id, PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else {}
+
+
+def _close_events(state_dir: Path, dispatch_id: str) -> list[dict]:
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM coordination_events WHERE entity_id = ? "
+        "AND event_type = 'deliverable_completed' ORDER BY id",
+        (dispatch_id,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def _add_and_promote(state_dir: Path, track_id: str, title: str) -> str:
+    """Add a deliverable and promote it to ready; return its dispatch_id."""
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", title,
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+    rc = planning_cli.main([
+        "deliverable", "promote", dispatch_id,
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    return dispatch_id
+
+
+# ---------------------------------------------------------------------------
+# close with evidence
+# ---------------------------------------------------------------------------
+
+def test_close_with_evidence_succeeds_and_readable_from_disk(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    dispatch_id = _add_and_promote(state_dir, track_id, "Q3 launch post")
+
+    rc = planning_cli.main([
+        "deliverable", "close", dispatch_id,
+        "--evidence", "123",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ready -> completed" in out
+    assert "#123" in out
+
+    # The deliverable row itself is the source of truth: completed + pr_ref.
+    row = _dispatch_row(state_dir, dispatch_id)
+    assert row["state"] == "completed"
+    assert row["pr_ref"] == "#123"
+
+    # The audit event (who/when/what) is readable back from disk.
+    events = _close_events(state_dir, dispatch_id)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["event_type"] == "deliverable_completed"
+    assert ev["from_state"] == "ready"
+    assert ev["to_state"] == "completed"
+    assert ev["actor"] == "operator"
+    assert ev["project_id"] == PROJECT_ID
+    assert ev["occurred_at"]
+    meta = json.loads(ev["metadata_json"])
+    assert meta["evidence_pr"] == 123
+    assert meta["pr_ref"] == "#123"
+    assert meta["attestation"] == "operator"
+
+    # The deliverables VIEW now derives 'done' for this deliverable.
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    derived = conn.execute(
+        "SELECT derived_status FROM deliverables "
+        "WHERE project_id = ? AND deliverable_ref = ?",
+        (PROJECT_ID, f"post:{dispatch_id}"),
+    ).fetchone()
+    conn.close()
+    assert derived is not None and derived[0] == "done"
+
+
+def test_close_is_idempotent_on_already_completed(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    dispatch_id = _add_and_promote(state_dir, track_id, "Close me twice")
+    for _ in range(2):
+        rc = planning_cli.main([
+            "deliverable", "close", dispatch_id,
+            "--evidence", "42",
+            "--project-id", PROJECT_ID,
+            "--state-dir", str(state_dir),
+        ])
+        assert rc == 0
+        capsys.readouterr()
+    # A single audit event: the second close was a no-op, not a second write.
+    assert len(_close_events(state_dir, dispatch_id)) == 1
+
+
+# ---------------------------------------------------------------------------
+# evidence required
+# ---------------------------------------------------------------------------
+
+def test_close_without_evidence_fails(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    dispatch_id = _add_and_promote(state_dir, track_id, "No evidence")
+
+    with pytest.raises(SystemExit) as exc:
+        planning_cli.main([
+            "deliverable", "close", dispatch_id,
+            "--project-id", PROJECT_ID,
+            "--state-dir", str(state_dir),
+        ])
+    assert exc.value.code == 2  # argparse: --evidence is required
+    capsys.readouterr()
+    assert _dispatch_row(state_dir, dispatch_id)["state"] == "ready"
+    assert _close_events(state_dir, dispatch_id) == []
+
+
+def test_close_with_invalid_evidence_fails(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    dispatch_id = _add_and_promote(state_dir, track_id, "Bad evidence")
+
+    rc = planning_cli.main([
+        "deliverable", "close", dispatch_id,
+        "--evidence", "not-a-pr",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--evidence <pr> is REQUIRED" in err
+    assert _dispatch_row(state_dir, dispatch_id)["state"] == "ready"
+    assert _close_events(state_dir, dispatch_id) == []
+
+
+# ---------------------------------------------------------------------------
+# unknown id / wrong state
+# ---------------------------------------------------------------------------
+
+def test_close_unknown_deliverable_fails_loud(state_with_track: tuple[Path, str], capsys):
+    state_dir, _ = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "close", "no-such-deliverable",
+        "--evidence", "123",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err
+
+
+def test_close_proposed_deliverable_refused(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "doc",
+        "--title", "Still proposed",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    capsys.readouterr()
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+
+    rc = planning_cli.main([
+        "deliverable", "close", dispatch_id,
+        "--evidence", "7",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "expected state 'ready'" in err
+    assert "promote" in err
+    assert _dispatch_row(state_dir, dispatch_id)["state"] == "proposed"
+
+
+# ---------------------------------------------------------------------------
+# untouched sibling
+# ---------------------------------------------------------------------------
+
+def test_close_leaves_other_deliverable_untouched(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    closed = _add_and_promote(state_dir, track_id, "Closed one")
+    untouched = _add_and_promote(state_dir, track_id, "Untouched one")
+
+    rc = planning_cli.main([
+        "deliverable", "close", closed,
+        "--evidence", "99",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    capsys.readouterr()
+
+    assert _dispatch_row(state_dir, closed)["state"] == "completed"
+    # The NOT-closed deliverable keeps its status and pr_ref untouched.
+    untouched_row = _dispatch_row(state_dir, untouched)
+    assert untouched_row["state"] == "ready"
+    assert untouched_row["pr_ref"] is None
+    assert _close_events(state_dir, untouched) == []
+
+
+# ---------------------------------------------------------------------------
+# project_id scoping (ADR-007)
+# ---------------------------------------------------------------------------
+
+def test_close_scoped_by_project_id(state_with_track: tuple[Path, str], capsys):
+    """A deliverable id that exists in ANOTHER project is not found here."""
+    state_dir, track_id = state_with_track
+    dispatch_id = _add_and_promote(state_dir, track_id, "Other project's")
+
+    rc = planning_cli.main([
+        "deliverable", "close", dispatch_id,
+        "--evidence", "5",
+        "--project-id", "some-other-project",
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err
+    # The deliverable under its real project_id is untouched.
+    assert _dispatch_row(state_dir, dispatch_id)["state"] == "ready"

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -326,6 +326,7 @@ _DELIVERABLE_ARGV = {
     "add": ["--objective", "delegate-track", "--output-kind", "doc", "--title", "Delegate deliverable"],
     "list": [],
     "promote": ["dlv-fake-id"],
+    "close": ["dlv-fake-id", "--evidence", "123"],
 }
 _PLAN_GATE_ARGV = {
     "seed": ["delegate-track"],

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -240,10 +240,17 @@ def _cmd_deliverable_promote(args: Any) -> int:
     return pc.cmd_deliverable_promote(args)
 
 
+def _cmd_deliverable_close(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_deliverable_close(args)
+
+
 _DELIVERABLE_DISPATCH: dict[str, Callable[[Any], int]] = {
     "add": _cmd_deliverable_add,
     "list": _cmd_deliverable_list,
     "promote": _cmd_deliverable_promote,
+    "close": _cmd_deliverable_close,
 }
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -749,6 +749,20 @@ def _register_deliverable_verbs(subs: argparse.Action) -> None:
     _common_horizon_args(p_dpromote)
     p_dpromote.add_argument("dispatch_id")
 
+    p_dclose = subs.add_parser(
+        "close",
+        help="afboeken (done): close a ready deliverable -> completed "
+             "(operator-attested PR evidence)",
+    )
+    _common_horizon_args(p_dclose)
+    p_dclose.add_argument("dispatch_id")
+    p_dclose.add_argument(
+        "--evidence", required=True, metavar="PR",
+        help="delivering PR as #NNN or NNN (REQUIRED). Records an operator "
+             "attestation of what delivered the work; VNX does not verify the "
+             "merge state at close time.",
+    )
+
 
 def _register_plan_gate_verbs(subs: argparse.Action) -> None:
     """Register the plan-gate-domain verbs under `vnx horizon plan-gate`."""


### PR DESCRIPTION
## What

A deliverable promoted to `ready` had no verb to move it to a terminal state once its work landed via a burn-PR. Ready deliverables stayed ready forever. This adds the missing half of the lifecycle.

## Changes

- `vnx deliverable close <id> --evidence <pr>` — transitions `ready -> completed` (the `deliverables` VIEW then derives `done`).
- `--evidence` is REQUIRED (a PR number, normalized to `#NNN`), not a bare flag.
- Writes a `deliverable_completed` audit event with actor, `occurred_at`, and structured evidence (`evidence_pr`, `pr_ref`, `attestation=operator`); also stamps `dispatches.pr_ref`.
- Unknown id refuses loudly (exit 1); `proposed` refuses with a promote-first hint (exit 2); already-completed is an idempotent no-op.
- ADR-007: lookup and audit event both carry the resolved `project_id`; empty project_id is refused (exit 2), never a silent `vnx-dev`.

## Evidence verification decision

The `--evidence` PR is an **operator attestation**, not a gh-verified merge. The deliverable plane is the lightweight NO-NODE model (a single dispatch row, no reconciler), so there is no merge-evidence gather to reuse, and bolting live `gh` verification on would make close fail whenever gh is unreachable. The operator signed at `promote`; they sign again here, and the audit event names it `attestation: operator` so it is never mistaken for a verified merge.

## Verification

- `tests/test_deliverable_close.py` — 8 passed (new)
- `tests/test_planning_deliverables.py` — 9 passed
- `tests/test_objective_close.py` — 15 passed
- `tests/test_horizon_parity.py` — 105 passed (added `close` to `_DELIVERABLE_ARGV`)
- `tests/test_horizon_cli.py` — 26 passed
- `tests/test_planning_cli.py` — 51 passed

214 passed total. (`test_planning_cli_objective.py` has 2 pre-existing failures on HEAD unrelated to this change — verified via stash.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)