### PR TITLE
fix(worktree): occupancy lock + unpushed-commit warning + fabric freeze (OI-1232/1149/1061)

### DIFF
--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -35,6 +35,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -85,6 +86,25 @@ class WorktreeIdentityMissing(WorktreeClaimError):
     Identity cannot be verified, so a worker must not operate in it.  A missing
     claim means the worktree predates the stamping mechanism or was created by
     a lane that does not stamp — either way it is not provably this dispatch's.
+    """
+
+
+class WorktreeOccupied(WorktreeClaimError):
+    """A SIBLING live process already holds the occupancy lock for this worktree.
+
+    OI-1232 (2026-08-15): three dispatches collided in ONE worktree and a
+    sibling's operation reset another's branch pointer, wiping committed files
+    from disk.  The identity-claim system above already refuses two DIFFERENT
+    dispatch ids racing for one slot (``WorktreeIdentityConflict``).  The gap
+    it leaves open is the SAME dispatch id claimed twice by two live
+    processes at once: ``create_dispatch_worktree``'s idempotent re-entry
+    ("same id → hand back the existing path") cannot tell a legitimate
+    sequential retry (the earlier call already finished) apart from a second
+    live process claiming the same worktree WHILE the first is still running
+    — both get the same path with no signal, and whichever runs a
+    destructive git operation first (e.g. a "clean start" reset on a
+    presumed-dead retry) can wipe the other's work.  See ``_acquire_occupancy``
+    for how the lock is held and released.
     """
 
 
@@ -185,6 +205,8 @@ def _write_claim_atomic(
     base_ref: str = "",
     branch: str = "",
     main_head_sha: str = "",
+    fabric_version: str = "",
+    unpushed_local_commits: "dict | None" = None,
 ) -> dict:
     """Claim *worktree_path* for *dispatch_id* with an O_EXCL write.
 
@@ -201,6 +223,14 @@ def _write_claim_atomic(
     *main_head_sha* is the main checkout's HEAD captured before worktree
     creation (OI-975): compared against the current HEAD at teardown to detect
     unexpected checkout jumps during a dispatch.
+
+    *fabric_version* freezes the ``~/.vnx-system/current`` symlink target at
+    creation time (OI-1149/OI-1061): compared against the live marker at
+    teardown to detect a ``vnx update`` that ran mid-dispatch.
+
+    *unpushed_local_commits* records local-vs-``origin/main`` divergence
+    detected at creation time (OI-1149/OI-1061), or None when there was
+    nothing to warn about — see ``_check_unpushed_local_commits``.
     """
     safe_id = _sanitize_dispatch_id(dispatch_id)
     path = _claim_path(safe_id, project_root)
@@ -214,6 +244,8 @@ def _write_claim_atomic(
         "base_ref": base_ref,
         "branch": branch,
         "main_head_sha": main_head_sha,
+        "fabric_version": fabric_version,
+        "unpushed_local_commits": unpushed_local_commits,
     }
     try:
         with open(path, "x", encoding="utf-8") as fh:
@@ -466,6 +498,161 @@ def _worktree_lock(root: Path):
             fcntl.flock(lf, fcntl.LOCK_UN)
 
 
+# ---------------------------------------------------------------------------
+# Occupancy lock (OI-1232) — held for the dispatch's FULL create -> ... ->
+# remove lifetime, not just the brief git-porcelain window _worktree_lock
+# covers above.  Scoped per safe-id, one lock file per worktree slot, kept
+# under the same canonical claim registry as the identity claims.
+#
+# Held via an flock on an OPEN file description, so a crashed holder's lock
+# is released by the KERNEL the instant its process exits — no manual
+# cleanup, no stale-lock timeout logic, and a lock nobody ever heals is
+# impossible by construction (the task's own warning: "een lock die niet
+# vrijgegeven wordt bij een crash is erger dan geen lock").
+#
+# Same-PROCESS re-entry (the idempotent-retry contract already exercised by
+# test_dispatch_worktree_identity_race.py::test_same_dispatch_second_create_is_idempotent)
+# is preserved by the _OCCUPANCY_LOCKS short-circuit below: POSIX advisory
+# locks are per-OPEN-FILE-DESCRIPTION, not per-process, so a second open() +
+# flock() from the very same process that already holds the lock would
+# itself be treated as a conflicting request and must never be attempted.
+# ---------------------------------------------------------------------------
+
+_OCCUPANCY_LOCKS: "dict[str, object]" = {}
+
+
+def _occupancy_lock_path(safe_id: str, project_root: Path) -> Path:
+    return _claim_dir(project_root) / f"{safe_id}.occupancy"
+
+
+def _acquire_occupancy(dispatch_id: str, wt_path: Path, project_root: Path) -> None:
+    """Claim exclusive occupancy of *wt_path* for the calling process.
+
+    No-op when this SAME process already holds it (idempotent re-entry).
+    Raises WorktreeOccupied when a DIFFERENT live process holds it — the
+    OI-1232 shape: a sibling dispatch must never be handed a worktree another
+    dispatch is still actively using.
+    """
+    key = str(Path(wt_path).resolve())
+    if key in _OCCUPANCY_LOCKS:
+        return
+    safe_id = _sanitize_dispatch_id(dispatch_id)
+    lock_path = _occupancy_lock_path(safe_id, project_root)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fh = open(lock_path, "a")
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        fh.close()
+        raise WorktreeOccupied(
+            f"worktree for dispatch {dispatch_id!r} ({wt_path}) is already "
+            f"occupied by another live process; refusing to hand out the same "
+            f"worktree to a second concurrent claim (OI-1232) — a sibling "
+            f"dispatch must never mutate a branch that another dispatch is "
+            f"still using"
+        ) from None
+    _OCCUPANCY_LOCKS[key] = fh
+
+
+def _release_occupancy(wt_path: Path) -> None:
+    """Release this process's occupancy lock on *wt_path*.  Idempotent, never raises.
+
+    A no-op when this process never held it — e.g. teardown running in a
+    different process than the one that created the worktree.  That is safe:
+    if the creator process is still alive it keeps its own hold; if it is
+    dead the kernel already released the lock when it exited.
+    """
+    key = str(Path(wt_path).resolve())
+    fh = _OCCUPANCY_LOCKS.pop(key, None)
+    if fh is None:
+        return
+    try:
+        fcntl.flock(fh, fcntl.LOCK_UN)
+    except OSError as exc:
+        log.debug("dispatch_worktree_isolation: occupancy unlock failed for %s: %s", wt_path, exc)
+    finally:
+        fh.close()
+
+
+def _resolve_fabric_version_marker() -> str:
+    """Return the fabric version the ``~/.vnx-system/current`` symlink names.
+
+    Empty string when there is no central install (a from-source dev
+    checkout, or the marker is unreadable) — callers must treat that as "not
+    applicable", never as evidence of a version change.
+    """
+    marker = _CENTRAL_INSTALL_ROOT / "current"
+    try:
+        target = marker.resolve(strict=True)
+    except OSError:
+        return ""
+    return target.name
+
+
+def _check_unpushed_local_commits(
+    root: Path, resolved_base_ref: str, base_sha: str
+) -> "dict | None":
+    """Warn loudly when the local tracking branch is ahead of *base_sha*.
+
+    OI-1149/OI-1061: the worktree always branches from *resolved_base_ref*
+    (``origin/main`` by default), silently ignoring commits the operator has
+    made locally but not yet pushed — the worker then builds on a base the
+    operator does not see in their own checkout.  This never blocks (a
+    best-effort git probe must not gate a dispatch on its own failure), but a
+    real divergence must be LOUD: printed to stderr (the dispatch's own
+    output) and returned so the caller can stamp it on the claim — the one
+    place that survives into the receipt.
+
+    Returns None when there is nothing to warn about (no local branch of
+    that name, local matches the remote, or local has DIVERGED rather than
+    simply being ahead — a divergence is a rebase/merge situation this probe
+    must not guess about).
+    """
+    if not resolved_base_ref.startswith("origin/"):
+        return None
+    local_branch = resolved_base_ref[len("origin/") :]
+    local_sha_result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--verify", "-q", local_branch],
+        capture_output=True, text=True,
+    )
+    if local_sha_result.returncode != 0:
+        return None
+    local_sha = local_sha_result.stdout.strip()
+    if not local_sha or local_sha == base_sha:
+        return None
+    is_ancestor = subprocess.run(
+        ["git", "-C", str(root), "merge-base", "--is-ancestor", base_sha, local_sha],
+        capture_output=True, text=True,
+    )
+    if is_ancestor.returncode != 0:
+        return None
+    ahead_result = subprocess.run(
+        ["git", "-C", str(root), "rev-list", "--count", f"{base_sha}..{local_sha}"],
+        capture_output=True, text=True,
+    )
+    if ahead_result.returncode != 0:
+        return None
+    try:
+        ahead_count = int(ahead_result.stdout.strip())
+    except ValueError:
+        return None
+    if ahead_count <= 0:
+        return None
+    warning = (
+        f"WARN: worktree branches from {resolved_base_ref!r} (base {base_sha[:8]}) "
+        f"but local {local_branch!r} is {ahead_count} commit(s) ahead "
+        f"({local_sha[:8]}) — those unpushed commits are NOT in this worktree "
+        f"(OI-1149/OI-1061)"
+    )
+    print(warning, file=sys.stderr)
+    log.warning("create_dispatch_worktree: %s", warning)
+    return {
+        "local_branch": local_branch,
+        "local_sha": local_sha,
+        "ahead_count": ahead_count,
+    }
+
+
 def create_dispatch_worktree(
     dispatch_id: str,
     *,
@@ -497,131 +684,171 @@ def create_dispatch_worktree(
     loud error here — it would put a worker's changes on the wrong tree with
     no signal until a human reviews an empty or conflicting diff.
 
+    OI-1232: once this dispatch id is confirmed to own the slot (either as
+    the fresh creator, or via same-id idempotent re-entry) it claims an
+    OCCUPANCY lock for the resolved worktree path (see ``_acquire_occupancy``)
+    that is held for the dispatch's full lifetime, released only by
+    ``remove_dispatch_worktree``. A sibling process that already holds it
+    gets ``WorktreeOccupied`` instead of the silent shared-worktree hand-out
+    this function used to give a same-id double-fire while the original was
+    still running.
+
     Returns the resolved worktree Path.
     Raises RuntimeError when the base ref is unresolvable or worktree creation fails.
+    Raises WorktreeOccupied when a sibling live process already occupies this slot.
     """
     root = _resolve_project_root(project_root)
     wt_path = _dispatch_worktree_dir(root, dispatch_id)
     safe_id = _sanitize_dispatch_id(dispatch_id)
     branch_name = f"dispatch/{safe_id}"
 
-    # VNX_BENCH_WORKTREE_BASE_REF: see precedence note in the docstring above.
-    # The benchmark sets this to the bench checkout's HEAD so worktrees carry the bench
-    # branch's committed task seeds (e.g. the t4_02 SWE-bench seed) without merging WIP
-    # benchmark tasks to main. Default (unset) keeps origin/main — production unchanged.
-    bench_override = os.environ.get("VNX_BENCH_WORKTREE_BASE_REF", "").strip()
-    resolved_base_ref = (base_ref or "").strip() or bench_override or "origin/main"
-    is_remote = resolved_base_ref.startswith("origin/")
-
-    wt_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if is_remote:
-        try:
-            subprocess.run(
-                ["git", "fetch", "origin", resolved_base_ref[len("origin/"):]],
-                cwd=str(root),
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            log.warning(
-                "create_dispatch_worktree: git fetch %s failed (continuing): %s",
-                resolved_base_ref, (exc.stderr or "").strip(),
-            )
-
-    # Resolve base_sha BEFORE adding the worktree — needed for teardown
-    # classification (L3 provider-lane reap).  Mirrors tmux_worktree.allocate().
     try:
-        sha_result = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", resolved_base_ref],
-            check=True, capture_output=True, text=True,
-        )
-        base_sha = sha_result.stdout.strip()
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"create_dispatch_worktree: cannot resolve base_ref {resolved_base_ref!r} "
-            f"for dispatch {dispatch_id!r}: {(exc.stderr or '').strip()}"
-        ) from exc
+        # VNX_BENCH_WORKTREE_BASE_REF: see precedence note in the docstring above.
+        # The benchmark sets this to the bench checkout's HEAD so worktrees carry the bench
+        # branch's committed task seeds (e.g. the t4_02 SWE-bench seed) without merging WIP
+        # benchmark tasks to main. Default (unset) keeps origin/main — production unchanged.
+        bench_override = os.environ.get("VNX_BENCH_WORKTREE_BASE_REF", "").strip()
+        resolved_base_ref = (base_ref or "").strip() or bench_override or "origin/main"
+        is_remote = resolved_base_ref.startswith("origin/")
 
-    # OI-975: capture the main checkout HEAD BEFORE worktree creation so
-    # teardown can detect unexpected checkout jumps during the dispatch.
-    # Best-effort — a failed capture logs a warning and the field defaults
-    # to "" in the claim, which skips the comparison at teardown.
-    _main_head_sha = ""
-    try:
-        _main_head_result = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "HEAD"],
-            check=True, capture_output=True, text=True,
-        )
-        _main_head_sha = _main_head_result.stdout.strip()
-    except subprocess.CalledProcessError:
-        log.warning(
-            "create_dispatch_worktree: cannot resolve HEAD for %s; "
-            "HEAD-jump detection skipped (OI-975)",
-            dispatch_id,
-        )
+        wt_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with _worktree_lock(root):
-        # OI-861 identity check BEFORE creating: if this worktree already exists
-        # and is claimed by a DIFFERENT dispatch id, refuse immediately.  A
-        # same-id re-entry (double-fire/retry) is idempotent and returns the
-        # existing, correctly-stamped worktree.
-        existing = _read_claim(dispatch_id, root)
-        if existing is not None:
-            _claim_belongs_to_or_raise(dispatch_id, existing, wt_path)
-            log.info(
-                "dispatch worktree already exists (claimed by %s): %s",
-                dispatch_id, wt_path,
-            )
-            return wt_path.resolve()
+        if is_remote:
+            try:
+                subprocess.run(
+                    ["git", "fetch", "origin", resolved_base_ref[len("origin/"):]],
+                    cwd=str(root),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                log.warning(
+                    "create_dispatch_worktree: git fetch %s failed (continuing): %s",
+                    resolved_base_ref, (exc.stderr or "").strip(),
+                )
 
+        # Resolve base_sha BEFORE adding the worktree — needed for teardown
+        # classification (L3 provider-lane reap).  Mirrors tmux_worktree.allocate().
         try:
-            subprocess.run(
-                [
-                    "git", "worktree", "add",
-                    str(wt_path),
-                    "-b", branch_name,
-                    resolved_base_ref,
-                ],
-                cwd=str(root),
-                check=True,
-                capture_output=True,
-                text=True,
+            sha_result = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", resolved_base_ref],
+                check=True, capture_output=True, text=True,
             )
+            base_sha = sha_result.stdout.strip()
         except subprocess.CalledProcessError as exc:
-            # A concurrent dispatch collided on this slot between our identity
-            # check and the git add.  Re-read the claim: a different stamped id
-            # is the OI-861 crossing — fail loud with the identity error.
-            raced = _read_claim(dispatch_id, root)
-            if raced is not None:
-                _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
             raise RuntimeError(
-                f"create_dispatch_worktree failed for {dispatch_id!r} "
-                f"(base_ref={resolved_base_ref!r}): {(exc.stderr or '').strip()}"
+                f"create_dispatch_worktree: cannot resolve base_ref {resolved_base_ref!r} "
+                f"for dispatch {dispatch_id!r}: {(exc.stderr or '').strip()}"
             ) from exc
 
-        # Claim the freshly-created worktree atomically (O_EXCL).  From here on
-        # the worktree's identity is bound to dispatch_id and no other dispatch
-        # may reuse it.  The claim carries base_sha + base_ref + branch so
-        # teardown (L3 provider-lane reap) can construct a WorktreeHandle for
-        # classification without re-deriving values that may have shifted.
-        # main_head_sha is the OI-975 pre-dispatch HEAD snapshot.
+        # OI-975: capture the main checkout HEAD BEFORE worktree creation so
+        # teardown can detect unexpected checkout jumps during the dispatch.
+        # Best-effort — a failed capture logs a warning and the field defaults
+        # to "" in the claim, which skips the comparison at teardown.
+        _main_head_sha = ""
         try:
-            _write_claim_atomic(
-                dispatch_id,
-                worktree_path=wt_path,
-                project_root=root,
-                base_sha=base_sha,
-                base_ref=resolved_base_ref,
-                branch=branch_name,
-                main_head_sha=_main_head_sha,
+            _main_head_result = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "HEAD"],
+                check=True, capture_output=True, text=True,
             )
-        except WorktreeClaimError:
-            raced = _read_claim(dispatch_id, root)
-            if raced is not None:
-                _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
-            raise
+            _main_head_sha = _main_head_result.stdout.strip()
+        except subprocess.CalledProcessError:
+            log.warning(
+                "create_dispatch_worktree: cannot resolve HEAD for %s; "
+                "HEAD-jump detection skipped (OI-975)",
+                dispatch_id,
+            )
+
+        # OI-1149/OI-1061: warn loudly when local main is ahead of what this
+        # worktree is about to branch from, and freeze the fabric version so
+        # teardown can detect a mid-dispatch `vnx update`.
+        _unpushed = _check_unpushed_local_commits(root, resolved_base_ref, base_sha)
+        _fabric_version = _resolve_fabric_version_marker()
+
+        with _worktree_lock(root):
+            # OI-861 identity check BEFORE creating: if this worktree already exists
+            # and is claimed by a DIFFERENT dispatch id, refuse immediately.  A
+            # same-id re-entry (double-fire/retry) is idempotent and returns the
+            # existing, correctly-stamped worktree.
+            existing = _read_claim(dispatch_id, root)
+            if existing is not None:
+                _claim_belongs_to_or_raise(dispatch_id, existing, wt_path)
+                # OI-1232: the claim says this IS the same dispatch id, but a
+                # matching claim alone cannot tell "the earlier call already
+                # finished" apart from "a sibling process is still actively
+                # using it right now".  Occupancy is the signal that closes
+                # that gap — a live holder makes this raise WorktreeOccupied
+                # instead of silently handing out a worktree two processes
+                # then mutate at once.
+                _acquire_occupancy(dispatch_id, wt_path, root)
+                log.info(
+                    "dispatch worktree already exists (claimed by %s): %s",
+                    dispatch_id, wt_path,
+                )
+                return wt_path.resolve()
+
+            try:
+                subprocess.run(
+                    [
+                        "git", "worktree", "add",
+                        str(wt_path),
+                        "-b", branch_name,
+                        resolved_base_ref,
+                    ],
+                    cwd=str(root),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                # A concurrent dispatch collided on this slot between our identity
+                # check and the git add.  Re-read the claim: a different stamped id
+                # is the OI-861 crossing — fail loud with the identity error.
+                raced = _read_claim(dispatch_id, root)
+                if raced is not None:
+                    _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
+                raise RuntimeError(
+                    f"create_dispatch_worktree failed for {dispatch_id!r} "
+                    f"(base_ref={resolved_base_ref!r}): {(exc.stderr or '').strip()}"
+                ) from exc
+
+            # Claim the freshly-created worktree atomically (O_EXCL).  From here on
+            # the worktree's identity is bound to dispatch_id and no other dispatch
+            # may reuse it.  The claim carries base_sha + base_ref + branch so
+            # teardown (L3 provider-lane reap) can construct a WorktreeHandle for
+            # classification without re-deriving values that may have shifted.
+            # main_head_sha is the OI-975 pre-dispatch HEAD snapshot; fabric_version
+            # and unpushed_local_commits are the OI-1149/OI-1061 freeze + warning.
+            try:
+                _write_claim_atomic(
+                    dispatch_id,
+                    worktree_path=wt_path,
+                    project_root=root,
+                    base_sha=base_sha,
+                    base_ref=resolved_base_ref,
+                    branch=branch_name,
+                    main_head_sha=_main_head_sha,
+                    fabric_version=_fabric_version,
+                    unpushed_local_commits=_unpushed,
+                )
+            except WorktreeClaimError:
+                raced = _read_claim(dispatch_id, root)
+                if raced is not None:
+                    _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
+                raise
+
+            # We just won the O_EXCL claim write — nobody else can hold
+            # occupancy on this brand-new slot yet, so this always succeeds.
+            # From here on this process is the one a sibling's occupancy
+            # check above will find.
+            _acquire_occupancy(dispatch_id, wt_path, root)
+    except Exception:
+        # Creation never completed — this process must not keep holding the
+        # slot occupied.  A future retry (this process or another) needs a
+        # clean shot at the lock, not a phantom "still occupied".
+        _release_occupancy(wt_path)
+        raise
 
     log.info("dispatch worktree created: %s (branch %s)", wt_path, branch_name)
     return wt_path.resolve()
@@ -648,10 +875,16 @@ def remove_dispatch_worktree(
     (``worktree_state``, ``branch_kept_local``, ``branch_kept_remote``,
     ``preserved_path``) as the tmux lane's ``interactive_teardown_worktree``.
 
+    OI-1232: releases this process's occupancy lock (see ``_acquire_occupancy``)
+    unconditionally, before anything else — the calling process is done with
+    the worktree the moment teardown starts, regardless of what classification
+    or reap decide to do with it.
+
     Called on both success and failure paths.  Best-effort — never raises.
     """
     root = _resolve_project_root(project_root)
     wt_path = _dispatch_worktree_dir(root, dispatch_id)
+    _release_occupancy(wt_path)
 
     if not wt_path.exists():
         _clear_claim(dispatch_id, root)
@@ -696,6 +929,23 @@ def remove_dispatch_worktree(
                 "HEAD-jump check skipped",
                 dispatch_id,
             )
+
+    # ── OI-1149/OI-1061: detect fabric-version drift during the dispatch ───
+    # The worktree's fabric version was frozen at creation time (the
+    # ~/.vnx-system/current symlink target).  If it differs now, a `vnx
+    # update` (or equivalent) ran WHILE this dispatch was in flight — the
+    # fabric the worker actually ran under moved out from under it mid-run.
+    # Best-effort, never raises: an unreadable marker on either side degrades
+    # to "no comparison", never a false drift.
+    _claim_fabric_version = (claim or {}).get("fabric_version", "")
+    _current_fabric_version = _resolve_fabric_version_marker()
+    if _claim_fabric_version and _current_fabric_version and _current_fabric_version != _claim_fabric_version:
+        log.warning(
+            "OI-1149/OI-1061 FABRIC VERSION DRIFT: dispatch %s was created "
+            "against fabric %r but the fabric is now %r — the shared install "
+            "moved (e.g. `vnx update`) while this dispatch was in flight",
+            dispatch_id, _claim_fabric_version, _current_fabric_version,
+        )
 
     # ── L3: classify before removing ──────────────────────────────────────
     # Build a WorktreeHandle from the claim so we can call the single
@@ -796,6 +1046,11 @@ def remove_dispatch_worktree(
                         "preserved_path": str(reap_result.preserved_path)
                         if reap_result.preserved_path
                         else None,
+                        "fabric_version_at_create": _claim_fabric_version or None,
+                        "fabric_version_at_teardown": _current_fabric_version or None,
+                        "unpushed_local_commits_at_create": (claim or {}).get(
+                            "unpushed_local_commits"
+                        ),
                     },
                 },
             )

--- a/tests/test_dispatch_worktree_lifecycle_guards.py
+++ b/tests/test_dispatch_worktree_lifecycle_guards.py
@@ -1,0 +1,408 @@
+"""test_dispatch_worktree_lifecycle_guards.py — OI-1232, OI-1149, OI-1061.
+
+Three gaps in ``dispatch_worktree_isolation`` left over after the OI-861
+identity-claim system shipped:
+
+1. OI-1232: the OI-861 claim system refuses two DIFFERENT dispatch ids
+   racing for one worktree slot, but says nothing about the SAME dispatch id
+   claimed twice by two LIVE processes at once — that idempotent re-entry
+   silently hands the same worktree to a sibling still using it. Measured
+   2026-08-15: three dispatches collided in ONE worktree and a sibling's
+   git operation reset another's branch pointer, wiping committed files from
+   disk. Fixed by an occupancy lock (see ``_acquire_occupancy`` in the
+   module) held for the dispatch's full create -> ... -> remove lifetime.
+
+2. OI-1149/OI-1061 (unpushed commits): a worktree always branches from
+   ``origin/main`` by default, silently ignoring local commits the operator
+   has not pushed. Fixed by ``_check_unpushed_local_commits``, which warns
+   loudly (stderr + log) and stamps the divergence on the claim.
+
+3. OI-1149/OI-1061 (fabric version): the ``~/.vnx-system/current`` symlink
+   is never frozen at worktree-creation time, so a ``vnx update`` mid-dispatch
+   moves the fabric under a running worker silently. Fixed by freezing the
+   marker into the claim at creation and comparing it at teardown.
+
+Test (1) is a REAL cross-process test (subprocess.Popen, not threads): the
+occupancy lock is per-open-file-description, so a same-process race would
+not exercise it the way two independent OS processes do — which is exactly
+the OI-1232 shape (two independent dispatch attempts, not two threads of one
+attempt). ``WorktreeOccupied`` does not exist on the pre-fix module, so this
+test fails at import/collection time against old code — the required
+"fails on old code" property.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+
+def _set_shared_claim_dir(monkeypatch, tmp_path: Path) -> Path:
+    """Point the claim registry at a SHARED temp state root (mirrors
+    test_dispatch_worktree_identity_race.py's fixture)."""
+    data_dir = tmp_path / "shared-data"
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(data_dir / "state"))
+    return data_dir
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    """A real git repo on branch main with one committed seed file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "lifecycle-test@vnx"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "VNX Lifecycle Test"], check=True)
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True)
+    return repo
+
+
+def _init_git_repo_with_origin(tmp_path: Path) -> Path:
+    """Bare origin + local clone with an initial commit, pushed to origin.
+
+    Mirrors the fixture in test_provider_dispatch_worktree_isolation.py /
+    test_tmux_worktree.py.
+    """
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", str(bare), str(local)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "checkout", "-b", "main"], capture_output=True)
+    subprocess.run(["git", "-C", str(local), "config", "user.email", "test@test.local"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "config", "user.name", "Test"], check=True, capture_output=True)
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "push", "-u", "origin", "main"], check=True, capture_output=True)
+    return local
+
+
+# ─── (1) OI-1232: occupancy across two REAL processes ───────────────────────
+
+_WORKER_TEMPLATE = """
+import sys, os, time
+sys.path.insert(0, {scripts_lib!r})
+from pathlib import Path
+from dispatch_worktree_isolation import create_dispatch_worktree
+
+ready_marker = {ready_marker!r}
+release_marker = {release_marker!r}
+result_marker = {result_marker!r}
+
+try:
+    path = create_dispatch_worktree({dispatch_id!r}, project_root=Path({repo!r}))
+    with open(result_marker, "w", encoding="utf-8") as f:
+        f.write("ok:" + str(path))
+except Exception as exc:  # noqa: BLE001
+    with open(result_marker, "w", encoding="utf-8") as f:
+        f.write("err:" + repr(exc))
+
+with open(ready_marker, "w", encoding="utf-8") as f:
+    f.write("ready")
+
+deadline = time.time() + 30
+while not os.path.exists(release_marker) and time.time() < deadline:
+    time.sleep(0.05)
+"""
+
+
+class TestOccupancyAcrossProcesses:
+    def test_sibling_process_cannot_reclaim_a_live_worktree(self, tmp_path, monkeypatch):
+        """A SECOND live process double-firing the SAME dispatch id must be
+        refused, not silently handed the first process's still-in-use worktree.
+
+        This is the literal OI-1232 shape: on the OLD code, both processes
+        would succeed and BOTH would consider themselves the sole occupant of
+        the same worktree/branch — exactly what let a sibling's git operation
+        reset another's branch pointer and wipe committed files.
+        """
+        from dispatch_worktree_isolation import (
+            WorktreeOccupied,
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260816-p7-occupancy-race"
+
+        ready_marker = tmp_path / "ready.marker"
+        release_marker = tmp_path / "release.marker"
+        result_marker = tmp_path / "result.marker"
+
+        script = tmp_path / "sibling_worker.py"
+        script.write_text(
+            _WORKER_TEMPLATE.format(
+                scripts_lib=str(SCRIPTS_LIB),
+                dispatch_id=dispatch_id,
+                repo=str(repo),
+                ready_marker=str(ready_marker),
+                release_marker=str(release_marker),
+                result_marker=str(result_marker),
+            ),
+            encoding="utf-8",
+        )
+
+        proc = subprocess.Popen([sys.executable, str(script)])
+        try:
+            deadline = time.time() + 30
+            while not ready_marker.exists() and time.time() < deadline:
+                time.sleep(0.05)
+            assert ready_marker.exists(), "sibling process never signalled ready"
+
+            result = result_marker.read_text(encoding="utf-8")
+            assert result.startswith("ok:"), f"sibling process failed to create its worktree: {result}"
+
+            # The sibling is still alive and holding the worktree — a SECOND,
+            # genuinely different process (this test process) claiming the
+            # SAME dispatch id must be refused loudly, never silently handed
+            # the same path.
+            with pytest.raises(WorktreeOccupied, match=dispatch_id):
+                create_dispatch_worktree(dispatch_id, project_root=repo)
+        finally:
+            release_marker.write_text("release", encoding="utf-8")
+            proc.wait(timeout=30)
+
+        # After the sibling exits, the kernel releases its flock immediately
+        # (crash-safety property) — a fresh claim from this process succeeds
+        # again and a normal teardown still works.
+        wt = create_dispatch_worktree(dispatch_id, project_root=repo)
+        assert wt.exists()
+        remove_dispatch_worktree(dispatch_id, project_root=repo)
+
+    def test_dead_sibling_releases_the_lock_automatically(self, tmp_path, monkeypatch):
+        """A crashed (SIGKILLed) holder's lock is freed by the kernel at exit —
+        no manual cleanup, no stale-lock timeout logic required.
+        """
+        from dispatch_worktree_isolation import create_dispatch_worktree
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260816-p7-occupancy-crash"
+
+        ready_marker = tmp_path / "ready2.marker"
+        release_marker = tmp_path / "release2.marker"
+        result_marker = tmp_path / "result2.marker"
+
+        script = tmp_path / "sibling_worker_crash.py"
+        script.write_text(
+            _WORKER_TEMPLATE.format(
+                scripts_lib=str(SCRIPTS_LIB),
+                dispatch_id=dispatch_id,
+                repo=str(repo),
+                ready_marker=str(ready_marker),
+                release_marker=str(release_marker),
+                result_marker=str(result_marker),
+            ),
+            encoding="utf-8",
+        )
+
+        proc = subprocess.Popen([sys.executable, str(script)])
+        deadline = time.time() + 30
+        while not ready_marker.exists() and time.time() < deadline:
+            time.sleep(0.05)
+        assert ready_marker.exists()
+        assert result_marker.read_text(encoding="utf-8").startswith("ok:")
+
+        # Simulate a crash: kill -9 instead of releasing gracefully.
+        proc.kill()
+        proc.wait(timeout=30)
+
+        # No manual unlock happened — the kernel released it on process exit.
+        # A fresh claim for the same dispatch id must succeed immediately.
+        wt = create_dispatch_worktree(dispatch_id, project_root=repo)
+        assert wt.exists()
+
+
+# ─── (2) OI-1149/OI-1061: unpushed local commits ────────────────────────────
+
+class TestUnpushedLocalCommitsWarning:
+    def test_warns_and_stamps_claim_when_local_main_is_ahead(self, tmp_path, monkeypatch, capsys):
+        """Local main ahead of origin/main: loud stderr warning + claim field.
+
+        Old code silently branches the worktree from origin/main with no
+        signal at all that local commits exist and are missing from it.
+        """
+        from dispatch_worktree_isolation import create_dispatch_worktree, _read_claim
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        local = _init_git_repo_with_origin(tmp_path)
+
+        (local / "unpushed.txt").write_text("wip\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(local), "add", "unpushed.txt"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(local), "commit", "-m", "wip: not pushed yet"],
+            check=True, capture_output=True,
+        )
+
+        dispatch_id = "20260816-p8-unpushed-warn"
+        create_dispatch_worktree(dispatch_id, project_root=local)
+
+        captured = capsys.readouterr()
+        assert "OI-1149/OI-1061" in captured.err
+        assert "1 commit(s) ahead" in captured.err
+
+        claim = _read_claim(dispatch_id, local)
+        assert claim["unpushed_local_commits"] is not None
+        assert claim["unpushed_local_commits"]["ahead_count"] == 1
+        assert claim["unpushed_local_commits"]["local_branch"] == "main"
+
+    def test_unpushed_warning_lands_on_the_teardown_receipt(self, tmp_path, monkeypatch):
+        """The divergence recorded at creation survives into the teardown event."""
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        local = _init_git_repo_with_origin(tmp_path)
+        (local / "unpushed2.txt").write_text("wip2\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(local), "add", "unpushed2.txt"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(local), "commit", "-m", "wip: also not pushed"],
+            check=True, capture_output=True,
+        )
+
+        dispatch_id = "20260816-p8-unpushed-receipt"
+        create_dispatch_worktree(dispatch_id, project_root=local)
+
+        mock_store = MagicMock()
+        mock_store.append = MagicMock()
+        with patch("event_store.EventStore", return_value=mock_store):
+            remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        teardown_event = next(
+            c[0][1] for c in mock_store.append.call_args_list
+            if c[0][1]["type"] == "provider_teardown_worktree"
+        )
+        recorded = teardown_event["data"]["unpushed_local_commits_at_create"]
+        assert recorded is not None
+        assert recorded["ahead_count"] == 1
+
+    def test_no_warning_when_local_matches_origin(self, tmp_path, monkeypatch, capsys):
+        """Local main == origin/main: nothing to warn about."""
+        from dispatch_worktree_isolation import create_dispatch_worktree, _read_claim
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        local = _init_git_repo_with_origin(tmp_path)
+
+        dispatch_id = "20260816-p8-no-unpushed"
+        create_dispatch_worktree(dispatch_id, project_root=local)
+
+        captured = capsys.readouterr()
+        assert "OI-1149/OI-1061" not in captured.err
+
+        claim = _read_claim(dispatch_id, local)
+        assert claim["unpushed_local_commits"] is None
+
+
+# ─── (3) OI-1149/OI-1061: fabric version freeze + drift detection ──────────
+
+class TestFabricVersionFreeze:
+    def _fake_central_install(self, tmp_path: Path, version: str) -> Path:
+        root = tmp_path / "fake-vnx-system"
+        (root / "versions" / version).mkdir(parents=True)
+        (root / "current").symlink_to(root / "versions" / version)
+        return root
+
+    def test_fabric_version_is_frozen_at_creation(self, tmp_path, monkeypatch):
+        import dispatch_worktree_isolation as dwi
+        from dispatch_worktree_isolation import create_dispatch_worktree, _read_claim
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+
+        fake_root = self._fake_central_install(tmp_path, "v9.9.9")
+        monkeypatch.setattr(dwi, "_CENTRAL_INSTALL_ROOT", fake_root)
+
+        dispatch_id = "20260816-p8-fabric-freeze"
+        create_dispatch_worktree(dispatch_id, project_root=repo)
+
+        claim = _read_claim(dispatch_id, repo)
+        assert claim["fabric_version"] == "v9.9.9"
+
+    def test_fabric_version_drift_is_detected_and_surfaced_at_teardown(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A `vnx update` that moves ~/.vnx-system/current mid-dispatch must be
+        visible at teardown, not silently absorbed.
+        """
+        import dispatch_worktree_isolation as dwi
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+
+        fake_root = self._fake_central_install(tmp_path, "v9.9.9")
+        monkeypatch.setattr(dwi, "_CENTRAL_INSTALL_ROOT", fake_root)
+
+        dispatch_id = "20260816-p8-fabric-drift"
+        create_dispatch_worktree(dispatch_id, project_root=repo)
+
+        # Simulate `vnx update`: the symlink now points at a NEW version.
+        (fake_root / "versions" / "v9.9.10").mkdir(parents=True)
+        (fake_root / "current").unlink()
+        (fake_root / "current").symlink_to(fake_root / "versions" / "v9.9.10")
+
+        mock_store = MagicMock()
+        mock_store.append = MagicMock()
+        with caplog.at_level(logging.WARNING, logger="dispatch_worktree_isolation"):
+            with patch("event_store.EventStore", return_value=mock_store):
+                remove_dispatch_worktree(dispatch_id, project_root=repo, terminal_id="T1")
+
+        assert "FABRIC VERSION DRIFT" in caplog.text
+        assert "v9.9.9" in caplog.text
+        assert "v9.9.10" in caplog.text
+
+        teardown_event = next(
+            c[0][1] for c in mock_store.append.call_args_list
+            if c[0][1]["type"] == "provider_teardown_worktree"
+        )
+        assert teardown_event["data"]["fabric_version_at_create"] == "v9.9.9"
+        assert teardown_event["data"]["fabric_version_at_teardown"] == "v9.9.10"
+
+    def test_no_drift_when_fabric_version_is_stable(self, tmp_path, monkeypatch, caplog):
+        import dispatch_worktree_isolation as dwi
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+
+        fake_root = self._fake_central_install(tmp_path, "v9.9.9")
+        monkeypatch.setattr(dwi, "_CENTRAL_INSTALL_ROOT", fake_root)
+
+        dispatch_id = "20260816-p8-fabric-stable"
+        create_dispatch_worktree(dispatch_id, project_root=repo)
+
+        with caplog.at_level(logging.WARNING, logger="dispatch_worktree_isolation"):
+            remove_dispatch_worktree(dispatch_id, project_root=repo)
+
+        assert "FABRIC VERSION DRIFT" not in caplog.text


### PR DESCRIPTION
## Summary

Fixes points 7 and 8 from the p7p8 dispatch: concurrent dispatches were able to move each other's branch pointer (OI-1232), and worktree creation silently ignored unpushed local commits and never froze the fabric version (OI-1149, OI-1061).

## Changes

**OI-1232 — occupancy lock.** The existing OI-861 identity-claim system in `dispatch_worktree_isolation.py` already refuses two *different* dispatch ids racing for one worktree slot (`WorktreeIdentityConflict`). What it left open: the *same* dispatch id claimed twice by two *live* processes at once — `create_dispatch_worktree`'s idempotent re-entry ("same id → hand back the existing path") can't tell a legitimate sequential retry apart from a sibling process still actively using the worktree. Measured 2026-08-15: three dispatches collided in one worktree and a sibling's git operation reset another's branch pointer, wiping committed files from disk.

Added a new **occupancy lock** (`_acquire_occupancy`/`_release_occupancy`), scoped per safe-id, held via `fcntl.flock` on an open file description for the dispatch's full `create_dispatch_worktree` → … → `remove_dispatch_worktree` lifecycle. A sibling live process that tries to claim the same slot now gets a loud `WorktreeOccupied` instead of a silent shared hand-out. Crash-safe by construction: the kernel releases the lock the instant a holder's process exits (normal exit or SIGKILL), so there is no manual cleanup and no stale-lock timeout logic — a lock nobody heals is impossible by construction. Same-process idempotent re-entry (the existing, already-tested double-fire contract) is preserved via an in-process short-circuit, since POSIX advisory locks are per-open-file-description, not per-process, and a second `open()` from the same process would otherwise self-conflict.

The lock is deliberately acquired *after* the existing OI-861 identity check resolves ownership (not at function entry) so it never masks the pre-existing `WorktreeIdentityConflict` path for two different colliding ids — that stays exactly as tested today.

**OI-1149/OI-1061 — unpushed local commits + fabric version freeze.** `create_dispatch_worktree` always branched from `origin/main` (or the given base ref) silently, even when the operator's local `main` was ahead with unpushed commits — the worker then built on a base the operator couldn't see in their own checkout. Added `_check_unpushed_local_commits`, which warns loudly (stderr + log) and stamps the divergence (`local_branch`, `local_sha`, `ahead_count`) on the claim when local is strictly ahead of the resolved base (never guesses on a genuine divergence/rebase situation).

The fabric version (`~/.vnx-system/current` symlink target) was never recorded, so a `vnx update` mid-dispatch silently moved the shared install out from under a running worker. Added `_resolve_fabric_version_marker`, frozen into the claim at creation (`fabric_version`) and compared against the live marker at teardown — a drift is logged loudly (`OI-1149/OI-1061 FABRIC VERSION DRIFT`).

Both the unpushed-commits divergence and the fabric-version-at-create/at-teardown pair now ride along on the `provider_teardown_worktree` receipt event, so they're visible on the receipt, not just in logs.

## Verification

Ran (per the dispatch's "no full suite" instruction, only the touched files + direct neighbours):

```
python3 -m pytest tests/test_dispatch_worktree_identity_race.py tests/test_dispatch_worktree_lifecycle_guards.py \
  tests/test_provider_dispatch_worktree_isolation.py tests/test_subprocess_dispatch_worktree_isolation.py \
  tests/test_headless_worktree_isolation.py tests/test_tmux_worktree.py \
  tests/test_dispatch_envelope.py tests/test_dispatch_envelope_annotations_resolve.py \
  tests/test_dispatch_envelope_characterization.py tests/test_dispatch_envelope_fail_loud.py \
  tests/test_dispatch_envelope_field_propagation.py tests/test_dispatch_envelope_plan.py \
  tests/test_gate_worktree.py tests/test_dispatch_process_registry.py -q
```
→ **279 passed**, 0 failed.

New test file `tests/test_dispatch_worktree_lifecycle_guards.py` (8 tests):
- `TestOccupancyAcrossProcesses` — a **real cross-process** test (`subprocess.Popen`, not threads, since the lock is per-open-file-description and a same-process race wouldn't exercise it): a sibling process holding a live worktree causes a second `create_dispatch_worktree` call for the same dispatch id to raise `WorktreeOccupied`; plus a SIGKILL variant proving the lock releases automatically. `WorktreeOccupied` doesn't exist pre-fix, so this fails at collection time against old code.
- `TestUnpushedLocalCommitsWarning` — local-ahead-of-origin warns on stderr and lands on the claim + teardown receipt event; no-divergence case stays silent.
- `TestFabricVersionFreeze` — version is frozen at creation, drift is detected and surfaced (log + receipt event) at teardown, stable version stays silent.

Also confirmed no regression in the OI-861 race test (`test_exactly_one_winner_per_slot`) — the occupancy lock is scoped to fire only *after* identity resolution, so the pre-existing `WorktreeIdentityConflict` behavior for two colliding-but-different dispatch ids is untouched.

Ran the repo's own static gates against the changed files:
- `scripts/check_no_file_derived_data_paths.py` → PASS
- `scripts/ci_lint_patterns.py` → clean (no silent-except / atomic-write violations)
- `ruff check` on the new test file → clean (the one pre-existing unused `shutil` import in `dispatch_worktree_isolation.py` predates this change and is out of scope)

## Open Items

None — both points 7 and 8 are implemented, tested, and pushed together as one PR since they touch the same file and lifecycle.