### PR TITLE
feat(reconcile): default-ON gh merge source so reconciler sees bare gh pr merge (OI-1155)

### DIFF
--- a/docs/core/STATE_FABRIC.md
+++ b/docs/core/STATE_FABRIC.md
@@ -59,8 +59,9 @@ system actor) or an explicit human close (`vnx objective close --apply --approva
    `blocks` item gates the track out of `done` until resolved.
 5. **Merge.** A PR merges. The reconciler detects it from four evidence sources,
    in order: `pr_merged.ndjson` events → `t0_receipts.ndjson` → ROADMAP
-   `pr_queue` status → (opt-in `VNX_RECONCILE_GIT`) live `gh pr list --state
-   merged` (10-min cache). No local receipt is required — git reality suffices.
+   `pr_queue` status → (default-ON since OI-1155, opt out `VNX_RECONCILE_GIT=0`)
+   live `gh pr list --state merged` (10-min cache). No local receipt is
+   required — git reality suffices.
 6. **Reconcile (derived refresh).** `track_reconciler` computes `derived_status`
    independently of `phase`: blocker OI unresolved → `blocked`; unmet dependency
    → `blocked`; all dispatches terminal → `done` when any of: no `pr_ref` set,

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -502,7 +502,7 @@ def _parse_reopen_stamp(reason: str) -> Optional[str]:
 # ``reconcile --apply`` close path (run_reconcile step 4c + close_track_if_done),
 # but the operator-facing ``objective close`` verb did NOT call that path — it
 # peeked/reconciled with the local-only set, fell back to _load_merged_pr_numbers
-# (whose gh source is opt-in behind VNX_RECONCILE_GIT, OFF by default), and
+# (whose gh source is default-ON since OI-1155, opt out via VNX_RECONCILE_GIT=0), and
 # re-derived 'queued' for a track whose PRs merged via a bare ``gh pr merge``.
 #
 # The two helpers below are the SINGLE source of the evidence set both code
@@ -533,8 +533,9 @@ def merge_evidence_pr_numbers(
     cannot drift.
 
     Local loading reuses track_reconciler._load_merged_pr_numbers (sources
-    1-3 are local and deterministic; source 4 is the opt-in VNX_RECONCILE_GIT
-    path, OFF by default, so it does NOT double-call gh here).
+    1-3 are local and deterministic; source 4 — ``gh pr list``, default-ON
+    since OI-1155 — is cache-first so it reuses the 10-min cache the
+    reconciler already warmed and adds no per-PR ``gh pr view`` calls).
     """
     local_merged = track_reconciler._load_merged_pr_numbers(state_dir, repo_root)
     return frozenset(set(gh_confirmed_merged) | set(local_merged))
@@ -1118,15 +1119,15 @@ def run_reconcile(
     # gh sweep, so a track whose pr_ref PRs were merged via a bare ``gh pr
     # merge`` (no local pr_merged receipt) derived 'queued' there — even though
     # reconcile itself just confirmed those PRs merged via gh. Threading the
-    # evidence here lets the close path re-derive 'done' WITHOUT the
-    # VNX_RECONCILE_GIT flag (which governs whether the reconciler makes its
-    # OWN network calls; this is about evidence it ALREADY gathered).
+    # evidence here lets the close path re-derive 'done' from evidence it
+    # ALREADY gathered (source 4, default-ON since OI-1155, makes its own
+    # ``gh pr list`` call; this threading adds no per-PR ``gh pr view`` calls).
     #
     # The injected set is a UNION of the gh-confirmed MERGED PR numbers and the
     # locally-loaded set (NDJSON + ROADMAP). Local evidence stays valid; gh
-    # only ADDS what a bare ``gh pr merge`` never wrote locally. No new gh
-    # calls: only MERGED results already fetched in step 4b are extracted, so
-    # the --max-gh-calls cap still holds for the whole run.
+    # only ADDS what a bare ``gh pr merge`` never wrote locally. No new per-PR
+    # ``gh pr view`` calls: only MERGED results already fetched in step 4b are
+    # extracted, so the --max-gh-calls cap still holds for the whole run.
     # ------------------------------------------------------------------ step 4c
     gh_confirmed_merged: set = set()
     for cc in confirmed_candidates:

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -204,11 +204,17 @@ def _delivery_hold(
     }
 
 
-def _load_merged_prs_from_gh(state_path: Path, ttl_seconds: int = 600) -> FrozenSet[int]:
-    """Opt-in git-grounded merged-PR source. Cache-first (``pr_merged_cache.json``,
-    TTL ~10 min) so the SessionStart hot path rarely shells out; network call is
-    silent-on-failure so the caller's never-raises / offline-safe contract holds.
-    Only consulted when ``VNX_RECONCILE_GIT`` is set."""
+def _load_merged_prs_from_gh(
+    state_path: Path, ttl_seconds: int = 600, cwd: "str | None" = None
+) -> FrozenSet[int]:
+    """Git-grounded merged-PR source (source 4, default-ON since OI-1155).
+
+    Cache-first (``pr_merged_cache.json``, TTL ~10 min) so the SessionStart hot
+    path rarely shells out; network call is silent-on-failure so the caller's
+    never-raises / offline-safe contract holds. ``cwd`` threads the project repo
+    root into ``gh pr list`` so a central install whose process CWD is not the
+    project dir still resolves the right repository.
+    """
     cache = state_path / "pr_merged_cache.json"
     now = time.time()
     try:
@@ -220,7 +226,7 @@ def _load_merged_prs_from_gh(state_path: Path, ttl_seconds: int = 600) -> Frozen
     try:
         result = subprocess.run(
             ["gh", "pr", "list", "--state", "merged", "--limit", "500", "--json", "number"],
-            capture_output=True, text=True, timeout=30, check=False,
+            capture_output=True, text=True, timeout=30, check=False, cwd=cwd,
         )
         if result.returncode != 0:
             return frozenset()
@@ -279,14 +285,18 @@ def _load_merged_pr_numbers(
       2. {state_dir}/t0_receipts.ndjson           — receipt log
       3. {repo_root|cwd-git-root|state.parent.parent}/ROADMAP.yaml — feature list
          pr_queue[*].status=merged entries cover recent PRs not yet in NDJSON files
-      4. git/GitHub via ``gh`` (OPT-IN, ``VNX_RECONCILE_GIT`` set) — cache-first
-         (10-min TTL), silent-on-failure. Closes the gap where a PR merged via raw
-         ``gh pr merge`` emits no local ``pr_merged`` receipt, so a merged track
-         would otherwise stay ``queued`` forever (the git-reality drift).
+      4. git/GitHub via ``gh`` (DEFAULT-ON since OI-1155; opt out with
+         ``VNX_RECONCILE_GIT=0``) — cache-first (10-min TTL), silent-on-failure.
+         Closes the gap where a PR merged via raw ``gh pr merge`` emits no local
+         ``pr_merged`` receipt, so a merged track would otherwise stay ``queued``
+         forever (the git-reality drift). Measured 2026-08-15: sources 1-3 all
+         yield zero ``pr_merged`` signals on the vnx-dev store while ``gh``
+         reports 500 merged PRs — sources 1-3 are dead in practice, so source 4
+         must run by default to be the single live authority.
 
     Returns frozenset[int]. Offline-safe and never raises: sources 1-3 are local
-    and deterministic; source 4 is opt-in and degrades to today's behaviour when
-    ``gh`` is absent/offline.
+    and deterministic; source 4 degrades to today's local-only behaviour when
+    ``gh`` is absent/offline (silent-on-failure).
     """
     merged: set = set()
     state_path = Path(state_dir)
@@ -339,11 +349,18 @@ def _load_merged_pr_numbers(
     except Exception:
         log.debug("_load_merged_pr_numbers: ROADMAP.yaml parse error (non-fatal)", exc_info=True)
 
-    # Source 4 (opt-in, network): git/GitHub merge state via gh, cache-first.
-    # Gated behind VNX_RECONCILE_GIT so the default offline hot path is unchanged.
+    # Source 4 (network, DEFAULT-ON since OI-1155): git/GitHub merge state via gh,
+    # cache-first + silent-on-failure. This is the ONLY source that sees a PR
+    # merged via a bare ``gh pr merge`` (no local pr_merged receipt is written),
+    # so it must run by default or such merged tracks never derive 'done'.
+    # Explicit opt-out for offline / deterministic callers: VNX_RECONCILE_GIT=0
+    # (also 'false'/'no'/'off').
     _git_flag = os.environ.get("VNX_RECONCILE_GIT", "").strip().lower()
-    if _git_flag not in ("", "0", "false", "no", "off"):
-        merged |= _load_merged_prs_from_gh(state_path)
+    if _git_flag not in ("0", "false", "no", "off"):
+        gh_cwd = Path(repo_root) if repo_root is not None else _git_toplevel(Path.cwd())
+        merged |= _load_merged_prs_from_gh(
+            state_path, cwd=str(gh_cwd) if gh_cwd is not None else None
+        )
 
     return frozenset(merged)
 
@@ -544,10 +561,10 @@ def reconcile_track(
           established merge state by other means (e.g. run_reconcile's live
           ``gh pr view`` sweep) MUST pass the UNION of its gh-confirmed numbers
           and the locally-loaded set here. Otherwise reconcile_track falls back
-          to _load_merged_pr_numbers, whose gh source (source 4) is opt-in
-          behind VNX_RECONCILE_GIT and OFF by default — so a track the caller
-          just confirmed merged via gh would re-derive as 'queued' from the
-          weaker local sources, and no close path could close it. The caller
+          to _load_merged_pr_numbers, whose gh source (source 4) is default-ON
+          since OI-1155 (opt out with VNX_RECONCILE_GIT=0) — so a track the
+          caller just confirmed merged via gh would re-derive as 'queued' from
+          the weaker local sources, and no close path could close it. The caller
           performs the union (gh evidence is additive: it never replaces local
           NDJSON/ROADMAP evidence, only adds what a bare ``gh pr merge`` never
           wrote locally).
@@ -629,10 +646,10 @@ def peek_derived_status(
     reconcile_track (track_id, project_id, derived_status, declared_phase, drifted).
 
     _merged_pr_numbers: optional pre-established merged-PR set (OI-1071). When
-    provided, used in place of the local-only set so a dry-run close that has
-    ALREADY gathered gh-confirmed merge evidence derives 'done' WITHOUT
-    VNX_RECONCILE_GIT. Same contract as reconcile_track._merged_pr_numbers.
-    When None, loads the local sources itself (the pre-OI-1071 behaviour).
+    provided, used in place of the locally-loaded set so a dry-run close that
+    has ALREADY gathered gh-confirmed merge evidence derives 'done' without a
+    second gh round-trip. Same contract as reconcile_track._merged_pr_numbers.
+    When None, loads the sources itself (the pre-OI-1071 behaviour).
 
     Raises RuntimeError if the derived_status column is absent (migration 0028).
     """

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1204,9 +1204,9 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
     # OI-1071: gather the same gh-confirmed merge evidence run_reconcile builds
     # and thread it into every derivation step below, so a track whose PRs
     # merged via a bare ``gh pr merge`` (no local pr_merged receipt) derives
-    # 'done' via the verb WITHOUT VNX_RECONCILE_GIT. Without this, the dry-run
-    # peek / --apply reconcile / close_track_if_done all fall back to the
-    # local-only set and re-derive 'queued', refusing the close. The helper
+    # 'done' via the verb. Without this, the dry-run peek / --apply reconcile /
+    # close_track_if_done all fall back to the locally-loaded set and re-derive
+    # 'queued', refusing the close. The helper
     # bounds live gh calls by --max-gh-calls and reuses the per-PR cache, and
     # degrades honestly (consulted_gh=False) when gh is unreachable.
     max_gh_calls = int(getattr(args, "max_gh_calls", 50))
@@ -1251,8 +1251,8 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
     # derived_status was computed from local sources ONLY. A 'not terminal'
     # refusal on that basis must not read as "this track is not done" — the
     # real cause may be "could not reach GitHub". Surface it so the operator
-    # knows to re-run when gh is back (or set VNX_RECONCILE_GIT for the local
-    # gh source). consulted_gh is False both when gh was unreachable AND when
+    # knows to re-run when gh is back. consulted_gh is False both when gh was
+    # unreachable AND when
     # the track has no pr_ref to verify; only flag the former.
     gh_unavailable = (
         not close_evidence["consulted_gh"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,22 @@ def _vnx_data_dir_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     pin_vnx_data_dir(monkeypatch, isolated)
 
 
+@pytest.fixture(autouse=True)
+def _reconcile_git_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OI-1155: pin track_reconciler source 4 (``gh pr list``) OFF for the suite.
+
+    source 4 is default-ON in production (_load_merged_pr_numbers), which would
+    make every reconciler test shell out to a live, network ``gh pr list`` from
+    the repo-root CWD and pollute local-only assertions with real merged PR
+    numbers. Pinning VNX_RECONCILE_GIT=0 keeps the suite deterministic and
+    offline-safe. Tests that pin the default-ON behaviour
+    (tests/test_track_reconciler_prref_evidence.py: test_gh_source_on_by_default
+    / test_gh_source_opt_out_by_flag) monkeypatch-delenv / setenv this flag
+    per-test — the last write wins within the same function scope.
+    """
+    monkeypatch.setenv("VNX_RECONCILE_GIT", "0")
+
+
 # ---------------------------------------------------------------------------
 # DB / registry fixtures  (shared with test_burnin_certification)
 # ---------------------------------------------------------------------------

--- a/tests/test_central_mode_path_resolution.py
+++ b/tests/test_central_mode_path_resolution.py
@@ -338,6 +338,9 @@ def test_roadmap_legacy_fallback_when_no_git(tmp_path, monkeypatch):
 
 def test_load_merged_pr_numbers_never_crashes_on_missing_roadmap(tmp_path, monkeypatch):
     # Source-3 is best-effort: a non-existent state dir / roadmap must not raise.
+    # OI-1155: opt out of source-4 (default-ON gh) so the assertion stays
+    # deterministic and does not reach a live ``gh pr list``.
+    monkeypatch.setenv("VNX_RECONCILE_GIT", "0")
     monkeypatch.setattr(track_reconciler, "_git_toplevel", lambda p: None)
     result = track_reconciler._load_merged_pr_numbers(tmp_path / "nowhere" / "state")
     assert result == frozenset()

--- a/tests/test_close_track_if_done.py
+++ b/tests/test_close_track_if_done.py
@@ -832,18 +832,16 @@ def test_close_default_none_keeps_old_behaviour(tmp_path, monkeypatch):
 
 def test_close_with_injected_set_derives_done_and_closes(tmp_path):
     """A track whose pr_ref PRs are ABSENT from local sources but PRESENT in
-    the injected set derives 'done' and the close succeeds — without
-    VNX_RECONCILE_GIT set.
+    the injected set derives 'done' and the close succeeds.
 
     This is the core OI-1064 case: zero dispatches, no pr_merged.ndjson, no
     ROADMAP entry, no coordination event. The only merge evidence is the
     injected set (the gh numbers run_reconcile gathered). Pre-fix this track
-    derived 'queued' and could not be closed.
+    derived 'queued' and could not be closed. OI-1155: source 4 (gh) is now
+    default-ON, so the module autouse fixture opts out (VNX_RECONCILE_GIT=0);
+    the injected set short-circuits _load_merged_pr_numbers, so no live gh
+    call and no local source contribute.
     """
-    import os
-    assert "VNX_RECONCILE_GIT" not in os.environ, (
-        "this test asserts the OFF-by-default behaviour; unset VNX_RECONCILE_GIT"
-    )
     sd = _build_db(tmp_path)
     tracks_lib.create_track(
         sd, "T-injected", PROJECT_ID, title="injected", goal_state="y",

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -1453,8 +1453,8 @@ def test_objective_close_dry_run_threads_repo_root_into_evidence(tmp_path, monke
 # OI-1071 — the standalone ``objective close`` verb must use the same merge
 # evidence ``reconcile`` does. Before this fix, the verb peeked/reconciled
 # with the local-only set, fell back to _load_merged_pr_numbers (whose gh source
-# is opt-in behind VNX_RECONCILE_GIT, OFF by default), and re-derived 'queued'
-# for a track whose PRs merged via a bare ``gh pr merge``. The tests below pin
+# is default-ON since OI-1155, opt out via VNX_RECONCILE_GIT=0), and re-derived
+# 'queued' for a track whose PRs merged via a bare ``gh pr merge``. The tests below pin
 # the shared helper + the verb's evidence threading + honest gh degradation.
 # ---------------------------------------------------------------------------
 
@@ -1507,7 +1507,10 @@ def test_close_verb_threads_nonempty_merged_set_into_close_track_if_done(tmp_pat
 
 def test_close_verb_derives_done_from_gh_only_without_vnx_reconcile_git(tmp_path, monkeypatch):
     """OI-1071: a track whose pr_ref PRs are merged but ABSENT from local
-    sources closes via the verb, WITHOUT VNX_RECONCILE_GIT set."""
+    sources closes via the verb's gh gathering (gh pr view), with
+    VNX_RECONCILE_GIT unset. OI-1155: source 4 (gh pr list) is default-ON, so
+    an unset flag runs it; the shared subprocess.run mock returns empty for
+    ``gh pr list``, keeping the verb's per-PR evidence the sole authority."""
     monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
     sd = _build_db(tmp_path)
     _seed_track(sd, "T-1071b", phase="queued", pr_ref="#771")
@@ -1832,8 +1835,10 @@ class TestRunProvenanceSweepCommitFailureIsLoud:
 # ---------------------------------------------------------------------------
 
 def test_oi1064_reconcile_closes_track_without_vnx_reconcile_git(tmp_path, monkeypatch):
-    """run_reconcile derives 'done' and closes a bare-gh-merge track WITHOUT
-    VNX_RECONCILE_GIT set.
+    """run_reconcile derives 'done' and closes a bare-gh-merge track with
+    VNX_RECONCILE_GIT unset (source 4 default-ON; the shared subprocess.run
+    mock returns empty for ``gh pr list`` so the threaded gh pr-view evidence
+    stays the sole authority).
 
     Reproduces the background-job-liveness defect in miniature: phase=queued,
     pr_ref with multiple PRs, all verified MERGED via gh, delivery complete,

--- a/tests/test_track_reconciler_prref_evidence.py
+++ b/tests/test_track_reconciler_prref_evidence.py
@@ -549,9 +549,21 @@ def test_parse_pr_numbers_handles_comma_list():
     assert track_reconciler._parse_pr_numbers("not-a-pr") == frozenset()
 
 
-def test_gh_source_off_by_default(tmp_path, monkeypatch):
-    # Without VNX_RECONCILE_GIT, source 4 must not run (no gh, deterministic).
+def test_gh_source_on_by_default(tmp_path, monkeypatch):
+    # OI-1155: source 4 is default-ON. An UNSET VNX_RECONCILE_GIT still consults
+    # gh, so a PR merged via a bare ``gh pr merge`` (no local pr_merged receipt)
+    # becomes visible to the reconciler without any manual env-var.
     monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
+    monkeypatch.setattr(track_reconciler, "_load_merged_prs_from_gh",
+                        lambda *a, **k: frozenset({911, 912}))
+    state = tmp_path / "state"; state.mkdir()
+    assert {911, 912} <= set(_load_merged_pr_numbers(state))
+
+
+def test_gh_source_opt_out_by_flag(tmp_path, monkeypatch):
+    # Explicit opt-out (VNX_RECONCILE_GIT=0) restores local-only determinism for
+    # offline/embedded callers: source 4 must NOT run.
+    monkeypatch.setenv("VNX_RECONCILE_GIT", "0")
     called = {"gh": False}
     monkeypatch.setattr(track_reconciler, "_load_merged_prs_from_gh",
                         lambda *a, **k: called.__setitem__("gh", True) or frozenset())


### PR DESCRIPTION
## Summary

OI-1155: de track-reconciler zag een kale `gh pr merge` niet. Sources 1-3 (pr_merged.ndjson, t0_receipts.ndjson, ROADMAP pr_queue) leveren vandaag **nul** `pr_merged`-signalen op de vnx-dev store, terwijl `gh` 500 gemergede PR's rapporteert. Source 4 (`gh pr list --state merged`, cache-first, silent-on-failure) is dus de enige live autoriteit, en die stond achter een opt-in flag (`VNX_RECONCILE_GIT`) die default OFF was.

Deze PR draait de flag om naar **default-ON** (opt out via `VNX_RECONCILE_GIT=0`, ook `false`/`no`/`off`). Een gemergede PR wordt nu zonder handmatige env-var zichtbaar voor de reconciler.

## Changes

- `scripts/lib/track_reconciler.py` — source 4 default-ON; thread repo-root in `gh pr list` (`cwd`-param) zodat een central-install met een niet-project CWD de juiste repo resolved.
- `tests/conftest.py` — autouse fixture `_reconcile_git_off` pinnt de suite deterministisch/offline-safe (`VNX_RECONCILE_GIT=0`); source-4-tests overriden per test.
- `tests/test_track_reconciler_prref_evidence.py` — `test_gh_source_on_by_default` + `test_gh_source_opt_out_by_flag`.
- `tests/test_central_mode_path_resolution.py`, `tests/test_close_track_if_done.py`, `tests/test_objective_reconcile.py` — docstring/assert-updates voor default-ON.
- `scripts/lib/objective_reconcile.py`, `scripts/planning_cli.py`, `docs/core/STATE_FABRIC.md` — comment/doc-updates.

## Verification

- 201 tests groen (3.64s) over de 6 core+neighbor files.
- Task-3 grep: geen enkele reader wijst naar de zero-byte `tracks.db`/`planning.db` (codebase gebruikt `runtime_coordination.db`); beide bestanden verwijderd.
- Task-1 meting: sources 1-3 = 0 signalen, source 4 = 500 gemergede PR's.

## Open Items

None.