### PR TITLE
fix(dispatch): read completion_text in classify_failure instead of discarding it

### DIFF
--- a/scripts/lib/envelope_govern.py
+++ b/scripts/lib/envelope_govern.py
@@ -361,12 +361,16 @@ def _govern(
 
                 # OI-866: classify failure so the receipt carries a distinguishable
                 # failure_reason + failure_class instead of a silent
-                # "(no error captured)" log line.
+                # "(no error captured)" log line. classify_failure_safe (dispatch
+                # 20260816-p9p10-failure-reason-root) never raises and never
+                # returns an empty failure_reason for a non-success status —
+                # a classify_failure regression can no longer land a receipt
+                # with the field silently unset.
                 _classification: Dict[str, Optional[str]] = {"failure_class": None, "failure_reason": None}
                 if adapter_result.status != "success":
                     try:
-                        from failure_classification import classify_failure  # noqa: PLC0415
-                        _classification = classify_failure(
+                        from failure_classification import classify_failure_safe  # noqa: PLC0415
+                        _classification = classify_failure_safe(
                             status=adapter_result.status,
                             error=adapter_result.error,
                             completion_text=adapter_result.completion_text,
@@ -374,13 +378,24 @@ def _govern(
                             provider=spec.provider,
                             duration_seconds=duration,
                             returncode=adapter_result.returncode,
+                            dispatch_id=spec.dispatch_id,
                         )
-                    except Exception:  # noqa: BLE001 — classification is best-effort
+                    except Exception as _classify_exc:  # noqa: BLE001 — the failure_classification
+                        # module itself failing to import is the one thing
+                        # classify_failure_safe cannot guard against from
+                        # inside itself; keep the same never-empty guarantee.
                         logger.debug(
-                            "envelope._govern: failure classification failed dispatch=%s (non-fatal)",
+                            "envelope._govern: failure_classification unavailable dispatch=%s (non-fatal)",
                             spec.dispatch_id,
                             exc_info=True,
                         )
+                        _classification = {
+                            "failure_class": "unknown",
+                            "failure_reason": (
+                                f"failure_classification unavailable: {_classify_exc!r} "
+                                f"(dispatch={spec.dispatch_id})"
+                            ),
+                        }
 
                 receipt_path = emit_dispatch_receipt(
                     dispatch_id=spec.dispatch_id,

--- a/scripts/lib/failure_classification.py
+++ b/scripts/lib/failure_classification.py
@@ -14,11 +14,26 @@ auth_rejected    — HTTP 401/403 from the provider endpoint (proxy, API, etc.)
 empty_completion — call succeeded (HTTP 200) but the model returned zero text
 timeout          — call exceeded its deadline
 model_error      — the model/provider itself returned an error (5xx, rate-limit, etc.)
+credit_exhausted — provider/gateway balance or credits ran out (HTTP 402 and
+                    variants); dispatch 20260816-p9p10-failure-reason-root
 unknown          — everything else; should be rare after OI-866
+
+dispatch 20260816-p9p10-failure-reason-root: the glm-harness and
+deepseek-harness lanes route through the `claude` CLI, so a provider-side API
+error (e.g. "API Error: 402 Insufficient Balance") arrives as ordinary
+assistant TEXT in ``completion_text`` — the spawn never populates ``error``
+for that case. classify_failure previously only pattern-matched ``error``,
+so any failure with a real, readable completion and no separate ``error``
+fell through to the contentless ``"(no error captured)"`` fallback even
+though the reason was sitting right there on disk. classify_failure now also
+scans ``completion_text`` (only when ``error`` is empty — a caller-supplied
+``error`` stays authoritative) and, failing a specific pattern match, surfaces
+a bounded snippet of the completion itself instead of just its length.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, Optional
 
 
@@ -27,8 +42,50 @@ FAILURE_CLASSES = frozenset({
     "empty_completion",
     "timeout",
     "model_error",
+    "credit_exhausted",
     "unknown",
 })
+
+# Credit/balance exhaustion — matched on phrases actually observed in the
+# ledger (measured 2026-08-16, dispatch 20260816-p9p10-failure-reason-root):
+# deepseek-harness prints a direct "API Error: 402 Insufficient Balance";
+# glm-harness's OpenRouter gateway wraps the same signal inside a 500
+# "litellm.acompletion" envelope ("...requires more credits...",
+# "openrouter_credits" in the error metadata). Provider error text is not a
+# stable contract — a future variant that does not match one of these phrases
+# falls through to `unknown` below and must be added here explicitly once
+# observed, never silently absorbed back into a contentless placeholder.
+CREDIT_EXHAUSTED_KEYWORDS = (
+    "insufficient balance",
+    "insufficient_balance",
+    "insufficient credits",
+    "requires more credits",
+    "add more credits",
+    "openrouter_credits",
+)
+
+# Provider gateways (observed: glm-harness's litellm/OpenRouter proxy) can wrap
+# the real one-line reason inside a multi-KB nested JSON blob carrying dozens
+# of duplicated retry attempts. Prefer the first quoted "message" field (the
+# provider's own sentence) when present.
+_JSON_MESSAGE_RE = re.compile(r'"message"\s*:\s*"([^"]*)"')
+_MAX_DETAIL_LEN = 300
+
+
+def _extract_detail(text: Optional[str], max_len: int = _MAX_DETAIL_LEN) -> str:
+    """Pull a bounded, human-readable detail out of raw error/completion text.
+
+    Falls back to a truncated, whitespace-collapsed prefix of the raw text
+    when no JSON "message" field is present, so a receipt's failure_reason
+    never carries a multi-KB blob.
+    """
+    text = text or ""
+    match = _JSON_MESSAGE_RE.search(text)
+    detail = match.group(1) if match else text
+    detail = " ".join(detail.split())
+    if len(detail) > max_len:
+        detail = detail[:max_len].rstrip() + "…"
+    return detail or "(empty)"
 
 
 def classify_failure(
@@ -79,6 +136,23 @@ def classify_failure(
 
     error_lower = (error or "").lower()
 
+    # A caller-supplied `error` stays authoritative and completion_text is
+    # never consulted for it. Only when `error` is empty does the provider's
+    # failure text live solely in the completion (see module docstring) —
+    # scan that instead so it is never silently discarded.
+    signal_text = error_lower if error else completion.lower()
+
+    # ── credit / balance exhaustion ────────────────────────────────────────
+    # Checked before model_keywords so glm-harness's outer "500" wrapper never
+    # hides the real, actionable 402-credits cause nested inside it.
+    if any(kw in signal_text for kw in CREDIT_EXHAUSTED_KEYWORDS):
+        source = _error_source(provider, sub_provider)
+        detail = _extract_detail(error if error else completion)
+        return {
+            "failure_class": "credit_exhausted",
+            "failure_reason": f"{source}: credit/balance exhausted — {detail}",
+        }
+
     # ── auth rejection ───────────────────────────────────────────────────
     auth_keywords = (
         "authentication", "auth",
@@ -87,11 +161,12 @@ def classify_failure(
         "unauthorized", "forbidden",
         "401", "403",
     )
-    if any(kw in error_lower for kw in auth_keywords):
+    if any(kw in signal_text for kw in auth_keywords):
         source = _error_source(provider, sub_provider)
+        detail = error if error else _extract_detail(completion)
         return {
             "failure_class": "auth_rejected",
-            "failure_reason": f"{source}: {error}",
+            "failure_reason": f"{source}: {detail}",
         }
 
     # ── model / provider error ──────────────────────────────────────────
@@ -102,18 +177,66 @@ def classify_failure(
         "500", "502", "503", "504",
         "bad gateway", "service unavailable",
     )
-    if any(kw in error_lower for kw in model_keywords):
-        return {"failure_class": "model_error", "failure_reason": error}
+    if any(kw in signal_text for kw in model_keywords):
+        detail = error if error else _extract_detail(completion)
+        return {"failure_class": "model_error", "failure_reason": detail}
 
     # ── error present but no keyword match ───────────────────────────────
     if error:
         return {"failure_class": "unknown", "failure_reason": error}
 
-    # ── status is failure with no error at all ───────────────────────────
+    # ── error absent but completion is non-empty (guaranteed by the
+    # empty_completion guard above) — surface the completion itself instead
+    # of a contentless "(no error captured)" placeholder; the provider's own
+    # words are on disk, even if they match no known pattern above.
     return {
         "failure_class": "unknown",
-        "failure_reason": f"provider={provider} returncode={returncode} completion_len={len(completion)} (no error captured)",
+        "failure_reason": f"provider={provider} returncode={returncode}: {_extract_detail(completion)}",
     }
+
+
+def classify_failure_safe(
+    *,
+    status: str,
+    error: Optional[str] = None,
+    completion_text: Optional[str] = None,
+    timed_out: bool = False,
+    provider: str = "",
+    sub_provider: Optional[str] = None,
+    duration_seconds: Optional[float] = None,
+    returncode: Optional[int] = None,
+    dispatch_id: str = "",
+) -> Dict[str, Optional[str]]:
+    """classify_failure(), guaranteed to never raise and never leave a
+    non-success receipt with a completely empty failure_reason.
+
+    Both receipt-emit call sites (envelope_govern._govern,
+    provider_dispatch._emit_governance) previously wrapped classify_failure()
+    in their own best-effort try/except and, on an exception, left
+    failure_reason/failure_class at their None default — the exact
+    "completely empty field" gap dispatch 20260816-p9p10-failure-reason-root
+    measured on the ledger (100 receipts, all pre-OI-866; none since). Routing
+    both call sites through this single safety net means a future
+    classify_failure regression can no longer reintroduce that gap silently.
+    """
+    if status == "success":
+        return {"failure_class": None, "failure_reason": None}
+    try:
+        return classify_failure(
+            status=status,
+            error=error,
+            completion_text=completion_text,
+            timed_out=timed_out,
+            provider=provider,
+            sub_provider=sub_provider,
+            duration_seconds=duration_seconds,
+            returncode=returncode,
+        )
+    except Exception as exc:  # noqa: BLE001 — this IS the safety net; must never raise
+        return {
+            "failure_class": "unknown",
+            "failure_reason": f"failure classification raised {exc!r} (dispatch={dispatch_id})",
+        }
 
 
 def _build_reason(

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -837,32 +837,41 @@ def _emit_governance(
     for attempt in range(_EMIT_MAX_RETRIES):
         try:
             # OI-866: classify failure so the receipt carries a distinguishable
-            # failure_reason + failure_class.
+            # failure_reason + failure_class. classify_failure_safe (dispatch
+            # 20260816-p9p10-failure-reason-root) never raises and never
+            # returns an empty failure_reason for a non-success status — a
+            # classify_failure regression can no longer land a receipt with
+            # the field silently unset.
             _fail_reason: Optional[str] = None
             _fail_class: Optional[str] = None
             if status != "success":
                 try:
-                    from failure_classification import classify_failure  # noqa: PLC0415
-                    _error = getattr(result, "error", None)
-                    _completion = getattr(result, "completion_text", None)
-                    _timed_out = getattr(result, "timed_out", False)
-                    _rc = getattr(result, "returncode", None)
-                    _classification = classify_failure(
+                    from failure_classification import classify_failure_safe  # noqa: PLC0415
+                    _classification = classify_failure_safe(
                         status=status,
-                        error=_error,
-                        completion_text=_completion,
-                        timed_out=_timed_out,
+                        error=getattr(result, "error", None),
+                        completion_text=getattr(result, "completion_text", None),
+                        timed_out=getattr(result, "timed_out", False),
                         provider=provider,
                         duration_seconds=duration,
-                        returncode=_rc,
+                        returncode=getattr(result, "returncode", None),
+                        dispatch_id=getattr(args, "dispatch_id", "?"),
                     )
                     _fail_reason = _classification.get("failure_reason")
                     _fail_class = _classification.get("failure_class")
-                except Exception:  # noqa: BLE001 — classification is best-effort
+                except Exception as _classify_exc:  # noqa: BLE001 — the failure_classification
+                    # module itself failing to import is the one thing
+                    # classify_failure_safe cannot guard against from inside
+                    # itself; keep the same never-empty guarantee here.
                     logger.debug(
-                        "_emit_governance: failure classification failed dispatch=%s (non-fatal)",
+                        "_emit_governance: failure_classification unavailable dispatch=%s (non-fatal)",
                         getattr(args, "dispatch_id", "?"),
                         exc_info=True,
+                    )
+                    _fail_class = "unknown"
+                    _fail_reason = (
+                        f"failure_classification unavailable: {_classify_exc!r} "
+                        f"(dispatch={getattr(args, 'dispatch_id', '?')})"
                     )
 
             receipt_path = emit_dispatch_receipt(

--- a/tests/test_failclass_registry.py
+++ b/tests/test_failclass_registry.py
@@ -129,7 +129,10 @@ class TestClassifyFailure:
         assert result["failure_class"] == "model_error"
 
     def test_unknown_when_no_error_provided(self):
-        """A failure with no error at all produces unknown classification."""
+        """A failure with no `error` but a non-empty, unrecognized completion
+        surfaces the completion's own content — dispatch 20260816-p9p10-
+        failure-reason-root: the old contentless '(no error captured)'
+        placeholder discarded exactly this text even though it was on disk."""
         from failure_classification import classify_failure
 
         result = classify_failure(
@@ -142,7 +145,8 @@ class TestClassifyFailure:
         )
         assert result["failure_class"] == "unknown"
         assert result["failure_reason"] is not None
-        assert "no error captured" in result["failure_reason"]
+        assert "some text" in result["failure_reason"]
+        assert "no error captured" not in result["failure_reason"]
 
     def test_success_returns_none_fields(self):
         """A success status returns None for both fields."""
@@ -157,6 +161,185 @@ class TestClassifyFailure:
         )
         assert result["failure_class"] is None
         assert result["failure_reason"] is None
+
+
+# ===========================================================================
+# Dispatch 20260816-p9p10-failure-reason-root: the provider-lane completion
+# carries the failure reason, not `error` — classify_failure must read it.
+#
+# Ledger measurement (2026-08-16, t0_receipts.ndjson, glm-harness +
+# deepseek-harness, no head/sampling — full ledger walk):
+#   glm-harness      : 85 failures — 7 named, 13 "(no error captured)", 65 empty
+#   deepseek-harness : 47 failures — 0 named, 12 "(no error captured)", 35 empty
+# All 100 empty-failure_reason receipts predate the OI-866 commit
+# (c0979272, 2026-07-31) that first added the field to ReceiptV2 — the last
+# empty one is timestamped 2026-07-29T18:35:42Z, none since. That gap is
+# closed by construction (the field did not exist yet); classify_failure_safe
+# below adds a defensive backstop so a *future* classify_failure regression
+# cannot silently reopen it. The remaining 25 "(no error captured)" receipts
+# are the live bug this dispatch fixes: `error` was empty but `completion_text`
+# held the provider's own words (deepseek: "API Error: 402 Insufficient
+# Balance"; glm: a 500-wrapped OpenRouter 402 credits error; glm: "API Error:
+# Content block not found") and classify_failure never looked at it.
+# ===========================================================================
+
+
+class TestCompletionTextCarriesFailureReason:
+    """OI-866 follow-up: classify_failure must read completion_text when
+    `error` is empty, instead of collapsing a readable provider error into
+    '(no error captured)'."""
+
+    def test_deepseek_402_insufficient_balance_in_completion(self):
+        """deepseek-harness's direct '402 Insufficient Balance' text lands in
+        completion_text with error=None (observed dispatch
+        20260816-p1-gate-reads-deliverables, completion_len=35)."""
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error=None,
+            completion_text="API Error: 402 Insufficient Balance",
+            timed_out=False,
+            provider="deepseek-harness",
+            returncode=1,
+        )
+        assert result["failure_class"] == "credit_exhausted"
+        assert "Insufficient Balance" in result["failure_reason"]
+        assert "deepseek-api" in result["failure_reason"]
+        assert "no error captured" not in result["failure_reason"]
+
+    def test_glm_500_wrapped_openrouter_402_credits_in_completion(self):
+        """glm-harness's litellm/OpenRouter proxy wraps the real 402-credits
+        cause inside a 500 'litellm.acompletion' envelope with a multi-KB
+        nested JSON blob (observed dispatch 20260815-horizon-flag-parity-glm,
+        completion_len=7626). The receipt must name the 402 credits cause —
+        not the outer 500 — and must not carry the multi-KB blob verbatim."""
+        from failure_classification import classify_failure
+
+        raw = (
+            'API Error: 500 Error calling litellm.acompletion for non-Anthropic '
+            'model: litellm.APIError: APIError: OpenrouterException - '
+            '{"error":{"message":"This request requires more credits, or fewer '
+            'max_tokens. You requested up to 32000 tokens, but can only afford '
+            '8734. To increase, visit https://openrouter.ai/settings/credits and '
+            'add more credits","code":402,"metadata":{"limit_source":'
+            '"openrouter_credits"' + (",\"padding\":\"x\"" * 200) + "}}}"
+        )
+        result = classify_failure(
+            status="failure",
+            error=None,
+            completion_text=raw,
+            timed_out=False,
+            provider="glm-harness",
+            returncode=1,
+        )
+        assert result["failure_class"] == "credit_exhausted"
+        assert "requires more credits" in result["failure_reason"]
+        assert "openrouter/z-ai" in result["failure_reason"]
+        assert "no error captured" not in result["failure_reason"]
+        # bounded — the raw blob is > 2KB, the reason must not be
+        assert len(result["failure_reason"]) < 500
+
+    def test_glm_unrecognized_api_error_in_completion_still_named(self):
+        """A glm-harness completion that names a real API error but matches no
+        specific pattern (observed: 'API Error: Content block not found',
+        completion_len=34) must still surface that text, not a bare length."""
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error=None,
+            completion_text="API Error: Content block not found",
+            timed_out=False,
+            provider="glm-harness",
+            returncode=1,
+        )
+        assert result["failure_class"] == "unknown"
+        assert "Content block not found" in result["failure_reason"]
+        assert "no error captured" not in result["failure_reason"]
+
+    def test_error_field_stays_authoritative_over_completion_text(self):
+        """When `error` IS set, completion_text must never override it — a
+        completion that happens to mention credits must not hijack a
+        classification that `error` already pins to something else."""
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error="HTTP 401 Unauthorized",
+            completion_text="This request requires more credits",
+            timed_out=False,
+            provider="deepseek-harness",
+            returncode=1,
+        )
+        assert result["failure_class"] == "auth_rejected"
+
+    def test_proxy_unreachable_reason_unchanged(self):
+        """The glm-harness proxy-unreachable message (7x in the ledger) is one
+        of the already-working named reasons this dispatch must not touch —
+        `error` carries it directly, completion_text is irrelevant."""
+        from failure_classification import classify_failure
+
+        msg = "glm-harness proxy unreachable at http://localhost:4141 (start the litellm proxy first)"
+        result = classify_failure(
+            status="failure",
+            error=msg,
+            completion_text="",
+            timed_out=False,
+            provider="glm-harness",
+            returncode=1,
+        )
+        assert result["failure_class"] == "unknown"
+        assert result["failure_reason"] == msg
+
+
+class TestClassifyFailureSafe:
+    """classify_failure_safe must never raise and must never leave a
+    non-success receipt with a completely empty failure_reason — the 100-
+    receipt gap dispatch 20260816-p9p10-failure-reason-root measured (all
+    pre-OI-866; closed by construction, but nothing previously stopped a
+    classify_failure regression from reopening it)."""
+
+    def test_success_passthrough(self):
+        from failure_classification import classify_failure_safe
+
+        result = classify_failure_safe(status="success", provider="claude")
+        assert result == {"failure_class": None, "failure_reason": None}
+
+    def test_delegates_to_classify_failure_on_the_happy_path(self):
+        from failure_classification import classify_failure_safe
+
+        result = classify_failure_safe(
+            status="failure",
+            error="HTTP 401 Unauthorized",
+            completion_text="",
+            provider="deepseek-harness",
+            returncode=1,
+        )
+        assert result["failure_class"] == "auth_rejected"
+
+    def test_never_empty_when_classify_failure_raises(self, monkeypatch):
+        """If classify_failure itself throws, the receipt must still get a
+        countable, non-empty failure_reason instead of None."""
+        import failure_classification
+
+        def _boom(**kwargs):
+            raise RuntimeError("synthetic classify_failure blowup")
+
+        monkeypatch.setattr(failure_classification, "classify_failure", _boom)
+
+        result = failure_classification.classify_failure_safe(
+            status="failure",
+            error=None,
+            completion_text="whatever",
+            provider="deepseek-harness",
+            returncode=1,
+            dispatch_id="test-dispatch-safe-001",
+        )
+        assert result["failure_class"] == "unknown"
+        assert result["failure_reason"]
+        assert result["failure_reason"].strip() != ""
+        assert "test-dispatch-safe-001" in result["failure_reason"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

`classify_failure` only pattern-matched the `error` field, never `completion_text`. glm-harness and deepseek-harness route through the `claude` CLI harness, so a provider API error (e.g. `API Error: 402 Insufficient Balance`, or GLM's OpenRouter gateway wrapping the same 402-credits cause inside a `500 litellm.acompletion` envelope) arrives as ordinary assistant text in `completion_text` with `error=None`. These failures fell through to a contentless `"(no error captured)"` fallback even though the reason was on disk in the report body.

Ledger measurement (2026-08-16, `t0_receipts.ndjson`, full walk, no sampling):

```
glm-harness      : 85 failures — 7 named, 13 "(no error captured)", 65 empty
deepseek-harness : 47 failures — 0 named,  12 "(no error captured)", 35 empty
```

The 100 "empty `failure_reason`" receipts all predate the OI-866 commit (`c0979272`, 2026-07-31) that first added the field to `ReceiptV2` — the last one is timestamped 2026-07-29T18:35:42Z, none since. That gap is closed by construction. The 25 "(no error captured)" receipts are the live bug this PR fixes.

## Changes

- `scripts/lib/failure_classification.py`
  - `classify_failure` now scans `completion_text` for a failure signal when `error` is empty (a caller-supplied `error` stays authoritative and completion_text is never consulted when it's present).
  - New `credit_exhausted` failure_class, matched on phrases actually observed in the ledger: deepseek's direct `"API Error: 402 Insufficient Balance"` and GLM's OpenRouter gateway wrapping the same signal inside a 500 envelope (`"requires more credits"`, `"openrouter_credits"`). A `_extract_detail()` helper pulls the JSON `"message"` field when present so a multi-KB nested-retry blob doesn't get dumped into the receipt.
  - The final fallback (previously `"(no error captured)"`) now surfaces a bounded snippet of the completion text itself, so a form that doesn't match any specific pattern (e.g. observed `"API Error: Content block not found"`) still lands a real, readable reason instead of just a byte count.
  - New `classify_failure_safe()`: wraps `classify_failure` so a future exception inside it can never again leave a receipt's `failure_reason` completely empty — a forward-looking backstop for the exact gap this dispatch measured (all pre-OI-866, already closed, but nothing previously stopped a regression from reopening it).
- `scripts/lib/envelope_govern.py` / `scripts/lib/provider_dispatch.py` — both receipt-emit call sites now route through `classify_failure_safe` instead of duplicating a best-effort try/except that silently left the fields at `None`.
- `tests/test_failclass_registry.py` — new tests for both recognized forms (deepseek plain 402, GLM 500-wrapped 402), the unrecognized-but-readable fallback, the `error`-stays-authoritative guard, a regression guard on the already-working proxy-unreachable message, and `classify_failure_safe`'s never-raises/never-empty guarantee. Updated the pre-existing `test_unknown_when_no_error_provided` to assert the completion text now surfaces instead of the old placeholder.

This is a read-side fix only — no historical receipts are rewritten.

## Verification

`python3 -m pytest tests/test_failclass_registry.py tests/test_dispatch_envelope_fail_loud.py tests/test_emit_governance_retry.py tests/test_envelope_govern_contract_enforce.py tests/test_glm_harness_normalization.py -q` → **75 passed**.

Confirmed 20 pre-existing failures in `tests/test_provider_dispatch_governance_integration.py` / `tests/test_provider_dispatch_deepseek_harness.py` / `tests/test_receipt_v2_pr4_wiring.py` are unrelated (identical failure set before and after via `git stash` comparison) — not run as part of this PR's targeted scope per dispatch instructions (touched files + direct neighbours only, not the full suite).

Re-classified every historical glm-harness/deepseek-harness failure through the new code using its real report-body completion text:

```
glm-harness      after: {'EMPTY': 0, 'NO_ERROR_CAPTURED': 1, 'NAMED': 84}
deepseek-harness after: {'EMPTY': 0, 'NO_ERROR_CAPTURED': 4, 'NAMED': 43}
```

The 5 remaining "NO_ERROR_CAPTURED" are receipts whose report file no longer exists on disk (evicted/archived) — could not be re-verified against real text, left as-is.

## Open Items

None.