### PR TITLE
fix(permissions): translate multi-token bash_allow_patterns into --allowedTools

### DIFF
--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -409,6 +409,58 @@ def resolve_worker_profile(
     return default_code_worker_profile()
 
 
+def _bash_allow_pattern_to_tool(pattern: str) -> Optional[str]:
+    """Translate one ``bash_allow_pattern`` into a ``Bash(<prefix>:*)`` allowedTool.
+
+    The yaml patterns are shell-globs whose intent is "allow ``<prefix> …``"
+    (``git add*`` means allow ``git add <anything>``). Claude Code's
+    ``--allowedTools`` expresses exactly that as ``Bash(<prefix>:*)`` — the ``:*``
+    globs the argument tail, the same form the working-tree-only deny already
+    uses (``Bash(git commit:*)``). A pattern that is a literal prefix followed by
+    a single trailing ``*`` maps losslessly for any token count: ``git*`` →
+    ``Bash(git:*)``, ``git add*`` → ``Bash(git add:*)``, ``git push origin*`` →
+    ``Bash(git push origin:*)``.
+
+    Returns ``None`` when the pattern cannot be expressed as a prefix glob: a
+    mid-pattern ``*`` (``git*log``), a ``?``/``[`` metacharacter, or a bare ``*``
+    (which would mean "allow every command" — refuse to widen). The caller logs
+    the drop loudly rather than silently losing the pattern.
+    """
+    pat = (pattern or "").strip()
+    if not pat.endswith("*"):
+        return None
+    prefix = pat[:-1].rstrip()
+    if not prefix:
+        return None
+    if any(c in prefix for c in ("*", "?", "[")):
+        return None
+    return f"Bash({prefix}:*)"
+
+
+def _bash_allow_tool_entries(profile: PermissionProfile) -> list[str]:
+    """Translate ``profile.bash_allow_patterns`` into ``Bash(<prefix>:*)`` tools.
+
+    Every translatable pattern becomes one entry. A pattern that cannot be
+    expressed as a prefix glob is logged (role + pattern) and skipped — a
+    permission profile silently losing half its rules is worse than one that
+    refuses loudly (20260816-p4-bash-pattern-loss).
+    """
+    tools: list[str] = []
+    for pattern in profile.bash_allow_patterns:
+        tool = _bash_allow_pattern_to_tool(pattern)
+        if tool is None:
+            logger.warning(
+                "worker_permissions: role '%s' bash_allow_pattern %r cannot be "
+                "translated to a Bash(<prefix>:*) allowedTool — dropping it from "
+                "--allowedTools (pattern will not be enforced)",
+                profile.role,
+                pattern,
+            )
+            continue
+        tools.append(tool)
+    return tools
+
+
 def build_claude_scope_args(
     profile: PermissionProfile,
     *,
@@ -437,6 +489,11 @@ def build_claude_scope_args(
         allowlist does not apply in that case (Open Item: reconcile the two).
       - ``--allowedTools`` / ``--disallowedTools`` — the profile's tool allow/deny
         lists (the previously-dead :func:`generate_claude_settings`, now live).
+        ``profile.bash_allow_patterns`` are translated into ``Bash(<prefix>:*)``
+        entries here as well (``git add*`` → ``Bash(git add:*)``), so a
+        multi-token pattern keeps its intent in the argv instead of being
+        silently dropped (20260816-p4-bash-pattern-loss). A pattern that cannot
+        be expressed as a prefix glob is logged (role + pattern) and skipped.
         The whole MCP tool namespace (``mcp__*``) is denied here as well when
         ``requires_mcp=False`` — the empty ``--mcp-config`` above only reaches
         the ``mcpServers`` group, not extension bridges (see
@@ -447,7 +504,10 @@ def build_claude_scope_args(
     ambient MCP config (and its MCP tools) are used instead.
     """
     settings = generate_claude_settings(profile)
-    allowed = settings.get("allowedTools", [])
+    allowed = list(settings.get("allowedTools", []))
+    for tool in _bash_allow_tool_entries(profile):
+        if tool not in allowed:
+            allowed.append(tool)
     args: list[str] = ["--permission-mode", permission_mode]
     if not requires_mcp:
         if profile.mcp_servers:

--- a/tests/test_worker_permissions.py
+++ b/tests/test_worker_permissions.py
@@ -582,6 +582,142 @@ class TestMcpNamespaceDeny:
 
 
 # ---------------------------------------------------------------------------
+# 20260816-p4-bash-pattern-loss — bash_allow_patterns reach --allowedTools
+# ---------------------------------------------------------------------------
+
+class TestBashAllowPatternTranslation:
+    """bash_allow_patterns must reach --allowedTools as Bash(<prefix>:*) entries.
+
+    Regression for dispatch 20260816-p4-bash-pattern-loss: the translation only
+    survived single-token patterns, so multi-token ones (``git add*``,
+    ``git push origin*``, ``python3 -m pytest*``) silently dropped out of the
+    spawn argv for quality-engineer / frontend-developer / system-architect /
+    security-engineer. The fix maps ``<prefix>*`` → ``Bash(<prefix>:*)`` for any
+    token count, and logs (never silently drops) a pattern it cannot express.
+    """
+
+    @pytest.mark.parametrize(
+        "pattern,expected",
+        [
+            ("git*", "Bash(git:*)"),
+            ("pytest*", "Bash(pytest:*)"),
+            ("npm*", "Bash(npm:*)"),
+            ("git add*", "Bash(git add:*)"),
+            ("git commit*", "Bash(git commit:*)"),
+            ("git push origin*", "Bash(git push origin:*)"),
+            ("pip install*", "Bash(pip install:*)"),
+            ("bash -n*", "Bash(bash -n:*)"),
+            ("python3 -c*", "Bash(python3 -c:*)"),
+            ("python3 -m pytest*", "Bash(python3 -m pytest:*)"),
+            ("python3 -m py_compile*", "Bash(python3 -m py_compile:*)"),
+        ],
+    )
+    def test_pattern_translates_to_prefix_tool(self, pattern: str, expected: str) -> None:
+        profile = PermissionProfile(
+            role="r", allowed_tools=["Read"], bash_allow_patterns=[pattern]
+        )
+        args = build_claude_scope_args(profile)
+        allowed = args[args.index("--allowedTools") + 1].split(",")
+        assert expected in allowed
+
+    @pytest.mark.skipif(
+        not REPO_PERMISSIONS_YAML.exists(),
+        reason="repo .vnx/worker_permissions.yaml not present in this checkout",
+    )
+    def test_multi_token_patterns_survive_in_all_four_affected_roles(self) -> None:
+        """The four roles from the defect report keep their multi-token intent."""
+        expectations = {
+            "quality-engineer": [
+                "Bash(git add:*)",
+                "Bash(git commit:*)",
+                "Bash(git push origin:*)",
+                "Bash(python3 -m pytest:*)",
+                "Bash(python3 -m py_compile:*)",
+            ],
+            "frontend-developer": [
+                "Bash(npm:*)",
+                "Bash(npx:*)",
+                "Bash(node:*)",
+                "Bash(git add:*)",
+                "Bash(git commit:*)",
+                "Bash(git push origin:*)",
+            ],
+            "system-architect": [
+                "Bash(git add:*)",
+                "Bash(git commit:*)",
+                "Bash(git push origin:*)",
+                "Bash(python3 -c:*)",
+                "Bash(python3 -m py_compile:*)",
+                "Bash(bash -n:*)",
+            ],
+            "security-engineer": [
+                "Bash(git add:*)",
+                "Bash(git commit:*)",
+                "Bash(git push origin:*)",
+                "Bash(python3 -c:*)",
+                "Bash(python3 -m py_compile:*)",
+                "Bash(bash -n:*)",
+                "Bash(grep:*)",
+            ],
+        }
+        for role, expected in expectations.items():
+            profile = load_permissions(role, REPO_PERMISSIONS_YAML)
+            args = build_claude_scope_args(profile)
+            allowed = args[args.index("--allowedTools") + 1].split(",")
+            missing = [entry for entry in expected if entry not in allowed]
+            assert not missing, (
+                f"role '{role}' lost translated patterns {missing} in --allowedTools: "
+                f"{allowed}"
+            )
+
+    def test_untranslatable_pattern_is_logged_not_silent(self, caplog) -> None:
+        """A pattern that cannot become a Bash(<prefix>:*) entry must be logged
+        with the role and pattern — never silently dropped."""
+        import logging
+
+        profile = PermissionProfile(
+            role="r",
+            allowed_tools=["Read"],
+            bash_allow_patterns=["git*log", "foo[bar]*"],
+        )
+        with caplog.at_level(logging.WARNING, logger="worker_permissions"):
+            args = build_claude_scope_args(profile)
+        allowed = args[args.index("--allowedTools") + 1].split(",")
+        assert allowed == ["Read"], (
+            "untranslatable patterns must not leak a bogus Bash(...) entry"
+        )
+        messages = [rec.getMessage() for rec in caplog.records]
+        assert any("git*log" in m and "'r'" in m for m in messages), (
+            "dropped pattern 'git*log' must be logged with the role"
+        )
+        assert any("foo[bar]*" in m for m in messages), (
+            "dropped pattern 'foo[bar]*' must be logged"
+        )
+
+    def test_bare_star_pattern_refuses_to_widen(self) -> None:
+        """A bare ``*`` would mean 'allow every command' — refuse to widen."""
+        profile = PermissionProfile(
+            role="r", allowed_tools=["Read"], bash_allow_patterns=["*"]
+        )
+        args = build_claude_scope_args(profile)
+        allowed = args[args.index("--allowedTools") + 1].split(",")
+        assert allowed == ["Read"]
+
+    def test_no_duplicate_entries_when_allowed_tools_already_carry_prefix(self) -> None:
+        """backend-developer already lists Bash(git:*) in allowed_tools AND
+        carries ``git*`` in bash_allow_patterns — no duplicate entry."""
+        profile = PermissionProfile(
+            role="r",
+            allowed_tools=["Read", "Bash(git:*)"],
+            bash_allow_patterns=["git*", "git add*"],
+        )
+        args = build_claude_scope_args(profile)
+        allowed = args[args.index("--allowedTools") + 1].split(",")
+        assert allowed.count("Bash(git:*)") == 1
+        assert "Bash(git add:*)" in allowed
+
+
+# ---------------------------------------------------------------------------
 # classify_permission_posture (OI-864)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`build_claude_scope_args` (the single argv-assembly point for both the tmux-spawn and subprocess lanes) emitted only a profile's literal `allowed_tools`. Its `bash_allow_patterns` never reached `--allowedTools`, so every multi-token pattern (`git add*`, `git push origin*`, `python3 -m pytest*`) silently dropped out of the spawn argv. Measured against `.vnx/worker_permissions.yaml`:

- `backend-developer` shows `Bash(git:*)` etc. only because those are literal `allowed_tools` entries, not a translation.
- `security-engineer`, `quality-engineer`, `frontend-developer`, `system-architect` produce zero `Bash(...)` entries, losing all of `git add/commit/push`, `npm/npx/node`, `python3 -m pytest/py_compile`, `bash -n`, `grep`.

## Fix

- Add `_bash_allow_pattern_to_tool` + `_bash_allow_tool_entries`: translate each `bash_allow_pattern` of the form `<prefix>*` into `Bash(<prefix>:*)` for any token count (`git add*` → `Bash(git add:*)`), dedupe against literal `allowed_tools`.
- A pattern that cannot be expressed as a prefix glob (mid-pattern `*`, `?`/`[`, bare `*`) is logged with role + pattern and skipped — never silently dropped.

The `.vnx/worker_permissions.yaml` profiles are untouched; the translation was the broken half.

## Verification

- New regression tests in `tests/test_worker_permissions.py` cover all four affected roles against the real yaml, a param-sweep of single/multi-token translation, the loud-drop log, and the bare-`*` refuse-to-widen path.
- Targeted runs (touched file + direct neighbours): `270 passed`, plus `63 passed` across the other `build_claude_scope_args` consumers.

Dispatch-ID: 20260816-p4-bash-pattern-loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)