### PR TITLE
feat(horizon): add deliverable task_class/routing_floor door

### DIFF
--- a/docs/core/HORIZON_PLANNING.md
+++ b/docs/core/HORIZON_PLANNING.md
@@ -44,9 +44,11 @@ top-level alias `vnx deliverable <verb>`:
 
 | Verb | Purpose |
 |---|---|
-| `add` | Add a deliverable to a track. |
-| `list` | List a track's deliverables. |
+| `add` | Add a deliverable to a track (optional `--task-class`/`--routing-floor`). |
+| `list` | List a track's deliverables, incl. `task_class`/`routing_floor` (explicit "not set" when absent). |
 | `promote` | Promote a deliverable (proposed → ready; human gate). |
+| `close` | afboeken (done): close a ready deliverable → completed (operator-attested PR evidence). |
+| `set` | Tag an EXISTING deliverable with `task_class`/`routing_floor` — the rubric fields the plan-gate reads (see `_format_deliverable_for_plan`). |
 
 ### Plan-gate verbs
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -7,14 +7,22 @@ Delegated from `bin/vnx`:
   vnx objective sync [--apply] [--roadmap PATH] [--json]
   vnx objective drift [--json]
   vnx deliverable add --objective <track_id> --output-kind <kind> --title "..."
+                       [--task-class <class>] [--routing-floor <floor>]
   vnx deliverable list [--objective <track_id>] [--json]
   vnx deliverable promote <dispatch_id>
   vnx deliverable close <dispatch_id> --evidence <pr>
+  vnx deliverable set <dispatch_id> [--task-class <class>] [--routing-floor <floor>]
 
 NO-NODE model: a deliverable is a proposed dispatch row with output_kind.
 `vnx deliverable promote` is the human gate (proposed -> ready).
 `vnx deliverable close` closes the loop (ready -> completed) on an
 operator-attested delivering PR.
+`vnx deliverable set` tags an EXISTING deliverable with task_class/routing_floor
+metadata (rubric axes 3/5 the plan-gate reads via `_format_deliverable_for_plan`)
+without recreating it. `task_class` is validated against smart_router's closed
+set (01_code_generation .. 07_translation); `routing_floor` is free text (no
+canonical vocabulary exists for it — see `plan_gate_panel.py`'s "quality
+FLOOR" framing).
 `vnx promote` (top-level) is the PR-queue command — NOT the same.
 
 Planning turn-on (auto-seed + advisory drift):
@@ -2089,12 +2097,55 @@ def cmd_objective_set_goal(args: argparse.Namespace) -> int:
     return 0
 
 
+def _load_valid_task_classes() -> frozenset[str]:
+    """The canonical task_class vocabulary for the Horizon planning layer:
+    smart_router's own closed set (01_code_generation .. 07_translation) —
+    the SAME vocabulary `vnx horizon plan-gate run --task-class` already
+    documents (HORIZON_PLANNING.md: ``task_class == 01_code_generation``
+    marks a new feature). Not the separate FP-C execution-routing vocabulary
+    in `execution_target_registry.VALID_TASK_CLASSES`
+    (coding_interactive/research_structured/...) — that one classifies
+    dispatch TARGETS at execution time, a different axis from the
+    deliverable-planning tag this validates.
+
+    Lazy import (matches ``_derive_panel_weight``'s convention): keeps
+    ``_build_parser()`` free of engine-module imports at argparse-build time.
+    """
+    import smart_router  # noqa: PLC0415
+
+    return frozenset(smart_router.TASK_CLASSES.keys())
+
+
+def _validate_task_class(task_class: Optional[str]) -> None:
+    """Raise ValueError with an actionable message on an unknown task_class.
+
+    A falsy value (None or empty string) is not validated — nothing to check
+    when the field is simply absent, which is the normal case pre-#1560.
+    """
+    if not task_class:
+        return
+    valid = _load_valid_task_classes()
+    if task_class not in valid:
+        raise ValueError(
+            f"unknown task_class {task_class!r}. Must be one of the "
+            f"smart-router closed set: {sorted(valid)}"
+        )
+
+
 def cmd_deliverable_add(args: argparse.Namespace) -> int:
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
     track_id = args.objective
     output_kind = args.output_kind
     title = args.title
+    task_class = getattr(args, "task_class", None)
+    routing_floor = getattr(args, "routing_floor", None)
+
+    try:
+        _validate_task_class(task_class)
+    except ValueError as exc:
+        print(f"deliverable add: {exc}. No change made.", file=sys.stderr)
+        return 2
 
     track = tracks_lib.get_track(state_dir, track_id, project_id)
     if track is None:
@@ -2107,7 +2158,12 @@ def cmd_deliverable_add(args: argparse.Namespace) -> int:
 
     dispatch_id = f"dlv-{uuid.uuid4().hex[:12]}"
     output_ref = f"{output_kind}:{dispatch_id}"
-    metadata = json.dumps({"title": title, "deliverable": True})
+    metadata_dict: dict[str, Any] = {"title": title, "deliverable": True}
+    if task_class:
+        metadata_dict["task_class"] = task_class
+    if routing_floor:
+        metadata_dict["routing_floor"] = routing_floor
+    metadata = json.dumps(metadata_dict)
     now = _now_utc()
 
     conn = _db_conn(state_dir)
@@ -2148,12 +2204,14 @@ def cmd_deliverable_add(args: argparse.Namespace) -> int:
         conn.close()
 
     print(f"Deliverable created: {dispatch_id}")
-    print(f"  objective  : {track_id}")
-    print(f"  output_kind: {output_kind}")
-    print(f"  output_ref : {output_ref}")
-    print(f"  state      : proposed")
-    print(f"  title      : {title}")
-    print(f"  next       : vnx deliverable promote {dispatch_id}")
+    print(f"  objective    : {track_id}")
+    print(f"  output_kind  : {output_kind}")
+    print(f"  output_ref   : {output_ref}")
+    print("  state        : proposed")
+    print(f"  title        : {title}")
+    print(f"  task_class   : {task_class or '(not set)'}")
+    print(f"  routing_floor: {routing_floor or '(not set)'}")
+    print(f"  next         : vnx deliverable promote {dispatch_id}")
     return 0
 
 
@@ -2257,9 +2315,24 @@ def _fetch_deliverable_records(
 
 
 def cmd_deliverable_list(args: argparse.Namespace) -> int:
+    """List deliverables, one section per track.
+
+    Fetches WITH metadata (``include_metadata=True``) and surfaces
+    ``task_class``/``routing_floor`` explicitly — the same two fields the
+    plan-gate reads via ``_format_deliverable_for_plan`` (rubric axes 3/5) —
+    so an operator can see, before the gate ever runs, exactly what the
+    panelists will see: a real value, or an explicit "not set" rather than
+    the field silently disappearing from the listing.
+    """
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
-    records = _fetch_deliverable_records(state_dir, project_id, args.objective)
+    records = _fetch_deliverable_records(
+        state_dir, project_id, args.objective, include_metadata=True,
+    )
+    for r in records:
+        meta = r.get("metadata") or {}
+        r["task_class"] = meta.get("task_class")
+        r["routing_floor"] = meta.get("routing_floor")
 
     if args.json:
         print(json.dumps(records, indent=2, default=str))
@@ -2282,7 +2355,10 @@ def cmd_deliverable_list(args: argparse.Namespace) -> int:
         status = r.get("derived_status") or "-"
         kind = r.get("output_kind") or "-"
         count = r.get("dispatch_count", 1)
+        meta = r.get("metadata") or {}
         print(f"    {ref:<36} {kind:<6} {status:<12} ({count} dispatch(es))")
+        print(f"        {_format_deliverable_field(meta, 'task_class')}")
+        print(f"        {_format_deliverable_field(meta, 'routing_floor')}")
     print()
     return 0
 
@@ -2505,6 +2581,111 @@ def cmd_deliverable_close(args: argparse.Namespace) -> int:
     else:
         print(f"\nvnx deliverable close — {dispatch_id} (project '{project_id}')\n")
         print(f"  ready -> completed (operator attestation: PR {pr_ref})\n")
+    return 0
+
+
+def cmd_deliverable_set(args: argparse.Namespace) -> int:
+    """Set task_class and/or routing_floor metadata on an EXISTING deliverable.
+
+    The write-side half of what PR #1560 shipped read-only:
+    `_format_deliverable_for_plan` has rendered task_class/routing_floor from
+    deliverable metadata since that PR, `deliverable add` can now set them at
+    creation time (this same dispatch), but nothing could set them on a
+    deliverable that already exists — the exact "state the gate demands with
+    no door to reach it" pattern `objective set-goal` and `deliverable close`
+    were each built to close, a third instance of it.
+
+    A dedicated verb rather than an idempotent `add` upsert: `add` always
+    mints a fresh `dispatch_id` (a new row), so reusing it for an in-place
+    update would either silently create a duplicate deliverable or need a
+    fragile lookup-by-title heuristic. `set` looks up the existing row by
+    `dispatch_id` instead — the same identifier `promote`/`close` already key
+    on — and patches only the metadata JSON blob. No schema change: this is
+    the same `metadata_json` column `add` already writes to (ADR-007 does not
+    apply — no new table, no new column, no project_id-scoped uniqueness to
+    add).
+
+    Only the given field(s) are touched: passing `--task-class` alone leaves
+    an existing `routing_floor` (or its absence) untouched, and vice versa.
+    `title` and any other existing metadata keys survive unmodified — this is
+    a patch, not a replace.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    dispatch_id = args.dispatch_id
+    task_class = getattr(args, "task_class", None)
+    routing_floor = getattr(args, "routing_floor", None)
+
+    if not task_class and not routing_floor:
+        print(
+            "deliverable set: nothing to set — pass --task-class and/or "
+            "--routing-floor. No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        _validate_task_class(task_class)
+    except ValueError as exc:
+        print(f"deliverable set: {exc}. No change made.", file=sys.stderr)
+        return 2
+
+    conn = _db_conn(state_dir)
+    try:
+        row = conn.execute(
+            "SELECT * FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+            (dispatch_id, project_id),
+        ).fetchone()
+
+        if row is None:
+            print(
+                f"deliverable set: deliverable not found: {dispatch_id!r} "
+                f"(project {project_id!r}). No change made.",
+                file=sys.stderr,
+            )
+            return 1
+
+        meta = json.loads(row["metadata_json"] or "{}")
+        if task_class:
+            meta["task_class"] = task_class
+        if routing_floor:
+            meta["routing_floor"] = routing_floor
+        new_metadata_json = json.dumps(meta)
+
+        now = _now_utc()
+        conn.execute(
+            """
+            UPDATE dispatches
+            SET metadata_json = ?, updated_at = ?
+            WHERE dispatch_id = ? AND project_id = ?
+            """,
+            (new_metadata_json, now, dispatch_id, project_id),
+        )
+        _append_coordination_event(
+            conn,
+            event_type="deliverable_metadata_set",
+            dispatch_id=dispatch_id,
+            from_state=row["state"],
+            to_state=row["state"],
+            actor="operator",
+            reason="deliverable set: task_class/routing_floor",
+            project_id=project_id,
+            metadata={
+                k: v
+                for k, v in {"task_class": task_class, "routing_floor": routing_floor}.items()
+                if v
+            },
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    parts = []
+    if task_class:
+        parts.append(f"task_class={task_class}")
+    if routing_floor:
+        parts.append(f"routing_floor={routing_floor}")
+    print(f"Set {', '.join(parts)} on {dispatch_id} (project {project_id!r})")
     return 0
 
 
@@ -4548,6 +4729,17 @@ def _build_parser() -> argparse.ArgumentParser:
     p_dadd.add_argument("--output-kind", required=True, choices=_VALID_OUTPUT_KINDS,
                         metavar="KIND", dest="output_kind")
     p_dadd.add_argument("--title", required=True)
+    p_dadd.add_argument(
+        "--task-class", dest="task_class", default=None, metavar="CLASS",
+        help="optional task class from the smart-router closed set "
+             "(01_code_generation .. 07_translation) — the same rubric axis "
+             "the plan-gate reads. Unknown values are refused.",
+    )
+    p_dadd.add_argument(
+        "--routing-floor", dest="routing_floor", default=None, metavar="FLOOR",
+        help="optional model-routing quality floor for this deliverable "
+             "(free text, e.g. a model name) — the plan-gate's rubric axis 5.",
+    )
     p_dadd.set_defaults(func=cmd_deliverable_add)
 
     p_dlist = dlv_sub.add_parser("list", help="list deliverables grouped by objective")
@@ -4577,6 +4769,27 @@ def _build_parser() -> argparse.ArgumentParser:
              "merge state at close time.",
     )
     p_dclose.set_defaults(func=cmd_deliverable_close)
+
+    p_dset = dlv_sub.add_parser(
+        "set",
+        help="tag an EXISTING deliverable with task_class/routing_floor "
+             "(the rubric fields the plan-gate reads)",
+    )
+    _common(p_dset)
+    p_dset.add_argument("dispatch_id")
+    p_dset.add_argument(
+        "--task-class", dest="task_class", default=None, metavar="CLASS",
+        help="task class from the smart-router closed set (01_code_generation "
+             ".. 07_translation). Unknown values are refused. At least one of "
+             "--task-class/--routing-floor is required.",
+    )
+    p_dset.add_argument(
+        "--routing-floor", dest="routing_floor", default=None, metavar="FLOOR",
+        help="model-routing quality floor for this deliverable (free text, "
+             "e.g. a model name). At least one of --task-class/--routing-floor "
+             "is required.",
+    )
+    p_dset.set_defaults(func=cmd_deliverable_set)
 
     # ------------------------------------------------------------------
     # plan-gate subcommand (PM plan-first gate)

--- a/tests/test_deliverable_task_class_routing_floor.py
+++ b/tests/test_deliverable_task_class_routing_floor.py
@@ -1,0 +1,581 @@
+"""tests/test_deliverable_task_class_routing_floor.py — the deliverable-tag door.
+
+PR #1560 made the plan-gate READ `task_class`/`routing_floor` from a
+deliverable's metadata (rubric axes 3/5, via `_format_deliverable_for_plan`).
+Nothing could WRITE them: `vnx deliverable add --help` exposed only
+`--objective`/`--output-kind`/`--title`, and no verb touched an EXISTING
+deliverable's metadata at all. Every real `ready` deliverable therefore
+rendered both fields as `(missing — not set on this deliverable)` regardless
+of what an operator intended.
+
+This suite proves the three cases the dispatch calls out, each of which fails
+against the pre-fix CLI (no `--task-class`/`--routing-floor` flags on `add`,
+no `set` verb, `list` never surfaced the fields):
+
+  (a) `deliverable add --task-class ... --routing-floor ...` stores both, and
+      `deliverable list` shows them (human + JSON).
+  (b) `deliverable set <id> --task-class ... --routing-floor ...` on an
+      ALREADY-EXISTING deliverable works, and does not overwrite `title` or
+      any other pre-existing metadata key.
+  (c) a deliverable with neither field keeps working exactly as before, and
+      both `list` and the plan-gate plan text show them as explicitly missing
+      — never silently omitted.
+
+Plus the validation contract from point 4 of the dispatch: `task_class` is
+checked against `smart_router.TASK_CLASSES` (the SAME closed set
+`vnx horizon plan-gate run --task-class` already documents — see
+HORIZON_PLANNING.md's `task_class == 01_code_generation` new-feature axis);
+`routing_floor` is free text (no canonical vocabulary for it exists anywhere
+in the repo — `plan_gate_panel.py` calls it a "quality FLOOR", not a closed
+set), so it is never validated against a list.
+
+Real-command-output proof of the plan-gate seeing tagged values (not
+`(missing ...)`) lives in `test_set_tag_reaches_real_plan_gate_text` at the
+bottom — the panel model call is stubbed (same pattern as
+`test_plan_gate_deliverables_source.py`), but `cmd_deliverable_add` /
+`cmd_plan_gate_run` / `resolve_plan_source` / `_format_deliverable_for_plan`
+are all the real, unmodified functions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import planning_cli  # noqa: E402
+import plan_gate_panel as pgp  # noqa: E402
+import schema_migration  # noqa: E402
+import smart_router  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
+PROJECT_ID = "test-proj"
+_THICK_GOAL = "Ship a coherent plan for the widget. " * 10  # 390 chars
+
+
+def _build_db(tmp_path: Path) -> Path:
+    """Return a state_dir with migrations 0022 + 0024 + 0027 applied — same
+    shape as test_deliverable_close.py / test_planning_deliverables.py."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch',
+            entity_id TEXT NOT NULL,
+            from_state TEXT,
+            to_state TEXT,
+            actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+
+    for ver, fname in (
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    ensure_dispatches_columns(conn)
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    schema_migration.apply_script_if_below(
+        conn,
+        27,
+        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+@pytest.fixture()
+def state_with_track(tmp_path: Path) -> tuple[Path, str]:
+    state_dir = _build_db(tmp_path)
+    track_id = "feat-alpha"
+    tracks_lib.create_track(
+        state_dir,
+        track_id,
+        PROJECT_ID,
+        title="Feature Alpha",
+        goal_state="ship Feature Alpha",
+        phase="queued",
+        horizon="now",
+    )
+    return state_dir, track_id
+
+
+def _dispatch_ids(state_dir: Path, state: str) -> list[str]:
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    rows = conn.execute(
+        "SELECT dispatch_id FROM dispatches WHERE project_id = ? AND state = ? ORDER BY id",
+        (PROJECT_ID, state),
+    ).fetchall()
+    conn.close()
+    return [r[0] for r in rows]
+
+
+def _metadata(state_dir: Path, dispatch_id: str) -> dict:
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    row = conn.execute(
+        "SELECT metadata_json FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+        (dispatch_id, PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    return json.loads(row[0]) if row and row[0] else {}
+
+
+# ---------------------------------------------------------------------------
+# smart_router closed set sanity: the fixture below assumes these two values
+# are real members. If the classifier's vocabulary ever changes, this fails
+# loud here instead of silently validating against a stale assumption.
+# ---------------------------------------------------------------------------
+
+def test_fixture_task_classes_are_real_smart_router_values():
+    assert "01_code_generation" in smart_router.TASK_CLASSES
+    assert "02_code_review" in smart_router.TASK_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# (a) `deliverable add` with both flags stores them, `list` shows them
+# ---------------------------------------------------------------------------
+
+def test_add_with_task_class_and_routing_floor_stored_and_listed(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "pr",
+        "--title", "Implement the widget",
+        "--task-class", "01_code_generation",
+        "--routing-floor", "sonnet",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    add_out = capsys.readouterr().out
+    assert "task_class   : 01_code_generation" in add_out
+    assert "routing_floor: sonnet" in add_out
+
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+    meta = _metadata(state_dir, dispatch_id)
+    assert meta["task_class"] == "01_code_generation"
+    assert meta["routing_floor"] == "sonnet"
+    assert meta["title"] == "Implement the widget"  # untouched
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    list_out = capsys.readouterr().out
+    assert "task_class: 01_code_generation" in list_out
+    assert "routing_floor: sonnet" in list_out
+    assert "(missing" not in list_out
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+        "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data[0]["task_class"] == "01_code_generation"
+    assert data[0]["routing_floor"] == "sonnet"
+
+
+def test_add_with_unknown_task_class_refused(state_with_track: tuple[Path, str], capsys):
+    """Point 4: task_class IS validated against the smart-router closed set —
+    an unknown value is refused loud, nothing is created."""
+    state_dir, track_id = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "pr",
+        "--title", "Bad tag",
+        "--task-class", "not-a-real-class",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown task_class" in err
+    assert _dispatch_ids(state_dir, "proposed") == []
+
+
+def test_add_routing_floor_is_free_text_not_validated(
+    state_with_track: tuple[Path, str], capsys
+):
+    """routing_floor has NO canonical vocabulary anywhere in the repo (point
+    4) — any non-empty value is accepted."""
+    state_dir, track_id = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "pr",
+        "--title", "Free-text floor",
+        "--routing-floor", "some-made-up-floor-value",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    capsys.readouterr()
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+    assert _metadata(state_dir, dispatch_id)["routing_floor"] == "some-made-up-floor-value"
+
+
+# ---------------------------------------------------------------------------
+# (b) `deliverable set` on an EXISTING deliverable, title untouched
+# ---------------------------------------------------------------------------
+
+def test_set_on_existing_deliverable_works_and_preserves_title(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Q3 launch post",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    capsys.readouterr()
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+    assert "task_class" not in _metadata(state_dir, dispatch_id)
+
+    rc = planning_cli.main([
+        "deliverable", "set", dispatch_id,
+        "--task-class", "02_code_review",
+        "--routing-floor", "opus",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "task_class=02_code_review" in out
+    assert "routing_floor=opus" in out
+
+    meta = _metadata(state_dir, dispatch_id)
+    assert meta["task_class"] == "02_code_review"
+    assert meta["routing_floor"] == "opus"
+    assert meta["title"] == "Q3 launch post"  # NOT overwritten
+    assert meta["deliverable"] is True  # NOT dropped
+
+
+def test_set_partial_update_leaves_the_other_field_untouched(
+    state_with_track: tuple[Path, str], capsys
+):
+    """Setting only --task-class does not clobber a routing_floor set earlier
+    (and vice versa) — a patch, not a replace."""
+    state_dir, track_id = state_with_track
+    planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Partial update target",
+        "--routing-floor", "kimi",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    capsys.readouterr()
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+
+    rc = planning_cli.main([
+        "deliverable", "set", dispatch_id,
+        "--task-class", "03_refactoring",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    capsys.readouterr()
+
+    meta = _metadata(state_dir, dispatch_id)
+    assert meta["task_class"] == "03_refactoring"
+    assert meta["routing_floor"] == "kimi"  # untouched by the task_class-only set
+
+
+def test_set_unknown_task_class_refused_no_change(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Guard me",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    capsys.readouterr()
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+
+    rc = planning_cli.main([
+        "deliverable", "set", dispatch_id,
+        "--task-class", "definitely-not-in-the-closed-set",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown task_class" in err
+    assert "task_class" not in _metadata(state_dir, dispatch_id)
+
+
+def test_set_requires_at_least_one_field(state_with_track: tuple[Path, str], capsys):
+    state_dir, track_id = state_with_track
+    planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Nothing to set",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    capsys.readouterr()
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+
+    rc = planning_cli.main([
+        "deliverable", "set", dispatch_id,
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "nothing to set" in err.lower()
+
+
+def test_set_unknown_deliverable_fails_loud(state_with_track: tuple[Path, str], capsys):
+    state_dir, _ = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "set", "no-such-deliverable",
+        "--task-class", "01_code_generation",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err
+
+
+# ---------------------------------------------------------------------------
+# (c) a deliverable with NEITHER field keeps working, shown as missing
+# ---------------------------------------------------------------------------
+
+def test_untagged_deliverable_still_works_and_shows_missing(
+    state_with_track: tuple[Path, str], capsys
+):
+    state_dir, track_id = state_with_track
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "doc",
+        "--title", "No tags here",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    add_out = capsys.readouterr().out
+    assert "task_class   : (not set)" in add_out
+    assert "routing_floor: (not set)" in add_out
+
+    dispatch_id = _dispatch_ids(state_dir, "proposed")[-1]
+    meta = _metadata(state_dir, dispatch_id)
+    assert "task_class" not in meta
+    assert "routing_floor" not in meta
+    assert meta["title"] == "No tags here"  # the deliverable is otherwise intact
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "task_class: (missing" in out
+    assert "routing_floor: (missing" in out
+
+    # promote still works normally — tagging is orthogonal to the lifecycle gate.
+    rc = planning_cli.main([
+        "deliverable", "promote", dispatch_id,
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Real-command-output proof: the plan-gate plan text sees the SET values.
+# ---------------------------------------------------------------------------
+
+def _bootstrap_plan_gate(tmp_path: Path) -> Path:
+    """Same migration set as test_plan_gate_deliverables_source.py's
+    _bootstrap — the plan-gate path additionally needs 28/29/30/33."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS dispatches (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL DEFAULT 'vnx-dev', "
+        "state TEXT NOT NULL DEFAULT 'queued', terminal_id TEXT, track TEXT, "
+        "priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT, "
+        "attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT, "
+        "created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "expires_after TEXT, metadata_json TEXT DEFAULT '{}', "
+        "UNIQUE(dispatch_id, project_id))"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS coordination_events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "event_id TEXT, event_type TEXT, entity_type TEXT, entity_id TEXT, from_state TEXT, "
+        "to_state TEXT, actor TEXT, reason TEXT, metadata_json TEXT, occurred_at TEXT, project_id TEXT)"
+    )
+    conn.commit()
+    for version, filename in [
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    ensure_dispatches_columns(conn)
+    conn.commit()
+    for version, filename in [
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+        (29, "0029_track_type_discriminator.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+        (33, "0033_track_decision_ref.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _pass_result(track_id: str, project_id: str, panel: list) -> dict:
+    return {
+        "track_id": track_id, "project_id": project_id, "decision": "PASS",
+        "summary": {"decision": "PASS", "pass_count": len(panel),
+                    "revise_count": 0, "block_count": 0, "rationale": "ok"},
+        "panelists": [], "doc_truncation": {"truncated": False},
+    }
+
+
+def _stub_panel(monkeypatch, tmp_path: Path, captured: list) -> None:
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+
+    def _capture_run_panel(doc_path, *, doc_text=None, track_id, project_id, panel, data_dir, **kw):
+        captured.append({"doc_path": doc_path, "doc_text": doc_text, "panel": panel})
+        return _pass_result(track_id, project_id, panel)
+
+    monkeypatch.setattr(pgp, "run_panel", _capture_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
+
+
+def test_set_tag_reaches_real_plan_gate_text(tmp_path, monkeypatch, capsys):
+    """(a)+(c) proved via real command output at the plan-gate boundary: a
+    track with one tagged deliverable and one untagged deliverable gates
+    successfully, and the text handed to the panel shows the tagged
+    deliverable's real values while the untagged one still reads as missing —
+    exactly the axis-3/5 gap #1560 flagged and this dispatch closes."""
+    state_dir = _bootstrap_plan_gate(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-tagged", "p1", "t", _THICK_GOAL, phase="queued")
+
+    rc_tagged = planning_cli.main([
+        "deliverable", "add",
+        "--objective", "feat-tagged", "--output-kind", "pr",
+        "--title", "Tagged deliverable",
+        "--task-class", "01_code_generation", "--routing-floor", "opus",
+        "--project-id", "p1", "--state-dir", str(state_dir),
+    ])
+    assert rc_tagged == 0
+    tagged_out = capsys.readouterr().out
+    assert "task_class   : 01_code_generation" in tagged_out
+
+    rc_untagged = planning_cli.main([
+        "deliverable", "add",
+        "--objective", "feat-tagged", "--output-kind", "doc",
+        "--title", "Untagged deliverable",
+        "--project-id", "p1", "--state-dir", str(state_dir),
+    ])
+    assert rc_untagged == 0
+    capsys.readouterr()
+
+    captured: list = []
+    _stub_panel(monkeypatch, tmp_path, captured)
+
+    args = argparse.Namespace(
+        track_id="feat-tagged", project_id="p1", state_dir=str(state_dir),
+        doc=None, json=False, panel_seats=None,
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    err = capsys.readouterr().err
+
+    assert rc == 0
+    assert len(captured) == 1
+    doc_text = captured[0]["doc_text"]
+
+    # Real command output — the SET values reach the panel-visible plan text.
+    assert "task_class: 01_code_generation" in doc_text
+    assert "routing_floor: opus" in doc_text
+    # The untagged sibling still reads as explicitly missing, not omitted.
+    assert "task_class: (missing" in doc_text
+    assert "routing_floor: (missing" in doc_text
+    assert "plan-gate source: track goal_state + 2 deliverable(s)" in err

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -327,6 +327,7 @@ _DELIVERABLE_ARGV = {
     "list": [],
     "promote": ["dlv-fake-id"],
     "close": ["dlv-fake-id", "--evidence", "123"],
+    "set": ["dlv-fake-id", "--task-class", "01_code_generation"],
 }
 _PLAN_GATE_ARGV = {
     "seed": ["delegate-track"],

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -246,11 +246,18 @@ def _cmd_deliverable_close(args: Any) -> int:
     return pc.cmd_deliverable_close(args)
 
 
+def _cmd_deliverable_set(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_deliverable_set(args)
+
+
 _DELIVERABLE_DISPATCH: dict[str, Callable[[Any], int]] = {
     "add": _cmd_deliverable_add,
     "list": _cmd_deliverable_list,
     "promote": _cmd_deliverable_promote,
     "close": _cmd_deliverable_close,
+    "set": _cmd_deliverable_set,
 }
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -738,6 +738,17 @@ def _register_deliverable_verbs(subs: argparse.Action) -> None:
     p_dadd.add_argument("--output-kind", required=True, choices=_OUTPUT_KIND_CHOICES,
                         metavar="KIND", dest="output_kind")
     p_dadd.add_argument("--title", required=True)
+    p_dadd.add_argument(
+        "--task-class", dest="task_class", default=None, metavar="CLASS",
+        help="optional task class from the smart-router closed set "
+             "(01_code_generation .. 07_translation) — the same rubric axis "
+             "the plan-gate reads. Unknown values are refused.",
+    )
+    p_dadd.add_argument(
+        "--routing-floor", dest="routing_floor", default=None, metavar="FLOOR",
+        help="optional model-routing quality floor for this deliverable "
+             "(free text, e.g. a model name) — the plan-gate's rubric axis 5.",
+    )
 
     p_dlist = subs.add_parser("list", help="list deliverables grouped by objective")
     _common_horizon_args(p_dlist)
@@ -761,6 +772,26 @@ def _register_deliverable_verbs(subs: argparse.Action) -> None:
         help="delivering PR as #NNN or NNN (REQUIRED). Records an operator "
              "attestation of what delivered the work; VNX does not verify the "
              "merge state at close time.",
+    )
+
+    p_dset = subs.add_parser(
+        "set",
+        help="tag an EXISTING deliverable with task_class/routing_floor "
+             "(the rubric fields the plan-gate reads)",
+    )
+    _common_horizon_args(p_dset)
+    p_dset.add_argument("dispatch_id")
+    p_dset.add_argument(
+        "--task-class", dest="task_class", default=None, metavar="CLASS",
+        help="task class from the smart-router closed set (01_code_generation "
+             ".. 07_translation). Unknown values are refused. At least one of "
+             "--task-class/--routing-floor is required.",
+    )
+    p_dset.add_argument(
+        "--routing-floor", dest="routing_floor", default=None, metavar="FLOOR",
+        help="model-routing quality floor for this deliverable (free text, "
+             "e.g. a model name). At least one of --task-class/--routing-floor "
+             "is required.",
     )
 
 


### PR DESCRIPTION
## Summary

PR #1560 made the plan-gate READ `task_class`/`routing_floor` from a deliverable's `metadata_json` (`_format_deliverable_for_plan`, rubric axes 3/5), but nothing could WRITE them: `vnx deliverable add --help` exposed only `--objective`/`--output-kind`/`--title`, and no verb touched an existing deliverable's metadata at all. Every real `ready` deliverable therefore rendered both fields as `(missing — not set on this deliverable)`.

This closes the write-side gap — the third instance of the "state the gate demands with no door to reach it" pattern (`objective set-goal`, `deliverable close` were the first two).

- `vnx deliverable add` gains optional `--task-class`/`--routing-floor`.
- New `vnx deliverable set <dispatch_id> [--task-class ...] [--routing-floor ...]` tags an **existing** deliverable in place (patches `metadata_json`, preserves `title` and any other keys; requires at least one flag).
- `vnx deliverable list` now surfaces both fields (human + `--json`), explicitly marked missing when absent — never silently omitted.
- `task_class` is validated against `smart_router.TASK_CLASSES` — the same closed set (`01_code_generation`..`07_translation`) that `vnx horizon plan-gate run --task-class` already documents (HORIZON_PLANNING.md: `task_class == 01_code_generation` marks a new feature). Unknown values are refused loud, nothing is written.
- `routing_floor` is free text — no canonical vocabulary for it exists anywhere in the repo (`plan_gate_panel.py` calls it a "quality FLOOR", not a closed set), so per the dispatch instructions it is not validated against a list.

No schema change: both verbs write to the existing `metadata_json` JSON blob column on `dispatches`. ADR-007 does not apply (no new table/column/uniqueness).

Both the raw engine (`scripts/planning_cli.py`) and the pip-CLI parity layer (`vnx_cli/main.py` + `vnx_cli/commands/horizon.py`) were updated together — `tests/test_horizon_parity.py` (updated with a `set` entry) enforces this stays in sync.

## Changes

- `scripts/planning_cli.py`: `_load_valid_task_classes`/`_validate_task_class` helpers; `cmd_deliverable_add` gains `--task-class`/`--routing-floor`; new `cmd_deliverable_set`; `cmd_deliverable_list` surfaces both fields; argparse wiring for `add`/new `set` subcommand.
- `vnx_cli/main.py`: mirrors the `--task-class`/`--routing-floor` flags on `add` and the new `set` subparser (pip-CLI parity).
- `vnx_cli/commands/horizon.py`: `_cmd_deliverable_set` delegate + `_DELIVERABLE_DISPATCH["set"]`.
- `tests/test_deliverable_task_class_routing_floor.py` (new): the three required cases (add-with-flags+list, set-on-existing preserves title, untagged-stays-missing) plus validation/negative-path tests and a real-command-output plan-gate integration test.
- `tests/test_horizon_parity.py`: added `set` to `_DELIVERABLE_ARGV` so the new verb is covered by the delegation-parity test.
- `docs/core/HORIZON_PLANNING.md`: deliverable-verbs table updated (also backfilled the pre-existing-stale missing `close` row while I was there).

## Verification

Targeted suite (files touched + direct neighbours), all green, run twice — once pre fast-forward to origin/main, once after:

```
python3 -m pytest \
  tests/test_deliverable_task_class_routing_floor.py \
  tests/test_planning_deliverables.py \
  tests/test_deliverable_close.py \
  tests/test_plan_gate_deliverables_source.py \
  tests/test_horizon_parity.py \
  tests/test_horizon_cli.py \
  -q
# 171 passed
```

`tests/test_planning_cli.py` and `tests/test_cli_flag_forwarding.py::test_rgm_request_auto_computes_changed_files_when_blank` were also run; both have pre-existing, unrelated failures confirmed identical on `git stash` (baseline) — a migration-prereq-guard fixture issue (OI-1213) and an unrelated `strict=` kwarg mismatch, neither touching deliverables.

Real command output (bootstrapped a scratch state DB, migrations 22/24/27):

```
$ vnx deliverable add --objective feat-demo --output-kind pr --title "Tagged deliverable" \
    --task-class 01_code_generation --routing-floor opus ...
  task_class   : 01_code_generation
  routing_floor: opus

$ vnx deliverable set dlv-7df9de983f67 --task-class 02_code_review --routing-floor sonnet ...
Set task_class=02_code_review, routing_floor=sonnet on dlv-7df9de983f67 (project 'demo-proj')

$ vnx deliverable set dlv-7df9de983f67 --task-class not-a-real-class ...
deliverable set: unknown task_class 'not-a-real-class'. Must be one of the smart-router
closed set: ['01_code_generation', ..., '07_translation']. No change made.
(exit 2)
```

And the plan-gate's real `resolve_plan_source` output for the same track (via `_format_deliverable_for_plan`) now shows real values instead of `(missing ...)` for both deliverables once tagged — confirmed both via a pytest integration test with the model call stubbed (`test_set_tag_reaches_real_plan_gate_text`) and via the direct `resolve_plan_source` call shown above.

`ruff check` on all touched files: clean (5 pre-existing findings in `scripts/planning_cli.py`, none in code added/touched by this PR — confirmed by diff line ranges).

## Test plan

- [x] `deliverable add --task-class/--routing-floor` stores them; `deliverable list` shows them (human + JSON)
- [x] `deliverable set` on an existing deliverable works, preserves `title`/other metadata, supports partial updates
- [x] untagged deliverable still works, shows explicit "not set"/"(missing...)" everywhere
- [x] unknown `task_class` refused loud (add + set), no change made
- [x] `routing_floor` accepts arbitrary free text (no canonical list)
- [x] `vnx horizon`/`vnx objective`/`vnx deliverable` pip-CLI parity (`test_horizon_parity.py`)
- [x] real command-line evidence captured (see Verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)