### PR TITLE
fix(governance): derive synthesized receipt status from declared outcome

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -173,6 +174,7 @@ def ensure_receipt(
     report_path: Optional[Path],
     contract_status: str,
     permission_enforcement: str,
+    status: Optional[str] = None,
 ) -> None:
     """Append a lane-synthesized completion receipt when the worker never emitted one.
 
@@ -207,6 +209,20 @@ def ensure_receipt(
     # caller does not compute it, in which case these three fields stay
     # omitted exactly as before this change.
     _posture = spec.permission_posture or {}
+    # OI-1202: the lane-synthesized fallback receipt is NOT always a failure.
+    # When govern found a valid worker-authored report (contract_status="authored")
+    # the dispatch demonstrably produced a complete deliverable, and stamping the
+    # only receipt in the ledger with status="failed" silently pollutes every
+    # failure-percentage count with a false failure. The caller (govern) passes an
+    # explicit `status` derived from the report's DECLARED outcome; when it does
+    # not (direct callers / the error handler), fall back to the contract-status
+    # derivation: authored -> done, anything else -> failed (no valid report = no
+    # evidence of completion). The source marker stays
+    # "tmux_interactive_lane_synthesized" and synthesized=True, so a real worker
+    # receipt that lands later still wins on readback.
+    if status is None:
+        status = "done" if contract_status == "authored" else "failed"
+
     # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the spec carries
     # the fields when the door threaded them; otherwise the door's env vars the
     # tmux pane inherited (the worker-authored receipt path reads the same env in
@@ -219,6 +235,7 @@ def ensure_receipt(
         lane=lane,
         failure_reason=raw.failure_reason,
         contract_status=contract_status,
+        status=status,
         permission_enforcement=permission_enforcement,
         role=_resolve_govern_role(spec),
         parent_dispatch=(
@@ -360,6 +377,42 @@ def _split_yaml_frontmatter(text: str) -> "tuple[dict, str]":
         return fm, body
     except Exception:  # noqa: BLE001
         return {}, text
+
+
+# OI-1202: terminal-failure statuses a worker report can DECLARE (bold
+# ``**Status**: value`` in the body, or a ``status`` key in YAML frontmatter).
+# Mirrors report_to_receipt_converter's ``_TERMINAL_FAILURE_STATUSES`` plus the
+# other failure-shaped literals, so a 4-heading report that declares failure
+# (e.g. worker_heartbeat's heartbeat_killed / worker_process_gone reports) is
+# never re-labeled "done" by the lane-synthesized fallback.
+_DECLARED_FAILURE_STATUSES = frozenset({
+    "failed", "failure", "heartbeat_killed", "error", "blocked", "timeout",
+    "contract_invalid",
+})
+
+# Bold-field shape the worker_heartbeat failure reports use ("**Status**: failed").
+_STATUS_BOLD_RE = re.compile(r"\*\*Status\*\*\s*:\s*([^\n]+)", re.IGNORECASE)
+
+
+def _report_declares_failure(body: str) -> bool:
+    """True when a report body explicitly declares a terminal failure status.
+
+    Source order mirrors report_to_receipt_converter.build_receipt_from_report:
+    a ``status`` key in YAML frontmatter wins, then a bold ``**Status**:``
+    field in the body prose. Only an EXPLICIT failure literal counts — an
+    absent or unknown status is not evidence of failure (OI-1202).
+    """
+    fm, body_text = _split_yaml_frontmatter(body)
+    status: Optional[str] = None
+    if isinstance(fm, dict):
+        raw = fm.get("status")
+        if raw:
+            status = str(raw).strip()
+    if not status:
+        m = _STATUS_BOLD_RE.search(body_text[:3000])
+        if m:
+            status = m.group(1).strip()
+    return bool(status) and status.lower() in _DECLARED_FAILURE_STATUSES
 
 
 def govern(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome:
@@ -591,6 +644,18 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
 
     permission_enforcement = "strict" if enforce else "soft"
 
+    # OI-1202: the lane-synthesized fallback status reflects the worker's
+    # DECLARED outcome, not just the presence of a 4-heading report. A report
+    # that passes the body contract but declares failure (heartbeat_killed,
+    # worker_process_gone, or an explicit "failed" status) must stay "failed";
+    # only an authored report with no declared failure is "done". Non-authored
+    # (synthesized/violated) = no valid report = no evidence of completion.
+    receipt_status = (
+        "failed"
+        if (contract_status != "authored" or _report_declares_failure(body))
+        else "done"
+    )
+
     # -- d. Emit report with final body ---------------------------------------
     # authored: force-write with frontmatter so ALL reports are schema-uniform.
     #   The worker body is preserved; the frontmatter block is prepended.
@@ -699,6 +764,7 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
             report_path=None,
             contract_status=contract_status,
             permission_enforcement=permission_enforcement,
+            status=receipt_status,
         )
         return GovernedOutcome(
             report_path=None,
@@ -713,6 +779,7 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
         report_path=report_path,
         contract_status=contract_status,
         permission_enforcement=permission_enforcement,
+        status=receipt_status,
     )
 
     return GovernedOutcome(

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -288,6 +288,11 @@ class SynthesizedLaneReceipt:
     role: Optional[str] = None
     receipt_kind: str = "dispatch"
     event_type: str = "subprocess_completion"
+    # Default "failed" preserves the pre-PR-B0 byte-identical shape (and the
+    # honest no-evidence outcome). The caller (dispatch_govern.ensure_receipt)
+    # derives the real status from the worker's DECLARED outcome: "done" for an
+    # authored report that does not declare failure, "failed" otherwise — for a
+    # declared-failure report or when no valid report exists (OI-1202).
     status: str = "failed"
     source: str = "tmux_interactive_lane_synthesized"
     synthesized: bool = True

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -24,6 +24,7 @@ from dispatch_govern import (
     ensure_receipt,
     govern,
     _split_yaml_frontmatter,
+    _report_declares_failure,
     _synthesize,
     _git_changes,
     _git_summary,
@@ -593,6 +594,20 @@ def test_govern_body_override_passed_to_emit(tmp_data, tmp_state, monkeypatch):
 # _synthesize() — direct unit tests
 # ---------------------------------------------------------------------------
 
+def test_report_declares_failure_detects_body_and_frontmatter():
+    """_report_declares_failure: explicit failure literals (bold body field or
+    frontmatter status) count; absent/unknown/success statuses do not."""
+    body_failure = "**Status**: failed\n**Failure-Reason**: heartbeat_killed\n" + _valid_body()
+    assert _report_declares_failure(body_failure) is True
+
+    fm_failure = "---\nstatus: failure\n---\n" + _valid_body()
+    assert _report_declares_failure(fm_failure) is True
+
+    assert _report_declares_failure(_valid_body()) is False  # no status field
+    assert _report_declares_failure("**Status**: done\n" + _valid_body()) is False
+    assert _report_declares_failure("**Status**: unknown\n" + _valid_body()) is False
+
+
 def test_synthesize_contains_all_required_sections(tmp_data, tmp_state):
     spec = _make_spec(tmp_data, tmp_state)
     raw = _make_raw()
@@ -1149,6 +1164,46 @@ def test_ensure_receipt_appended_when_no_worker_receipt(tmp_data, tmp_state):
     assert receipt["failure_reason"] == "tmux_receipt_deadline_exceeded"
 
 
+def test_ensure_receipt_authored_status_is_done(tmp_data, tmp_state):
+    """OI-1202: a successful tmux dispatch (valid worker report = contract_status
+    "authored") must NOT leave a 'failed' receipt in the ledger. The fallback
+    receipt derives status="done" from the authored evidence, so failure counts
+    are not polluted by a dispatch that demonstrably completed."""
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = GovernRaw(receipt=None, duration_seconds=60.0)
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+
+    ensure_receipt(spec, raw, lane="tmux_interactive", report_path=None,
+                   contract_status="authored", permission_enforcement="soft")
+
+    assert receipts_file.exists(), "ensure_receipt must create t0_receipts.ndjson"
+    receipt = json.loads(receipts_file.read_text().splitlines()[0])
+    assert receipt["status"] == "done", (
+        f"authored fallback receipt must carry status='done', got {receipt['status']!r}"
+    )
+    assert receipt["source"] == "tmux_interactive_lane_synthesized"
+    assert receipt["synthesized"] is True
+
+
+def test_ensure_receipt_synthesized_status_stays_failed(tmp_data, tmp_state):
+    """OI-1202: a genuinely failed dispatch (no valid report = contract_status
+    "synthesized") keeps status="failed" — the failure signal stays where it
+    belongs instead of being diluted into a neutral 'unknown'."""
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = GovernRaw(receipt=None, duration_seconds=60.0)
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+
+    ensure_receipt(spec, raw, lane="tmux_interactive", report_path=None,
+                   contract_status="synthesized", permission_enforcement="soft")
+
+    assert receipts_file.exists(), "ensure_receipt must create t0_receipts.ndjson"
+    receipt = json.loads(receipts_file.read_text().splitlines()[0])
+    assert receipt["status"] == "failed", (
+        f"synthesized fallback receipt must keep status='failed', got {receipt['status']!r}"
+    )
+    assert receipt["source"] == "tmux_interactive_lane_synthesized"
+
+
 def test_ensure_receipt_includes_report_path_when_provided(tmp_data, tmp_state):
     """Lane-synthesized receipt includes report_path when a report was emitted."""
     spec = _make_spec(tmp_data, tmp_state)
@@ -1388,6 +1443,64 @@ def test_govern_timeout_appends_synthesized_receipt(tmp_data, tmp_state, monkeyp
     assert len(synthesized) == 1, f"Expected exactly 1 lane-synthesized receipt, got {synthesized}"
     assert synthesized[0]["synthesized"] is True
     assert synthesized[0]["dispatch_id"] == spec.dispatch_id
+
+
+def test_govern_authored_report_no_receipt_status_done(tmp_data, tmp_state, monkeypatch):
+    """OI-1202: a successful tmux dispatch whose worker receipt never landed (but
+    whose valid 4-heading report did) must NOT leave a 'failed' receipt. The
+    lane-synthesized fallback derives status='done' from the authored report."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+    monkeypatch.setenv("VNX_RECEIPT_FALLBACK", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "test-govern-001.md").write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = GovernRaw(receipt=None, duration_seconds=3600.0)
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+
+    govern(spec, raw, lane="tmux_interactive")
+
+    assert receipts_file.exists(), "ensure_receipt must create t0_receipts.ndjson"
+    synthesized = [json.loads(l) for l in receipts_file.read_text().splitlines()
+                   if json.loads(l).get("source") == "tmux_interactive_lane_synthesized"]
+    assert len(synthesized) == 1
+    assert synthesized[0]["status"] == "done", (
+        f"authored fallback receipt must be 'done', got {synthesized[0]['status']!r}"
+    )
+
+
+def test_govern_authored_failure_report_no_receipt_status_failed(tmp_data, tmp_state, monkeypatch):
+    """OI-1202: a worker report that passes the 4-heading contract but DECLARES
+    failure (**Status**: failed, the heartbeat-kill shape) must stay 'failed' —
+    the fallback must not dress a declared failure as success."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+    monkeypatch.setenv("VNX_RECEIPT_FALLBACK", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    failed_body = (
+        "**Dispatch-ID**: test-govern-001\n"
+        "**Status**: failed\n"
+        "**Failure-Reason**: heartbeat_killed\n\n"
+        + _valid_body()
+    )
+    (reports_dir / "test-govern-001.md").write_text(failed_body, encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = GovernRaw(receipt=None, duration_seconds=3600.0)
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+
+    govern(spec, raw, lane="tmux_interactive")
+
+    assert receipts_file.exists(), "ensure_receipt must create t0_receipts.ndjson"
+    synthesized = [json.loads(l) for l in receipts_file.read_text().splitlines()
+                   if json.loads(l).get("source") == "tmux_interactive_lane_synthesized"]
+    assert len(synthesized) == 1
+    assert synthesized[0]["status"] == "failed", (
+        f"declared-failure fallback receipt must stay 'failed', got {synthesized[0]['status']!r}"
+    )
 
 
 def test_govern_normal_path_no_synthesized_receipt(tmp_data, tmp_state, monkeypatch):

--- a/tests/test_receipt_schema.py
+++ b/tests/test_receipt_schema.py
@@ -321,6 +321,20 @@ def test_synthesized_receipt_optional_fields_omitted_when_absent():
     assert "report_path" not in receipt
 
 
+def test_synthesized_receipt_status_is_passable():
+    """OI-1202: the caller derives status from contract_status (authored -> done)
+    and passes it explicitly. The field must serialize through, not be shadowed
+    by the "failed" default."""
+    kw = _synth_kwargs()
+    kw["contract_status"] = "authored"
+    kw["status"] = "done"
+    receipt = SynthesizedLaneReceipt(**kw).to_dict()
+    assert receipt["status"] == "done"
+    assert receipt["contract_status"] == "authored"
+    assert receipt["source"] == "tmux_interactive_lane_synthesized"
+    assert receipt["synthesized"] is True
+
+
 def test_synthesized_receipt_receipt_kind_closed_set_raises():
     kw = _synth_kwargs()
     kw["receipt_kind"] = "bogus"


### PR DESCRIPTION
## Wat

Een geslaagde tmux-dispatch bleef als `failed` in het grootboek staan. De lane-synthesized fallback receipt (`SynthesizedLaneReceipt`) had `status="failed"` hardgecodeerd, ook wanneer de worker netjes een 4-heading report had geschreven (`contract_status="authored"`).

## Meting

204 receipts in `t0_receipts.ndjson` staan op `failed` terwijl hun dispatch aantoonbaar iets opleverde: 165 report-only, 34 report+merged-PR, 5 merged-PR-only.

## Fix

De fallback status wordt nu afgeleid uit wat govern al heeft opgelost:

- authored report dat geen failure declareert -> `done`
- report dat wel failure declareert (heartbeat_killed / worker_process_gone / expliciet `Status: failed`) -> `failed`
- geen geldig report (synthesized/violated) -> `failed`

De source-marker (`tmux_interactive_lane_synthesized`) en `synthesized=True` blijven, zodat een echte worker receipt die later binnenkomt nog steeds wint bij dedup.

## Waarom geen neutrale "unknown" placeholder

`failed` is hier niet "nog niet bekend": op het moment dat de fallback afgaat heeft govern het report al opgelost en weten we of er bewijs van oplevering is. Een echte "nog niet bekend"-race wordt afgedekt door dedup (authored > synthesized). Stroomafwaarts stuurt `status` op: `receipt_verdict` (failed -> reject), `dispatch_outcome_classifier` (failed -> failed⟨reason⟩ in FPY). Een neutrale status zou zowel false-failures als false-successes kunnen introduceren; afleiden uit bewijs is preciezer.

## Rest

De 5 merged-PR-only gevallen (PR gemerged, geen report) blijven op `failed`; hun outcome wordt al door `dispatch_outcome_classifier` gecorrigeerd naar `merged-PR` (recompute heeft prioriteit). Dit is 2.5% en een apart correctiemechanisme.

Dispatch-ID: 20260815-nn-w23-tmux-placeholder-receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)