### PR TITLE
feat(plan-gate): register plan-reviewer role in agents/ and worker_permissions.yaml

### DIFF
--- a/.vnx/worker_permissions.yaml
+++ b/.vnx/worker_permissions.yaml
@@ -8,7 +8,11 @@ version: 1
 # the role-selection table in .claude/terminals/T0/role-orchestrator.md. A profile
 # exists for every role T0 actually dispatches (backend-developer, code-reviewer,
 # frontend-developer, quality-engineer, research-analyst, security-engineer,
-# system-architect). Legacy names (test-engineer, architect) are NOT carried here:
+# system-architect). plan-reviewer is NOT T0-dispatched: it is the plan-gate
+# panel's seat role (scripts/lib/plan_gate_panel.py passes --role plan-reviewer
+# to its claude/tmux seats) and is registered here because resolve_worker_profile
+# refuses fail-closed (OI-1069 pt.5, #1563) on a role absent from every register.
+# Legacy names (test-engineer, architect) are NOT carried here:
 # they were old labels for quality-engineer / system-architect and nobody dispatches
 # them. database-engineer / intelligence-engineer are not dispatched either and were
 # dropped for the same reason.
@@ -201,11 +205,11 @@ profiles:
       - "docs/operations/WORKER_PERMISSIONS.md"  # 4  — permission docs
       - "docs/governance/KEY_PROVISIONING.md"     # 1  — key provisioning doc
 
-  # Read roles — default_instruction says "Do not modify code" (code-reviewer) or
-  # carries governance_profile: light (research-analyst). They deny code-mutation
-  # tools and git history mutation, and are NOT dispatched with the push-mandatory
-  # footer. file_write_scope is restricted to the report drop so they can still
-  # deliver their findings report.
+  # Read roles — default_instruction says "Do not modify code" (code-reviewer,
+  # plan-reviewer) or carries governance_profile: light (research-analyst). They
+  # deny code-mutation tools and git history mutation, and are NOT dispatched
+  # with the push-mandatory footer. file_write_scope is restricted to the report
+  # drop so they can still deliver their findings report.
   code-reviewer:
     allowed_tools: [Read, Write, Grep, Glob, Bash]
     denied_tools: [Edit, MultiEdit, WebSearch, WebFetch]
@@ -233,6 +237,32 @@ profiles:
       - "git diff*"
       - "git show*"
       - "python3 -c*"
+      - "bash -n*"
+      - "grep*"
+    bash_deny_patterns:
+      - "git add*"
+      - "git commit*"
+      - "git push*"
+      - "rm*"
+    file_write_scope:
+      - ".vnx-data/unified_reports/**"
+
+  plan-reviewer:
+    # Read role — plan-gate panel seat (OI-1238). The panel's claude/tmux seats
+    # run with --role plan-reviewer --working-tree-only: read a plan doc, ground
+    # the review against the real repo (git log/diff/show, grep), write ONE
+    # verdict report to the unified-reports drop. Never modifies code, never
+    # dispatched with the push-mandatory footer. The role is deliberately
+    # distinct from code-reviewer so govern() and the phantom-guard evaluate the
+    # dispatch as a plan review, not a code review.
+    allowed_tools: [Read, Write, Grep, Glob, Bash]
+    denied_tools: [Edit, MultiEdit, WebSearch, WebFetch]
+    bash_allow_patterns:
+      - "git log*"
+      - "git diff*"
+      - "git show*"
+      - "python3 -c*"
+      - "python3 -m py_compile*"
       - "bash -n*"
       - "grep*"
     bash_deny_patterns:

--- a/agents/plan-reviewer/CLAUDE.md
+++ b/agents/plan-reviewer/CLAUDE.md
@@ -1,0 +1,47 @@
+# Plan Reviewer Agent
+
+You are a plan-reviewer worker: an independent plan-beoordelaar seated by the VNX plan-gate panel (`scripts/lib/plan_gate_panel.py`) for a single governed dispatch.
+
+## Role
+
+Review an IMPLEMENTATION PLAN — the plan only, no code exists yet. Judge it against the rubric in your dispatch instruction:
+
+1. Problem: is the problem stated, and is it real?
+2. Approach: is it sound, or are there unaddressed failure modes?
+3. Deliverables: each scoped, independently shippable, task_class tagged?
+4. Risks: are the real risks named, each with a mitigation?
+5. Model-routing plan: a sane quality FLOOR per deliverable (not a hand-picked lane)?
+6. ADR-007: if it touches a central-DB table, does it carry a composite key over project_id?
+
+Be a skeptic. Surface concrete, fixable gaps. Do not rubber-stamp. Ground every finding in the actual plan text and, where the plan makes claims about the codebase, in the real repo — read files and run `git log` / `git diff` / `grep` to verify before you assert. You produce ONE VERDICT REPORT, not code changes.
+
+## Input
+
+- The plan document, passed by file reference in your instruction. Read it in full.
+- A rubric and verdict contract (in the instruction).
+- `REPORT FILE (MANDATORY)` — the exact absolute path your report must land at, under `$VNX_DATA_DIR/unified_reports/`.
+
+## Output
+
+- Your complete review, written to the exact report path from the instruction and nowhere else. The panel reads only that file.
+- The report ends with EXACTLY ONE fenced verdict block and nothing after it:
+
+  ````
+  ```vnx-plan-verdict
+  {
+    "verdict": "pass" | "revise" | "block",
+    "blocking_findings": ["short concrete issue", "..."],
+    "rationale": "one or two sentences"
+  }
+  ```
+  ````
+
+  - `block`: a fundamental flaw makes the plan unsafe to build as written.
+  - `revise`: real, fixable gaps remain but the approach is salvageable.
+  - `pass`: the plan is sound enough to implement.
+
+## Constraints
+
+- Do NOT modify code — this is a review-only role. No branch, no commit, no push.
+- Do NOT write to any path other than the mandated report file.
+- Every finding cites concrete evidence (plan section, file:line, or command output). No speculative findings.

--- a/tests/test_plan_reviewer_role.py
+++ b/tests/test_plan_reviewer_role.py
@@ -1,0 +1,109 @@
+"""Tests for the plan-reviewer role registration (dispatch 20260816-plan-reviewer-role-register).
+
+The plan-gate panel (scripts/lib/plan_gate_panel.py) seats its claude/tmux lanes
+with ``--role plan-reviewer``. Since #1563 (OI-1069 pt.5) ``resolve_worker_profile``
+refuses fail-closed on a role present in NO register — and ``plan-reviewer`` was in
+none, so every opus seat died at spawn and the panel fell over on liveness quorum.
+These tests pin the registration:
+
+  1. ``resolve_worker_profile("plan-reviewer")`` resolves to a REAL profile
+     (is_fallback=False) against the repo YAML — not the code-worker fallback;
+  2. the profile's file_write_scope admits the unified-reports drop and nothing
+     else in the repo (read-only-plus-one-report posture);
+  3. a role that exists in NO register still raises UnknownRoleError — the
+     #1563 fail-closed guarantee must not be weakened by this registration.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_PERMISSIONS_YAML = REPO_ROOT / ".vnx" / "worker_permissions.yaml"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+from worker_permissions import (
+    UnknownRoleError,
+    match_file_write_scope,
+    resolve_worker_profile,
+)
+
+pytestmark = pytest.mark.skipif(
+    not REPO_PERMISSIONS_YAML.exists(),
+    reason="repo .vnx/worker_permissions.yaml not present in this checkout",
+)
+
+
+def _profile():
+    """Resolve plan-reviewer from the worktree-local YAML (bypasses env steering)."""
+    return resolve_worker_profile("plan-reviewer", REPO_PERMISSIONS_YAML)
+
+
+class TestPlanReviewerResolves:
+    def test_resolves_to_a_real_profile_not_fallback(self) -> None:
+        profile = _profile()
+        assert profile.is_fallback is False
+        assert profile.role == "plan-reviewer"
+
+    def test_registered_in_agents_registry(self) -> None:
+        """The agents/ registry is the role SSOT — agents/plan-reviewer/CLAUDE.md
+        must exist so the role is in BOTH registers."""
+        assert (REPO_ROOT / "agents" / "plan-reviewer" / "CLAUDE.md").is_file()
+
+    def test_profile_is_read_only_plus_report(self) -> None:
+        """Read posture like the other read roles: no Edit/MultiEdit, no git
+        history mutation, no code push — the verdict report is the only write."""
+        profile = _profile()
+        assert "Edit" in profile.denied_tools
+        assert "MultiEdit" in profile.denied_tools
+        assert "WebSearch" in profile.denied_tools
+        assert "WebFetch" in profile.denied_tools
+        deny_set = set(profile.bash_deny_patterns)
+        assert {"git add*", "git commit*", "git push*"} <= deny_set
+        for pat in profile.bash_allow_patterns:
+            assert not pat.startswith(("git add", "git commit", "git push")), pat
+
+
+class TestPlanReviewerWriteScope:
+    def test_unified_reports_drop_in_scope(self) -> None:
+        profile = _profile()
+        assert match_file_write_scope(
+            ".vnx-data/unified_reports/some-dispatch.md", profile, None
+        ) is True
+        assert match_file_write_scope(
+            ".vnx-data/unified_reports/nested/deep/report.md", profile, None
+        ) is True
+
+    def test_arbitrary_repo_paths_out_of_scope(self) -> None:
+        profile = _profile()
+        for path in (
+            "scripts/lib/plan_gate_panel.py",
+            ".vnx/worker_permissions.yaml",
+            "tests/test_plan_reviewer_role.py",
+            "agents/plan-reviewer/CLAUDE.md",
+            "docs/core/DISPATCH_RULES.md",
+            "VERSION",
+        ):
+            assert match_file_write_scope(path, profile, None) is False, path
+
+
+class TestFailClosedGuaranteeIntact:
+    def test_role_in_no_register_still_raises(self) -> None:
+        """#1563 (OI-1069 pt.5): a role absent from BOTH worker_permissions.yaml
+        and the agents/ registry must still refuse loudly. This name is
+        guaranteed to exist nowhere."""
+        with pytest.raises(UnknownRoleError):
+            resolve_worker_profile(
+                "no-such-role-exists-in-any-register-zzz", REPO_PERMISSIONS_YAML
+            )
+
+    def test_unknown_role_error_names_the_role(self) -> None:
+        with pytest.raises(
+            UnknownRoleError, match="no-such-role-exists-in-any-register-zzz"
+        ):
+            resolve_worker_profile(
+                "no-such-role-exists-in-any-register-zzz", REPO_PERMISSIONS_YAML
+            )


### PR DESCRIPTION
## Wat er stuk was

Het plan-gate-panel zet zijn claude/tmux-zetels met `--role plan-reviewer` (`scripts/lib/plan_gate_panel.py:918`, doorgegeven op 1010/1035), maar die rol stond in **geen enkel register**. Sinds #1563 (OI-1069 pt.5, commit `4bd4d100`) weigert `resolve_worker_profile` fail-closed op zo'n rol — gemeten: elke opus-zetel dood bij spawn (`rc=1`, `duration_seconds=0.064`, `unexpected_error`). Met een dode opus-zetel haalt een `class=default` panel (opus + kimi) het liveness-quorum `min(2, panelgrootte)=2` niet meer; elke plan-gate-run valt om op liveness in plaats van op planinhoud. Mechanische oorzaak onder OI-1238.

Het fail-closed-gedrag van #1563 is opzettelijk en blijft ongemoeid — de fout was het ontbrekende register.

## Wat dit doet

- **`agents/plan-reviewer/CLAUDE.md`** — roldefinitie: onafhankelijke plan-beoordelaar die het plan tegen de rubric toetst, bevindingen groundt tegen de echte repo (`git log`/`grep`), en één verdict-rapport met exact één `vnx-plan-verdict` blok wegschrijft. Schrijft geen code, commit niet, pusht niet.
- **`.vnx/worker_permissions.yaml`** — profiel `plan-reviewer` naar het model van de bestaande read-rollen (code-reviewer/research-analyst): brede lees-posture (`git log/diff/show`, `grep`), `file_write_scope` beperkt tot `.vnx-data/unified_reports/**`, `git add/commit/push` in de deny-lijst. De rol blijft bewust apart van `code-reviewer` zodat `govern()` en de phantom-guard de dispatch als plan-review beoordelen.
- **`tests/test_plan_reviewer_role.py`** — 8 tests:
  - `resolve_worker_profile("plan-reviewer")` resolvert zonder `UnknownRoleError`, `is_fallback=False`
  - write-scope laat de unified-reports-map toe en willekeurige repo-paden niet
  - een rol die in geen register staat blijft weigeren (#1563-garantie intact)

## Verificatie

- `resolve_worker_profile('plan-reviewer')` → `is_fallback= False` (was: `UnknownRoleError`)
- Lane-probe `tmux_interactive_dispatch.py --role plan-reviewer --model opus --shared-worktree --allow-unstaged --working-tree-only` met triviale rapport-instructie: `rc=0`, `duration_seconds=39.58`, bestand `plan-reviewer-probe-20260816.md` weggeschreven met de gevraagde inhoud
- Targeted tests: `tests/test_plan_reviewer_role.py` + directe buren — 98 + 171 passed (exacte commando's in het dispatch-rapport)

Dispatch-ID: 20260816-plan-reviewer-role-register
