### PR TITLE
feat(merge-gate): gate the blessed merge wrapper on VNX CI conclusion (OI-1216)

### DIFF
--- a/scripts/lib/merge_preflight_ci_check.py
+++ b/scripts/lib/merge_preflight_ci_check.py
@@ -14,6 +14,13 @@ Every unverifiable state (``gh`` missing, ``gh`` not authenticated, ``gh run
 list`` failing or unparseable, HEAD/branch unresolvable) is a NO-GO with its
 own message. A missing tool never passes as "no red found".
 
+Escape hatch (OI-1216 merge-gate): an operator may override the gate by
+supplying a non-empty reason via ``override_reason`` /
+``--override-reason`` / ``VNX_MERGE_OVERRIDE_REASON``. The reason IS the
+override: an empty/whitespace reason is a refusal, never a silent bypass, and
+every overridden verdict carries ``overridden=True`` plus the reason so it is
+visible in the output rather than hidden.
+
 This is the merge-preflight counterpart to ``pre_merge_gate.check_ci_workflow``
 (OI-931), which enforces the same invariant at gate time. The two share the
 same ``gh run list`` invocation shape and the same workflow-name resolution
@@ -37,6 +44,11 @@ from typing import Any, Dict, List, Optional, Tuple
 DEFAULT_CI_WORKFLOW_NAME = "VNX CI"
 CI_WORKFLOW_NAME_ENV_VAR = "VNX_CI_WORKFLOW_NAME"
 
+# Escape-hatch env var. The value is the required reason: a non-empty value
+# overrides the gate (visibly), an empty value is a refusal, an unset variable
+# means no override is attempted.
+OVERRIDE_ENV_VAR = "VNX_MERGE_OVERRIDE_REASON"
+
 # How many recent runs to pull per branch. Matching is by exact head SHA, so a
 # head older than the limit on a busy branch would read as "not run". The same
 # limit is used by pre_merge_gate.check_ci_workflow.
@@ -59,6 +71,23 @@ def _resolve_workflow_name(workflow_name: Optional[str]) -> str:
     if env_name:
         return env_name
     return DEFAULT_CI_WORKFLOW_NAME
+
+
+def _resolve_override_reason(override_reason: Optional[str]) -> Optional[str]:
+    """Resolve the escape-hatch reason: explicit arg > env var > None.
+
+    Returns the stripped reason string, or one of two sentinels that the caller
+    must distinguish:
+      - ``None``  -> no override attempted; run the normal fail-closed check.
+      - ``""``    -> override attempted WITHOUT a reason; refuse (fail closed).
+      - non-empty -> override granted, with this reason (visible in the verdict).
+    """
+    if override_reason is not None:
+        return override_reason.strip()
+    env_reason = os.environ.get(OVERRIDE_ENV_VAR)
+    if env_reason is not None:
+        return env_reason.strip()
+    return None
 
 
 def _capture(argv: List[str], *, timeout: int, cwd: Optional[str] = None) -> Tuple[Optional[subprocess.CompletedProcess], Optional[str]]:
@@ -93,9 +122,26 @@ def _no_go(message: str, **extra: Any) -> Dict[str, Any]:
         "ran_on_sha": False,
         "head_sha": None,
         "ci_run_id": None,
+        "overridden": False,
+        "override_reason": None,
     }
     base.update(extra)
     return base
+
+
+def _overridden_go(reason: str, head_sha: Optional[str], workflow_name: str) -> Dict[str, Any]:
+    """GO verdict for an explicit operator override. Always visible, never silent."""
+    return {
+        "verdict": "GO",
+        "message": f"OVERRIDE: VNX CI-check overgeslagen voor merge ({reason})",
+        "ci_conclusion": None,
+        "ran_on_sha": False,
+        "head_sha": head_sha,
+        "ci_run_id": None,
+        "workflow_name": workflow_name,
+        "overridden": True,
+        "override_reason": reason,
+    }
 
 
 def check_ci_run_for_head(
@@ -105,13 +151,31 @@ def check_ci_run_for_head(
     head_sha: Optional[str] = None,
     gh_bin: str = "gh",
     workflow_name: Optional[str] = None,
+    override_reason: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Fail-closed check: a VNX CI run with conclusion=success must exist for head_sha.
 
     Returns {"verdict": "GO"|"NO-GO", "message": str, ...}. ``project_root`` is
     the directory whose HEAD is being merged (the worktree under preflight).
+
+    ``override_reason`` is the escape hatch: a non-empty value skips the check
+    with a visible GO (``overridden=True``), an empty/whitespace value is a
+    refusal, and None (or an unset env var) runs the normal check.
     """
     resolved_workflow = _resolve_workflow_name(workflow_name)
+
+    # ── Escape hatch ──────────────────────────────────────────────────────
+    reason = _resolve_override_reason(override_reason)
+    if reason is not None:
+        if not reason:
+            return _no_go(
+                "override zonder reden geweigerd: een override vereist een niet-lege reden "
+                "(geen stille bypass)",
+                workflow_name=resolved_workflow,
+                overridden=True,
+                override_reason=reason,
+            )
+        return _overridden_go(reason, head_sha, resolved_workflow)
 
     # ── gh availability ────────────────────────────────────────────────────
     if shutil.which(gh_bin) is None:
@@ -221,6 +285,8 @@ def check_ci_run_for_head(
                 "head_sha": head_sha,
                 "ci_run_id": run_id,
                 "workflow_name": resolved_workflow,
+                "overridden": False,
+                "override_reason": None,
             }
         if status in ("in_progress", "queued"):
             return _no_go(
@@ -271,6 +337,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--head-sha", help="Exact HEAD SHA (defaults to git rev-parse HEAD)")
     parser.add_argument("--workflow", help="CI workflow name (default: VNX_CI_WORKFLOW_NAME or 'VNX CI')")
     parser.add_argument("--gh-bin", default="gh", help="Path/name of the gh binary")
+    parser.add_argument(
+        "--override-reason",
+        default=None,
+        help="Escape hatch: skip the check with this required reason (empty is refused). "
+             "Also read from VNX_MERGE_OVERRIDE_REASON.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit the full result as JSON")
     args = parser.parse_args(argv)
 
@@ -280,6 +352,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         head_sha=args.head_sha,
         gh_bin=args.gh_bin,
         workflow_name=args.workflow,
+        override_reason=args.override_reason,
     )
 
     if args.json:

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -5,6 +5,13 @@ T0 calls this instead of raw ``gh pr merge`` so every merge is captured in the
 audit trail (t0_receipts.ndjson + dispatch_register.ndjson).  Without this,
 FPY/rework-rate/history have no linkage between merged PRs and receipts.
 
+Merge gate (OI-1216): before merging, the CLI runs a fail-closed check that the
+VNX CI workflow has a run with ``conclusion=success`` for exactly the PR head
+SHA (see ``_run_ci_gate`` -> ``merge_preflight_ci_check.check_ci_run_for_head``).
+A run on an older head does not count, zero runs is a refusal, and any
+unverifiable state is a refusal — never a silent pass. ``--override-reason``
+skips the check visibly with a mandatory reason.
+
 Usage:
     python3 scripts/pr_merge.py --pr 123
     python3 scripts/pr_merge.py --pr 123 --dispatch-id 20260526-gov2-something
@@ -12,6 +19,7 @@ Usage:
     python3 scripts/pr_merge.py --pr 123 --rebase
     python3 scripts/pr_merge.py --pr 123 --merge
     python3 scripts/pr_merge.py --pr 123 --dry-run         # no merge, no write
+    python3 scripts/pr_merge.py --pr 123 --override-reason 'gate flaked, re-verified'
 
 Receipt written to t0_receipts.ndjson:
     event_type  : "pr_merged"
@@ -51,6 +59,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt
+from merge_preflight_ci_check import check_ci_run_for_head
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -99,7 +108,7 @@ def _query_pr(pr_number: int) -> Optional[Dict[str, Any]]:
     """Return PR metadata from GitHub, or None on failure."""
     result = _gh([
         "pr", "view", str(pr_number),
-        "--json", "number,title,state,headRefName,baseRefName,mergedAt,mergeCommit",
+        "--json", "number,title,state,headRefName,baseRefName,headRefOid,mergedAt,mergeCommit",
     ])
     if result.returncode != 0:
         return None
@@ -107,6 +116,43 @@ def _query_pr(pr_number: int) -> Optional[Dict[str, Any]]:
         return json.loads(result.stdout)
     except json.JSONDecodeError:
         return None
+
+
+def _run_ci_gate(
+    pr_number: int,
+    *,
+    override_reason: Optional[str] = None,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Fail-closed merge gate: VNX CI must have conclusion=success for the PR head.
+
+    Resolves the PR head (sha + branch) via ``gh pr view`` and delegates the
+    workflow-conclusion check to
+    ``merge_preflight_ci_check.check_ci_run_for_head``. Returns ``(gate,
+    pr_data)``; the caller merges only when ``gate["verdict"] == "GO"``.
+
+    A failed/empty PR query (no head sha or branch) is a NO-GO — the GitHub API
+    not answering is a refusal with a message, never a silent pass.
+    """
+    pr_data = _query_pr(pr_number)
+    head_sha = (pr_data or {}).get("headRefOid") or ""
+    branch = (pr_data or {}).get("headRefName") or ""
+    if not head_sha or not branch:
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                f"PR-head (sha/branch) kon niet worden bepaald voor #{pr_number}: "
+                "deze merge is niet toetsbaar"
+            ),
+            "overridden": False,
+            "override_reason": None,
+        }, pr_data
+    gate = check_ci_run_for_head(
+        SCRIPT_DIR.parent,
+        branch=branch,
+        head_sha=head_sha,
+        override_reason=override_reason,
+    )
+    return gate, pr_data
 
 
 def _do_merge(pr_number: int, method: str) -> tuple[bool, str]:
@@ -288,10 +334,33 @@ def main(argv: Optional[list[str]] = None) -> int:
     merge_group.add_argument("--rebase", dest="merge_method", action="store_const", const="rebase")
     merge_group.add_argument("--merge", dest="merge_method", action="store_const", const="merge")
     parser.add_argument("--dry-run", action="store_true", help="Skip merge and receipt write")
+    parser.add_argument(
+        "--override-reason", default=None,
+        help="Escape hatch: skip the CI gate with this required reason (empty is refused). "
+             "Also read from VNX_MERGE_OVERRIDE_REASON.",
+    )
     parser.add_argument("--json", action="store_true", help="Output result as JSON")
     args = parser.parse_args(argv)
 
     method = args.merge_method or "squash"
+
+    # ── Merge gate: VNX CI conclusion=success for the exact PR head ──────
+    gate, _ = _run_ci_gate(args.pr, override_reason=args.override_reason)
+    if gate["verdict"] != "GO":
+        if args.json:
+            print(json.dumps({
+                "success": False,
+                "pr_number": args.pr,
+                "error": gate["message"],
+                "ci_gate": gate,
+            }, indent=2))
+        else:
+            print(f"NO-GO: {gate['message']}", file=sys.stderr)
+        return EXIT_ERROR
+    if gate.get("overridden"):
+        print(f"OVERRIDE: {gate['message']}")
+    else:
+        print(f"CI gate: {gate['message']}")
 
     result = merge_pr(
         pr_number=args.pr,

--- a/tests/test_merge_preflight_ci_check.py
+++ b/tests/test_merge_preflight_ci_check.py
@@ -28,6 +28,7 @@ from merge_preflight_ci_check import (
     check_ci_run_for_head,
     DEFAULT_CI_WORKFLOW_NAME,
     CI_WORKFLOW_NAME_ENV_VAR,
+    OVERRIDE_ENV_VAR,
 )
 
 
@@ -236,7 +237,95 @@ class TestCheckCIRunForHead:
         assert gh_call_args[workflow_idx + 1] == "CI/CD Pipeline"
 
 
+class TestOverrideEscapeHatch:
+    """The escape hatch: override with a required, visible reason.
+
+    The reason IS the override. A non-empty reason skips the check with a
+    visible GO; an empty/whitespace reason (or empty env value) is a refusal,
+    never a silent bypass. Overrides short-circuit before any gh/git call.
+    """
+
+    def test_override_with_reason_is_go_and_visible(self, tmp_path):
+        """Non-empty reason -> GO, flagged overridden, reason in the message."""
+        reason = "hotfix: VNX CI flaked, run re-verified manually"
+        with patch("merge_preflight_ci_check.subprocess.run") as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path, override_reason=reason)
+        assert result["verdict"] == "GO"
+        assert result["overridden"] is True
+        assert result["override_reason"] == reason
+        assert "OVERRIDE" in result["message"]
+        assert "hotfix" in result["message"]
+        mock_run.assert_not_called()
+
+    def test_override_without_reason_is_refused(self, tmp_path):
+        """Empty reason -> NO-GO: the escape hatch requires a reason."""
+        with patch("merge_preflight_ci_check.subprocess.run") as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path, override_reason="")
+        assert result["verdict"] == "NO-GO"
+        assert "reden" in result["message"]
+        assert "niet toetsbaar" not in result["message"]
+        mock_run.assert_not_called()
+
+    def test_override_whitespace_reason_is_refused(self, tmp_path):
+        """Whitespace-only reason is treated as no reason -> NO-GO."""
+        result = check_ci_run_for_head(tmp_path, override_reason="   ")
+        assert result["verdict"] == "NO-GO"
+        assert "reden" in result["message"]
+
+    def test_override_env_var_with_reason(self, tmp_path, monkeypatch):
+        """VNX_MERGE_OVERRIDE_REASON with a reason -> visible GO override."""
+        monkeypatch.setenv(OVERRIDE_ENV_VAR, "operator-approved: manual verify")
+        with patch("merge_preflight_ci_check.subprocess.run") as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "GO"
+        assert result["overridden"] is True
+        assert "operator-approved" in result["message"]
+        mock_run.assert_not_called()
+
+    def test_override_env_var_empty_is_refused(self, tmp_path, monkeypatch):
+        """An empty env value is an override attempt without a reason -> NO-GO."""
+        monkeypatch.setenv(OVERRIDE_ENV_VAR, "")
+        with patch("merge_preflight_ci_check.subprocess.run") as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert "reden" in result["message"]
+        mock_run.assert_not_called()
+
+
 class TestCLI:
+    def test_cli_override_reason_flag_go(self, tmp_path, capsys):
+        """--override-reason with a reason exits 0 and reports overridden."""
+        with patch("merge_preflight_ci_check.subprocess.run") as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            rc = mpci.main([
+                "--project-root", str(tmp_path), "--json",
+                "--override-reason", "manual verify after flake",
+            ])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["verdict"] == "GO"
+        assert out["overridden"] is True
+        assert "manual verify" in out["message"]
+        mock_run.assert_not_called()
+
+    def test_cli_override_reason_empty_refused(self, tmp_path, capsys):
+        """--override-reason with an empty value exits 1 and refuses."""
+        with patch("merge_preflight_ci_check.subprocess.run") as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            rc = mpci.main([
+                "--project-root", str(tmp_path), "--json",
+                "--override-reason", "",
+            ])
+        assert rc == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["verdict"] == "NO-GO"
+        assert "reden" in out["message"]
+        mock_run.assert_not_called()
+
     def test_cli_json_go_exits_zero(self, tmp_path, capsys):
         sha = "m" * 40
         mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]

--- a/tests/test_pr_merge_ci_gate.py
+++ b/tests/test_pr_merge_ci_gate.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Tests for the merge gate wired into pr_merge.py (OI-1216 merge-gate).
+
+The CLI (``pr_merge.main``) runs a fail-closed VNX CI-workflow-conclusion check
+against the exact PR head SHA before delegating to ``merge_pr``. These tests
+cover the ``_run_ci_gate`` helper and the ``main()`` wiring: GO proceeds, NO-GO
+refuses before merge, an unresolvable PR head refuses (never a silent pass),
+and the override is loud.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+
+
+SHA = "a" * 40
+
+
+def _go_gate(**kw):
+    gate = {
+        "verdict": "GO",
+        "message": "VNX CI geslaagd op aaaaaaaaaaaa",
+        "ci_conclusion": "success",
+        "ran_on_sha": True,
+        "head_sha": SHA,
+        "ci_run_id": 1,
+        "workflow_name": "VNX CI",
+        "overridden": False,
+        "override_reason": None,
+    }
+    gate.update(kw)
+    return gate
+
+
+def _no_go_gate(message="Geen VNX CI-run gevonden: deze merge is niet toetsbaar"):
+    return {
+        "verdict": "NO-GO",
+        "message": message,
+        "overridden": False,
+        "override_reason": None,
+    }
+
+
+class TestRunCiGate:
+    def test_go_uses_pr_head_and_branch(self, monkeypatch):
+        """A resolvable PR head is passed to the check verbatim (exact head SHA)."""
+        pr_data = {"number": 5, "headRefOid": SHA, "headRefName": "feature/x"}
+        seen = {}
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: pr_data)
+
+        def fake_check(project_root, *, branch, head_sha, override_reason=None):
+            seen["branch"] = branch
+            seen["head_sha"] = head_sha
+            seen["override_reason"] = override_reason
+            return _go_gate()
+
+        monkeypatch.setattr(pr_merge, "check_ci_run_for_head", fake_check)
+
+        gate, data = pr_merge._run_ci_gate(5)
+
+        assert gate["verdict"] == "GO"
+        assert data is pr_data
+        assert seen["head_sha"] == SHA
+        assert seen["branch"] == "feature/x"
+        assert seen["override_reason"] is None
+
+    def test_no_go_when_ci_red(self, monkeypatch):
+        """A failing workflow conclusion is a NO-GO, not a silent pass."""
+        monkeypatch.setattr(
+            pr_merge, "_query_pr",
+            lambda n: {"headRefOid": SHA, "headRefName": "feature/x"},
+        )
+        monkeypatch.setattr(
+            pr_merge, "check_ci_run_for_head",
+            lambda *a, **k: _no_go_gate("VNX CI conclusion is 'failure' op aaaaaaaa"),
+        )
+
+        gate, _ = pr_merge._run_ci_gate(5)
+
+        assert gate["verdict"] == "NO-GO"
+        assert "failure" in gate["message"]
+
+    def test_refuses_when_head_unresolvable(self, monkeypatch):
+        """An unresolvable PR head is a refusal; the check never runs."""
+        called = []
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: None)
+
+        def fake_check(*a, **k):
+            called.append(1)
+            return _go_gate()
+
+        monkeypatch.setattr(pr_merge, "check_ci_run_for_head", fake_check)
+
+        gate, _ = pr_merge._run_ci_gate(5)
+
+        assert gate["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in gate["message"]
+        assert not called, "check must not run when the PR head is unresolvable"
+
+    def test_forwards_override_reason(self, monkeypatch):
+        """A non-empty override reason reaches the check and surfaces as overridden."""
+        monkeypatch.setattr(
+            pr_merge, "_query_pr",
+            lambda n: {"headRefOid": SHA, "headRefName": "feature/x"},
+        )
+        seen = {}
+
+        def fake_check(project_root, *, branch, head_sha, override_reason=None):
+            seen["override_reason"] = override_reason
+            return _go_gate(
+                overridden=True,
+                override_reason=override_reason,
+                message=f"OVERRIDE: VNX CI-check overgeslagen ({override_reason})",
+            )
+
+        monkeypatch.setattr(pr_merge, "check_ci_run_for_head", fake_check)
+
+        gate, _ = pr_merge._run_ci_gate(5, override_reason="hotfix: re-verified")
+
+        assert gate["verdict"] == "GO"
+        assert gate["overridden"] is True
+        assert seen["override_reason"] == "hotfix: re-verified"
+
+
+class TestMainGateWiring:
+    def _ok_result(self):
+        return {
+            "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
+            "pr_title": "", "branch": "", "receipt_status": None, "register_ok": False,
+            "error": "", "dry_run": True, "overlaps": [],
+        }
+
+    def test_no_go_refuses_before_merge(self, monkeypatch, capsys):
+        """A NO-GO gate exits nonzero and never calls merge_pr."""
+        merge_called = []
+        monkeypatch.setattr(
+            pr_merge, "_run_ci_gate",
+            lambda pr, **k: (_no_go_gate("Geen VNX CI-run gevonden"), None),
+        )
+        monkeypatch.setattr(
+            pr_merge, "merge_pr",
+            lambda **k: merge_called.append(1) or self._ok_result(),
+        )
+
+        rc = pr_merge.main(["--pr", "5", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not merge_called, "merge_pr must not run when the gate is NO-GO"
+        assert "NO-GO" in capsys.readouterr().err
+
+    def test_go_proceeds_to_merge(self, monkeypatch, capsys):
+        """A GO gate proceeds to merge_pr and prints the basis of the verdict."""
+        merge_called = []
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (_go_gate(), None))
+        monkeypatch.setattr(
+            pr_merge, "merge_pr",
+            lambda **k: merge_called.append(1) or self._ok_result(),
+        )
+
+        rc = pr_merge.main(["--pr", "5", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert merge_called, "merge_pr must run when the gate is GO"
+        assert "CI gate" in capsys.readouterr().out
+
+    def test_override_is_loud(self, monkeypatch, capsys):
+        """An overridden GO is printed loudly so the bypass is visible."""
+        monkeypatch.setattr(
+            pr_merge, "_run_ci_gate",
+            lambda pr, **k: (
+                _go_gate(overridden=True, override_reason="r",
+                         message="OVERRIDE: VNX CI-check overgeslagen (r)"),
+                None,
+            ),
+        )
+        monkeypatch.setattr(pr_merge, "merge_pr", lambda **k: self._ok_result())
+
+        rc = pr_merge.main(["--pr", "5", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert "OVERRIDE" in capsys.readouterr().out
+
+    def test_json_no_go_outputs_json(self, monkeypatch, capsys):
+        """--json emits a machine-readable failure object on NO-GO."""
+        monkeypatch.setattr(
+            pr_merge, "_run_ci_gate",
+            lambda pr, **k: (_no_go_gate("deze merge is niet toetsbaar"), None),
+        )
+
+        rc = pr_merge.main(["--pr", "5", "--json"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is False
+        assert "niet toetsbaar" in out["error"]


### PR DESCRIPTION
## What

Closes the direct `gh pr merge` side door: the fail-closed VNX CI-workflow-conclusion check now runs inside `scripts/pr_merge.py`, the blessed merge wrapper, before any merge.

Before this change, the check only hung off `vnx_doctor.sh`, `finish_worktree.sh`, and `vnx-ci.yml`. A bare `gh pr merge` bypassed it entirely.

## Design choice: wrapper command, not a git hook or server-side check

- **A pre-push / pre-merge-commit git hook cannot work.** `gh pr merge` merges via the GitHub API and never runs local git hooks, so no local hook can intercept the direct route.
- **A server-side required status check** would need per-repo branch-protection configuration and still leaves the workflow-conclusion gap: per-job `gh pr checks` names can read green while the workflow `conclusion=failure`.
- **The wrapper** (`scripts/pr_merge.py`) is the single blessed merge door T0 already uses. It emits `pr_merged` receipts to `t0_receipts.ndjson` + `dispatch_register.ndjson` and has `--dry-run`. Gating there closes the governed route without a second merge door.

A raw `gh pr merge` typed by hand is not intercepted (impossible from a local hook); it now sits outside the governed path and the wrapper is the documented door.

## The check (workflow conclusion, not per-job names)

`check_ci_run_for_head` queries `gh run list --workflow "VNX CI"` for the exact PR head SHA and requires `conclusion=success`:

- head match + success → GO
- head mismatch (success on an older head) → NO-GO
- zero runs → NO-GO (fail-closed on absence)
- `conclusion=failure` → NO-GO
- any unverifiable state (gh missing/unauthenticated, API error, unparseable output, unresolvable head) → NO-GO with a message, never a silent pass

## Escape hatch

`--override-reason <reason>` (or `VNX_MERGE_OVERRIDE_REASON`) skips the check with a visible `OVERRIDE: ...` GO. The reason IS the override: an empty or whitespace reason is refused.

## Tests

`tests/test_merge_preflight_ci_check.py` + `tests/test_pr_merge_ci_gate.py`: head match, head mismatch, zero runs, `conclusion=failure`, and the override with/without reason. 60 passed across the four touched/neighbour files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)