### PR TITLE
feat(planning): split blocked review state into unread vs refused

### DIFF
--- a/scripts/lib/plan_gate_enforcement.py
+++ b/scripts/lib/plan_gate_enforcement.py
@@ -24,6 +24,7 @@ gate-shaped result, but both share this one truth.
 """
 from __future__ import annotations
 
+import json
 import os
 import re
 import sqlite3
@@ -324,5 +325,113 @@ def _plan_gate_state_decision(db_path: "str | Path", track_id: str, project_id: 
                 (track_id, oi),
             ).fetchone()
         return UNRESOLVED if row is not None else PASSED
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Plan-gate review disposition — the "blocked" refinement
+# ---------------------------------------------------------------------------
+#
+# A single ``blocked`` state hides two facts under one name: a track the
+# plan-first gate has NEVER reviewed (queue depth) and a track the gate reviewed
+# and REFUSED (a finding with a reason). Both have an open ``OI-PLAN-<track>``
+# blocker; the difference is whether a plan-gate decision is on record. That
+# difference is DERIVED from the durable decision record — ``tracks.decision_ref``
+# (OI-1190), written by ``plan_gate_panel.build_decision_ref`` for every panel
+# outcome — never stored as a second flag, so the disposition can never drift
+# out of sync with the gate records.
+
+UNREAD = "unread"        # OI-PLAN blocker open; no refusal on record (never reviewed)
+REFUSED = "refused"      # OI-PLAN blocker open; the recorded decision was REVISE/BLOCK
+CLEARED = "cleared"      # no open OI-PLAN blocker (passed/attested/derived, or never seeded)
+
+# Panel decisions that are a refusal WITH a reason on record. INFRA_FAIL is
+# deliberately NOT a refusal: no lane produced a readable verdict, so the plan
+# was never actually reviewed and still reads UNREAD. Pre-panel refusals
+# (too-thin goal, zero deliverables) write no decision_ref at all and therefore
+# also read UNREAD — correct, because no panel looked at the plan.
+_REFUSAL_DECISIONS = frozenset({"revise", "block"})
+
+
+def _decision_ref_is_refusal(decision_ref: "str | None") -> bool:
+    """True when a track's ``decision_ref`` records a refused (REVISE/BLOCK) decision.
+
+    ``decision_ref`` is the JSON payload ``plan_gate_panel.build_decision_ref``
+    writes onto the track for every panel outcome. An empty or unparseable value
+    is not a refusal — fail-safe to "not refused" so a corrupt record can never
+    mint a finding the panel did not record.
+    """
+    if not decision_ref:
+        return False
+    try:
+        payload = json.loads(decision_ref)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    return str(payload.get("decision", "")).strip().lower() in _REFUSAL_DECISIONS
+
+
+def classify_review_state(
+    *,
+    open_plan_blocker: bool,
+    decision_ref: "str | None",
+) -> str:
+    """Map the two plan-gate facts to a review disposition (pure, no DB).
+
+    ``open_plan_blocker`` is whether the track has an OPEN OI-PLAN blocker;
+    ``decision_ref`` is the track's durable plan-gate decision record (``None``
+    on a store predating migration 0033, or when the gate never ran). This
+    mapping is the whole derivation — nothing is stored, so the disposition can
+    never diverge from the records it reads.
+    """
+    if not open_plan_blocker:
+        return CLEARED
+    if _decision_ref_is_refusal(decision_ref):
+        return REFUSED
+    return UNREAD
+
+
+def plan_gate_review_state(db_path: "str | Path", track_id: str, project_id: str) -> str:
+    """Return ``UNREAD`` / ``REFUSED`` / ``CLEARED`` / ``UNSUPPORTED`` for a track.
+
+    Read-only (``mode=ro``) over the same DB ``plan_gate_state`` reads: the open
+    OI-PLAN blocker comes from ``track_open_items`` and the recorded decision
+    from ``tracks.decision_ref`` (the OI-1190 durable pointer). ``UNSUPPORTED``
+    when the schema cannot determine whether the blocker is open — the same
+    predicate ``_plan_gate_state_decision`` uses. A store with the blocker
+    columns but no ``decision_ref`` column (pre-0033) reads every open blocker
+    as ``UNREAD``: that store has no decision record to derive a refusal from.
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
+    try:
+        if not (_has_table(conn, "track_open_items") and _has_col(conn, "track_open_items", "resolved_at")):
+            return UNSUPPORTED
+        oi = plan_blocker_oi(track_id)
+        if _has_col(conn, "track_open_items", "project_id"):
+            open_blocker = conn.execute(
+                "SELECT 1 FROM track_open_items "
+                "WHERE track_id=? AND project_id=? AND oi_id=? "
+                "AND link_type='blocks' AND resolved_at IS NULL LIMIT 1",
+                (track_id, project_id, oi),
+            ).fetchone() is not None
+        else:  # pre-0024 DB: no tenant column
+            open_blocker = conn.execute(
+                "SELECT 1 FROM track_open_items "
+                "WHERE track_id=? AND oi_id=? AND link_type='blocks' "
+                "AND resolved_at IS NULL LIMIT 1",
+                (track_id, oi),
+            ).fetchone() is not None
+        decision_ref = None
+        if _has_col(conn, "tracks", "decision_ref"):
+            row = conn.execute(
+                "SELECT decision_ref FROM tracks WHERE track_id=? AND project_id=?",
+                (track_id, project_id),
+            ).fetchone()
+            decision_ref = row[0] if row else None
+        return classify_review_state(
+            open_plan_blocker=open_blocker, decision_ref=decision_ref,
+        )
     finally:
         conn.close()

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -63,6 +63,7 @@ import tracks as tracks_lib  # noqa: E402
 import seed_tracks_from_roadmap as seeder  # noqa: E402
 import track_reconciler  # noqa: E402
 import objective_reconcile  # noqa: E402
+import plan_gate_enforcement  # noqa: E402
 
 _HORIZON_ORDER = ["now", "next", "later"]
 _HORIZON_LABEL = {"now": "NOW", "next": "NEXT", "later": "LATER", None: "UNSCHEDULED"}
@@ -240,6 +241,21 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
         tracks = [t for t in tracks if t["phase"] != "done"]
         hidden_done = before - len(tracks)
 
+    # Plan-gate review split (derived, never stored). The open OI-PLAN blocker
+    # set is read ONCE; each track's disposition is classified from that set
+    # plus its durable decision_ref (OI-1190) — no second truth, no per-track
+    # read. "blocked" alone hid unread (never reviewed) and refused (reviewed
+    # and rejected) under one name; this surfaces the difference while the
+    # total stays derivable from the ~blocked badge.
+    plan_blocked_ids = set(list_plan_blocked_tracks(state_dir, project_id))
+    review_by_track = {
+        t["track_id"]: plan_gate_enforcement.classify_review_state(
+            open_plan_blocker=t["track_id"] in plan_blocked_ids,
+            decision_ref=t.get("decision_ref"),
+        )
+        for t in tracks
+    }
+
     if args.json:
         out = [
             {
@@ -251,6 +267,7 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
                 "priority": t.get("priority"),
                 "pr_ref": t.get("pr_ref"),
                 "next_up": bool(t.get("next_up")),
+                "plan_gate_review": review_by_track[t["track_id"]],
                 "depends_on": _dependencies_for(state_dir, t["track_id"], project_id),
             }
             for t in tracks
@@ -284,13 +301,24 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
             marker = "*" if t.get("next_up") else " "
             dep_str = f"  deps: {', '.join(deps)}" if deps else ""
             pr_str = f"  pr: {t['pr_ref']}" if t.get("pr_ref") else ""
-            derived = t.get("derived_status")
-            drift_badge = f" ~{derived}" if derived and derived != t["phase"] else ""
+            review = review_by_track[t["track_id"]]
+            if review in (plan_gate_enforcement.UNREAD, plan_gate_enforcement.REFUSED):
+                drift_badge = f" ~blocked:{review}"
+            else:
+                derived = t.get("derived_status")
+                drift_badge = f" ~{derived}" if derived and derived != t["phase"] else ""
             print(
                 f" {marker} {t['track_id']:<28} [{t['phase']:<7}]{drift_badge} "
                 f"{t.get('priority') or '-':<3} {t['title']}{pr_str}{dep_str}"
             )
         print()
+    unread = sum(1 for t in tracks if review_by_track[t["track_id"]] == plan_gate_enforcement.UNREAD)
+    refused = sum(1 for t in tracks if review_by_track[t["track_id"]] == plan_gate_enforcement.REFUSED)
+    if unread or refused:
+        print(
+            f"plan-gate review: {unread + refused} blocked on the plan gate "
+            f"({unread} unread, {refused} refused)\n"
+        )
     if hidden_done:
         print(f"({hidden_done} done hidden — --all or --phase done to show)\n")
     return 0
@@ -307,6 +335,18 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
     deps = _dependencies_for(state_dir, args.track_id, project_id)
     open_items = tracks_lib.get_linked_open_items(state_dir, args.track_id, project_id)
 
+    # Plan-gate review disposition, derived from facts already loaded: the open
+    # OI-PLAN blocker (from the unresolved open-items read) + the durable
+    # decision_ref. No second store, no extra read.
+    open_plan_blocker = any(
+        oi.get("oi_id") == _plan_blocker_oi(args.track_id) and oi.get("link_type") == "blocks"
+        for oi in open_items
+    )
+    review = plan_gate_enforcement.classify_review_state(
+        open_plan_blocker=open_plan_blocker,
+        decision_ref=track.get("decision_ref"),
+    )
+
     conn = _db_conn(state_dir)
     try:
         pr_delivery = _load_pr_delivery(conn, project_id, args.track_id)
@@ -319,6 +359,7 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
         out["depends_on"] = deps
         out["open_items"] = open_items
         out["lane_hint"] = _lane_hint_of(track)
+        out["plan_gate_review"] = review
         out["pr_delivery"] = delivery_entries
         print(json.dumps(out, indent=2, default=str))
         return 0
@@ -333,6 +374,7 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
     print(f"  pr_ref   : {track.get('pr_ref') or '-'}")
     print(f"  delivery : {_format_pr_delivery(delivery_entries)}")
     print(f"  decision_ref: {_format_decision_ref(track.get('decision_ref'))}")
+    print(f"  plan-gate: {review}")
     print(f"  goal     : {track.get('goal_state') or '-'}")
     print(f"  depends  : {', '.join(deps) if deps else '(none)'}")
     if open_items:

--- a/tests/test_plan_gate_enforcement.py
+++ b/tests/test_plan_gate_enforcement.py
@@ -5,6 +5,7 @@ dispatch door (_check_track_link_verdict). Merge-gate wiring is tested separatel
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 import sys
 from pathlib import Path
@@ -26,24 +27,27 @@ def _make_db(
     tracks: "dict[str, str]",
     plan_blockers: "dict[str, bool] | None" = None,
     with_open_items: bool = True,
+    decision_refs: "dict[str, str] | None" = None,
 ) -> Path:
     """Build a runtime_coordination.db with `tracks` and (optionally) `track_open_items`.
 
     tracks: {track_id: phase}. plan_blockers: {track_id: resolved?} — seeds an
     OI-PLAN-<track> 'blocks' row; resolved=True stamps resolved_at, False leaves it NULL.
     with_open_items=False omits the table entirely (schema-unsupported case).
+    decision_refs: {track_id: json-str} — populates tracks.decision_ref (migration 0033).
     """
     state_dir.mkdir(parents=True, exist_ok=True)
     db_path = state_dir / "runtime_coordination.db"
     conn = sqlite3.connect(str(db_path))
     conn.execute(
         "CREATE TABLE tracks (track_id TEXT PRIMARY KEY, phase TEXT NOT NULL, "
-        "project_id TEXT NOT NULL DEFAULT 'vnx-dev', derived_status TEXT)"
+        "project_id TEXT NOT NULL DEFAULT 'vnx-dev', derived_status TEXT, decision_ref TEXT)"
     )
     for tid, phase in tracks.items():
         conn.execute(
-            "INSERT INTO tracks (track_id, phase, project_id) VALUES (?, ?, 'vnx-dev')",
-            (tid, phase),
+            "INSERT INTO tracks (track_id, phase, project_id, decision_ref) "
+            "VALUES (?, ?, 'vnx-dev', ?)",
+            (tid, phase, (decision_refs or {}).get(tid)),
         )
     if with_open_items:
         conn.execute(
@@ -319,3 +323,114 @@ class TestEnforceModeFailureLogs:
         assert not any(
             "config read failed" in r.message for r in caplog.records
         ), "a NOT-SET enforce flag must stay silent"
+
+
+# ------------------------------------------------------------------ review disposition
+def _decision_ref(decision: str) -> str:
+    """A minimal decision_ref payload as plan_gate_panel.build_decision_ref writes."""
+    return json.dumps({
+        "decision": decision,
+        "reports": [{"seat": "opus"}],
+        "rejected_alternatives": [],
+        "set_at": "2026-08-16T00:00:00Z",
+    })
+
+
+class TestClassifyReviewState:
+    """The review disposition is a pure mapping of two facts: whether the OI-PLAN
+    blocker is open, and whether a refusal (REVISE/BLOCK) is on record. Nothing is
+    stored, so each test pins exactly those two inputs."""
+
+    def test_unread_when_open_blocker_and_no_decision(self):
+        assert pge.classify_review_state(open_plan_blocker=True, decision_ref=None) == pge.UNREAD
+
+    def test_unread_when_open_blocker_and_empty_decision(self):
+        assert pge.classify_review_state(open_plan_blocker=True, decision_ref="") == pge.UNREAD
+
+    def test_refused_when_open_blocker_and_revise(self):
+        assert pge.classify_review_state(
+            open_plan_blocker=True, decision_ref=_decision_ref("REVISE")) == pge.REFUSED
+
+    def test_refused_when_open_blocker_and_block(self):
+        assert pge.classify_review_state(
+            open_plan_blocker=True, decision_ref=_decision_ref("BLOCK")) == pge.REFUSED
+
+    def test_unread_when_open_blocker_and_infra_fail(self):
+        # INFRA_FAIL wrote no readable verdict: the plan was never actually reviewed.
+        assert pge.classify_review_state(
+            open_plan_blocker=True, decision_ref=_decision_ref("INFRA_FAIL")) == pge.UNREAD
+
+    def test_cleared_when_no_open_blocker(self):
+        assert pge.classify_review_state(
+            open_plan_blocker=False, decision_ref=_decision_ref("REVISE")) == pge.CLEARED
+
+    def test_cleared_when_gated_pass(self):
+        # gated PASS lifts the blocker -> neither unread nor refused.
+        assert pge.classify_review_state(
+            open_plan_blocker=False, decision_ref=_decision_ref("PASS")) == pge.CLEARED
+
+    def test_unread_when_open_blocker_and_unparseable_decision(self):
+        assert pge.classify_review_state(
+            open_plan_blocker=True, decision_ref="not json") == pge.UNREAD
+
+    def test_refused_is_case_and_whitespace_insensitive(self):
+        assert pge.classify_review_state(
+            open_plan_blocker=True, decision_ref=_decision_ref(" revise ")) == pge.REFUSED
+
+
+class TestPlanGateReviewState:
+    """The DB-level reader joins the open OI-PLAN blocker with tracks.decision_ref."""
+
+    def test_unread_when_open_blocker_and_no_decision_ref(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={"t": False})
+        assert pge.plan_gate_review_state(db, "t", "vnx-dev") == pge.UNREAD
+
+    def test_refused_when_open_blocker_and_revise_on_record(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={"t": False},
+                      decision_refs={"t": _decision_ref("REVISE")})
+        assert pge.plan_gate_review_state(db, "t", "vnx-dev") == pge.REFUSED
+
+    def test_cleared_when_blocker_resolved(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={"t": True},
+                      decision_refs={"t": _decision_ref("REVISE")})
+        assert pge.plan_gate_review_state(db, "t", "vnx-dev") == pge.CLEARED
+
+    def test_cleared_when_no_blocker(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={})
+        assert pge.plan_gate_review_state(db, "t", "vnx-dev") == pge.CLEARED
+
+    def test_cleared_when_gated_pass(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"},
+                      decision_refs={"t": _decision_ref("PASS")})
+        assert pge.plan_gate_review_state(db, "t", "vnx-dev") == pge.CLEARED
+
+    def test_unsupported_when_no_open_items_table(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, with_open_items=False)
+        assert pge.plan_gate_review_state(db, "t", "vnx-dev") == pge.UNSUPPORTED
+
+    def test_unread_when_no_decision_ref_column(self, tmp_path):
+        """Pre-0033 store: open blocker, no decision_ref column -> UNREAD (there is
+        no record to derive a refusal from), never a crash."""
+        state_dir = tmp_path / "pre0033"
+        state_dir.mkdir()
+        conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        conn.execute(
+            "CREATE TABLE tracks (track_id TEXT PRIMARY KEY, phase TEXT NOT NULL, "
+            "project_id TEXT NOT NULL DEFAULT 'vnx-dev')"
+        )
+        conn.execute("INSERT INTO tracks (track_id, phase) VALUES ('t', 'active')")
+        conn.execute(
+            "CREATE TABLE track_open_items (track_id TEXT NOT NULL, "
+            "project_id TEXT NOT NULL DEFAULT 'vnx-dev', oi_id TEXT NOT NULL, "
+            "link_type TEXT NOT NULL, link_source TEXT, resolved_at TEXT, "
+            "PRIMARY KEY (track_id, project_id, oi_id, link_type))"
+        )
+        conn.execute(
+            "INSERT INTO track_open_items (track_id, oi_id, link_type, resolved_at) "
+            "VALUES ('t', ?, 'blocks', NULL)",
+            (pge.plan_blocker_oi("t"),),
+        )
+        conn.commit()
+        conn.close()
+        assert pge.plan_gate_review_state(
+            state_dir / "runtime_coordination.db", "t", "vnx-dev") == pge.UNREAD

--- a/tests/test_planning_cli_objective.py
+++ b/tests/test_planning_cli_objective.py
@@ -109,8 +109,10 @@ def test_objective_list_renders(seeded_state, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "feat-a" in out
-    assert "feat-b" in out
     assert "feat-c" in out
+    # feat-b is done -> hidden by default (actionable-by-default view).
+    assert "feat-b" not in out
+    assert "(1 done hidden" in out
     # Grouped by horizon bands.
     assert "NOW" in out
     assert "LATER" in out
@@ -124,11 +126,23 @@ def test_objective_list_json(seeded_state, capsys):
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     by_id = {d["track_id"]: d for d in data}
+    # feat-b is done -> hidden by default; --all reveals it (see below).
+    assert set(by_id) == {"feat-a", "feat-c"}
+    assert by_id["feat-a"]["phase"] == "queued"  # planned -> queued
+    assert by_id["feat-c"]["horizon"] == "later"
+
+
+def test_objective_list_json_all_includes_done(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "list", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state), "--json", "--all",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    by_id = {d["track_id"]: d for d in data}
     assert set(by_id) == {"feat-a", "feat-b", "feat-c"}
     # feat-b depends on feat-a.
     assert by_id["feat-b"]["depends_on"] == ["feat-a"]
-    assert by_id["feat-a"]["phase"] == "queued"  # planned -> queued
-    assert by_id["feat-c"]["horizon"] == "later"
 
 
 def test_objective_list_horizon_filter(seeded_state, capsys):
@@ -338,3 +352,157 @@ def test_objective_show_no_table_gracefully_shows_unmarked(seeded_state, capsys)
     assert rc == 0
     out = capsys.readouterr().out
     assert "#888 unmarked" in out
+
+
+# ---------------------------------------------------------------------------
+# objective list/show — plan-gate review disposition (unread vs refused)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def review_seeded_state(seeded_state: Path) -> Path:
+    """seeded_state + migrations 28/30/33 so the OI-PLAN blocker (resolved_at)
+    and the durable decision_ref both exist, and the disposition can be derived."""
+    conn = sqlite3.connect(str(seeded_state / "runtime_coordination.db"))
+    for ver, fname in (
+        (28, "0028_tracks_derived_status.sql"),
+        (29, "0029_track_type_discriminator.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+        (33, "0033_track_decision_ref.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.close()
+    return seeded_state
+
+
+def _plan_blocker_oi(track_id: str) -> str:
+    return f"OI-PLAN-{track_id}"
+
+
+def _link_plan_blocker(state_dir: Path, track_id: str) -> None:
+    tracks_lib.link_open_item(
+        state_dir, track_id, "vnx-dev", _plan_blocker_oi(track_id), "blocks", "manual",
+    )
+
+
+def _set_refused(state_dir: Path, track_id: str) -> None:
+    tracks_lib.set_decision_ref(
+        state_dir, track_id, "vnx-dev",
+        json.dumps({
+            "decision": "REVISE",
+            "reports": [{"seat": "opus"}],
+            "rejected_alternatives": [{"alternative": "thin goal", "reason": "no plan"}],
+            "set_at": "2026-08-16T00:00:00Z",
+        }),
+    )
+
+
+class TestObjectiveListReviewSplit:
+    def test_json_reports_unread_and_refused(self, review_seeded_state, capsys):
+        _link_plan_blocker(review_seeded_state, "feat-a")       # never gated -> unread
+        _link_plan_blocker(review_seeded_state, "feat-c")       # gated REVISE -> refused
+        _set_refused(review_seeded_state, "feat-c")
+        rc = planning_cli.main([
+            "objective", "list", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state), "--json",
+        ])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        by_id = {d["track_id"]: d for d in data}
+        assert by_id["feat-a"]["plan_gate_review"] == "unread"
+        assert by_id["feat-c"]["plan_gate_review"] == "refused"
+
+    def test_text_shows_badges_and_total_equals_sum(self, review_seeded_state, capsys):
+        _link_plan_blocker(review_seeded_state, "feat-a")
+        _link_plan_blocker(review_seeded_state, "feat-c")
+        _set_refused(review_seeded_state, "feat-c")
+        rc = planning_cli.main([
+            "objective", "list", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state),
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "~blocked:unread" in out
+        assert "~blocked:refused" in out
+        # total (2) == unread (1) + refused (1), both numbers apart.
+        assert "2 blocked on the plan gate (1 unread, 1 refused)" in out
+
+    def test_cleared_tracks_get_no_badge_and_no_summary(self, review_seeded_state, capsys):
+        rc = planning_cli.main([
+            "objective", "list", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state),
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "~blocked:" not in out
+        assert "plan-gate review:" not in out
+
+
+class TestObjectiveShowReviewSplit:
+    def test_show_reports_unread(self, review_seeded_state, capsys):
+        _link_plan_blocker(review_seeded_state, "feat-a")
+        rc = planning_cli.main([
+            "objective", "show", "feat-a", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state),
+        ])
+        assert rc == 0
+        assert "plan-gate: unread" in capsys.readouterr().out
+
+    def test_show_reports_refused_with_reason(self, review_seeded_state, capsys):
+        _link_plan_blocker(review_seeded_state, "feat-c")
+        _set_refused(review_seeded_state, "feat-c")
+        rc = planning_cli.main([
+            "objective", "show", "feat-c", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state),
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "plan-gate: refused" in out
+        assert "REVISE" in out  # the reason surfaces via decision_ref
+
+    def test_show_json_reports_review(self, review_seeded_state, capsys):
+        _link_plan_blocker(review_seeded_state, "feat-a")
+        rc = planning_cli.main([
+            "objective", "show", "feat-a", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state), "--json",
+        ])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["plan_gate_review"] == "unread"
+
+    def test_show_reports_cleared_when_no_blocker(self, review_seeded_state, capsys):
+        rc = planning_cli.main([
+            "objective", "show", "feat-a", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state),
+        ])
+        assert rc == 0
+        assert "plan-gate: cleared" in capsys.readouterr().out
+
+
+class TestReviewStateTransition:
+    """A track crossing unread -> refused -> cleared, each leg shown via `show`."""
+
+    def test_track_transitions_unread_refused_cleared(self, review_seeded_state, capsys):
+        _link_plan_blocker(review_seeded_state, "feat-a")
+
+        assert planning_cli.main([
+            "objective", "show", "feat-a", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state)]) == 0
+        assert "plan-gate: unread" in capsys.readouterr().out
+
+        _set_refused(review_seeded_state, "feat-a")
+        assert planning_cli.main([
+            "objective", "show", "feat-a", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state)]) == 0
+        assert "plan-gate: refused" in capsys.readouterr().out
+
+        tracks_lib.unlink_open_item(
+            review_seeded_state, "feat-a", "vnx-dev",
+            _plan_blocker_oi("feat-a"), "blocks", reason="plan gate passed",
+        )
+        assert planning_cli.main([
+            "objective", "show", "feat-a", "--project-id", "vnx-dev",
+            "--state-dir", str(review_seeded_state)]) == 0
+        assert "plan-gate: cleared" in capsys.readouterr().out


### PR DESCRIPTION
## What

A single `blocked` state hid two facts under one name: tracks the plan-first gate **never reviewed** (queue depth) and tracks it reviewed and **refused** (a finding with a reason). This splits them into `unread` vs `refused`, derived from facts already stored.

## Why

Measured on `vnx-dev`: 59 unread + 13 refused (all REVISE) = 72 open OI-PLAN blockers. Steering on the sum of 72 hides both and pushes toward speculative decomposition to move a counter.

## How (derivation, no second truth)

- `tracks.decision_ref` (OI-1190) is written by `plan_gate_panel.build_decision_ref` for every panel outcome. An open `OI-PLAN-<track>` blocker + a REVISE/BLOCK decision = `refused`; an open blocker with no refusal on record = `unread`; no open blocker = `cleared`.
- `INFRA_FAIL` and pre-panel refusals (too-thin goal, zero deliverables) write no decision_ref, so they read `unread` (no panel actually reviewed the plan).
- `objective list` shows `~blocked:unread` / `~blocked:refused` badges plus a summary line; `objective show` adds a `plan-gate:` line and JSON field.

Nothing new is stored, so the disposition can never drift from the gate records. Existing tracks get their correct state automatically (no record rewriting).

## Verification

- `objective list` before: 73 tracks `~blocked`. After: 58 `~blocked:unread` + 13 `~blocked:refused` + 2 `~blocked` (dependency-blocked) = 73. Total unchanged.
- Crossing reproduced read-only: 59 unread + 13 refused = 72 open OI-PLAN blockers; 13 refused all REVISE.
- Targeted tests: 301 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)