### PR TITLE
fix(dispatch): bind unbound model name on worker_process_gone/heartbeat failure paths (OI-1237)

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2252,6 +2252,7 @@ class TmuxInteractiveDispatch:
         label: "str | None" = None,
         raw_log_path: "Path | None" = None,
         session: str = "",
+        model: str = "",
     ) -> "dict | None":
         """Poll signals 1–3 until a NEW completion appears beyond the baseline.
 
@@ -2280,6 +2281,10 @@ class TmuxInteractiveDispatch:
           below; when either is missing the probe reports "unknown" every poll
           and every decision falls open to the pre-OI-1130 heartbeat-only
           behavior.
+
+        *model*: threaded through to the ``worker_process_gone`` and
+          heartbeat-kill failure reports (OI-1237) so those terminal reports
+          carry the actual model instead of an unbound name.
 
         OI-1130 deterministic liveness (see ``_check_worker_liveness``): each
         poll, independent of heartbeat silence, the worker's tmux session/pane
@@ -2433,10 +2438,10 @@ class TmuxInteractiveDispatch:
                             "written to %s",
                             _report_path,
                         )
-                    except Exception as _pg_write_exc:
-                        logger.warning(
+                    except Exception as _pg_write_exc:  # noqa: BLE001 — a failed report write must never crash the poll loop, but it must be LOUD (OI-1237): this is the audit trail's only record of the kill
+                        logger.error(
                             "interactive: worker_process_gone failure report "
-                            "write failed for %s: %s",
+                            "NOT written for dispatch=%s — audit trail gap: %s",
                             dispatch_id,
                             _pg_write_exc,
                         )
@@ -2515,10 +2520,10 @@ class TmuxInteractiveDispatch:
                                 "interactive: heartbeat failure report written to %s",
                                 _report_path,
                             )
-                        except Exception as _hb_write_exc:
-                            logger.warning(
-                                "interactive: heartbeat failure report write "
-                                "failed for %s: %s",
+                        except Exception as _hb_write_exc:  # noqa: BLE001 — a failed report write must never crash the poll loop, but it must be LOUD (OI-1237): this is the audit trail's only record of the kill
+                            logger.error(
+                                "interactive: heartbeat failure report NOT "
+                                "written for dispatch=%s — audit trail gap: %s",
                                 dispatch_id,
                                 _hb_write_exc,
                             )
@@ -3424,6 +3429,7 @@ class TmuxInteractiveDispatch:
                 label=label,
                 raw_log_path=_raw_log[0],
                 session=session,
+                model=model,
             )
 
             if receipt is None:

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -1230,6 +1230,104 @@ class TestAwaitingPermission(_LaneTestCase):
             "a genuinely stalled worker must be heartbeat-killed (failure report)",
         )
 
+    def test_heartbeat_failure_report_carries_model_oi1237(self):
+        """OI-1237: the heartbeat-kill failure report (tmux_interactive_dispatch.py
+        ~2510) referenced an unbound `model` name — on the OLD code this raised a
+        NameError that was swallowed by the surrounding except-block, so the report
+        was silently never written (see test_heartbeat_kills_genuinely_stalled_worker,
+        which was RED before this fix). Pin that `model` is now threaded through and
+        lands verbatim in the written report body."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("worker started\n", encoding="utf-8")
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            ready_content="some stale log line\nthat is not a prompt",
+        )
+        lane = self._make_lane(fake)
+        report_path = (
+            self.state_dir.parent / "unified_reports" / f"{self.DISPATCH_ID}.md"
+        )
+        if report_path.exists():
+            report_path.unlink()
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.05"}
+        ):
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=0.3,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+                model="glm-5.2",
+            )
+        self.assertIsNone(result)
+        self.assertTrue(report_path.exists())
+        from report_to_receipt_converter import _extract_body_fields
+        fields = _extract_body_fields(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            fields.get("model"), "glm-5.2",
+            "the model passed to _wait_for_receipt must reach the failure report "
+            "verbatim — before the fix `model` was an unbound name here",
+        )
+
+    def test_heartbeat_write_failure_logged_loud_not_swallowed_oi1237(self):
+        """OI-1237 second defect: a failure while writing the heartbeat-kill report
+        must be LOUD (ERROR, with the dispatch-id) — not a quietly-swallowed
+        exception a human has no reason to go looking for. Before this fix the
+        unbound `model` NameError was caught by the same except-block and only
+        ever surfaced as a WARNING, which is how the report went missing
+        unnoticed in the first place."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("worker started\n", encoding="utf-8")
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            ready_content="some stale log line\nthat is not a prompt",
+        )
+        lane = self._make_lane(fake)
+        report_path = (
+            self.state_dir.parent / "unified_reports" / f"{self.DISPATCH_ID}.md"
+        )
+        if report_path.exists():
+            report_path.unlink()
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.05"}
+        ), patch.object(
+            Path, "write_text", side_effect=OSError("disk full (simulated)")
+        ), self.assertLogs("tmux_interactive_dispatch", level="ERROR") as logs:
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=0.3,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+                model="sonnet",
+            )
+        self.assertIsNone(result, "a write failure must not crash the poll loop")
+        self.assertFalse(report_path.exists(), "the report genuinely was not written")
+        self.assertTrue(
+            any(
+                "ERROR" in rec and self.DISPATCH_ID in rec and "NOT written" in rec
+                for rec in logs.output
+            ),
+            f"the write failure must be logged loudly with the dispatch-id, got: {logs.output}",
+        )
+
 
 # ---------------------------------------------------------------------------
 # OI-1130 follow-up: deterministic worker liveness (thinking vs dead)
@@ -1484,6 +1582,100 @@ class TestOI1130DeterministicLiveness(_LaneTestCase):
         self.assertGreater(
             fake.has_session_calls, 0,
             "the liveness probe must still run on a healthy worker (no regression in coverage)",
+        )
+
+    def test_worker_process_gone_report_carries_model_oi1237(self):
+        """OI-1237: the worker_process_gone failure report (tmux_interactive_dispatch.py
+        ~2429) referenced an unbound `model` name — on the OLD code this raised a
+        NameError that was swallowed by the surrounding except-block, so the report
+        was silently never written (see
+        test_silent_and_dead_fails_within_one_poll_worker_process_gone, which was
+        RED before this fix). Pin that `model` is now threaded through and lands
+        verbatim in the written report body."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("worker started\n", encoding="utf-8")
+        fake = _LivenessFakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            has_session_ok=False,  # session gone -> deterministically dead
+        )
+        lane = self._make_lane(fake)
+        self._clear_report()
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "1800"}
+        ):
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=5.0,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+                model="glm-5.2",
+            )
+        self.assertIsNone(result)
+        report_path = self._report_path()
+        self.assertTrue(report_path.exists())
+        from report_to_receipt_converter import _extract_body_fields
+        fields = _extract_body_fields(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            fields.get("model"), "glm-5.2",
+            "the model passed to _wait_for_receipt must reach the failure report "
+            "verbatim — before the fix `model` was an unbound name here",
+        )
+
+    def test_worker_process_gone_write_failure_logged_loud_not_swallowed_oi1237(self):
+        """OI-1237 second defect: a failure while writing the worker_process_gone
+        report must be LOUD (ERROR, with the dispatch-id) — not a quietly-swallowed
+        exception a human has no reason to go looking for. Before this fix the
+        unbound `model` NameError was caught by the same except-block and only
+        ever surfaced as a WARNING, which is how the report went missing
+        unnoticed in the first place."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("worker started\n", encoding="utf-8")
+        fake = _LivenessFakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            has_session_ok=False,  # session gone -> deterministically dead
+        )
+        lane = self._make_lane(fake)
+        self._clear_report()
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "1800"}
+        ), patch.object(
+            Path, "write_text", side_effect=OSError("disk full (simulated)")
+        ), self.assertLogs("tmux_interactive_dispatch", level="ERROR") as logs:
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=5.0,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+                model="sonnet",
+            )
+        self.assertIsNone(result, "a write failure must not crash the poll loop")
+        self.assertFalse(
+            self._report_path().exists(), "the report genuinely was not written"
+        )
+        self.assertTrue(
+            any(
+                "ERROR" in rec and self.DISPATCH_ID in rec and "NOT written" in rec
+                for rec in logs.output
+            ),
+            f"the write failure must be logged loudly with the dispatch-id, got: {logs.output}",
         )
 
 


### PR DESCRIPTION
## Summary

`_wait_for_receipt` in `scripts/lib/tmux_interactive_dispatch.py` referenced a `model` name at two failure-report-writing sites, but `model` was never a parameter of that method — a `NameError` on every kill via either path. Both sites are wrapped in a broad `except Exception`, so the crash was caught and only logged as a `WARNING` — the failure report silently never got written exactly when the audit trail needed it most (a worker just died).

Confirmed with `ruff check --select F821` against the pre-fix file: both occurrences flagged, matching the review's claim that this is not a single-path defect.

## Changes

- `scripts/lib/tmux_interactive_dispatch.py`
  - `_wait_for_receipt`: added `model: str = ""` parameter (was missing — the true bug).
  - Call site (in `dispatch()`) now passes `model=model` through.
  - Both `except Exception` blocks around the failure-report write (`worker_process_gone` path ~L2441, heartbeat-kill path ~L2523) escalated from `logger.warning` to `logger.error`, matching this file's existing "non-fatal but must be visible" convention (see L984-989), with the dispatch-id and an explicit "NOT written — audit trail gap" message so a future write failure (for any reason) is loud, not swallowed.
- `tests/test_tmux_interactive_dispatch.py`
  - 4 new regression tests (2 per failure path): one pins `model` reaching the written report body verbatim, one pins that a genuine write failure (mocked `Path.write_text` raising `OSError`) is logged at `ERROR` with the dispatch-id.

## Verification

- `ruff check --select F821` against the pre-fix file confirmed exactly 2 occurrences (L2424, L2505); 0 after the fix.
- Two **pre-existing** tests were already red on `main` from this defect and now pass:
  - `TestOI1130DeterministicLiveness::test_silent_and_dead_fails_within_one_poll_worker_process_gone`
  - `TestAwaitingPermission::test_heartbeat_kills_genuinely_stalled_worker`
- 4 new tests added; all 4 verified RED on the pre-fix code (`git stash` the source-only diff, ran `-k oi1237` → 4 failures with `TypeError: got an unexpected keyword argument 'model'` for the "carries model" pair, since the argument didn't exist yet), GREEN after.
- `python3 -m pytest tests/test_tmux_interactive_dispatch.py -q` → **227 passed**
- `python3 -m pytest tests/test_worker_heartbeat_silence.py tests/test_model_canonicity.py tests/test_kimi_spawn_heartbeat.py -q` → **63 passed** (direct neighbours: same `worker_heartbeat.build_*_failure_report` functions under test)
- `python3 -m pytest tests/test_report_to_receipt_converter.py -q` → **128 passed** (direct neighbour: `_extract_body_fields`, used by the new tests to assert on report content)
- `ruff check --select F821,F841 scripts/lib/tmux_interactive_dispatch.py tests/test_tmux_interactive_dispatch.py` → 2 pre-existing F841 findings, both far from this change, confirmed present on `HEAD` before this PR too (not introduced here)
- `python3 scripts/ci_lint_patterns.py --files-from-stdin` on both touched files → clean

## Open Items

None. Scope explicitly limited to `scripts/lib/tmux_interactive_dispatch.py` and its test file per dispatch instructions — full suite was intentionally not run.

Dispatch-ID: 20260816-p6c-worker-gone-nameerror