### PR TITLE
feat(dispatch): escalation ladder climbs from failure_class

### DIFF
--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -304,6 +304,7 @@ def stage_escalation_bundle(
     *,
     rejected_dispatch_id: str,
     tier_from: str,
+    failure_class: str,
     instruction_text: str,
     dispatch_id: str,
     role: str,
@@ -318,18 +319,24 @@ def stage_escalation_bundle(
     state_dir: Optional[Path] = None,
     now: Optional[float] = None,
     data_dir: Optional[Path] = None,
+    retried: bool = False,
 ) -> Path:
     """Stage a QUALITY-escalation followup bundle (OI-1221, wired OI-1229).
 
     This is the CALLER that was missing: ``escalate_tier``/``next_tier`` already
     computed the climb (tier_to = tier_from + 1, parent_dispatch = the rejected
     attempt) but no call site ever fired a followup, so ``tier_from``/``tier_to``
-    stayed empty on 0 of 761 filled specs. Here the climb is resolved
-    deterministically from the cost ladder, the target rung's route is resolved
-    through ``resolve_tier_route`` (so the followup actually runs on the
-    escalated model, not re-classified back to the same cheap tier), and the
-    three chain-link fields are written into the staged ``dispatch-spec.json`` —
-    the same bytes the door carries onto the receipt.
+    stayed empty on 0 of 761 filled specs. Here the climb is resolved from the
+    cost ladder by ``failure_class`` (dispatch 20260816-p6-escalate-tier-ds), the
+    target rung's route is resolved through ``resolve_tier_route`` (so the
+    followup actually runs on the escalated model, not re-classified back to the
+    same cheap tier), and the three chain-link fields are written into the staged
+    ``dispatch-spec.json`` — the same bytes the door carries onto the receipt.
+
+    A failure class the table does not climb (``auth_rejected``, ``unknown``)
+    raises ValueError here — the caller must report it, never stage a silent
+    no-op. ``retried`` is passed through to ``escalate_tier`` so a
+    timeout/empty_completion that has already been retried once climbs instead.
 
     This STAGES ONLY; it never fires the dispatch (no automatic re-dispatch
     loop). The operator promotes the returned bundle through the single-entry
@@ -340,11 +347,34 @@ def stage_escalation_bundle(
         resolve_tier_route,
     )
 
-    escalation = escalate_tier(tier_from, parent_dispatch=rejected_dispatch_id)
+    escalation = escalate_tier(
+        tier_from,
+        parent_dispatch=rejected_dispatch_id,
+        failure_class=failure_class,
+        retried=retried,
+    )
+    if escalation.action == "no_climb":
+        if escalation.unknown_class:
+            raise ValueError(
+                f"refusing to stage escalation: failure_class={failure_class!r} is "
+                "UNKNOWN — the table does not know this class, and it must be "
+                "reported to the operator loudly, never silently absorbed"
+            )
+        raise ValueError(
+            f"refusing to stage escalation: failure_class={failure_class!r} does "
+            "not climb (auth_rejected — a higher tier has the same auth problem)"
+        )
     if escalation.tier_to is None:
         raise ValueError(
             f"cannot escalate: {tier_from!r} is already the top rung of the "
             "cost ladder (no rung above it)"
+        )
+    if escalation.notify_operator:
+        print(
+            f"[dispatch_bridge] OPERATOR NOTICE: failure_class={failure_class!r} "
+            f"on {tier_from!r}; escalation to {escalation.tier_to!r} staged — "
+            "notify the operator (e.g. credit_exhausted)",
+            file=sys.stderr,
         )
     route = resolve_tier_route(
         escalation.tier_to, env=env, state_dir=state_dir, now=now,

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1797,6 +1797,111 @@ def _persist_route_decision(
 # run_dispatch — the single door
 # ---------------------------------------------------------------------------
 
+def _maybe_stage_escalation(plan, result, *, vspec, state_dir, data_dir) -> None:
+    """On a provider-lane failure, classify it and — when the escalation table
+    says climb — stage a human-promoted escalation followup.
+
+    This is the production CALLER of ``stage_escalation_bundle`` (OI-1221's
+    missing call site, wired dispatch 20260816-p6-escalate-tier-ds): the
+    followup spec's ``tier_from``/``tier_to``/``parent_dispatch`` finally land on
+    a real spec, so the receipt carries the chain-link. It STAGES ONLY — the
+    operator promotes the bundle through the door; nothing is auto-fired.
+
+    Never raises and never changes the failed dispatch's exit code: a failure
+    class that must not climb (auth_rejected, unknown) or a staging error is
+    reported loudly and the door returns the original failure unchanged.
+    """
+    spec = vspec.spec
+
+    # The tier the failed attempt ran on (reverse-mapped from its model, or the
+    # explicit escalation rung). Without it the attempt cannot be placed on the
+    # cost ladder, so there is nothing to escalate from.
+    tier_ran_on = plan.tier_to or plan.tier_from
+    if not tier_ran_on:
+        print(
+            "[dispatch_cli] no escalation: failed attempt has no cost tier "
+            f"(tier_to={plan.tier_to!r}, tier_from={plan.tier_from!r})",
+            file=sys.stderr,
+        )
+        return
+
+    from failure_classification import classify_failure_safe  # noqa: PLC0415
+
+    classification = classify_failure_safe(
+        status=result.status,
+        error=result.error,
+        completion_text=result.completion_text,
+        timed_out=(result.status == "timeout"),
+        provider=getattr(plan.provider, "value", str(plan.provider)),
+        returncode=result.returncode,
+        dispatch_id=plan.dispatch_id,
+    )
+    failure_class = classification["failure_class"]
+    failure_reason = classification["failure_reason"]
+
+    if failure_class is None:
+        print(
+            "[dispatch_cli] no escalation: classify_failure returned no class "
+            f"(status={result.status!r}); cannot decide a climb",
+            file=sys.stderr,
+        )
+        return
+
+    # A same-tier retry already carries tier_from == tier_to; a second rejection
+    # must then climb rather than retry forever on the same rung.
+    retried = bool(plan.tier_from and plan.tier_to and plan.tier_from == plan.tier_to)
+
+    from dispatch_bridge import stage_escalation_bundle  # noqa: PLC0415
+    from headless_dispatch_writer import generate_dispatch_id  # noqa: PLC0415
+
+    followup_id = generate_dispatch_id("escalate", spec.target_slot)
+    instruction_text = (
+        f"Escalation followup for rejected dispatch {plan.dispatch_id}\n"
+        f"failure_class={failure_class}: {failure_reason}\n\n"
+        f"{vspec.instruction_text}"
+    )
+    try:
+        stage_escalation_bundle(
+            rejected_dispatch_id=plan.dispatch_id,
+            tier_from=tier_ran_on,
+            failure_class=failure_class,
+            retried=retried,
+            instruction_text=instruction_text,
+            dispatch_id=followup_id,
+            role=spec.role,
+            target_slot=spec.target_slot,
+            project_id=spec.project_id,
+            gate=spec.gate,
+            dispatch_paths=tuple(
+                {
+                    "path": str(dp.path),
+                    "access": dp.access.value,
+                    "materialize_at_cwd": dp.materialize_at_cwd,
+                }
+                for dp in vspec.normalized_paths
+            ),
+            deadline_seconds=spec.deadline_seconds,
+            base_ref=spec.base_ref,
+            task_class=plan.task_class,
+            env=dict(os.environ),
+            state_dir=state_dir,
+            data_dir=data_dir,
+        )
+    except ValueError as exc:
+        # A decision outcome that refuses to stage: unknown class, auth_rejected,
+        # or an already-topped ladder. Reported loud, never a silent no-op.
+        print(f"[dispatch_cli] no escalation: {exc}", file=sys.stderr)
+        return
+    except Exception as exc:  # vnx-silent-except: escalation staging is best-effort; a staging error must not change the failed dispatch's exit code
+        print(f"[dispatch_cli] escalation staging failed: {exc}", file=sys.stderr)
+        return
+    print(
+        f"[dispatch_cli] escalation followup staged: {followup_id} "
+        f"({failure_class}: {tier_ran_on} -> promote through the door)",
+        file=sys.stderr,
+    )
+
+
 def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
     """Turn a spec file into a governed dispatch for BOTH lanes.
 
@@ -2065,6 +2170,12 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                         f"[dispatch_cli] provider lane {result.status}: "
                         f"{result.error or '(no error captured)'}",
                         file=sys.stderr,
+                    )
+                    # The escalation ladder: classify the failure and stage a
+                    # human-promoted followup when the table says climb (OI-1221,
+                    # wired dispatch 20260816-p6-escalate-tier-ds).
+                    _maybe_stage_escalation(
+                        plan, result, vspec=vspec, state_dir=state_dir, data_dir=data_dir
                     )
                 return result.returncode
             elif plan.lane == "claude_tmux_subscription":

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -75,20 +75,58 @@ _TIER_MAP = load_tier_map()
 _TIER_LADDER = load_tier_ladder()
 
 
+# The escalation decision table (dispatch 20260816-p6-escalate-tier-ds): the
+# closed set of failure classes and the action each maps to. A class the table
+# does not know fails loudly — never a silent fallback to "climb".
+#   model_error      -> climb one tier
+#   credit_exhausted -> climb one tier AND notify the operator
+#   auth_rejected    -> no climb (a higher tier has the same auth problem)
+#   timeout          -> retry the same tier first, then climb
+#   empty_completion -> retry the same tier first, then climb
+#   unknown          -> no climb, report the unknown class loudly
+_ESCALATION_TABLE = {
+    "model_error": "climb",
+    "credit_exhausted": "climb",
+    "auth_rejected": "no_climb",
+    "timeout": "retry_same_tier",
+    "empty_completion": "retry_same_tier",
+    "unknown": "no_climb",
+}
+
+# Failure classes that must ALSO reach the operator, independent of whether a
+# climb is possible (credit_exhausted is actionable even at the top rung).
+_NOTIFY_OPERATOR_CLASSES = frozenset({"credit_exhausted"})
+
+
 @dataclass(frozen=True)
 class TierEscalation:
-    """Quality-escalation signal for a REJECTED result (OI-1221).
+    """Quality-escalation decision for a REJECTED result (OI-1221, extended
+    dispatch 20260816-p6-escalate-tier-ds).
 
-    This is the vertical counterpart to the availability fallback above: a
-    rejected result fires a followup dispatch one tier UP the cost ladder
-    (``tier_to = tier_from + 1``), linked back to the rejected attempt via
-    ``parent_dispatch``. ``tier_to`` is None when the ladder is already topped
-    (no rung above ``tier_from``) — a caller must then stop climbing, not wrap.
+    The decision is driven by ``failure_class`` (from ``classify_failure``, the
+    real reason the attempt failed), never a bare "it failed" boolean. ``action``
+    is one of:
+
+      * ``"climb"`` — fire a followup one tier UP the cost ladder (``tier_to`` is
+        the rung above ``tier_from``). ``tier_to`` is None only when the ladder
+        is already topped; a caller must then stop climbing, not wrap.
+      * ``"retry_same_tier"`` — fire a followup on the SAME tier
+        (``tier_to`` == ``tier_from``); timeout/empty_completion retry once
+        before climbing.
+      * ``"no_climb"`` — do not fire any followup (auth_rejected, unknown).
+
+    ``notify_operator`` is True when the failure class demands an operator
+    notification (credit_exhausted). ``unknown_class`` is True when the class is
+    ``unknown`` — the caller must report it loudly, never absorb it.
     """
 
     tier_from: str
     tier_to: Optional[str]
     parent_dispatch: str
+    failure_class: str
+    action: str
+    notify_operator: bool = False
+    unknown_class: bool = False
 
 
 def next_tier(tier: str) -> Optional[str]:
@@ -107,19 +145,47 @@ def next_tier(tier: str) -> Optional[str]:
     return names[idx + 1] if idx + 1 < len(names) else None
 
 
-def escalate_tier(tier_from: str, parent_dispatch: str) -> TierEscalation:
-    """Build the quality-escalation signal for a rejected result.
+def escalate_tier(
+    tier_from: str,
+    parent_dispatch: str,
+    *,
+    failure_class: str,
+    retried: bool = False,
+) -> TierEscalation:
+    """Decide the escalation for a rejected result from its failure class.
 
-    Deterministic: ``tier_to`` is exactly one rung above ``tier_from`` on the
-    cost ladder, and ``parent_dispatch`` names the rejected attempt so the
-    followup is traceable in the audit trail. This is quality escalation, NOT
-    availability fallback — it never walks the tier's ``fallback`` chain and it
-    never stays on the same tier.
+    The decision table lives in code (``_ESCALATION_TABLE``), not a docstring:
+    a class the table does not know raises ValueError — the caller must extend
+    the table explicitly, never silently fall back to a climb. ``retried``
+    encodes "this attempt is already a same-tier retry": timeout/empty_completion
+    retry the same tier once, then climb on the next rejection. Quality
+    escalation never walks the tier's ``fallback`` chain (availability fallback
+    does that, on the same tier) — a climb moves exactly one rung up.
     """
+    if failure_class not in _ESCALATION_TABLE:
+        raise ValueError(
+            f"unrecognized failure_class {failure_class!r}; escalation table "
+            f"knows {sorted(_ESCALATION_TABLE)} — refusing to guess a climb"
+        )
+    action = _ESCALATION_TABLE[failure_class]
+    if action == "retry_same_tier" and retried:
+        action = "climb"
+
+    if action == "climb":
+        tier_to = next_tier(tier_from)
+    elif action == "retry_same_tier":
+        tier_to = tier_from
+    else:  # no_climb
+        tier_to = None
+
     return TierEscalation(
         tier_from=tier_from,
-        tier_to=next_tier(tier_from),
+        tier_to=tier_to,
         parent_dispatch=parent_dispatch,
+        failure_class=failure_class,
+        action=action,
+        notify_operator=(failure_class in _NOTIFY_OPERATOR_CLASSES),
+        unknown_class=(failure_class == "unknown"),
     )
 
 

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -193,34 +193,34 @@ def test_load_tier_ladder_fails_on_non_monotonic_cost(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_escalate_rejected_result_climbs_one_tier():
-    esc = escalate_tier(TIER_LOW, "20260815-rejected-attempt")
+    esc = escalate_tier(TIER_LOW, "20260815-rejected-attempt", failure_class="model_error")
     assert esc.tier_from == TIER_LOW
     assert esc.tier_to == "kimi-k3"
     assert esc.parent_dispatch == "20260815-rejected-attempt"
 
 
 def test_escalate_from_zero_to_low():
-    assert escalate_tier(TIER_ZERO, "d-zero").tier_to == TIER_LOW
+    assert escalate_tier(TIER_ZERO, "d-zero", failure_class="model_error").tier_to == TIER_LOW
 
 
 def test_escalate_from_mid_to_high():
-    assert escalate_tier(TIER_MID, "d-mid").tier_to == TIER_HIGH
+    assert escalate_tier(TIER_MID, "d-mid", failure_class="model_error").tier_to == TIER_HIGH
 
 
 def test_escalate_at_top_returns_none():
-    assert escalate_tier("fable-5", "d-top").tier_to is None
+    assert escalate_tier("fable-5", "d-top", failure_class="model_error").tier_to is None
 
 
 def test_escalate_unknown_tier_returns_none():
-    assert escalate_tier("tier-unknown", "d-unknown").tier_to is None
+    assert escalate_tier("tier-unknown", "d-unknown", failure_class="model_error").tier_to is None
 
 
 def test_escalate_model_named_rungs_climb_in_cost_order():
     """The three escalation-only rungs slot into the climb at their cost position."""
-    assert escalate_tier("kimi-k3", "d1").tier_to == "gpt-5.5"
-    assert escalate_tier("gpt-5.5", "d2").tier_to == TIER_MID
-    assert escalate_tier(TIER_HIGH, "d3").tier_to == "fable-5"
-    assert escalate_tier("fable-5", "d4").tier_to is None
+    assert escalate_tier("kimi-k3", "d1", failure_class="model_error").tier_to == "gpt-5.5"
+    assert escalate_tier("gpt-5.5", "d2", failure_class="model_error").tier_to == TIER_MID
+    assert escalate_tier(TIER_HIGH, "d3", failure_class="model_error").tier_to == "fable-5"
+    assert escalate_tier("fable-5", "d4", failure_class="model_error").tier_to is None
 
 
 def test_next_tier_matches_escalate_tier():
@@ -231,6 +231,71 @@ def test_next_tier_matches_escalate_tier():
     assert next_tier(TIER_MID) == TIER_HIGH
     assert next_tier(TIER_HIGH) == "fable-5"
     assert next_tier("fable-5") is None
+
+
+# ---------------------------------------------------------------------------
+# Escalation decision table (dispatch 20260816-p6-escalate-tier-ds)
+# ---------------------------------------------------------------------------
+
+def test_model_error_climbs_one_tier():
+    """model_error -> climb one tier."""
+    esc = escalate_tier(TIER_LOW, "d-model", failure_class="model_error")
+    assert esc.action == "climb"
+    assert esc.tier_to == "kimi-k3"
+    assert esc.notify_operator is False
+    assert esc.unknown_class is False
+
+
+def test_credit_exhausted_climbs_and_notifies_operator():
+    """credit_exhausted -> climb one tier AND notify operator."""
+    esc = escalate_tier(TIER_LOW, "d-credit", failure_class="credit_exhausted")
+    assert esc.action == "climb"
+    assert esc.tier_to == "kimi-k3"
+    assert esc.notify_operator is True
+
+
+def test_auth_rejected_does_not_climb():
+    """auth_rejected -> no climb (a higher tier has the same auth problem)."""
+    esc = escalate_tier(TIER_LOW, "d-auth", failure_class="auth_rejected")
+    assert esc.action == "no_climb"
+    assert esc.tier_to is None
+    assert esc.notify_operator is False
+
+
+def test_timeout_retries_same_tier_then_climbs():
+    """timeout -> retry the same tier first, then climb on the next rejection."""
+    retry = escalate_tier(TIER_LOW, "d-timeout", failure_class="timeout")
+    assert retry.action == "retry_same_tier"
+    assert retry.tier_to == TIER_LOW  # same rung, not up
+
+    climbed = escalate_tier(TIER_LOW, "d-timeout", failure_class="timeout", retried=True)
+    assert climbed.action == "climb"
+    assert climbed.tier_to == "kimi-k3"
+
+
+def test_empty_completion_retries_same_tier_then_climbs():
+    """empty_completion -> retry the same tier first, then climb."""
+    retry = escalate_tier(TIER_LOW, "d-empty", failure_class="empty_completion")
+    assert retry.action == "retry_same_tier"
+    assert retry.tier_to == TIER_LOW
+
+    climbed = escalate_tier(TIER_LOW, "d-empty", failure_class="empty_completion", retried=True)
+    assert climbed.action == "climb"
+    assert climbed.tier_to == "kimi-k3"
+
+
+def test_unknown_class_does_not_climb_and_reports_loud():
+    """unknown -> no climb, and the caller is told the class is unknown."""
+    esc = escalate_tier(TIER_LOW, "d-unknown", failure_class="unknown")
+    assert esc.action == "no_climb"
+    assert esc.tier_to is None
+    assert esc.unknown_class is True
+
+
+def test_unrecognized_class_fails_loud():
+    """A class the table does not know raises — never a silent fallback to climb."""
+    with pytest.raises(ValueError, match="unrecognized failure_class"):
+        escalate_tier(TIER_LOW, "d-bogus", failure_class="something_else")
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +316,7 @@ def test_quality_escalation_climbs_where_fallback_stays(monkeypatch):
     route = resolve_tier_route(TIER_LOW, env={})
     assert route.tier == TIER_LOW
 
-    esc = escalate_tier(TIER_LOW, "d-rejected")
+    esc = escalate_tier(TIER_LOW, "d-rejected", failure_class="model_error")
     assert esc.tier_from == TIER_LOW
     assert esc.tier_to == "kimi-k3"
     assert esc.parent_dispatch == "d-rejected"

--- a/tests/test_dispatch_bridge_escalation.py
+++ b/tests/test_dispatch_bridge_escalation.py
@@ -44,6 +44,7 @@ def _stage_escalation(tmp_path, **over):
     base = dict(
         rejected_dispatch_id=_REJECTED_ID,
         tier_from="tier-low",
+        failure_class="model_error",
         instruction_text="escalate: the cheap attempt was rejected",
         dispatch_id=_FOLLOWUP_ID,
         role="dev",
@@ -93,6 +94,32 @@ def test_escalation_at_top_rung_refuses_to_stage(tmp_path, monkeypatch):
     _force_kimi(monkeypatch, present=True)
     with pytest.raises(ValueError, match="top rung"):
         _stage_escalation(tmp_path, tier_from="fable-5")
+
+
+def test_escalation_auth_rejected_refuses_to_stage(tmp_path, monkeypatch):
+    """auth_rejected must not climb: a higher tier has the same auth problem, so
+    staging a followup would just burn the more expensive model the same way."""
+    _force_kimi(monkeypatch, present=True)
+    with pytest.raises(ValueError, match="does not climb"):
+        _stage_escalation(tmp_path, failure_class="auth_rejected")
+
+
+def test_escalation_unknown_class_refuses_to_stage(tmp_path, monkeypatch):
+    """unknown must not climb, and the refusal names the unknown class loudly."""
+    _force_kimi(monkeypatch, present=True)
+    with pytest.raises(ValueError, match="UNKNOWN"):
+        _stage_escalation(tmp_path, failure_class="unknown")
+
+
+def test_escalation_timeout_retries_same_tier(tmp_path, monkeypatch):
+    """timeout retries on the SAME tier: the staged spec's tier_to == tier_from
+    (the ladder does not climb), and the followup still resolves a real route."""
+    _force_kimi(monkeypatch, present=True)
+    spec_file = _stage_escalation(tmp_path, failure_class="timeout")
+    payload = _read_payload(spec_file)
+    assert payload["tier_from"] == "tier-low"
+    assert payload["tier_to"] == "tier-low"
+    assert payload["provider"]  # a real route, not an empty staged spec
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Wat

De escalatieladder klom nooit. Gemeten: 27.751 receipts, `tier_from` 0 keer gevuld; `stage_escalation_bundle` werd alleen door zijn eigen test aangeroepen. Deze dispatch geeft `escalate_tier` een `failure_class` en zet de beslisregel in code, zodat de ketenlink-velden (`tier_from`/`tier_to`/`parent_dispatch`) daadwerkelijk op het receipt landen.

## Beslisregel (in code, niet in een docstring)

| failure_class | actie |
|---|---|
| `model_error` | klim één trede |
| `credit_exhausted` | klim één trede EN meld aan de operator |
| `auth_rejected` | klim NIET (een hoger model heeft hetzelfde auth-probleem) |
| `timeout` | eerst herkansing op dezelfde trede, daarna klimmen |
| `empty_completion` | eerst herkansing op dezelfde trede, daarna klimmen |
| `unknown` | klim niet, meld de onbekende klasse luid |

De verzameling is gesloten: een klasse die de tabel niet kent faalt luid (`ValueError`), nooit een stille fallback naar "klim".

## Productie-caller

`run_dispatch`'s provider-lane failure branch roept nu `_maybe_stage_escalation` (`scripts/lib/dispatch_cli.py:2177`), die de failure classificeert en via `stage_escalation_bundle` (`scripts/lib/dispatch_cli.py:1864`) een human-promoted followup stagert. Staging only, geen auto-redispatch.

## Tests

- `tests/smart_router/test_cost_ladder.py`: één test per tabelrij + unknown + gesloten-verzameling.
- `tests/test_dispatch_bridge_escalation.py`: write-path assertions (auth_rejected/unknown weigeren te stagen, timeout retryt op dezelfde trede).

Targeted run (alleen touched files + directe buren): 32 + 288 tests groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)