### PR TITLE
feat(governance): direction-aware receipt schema_version reader for the append-only ledger

### DIFF
--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,12 +1,30 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-08-16T06:34:57.551469+00:00
+**Last updated**: 2026-08-16T12:11:57.731578+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._
 
 **Other**
+- #1576 — feat(planning): split blocked review state into unread vs refused (#1576) (2026-08-16)
+- #1575 — feat(merge-gate): gate the blessed merge wrapper on VNX CI conclusion (OI-1216) (#1575) (2026-08-16)
+- #1574 — feat(dispatch): escalation ladder climbs from failure_class (#1574) (2026-08-16)
+- #1573 — docs(changelog): add #1571 to 1.5.0 and correct PR count 83 -> 84 (#1573) (2026-08-16)
+- #1572 — chore(release): bump VERSION 1.4.7 -> 1.5.0 + thematic changelog (83 PRs) (#1572) (2026-08-16)
+- #1571 — feat(plan-gate): register plan-reviewer role in agents/ and worker_permissions.yaml (#1571) (2026-08-16)
+- #1570 — docs(investigations): pin OI-1133 quarantine causes (init/migrate env-leak, t0-log inode reuse) (#1571) (#1570) (2026-08-16)
+- #1569 — fix(worktree): occupancy lock, unpushed-commit warning, fabric-version freeze (OI-1232, OI-1149, OI-1061) (#1569) (2026-08-16)
+- #1568 — fix(dispatch): read completion_text in classify_failure instead of discarding it (#1568) (2026-08-16)
+- #1567 — docs(horizon): derive deliverables for 12 plan-gate-blocked tracks (OI-1560-p3) (#1567) (2026-08-16)
+- #1566 — docs(horizon): document deliverable set/task_class and the no_deliverables plan-gate refusal (#1566) (2026-08-16)
+- #1564 — docs(governance): pin OI-1118's 19-vs-3792 unknown-receipt scale gap (#1564) (2026-08-16)
+- #1563 — [SALVAGED-UNVOUCHED] dispatch(20260816-p5-technical-writer-role): auto-created by VNX tmux-spawn lane (#1563) (2026-08-16)
+- #1562 — feat(horizon): add deliverable task_class/routing_floor door (OI-1560-p2) (#1562) (2026-08-16)
+- #1559 — fix(governance): pin event_type+status governed-outcome semantics (OI-1148) (#1559) (2026-08-16)
+- #1560 — fix(planning): plan-gate reads deliverables, not just the goal field (#1560) (2026-08-16)
+- #1558 — fix(dispatch): bind unbound `model` name on worker_process_gone/heartbeat failure paths (OI-1237) (#1558) (2026-08-16)
+- #1557 — fix(permissions): translate multi-token bash_allow_patterns into --allowedTools (#1557) (2026-08-16)
 - #1556 — fix(governance): orphan teardown sweep + unconditional 0030/0029 guard (OI-1192, OI-1213) (#1556) (2026-08-16)
 - #1555 — feat(reconcile): default-ON gh merge source so reconciler sees bare gh pr merge (OI-1155) (#1555) (2026-08-15)
 - #1554 — fix(governance): derive synthesized receipt status from declared outcome (#1554) (2026-08-15)
@@ -223,15 +241,6 @@ _Last 14 days — sourced from git merge commits._
 - #1337 — fix(ci): full history for profile-a checkout so check_pr_size resolves pinned SHAs (OI-838) (#1337) (2026-08-02)
 - #1333 — fix(tests): fail-closed guard tegen schrijfacties naar de echte centrale store onder pytest (#1333) (2026-08-02)
 - #1310 — fix(ci,tests): gate F39 replay behind marker, run full suite in CI (OI-908, OI-906) (#1310) (2026-08-02)
-- #1332 — fix(gate): temporary FILE_SIZE_ALLOWLIST entry for dispatch_cli (OI-937) (#1332) (2026-08-02)
-- #1331 — test(track-reconciler): toets plan-gate hint op betekenis i.p.v. dode commandovorm (OI-934) (#1331) (2026-08-02)
-- #1330 — chore(release): bump VERSION 1.4.1 -> 1.4.2 + changelog entry (#1330) (2026-08-02)
-- #1329 — refactor(scripts): close_track_if_done verhuist naar track_reconciler_closure.py (#1329) (2026-08-02)
-- #1328 — refactor(scripts): _compute_derived_status verhuist naar track_reconciler_status.py (#1328) (2026-08-02)
-- #1327 — fix(tests): align _archive_dispatch_events mock with tuple signature (OI-933) (#1327) (2026-08-02)
-- #1325 — feat(scripts): refactor-bewijstools landen met eigen tests (fase 0) (#1325) (2026-08-02)
-- #1313 — fix(governance): wire role context into provider prompts + deterministic role_applied check (#1313) (2026-08-02)
-- #1324 — docs(triage): land T9 meet-rapport OI-561..655 (uit #1306) (#1324) (2026-08-02)
 
 ## Active features
 

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -30,6 +30,11 @@ from .idempotency import (
 from .receipt_finalize import classify_receipt_v2_warnings, commit_receipt_v2_fields
 from .validation import _validate_receipt
 
+# Sibling scripts/lib module (scripts/lib is on sys.path whenever this package
+# is imported, since append_receipt_internals lives there). Single source of
+# truth for the monotonic receipt-schema stamp — see ledger_schema_version.py.
+from ledger_schema_version import CURRENT_SCHEMA_VERSION
+
 import logging
 log = logging.getLogger(__name__)
 
@@ -442,7 +447,7 @@ def append_receipt_payload(
     # (report_parser.py output, governance_receipts.py, state_mutation.py,
     # raw worker-authored JSON via the append_receipt.py CLI) funnels
     # through — never touched separately from the shape change.
-    receipt.setdefault("schema_version", 2)
+    receipt.setdefault("schema_version", CURRENT_SCHEMA_VERSION)
 
     receipt_path = _resolve_receipts_file(receipts_file).expanduser().resolve()
 

--- a/scripts/lib/ledger_schema_version.py
+++ b/scripts/lib/ledger_schema_version.py
@@ -1,0 +1,214 @@
+"""ledger_schema_version.py — direction-aware receipt-schema version discipline.
+
+The receipt ledger (``t0_receipts.ndjson``) is append-only and mixed-version by
+construction (ADR-005, ADR-035 §7): a v0/v1-shaped prefix followed by a
+``schema_version: 2`` suffix. The WRITE side already stamps a monotonic
+``schema_version`` on every new receipt — ``append_receipt_internals/payload.py``
+does ``receipt.setdefault("schema_version", CURRENT_SCHEMA_VERSION)`` (Path 2)
+and ``receipt_schema.ReceiptV2`` forces ``RECEIPT_V2_SCHEMA_VERSION`` (Path 1),
+both sourced from the single constant below. The READ side is the gap this
+module closes: a reader must refuse what it does not know, convert what it
+does, and never rewrite history.
+
+Deterministic read rules — pure version arithmetic plus a fixed migration
+ladder, no model judgment anywhere:
+
+  - ``schema_version`` absent  -> version 0 (the oldest generation; not an error)
+  - ``schema_version`` == CURRENT -> read as-is
+  - ``schema_version`` <  CURRENT -> convert in memory, read on; the conversion
+    is NEVER written back — it only lands on disk when the receipt is
+    continued (re-emitted through the writer, which stamps the current version)
+  - ``schema_version`` >  CURRENT -> refuse loudly (``ReceiptSchemaTooNewError``):
+    the reader does not know what it does not know, and silently reading a
+    newer shape produces a wrong interpretation
+
+Migration path for the existing ~27k mixed-version lines: none of them is ever
+rewritten (ADR-005 append-only). A backfill that edits history is explicitly
+not an option. The in-memory conversion in ``read_receipt``/``iter_receipts``
+is the migration — lazy, per-line, and durable only when a line is re-emitted.
+
+Two "absent" conventions coexist on purpose. The WRITE-side validator
+(``append_receipt_internals/validation.py::_resolve_schema_version``) resolves
+an absent stamp to ``1`` for its legacy-v1 tolerance rules (ADR-035 §3.2.1).
+This READ-side module resolves an absent stamp to ``0`` for the migration
+ladder. Both agree that absent means "legacy"; the numbers differ because the
+validator's floor is the v1 write-rule set, while the reader's floor is the
+true oldest generation that predates any explicit stamp.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, Union
+
+# Single source of truth for the current receipt-schema version. Bump here —
+# never at the individual stamp sites — so a future v3 lands monotonically on
+# every new receipt and the reader's ladder walks up to it in one place.
+CURRENT_SCHEMA_VERSION = 2
+
+# A receipt with no ``schema_version`` key is the oldest generation (version 0),
+# not an error. ``1`` is the legacy v1 stamp (ADR-035: "absent or 1 means the
+# legacy shape"); both are older than CURRENT and convert in memory.
+ABSENT_SCHEMA_VERSION = 0
+
+
+class ReceiptSchemaTooNewError(RuntimeError):
+    """A receipt carries a schema_version newer than this reader knows.
+
+    Refuse loudly: reading a newer shape with an older reader yields a wrong
+    interpretation, so there is no safe fallback.
+    """
+
+
+class ReceiptSchemaVersionError(RuntimeError):
+    """A receipt carries a schema_version the reader cannot parse at all."""
+
+
+class ReceiptSchemaMigrationMissingError(RuntimeError):
+    """No migration step is registered for a version in the read ladder."""
+
+
+def receipt_schema_version(receipt: Dict[str, Any]) -> int:
+    """Resolve a receipt's schema version.
+
+    Absent/None -> ``ABSENT_SCHEMA_VERSION`` (0, oldest generation). A present
+    integer-parseable scalar -> that integer. Anything else that is present but
+    cannot be parsed -> ``ReceiptSchemaVersionError``: the reader cannot
+    determine whether it is safe to read, so it refuses loudly.
+    """
+    raw = receipt.get("schema_version")
+    if raw is None:
+        return ABSENT_SCHEMA_VERSION
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ReceiptSchemaVersionError(
+            f"receipt schema_version={raw!r} is not an integer"
+        ) from exc
+
+
+def _migrate_0_to_1(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    """v0 -> v1: give the legacy shape its explicit stamp.
+
+    v0 (no stamp) and v1 (``schema_version: 1``) are the SAME legacy shape
+    (ADR-035 §7: "absent or 1 means the legacy v1 shape"). The step exists so
+    the ladder is uniform — every step is ``source -> source + 1`` — and a
+    future conversion between the two can slot in here without changing
+    ``read_receipt``. Returns a new dict; the input is never mutated.
+    """
+    migrated = dict(receipt)
+    migrated["schema_version"] = 1
+    return migrated
+
+
+def _migrate_1_to_2(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    """v1 -> v2: stamp the current version and canonicalize the event-name key.
+
+    v2 drops the legacy ``event`` alias (ADR-035 §3.2.1 r3 HIGH-2): for a
+    ``schema_version >= 2`` record only ``event_type`` is consulted. An
+    in-memory upgrade therefore promotes ``event`` to ``event_type`` when the
+    canonical key is absent, so a downstream v2 reader sees the field it
+    expects. Non-lossy: the ``event`` key is left in place (history is never
+    rewritten; a reader may still want it). This is schema canonicalization,
+    NOT the status-vocabulary cleanup (that is a separate track).
+
+    Returns a new dict; the input is never mutated.
+    """
+    migrated = dict(receipt)
+    migrated["schema_version"] = 2
+    if "event_type" not in migrated and migrated.get("event") is not None:
+        migrated["event_type"] = migrated["event"]
+    return migrated
+
+
+# Migration ladder: source version -> (dict -> dict) upgrade to source + 1.
+# Each step is a PURE function (new dict out, input never mutated) so it is
+# independently unit-testable and ``read_receipt`` can chain them blindly.
+SCHEMA_MIGRATIONS: Dict[int, Callable[[Dict[str, Any]], Dict[str, Any]]] = {
+    0: _migrate_0_to_1,
+    1: _migrate_1_to_2,
+}
+
+PathLike = Union[str, Path]
+
+
+def read_receipt(
+    raw: Dict[str, Any],
+    *,
+    current_version: int = CURRENT_SCHEMA_VERSION,
+) -> Dict[str, Any]:
+    """Read one receipt dict, converting it in memory to ``current_version``.
+
+    Direction-aware:
+      - newer than ``current_version`` -> ``ReceiptSchemaTooNewError`` (refuse)
+      - older, or absent -> walked through ``SCHEMA_MIGRATIONS`` in memory
+      - equal -> returned as a copy (never the caller's dict, never mutated)
+
+    Pure and I/O-free: it returns a new dict and writes nothing, so a read
+    round can never touch the ledger. Only a subsequent WRITE (through the
+    normal append path) persists the converted form.
+    """
+    if not isinstance(raw, dict):
+        raise TypeError(f"receipt must be a dict, got {type(raw).__name__}")
+
+    version = receipt_schema_version(raw)
+    if version > current_version:
+        raise ReceiptSchemaTooNewError(
+            f"receipt schema_version={version} is newer than this reader "
+            f"(current_version={current_version}); refusing to read a shape "
+            f"this reader does not know"
+        )
+
+    migrated: Dict[str, Any] = dict(raw)
+    for v in range(version, current_version):
+        step = SCHEMA_MIGRATIONS.get(v)
+        if step is None:
+            raise ReceiptSchemaMigrationMissingError(
+                f"no migration registered from schema_version={v} to {v + 1}; "
+                f"cannot convert a version-{v} receipt to {current_version}"
+            )
+        migrated = step(migrated)
+    return migrated
+
+
+def iter_receipts(
+    path: PathLike,
+    *,
+    current_version: int = CURRENT_SCHEMA_VERSION,
+) -> Iterator[Dict[str, Any]]:
+    """Stream a ledger through the direction-aware reader.
+
+    Yields each receipt converted in memory to ``current_version``. Built on
+    ``ndjson_io.iter_ndjson`` (torn-tail-safe), so a partial final line from a
+    crash mid-append is skipped, not raised. Never writes: the ledger bytes are
+    untouched by iterating.
+    """
+    # Lazy sibling import keeps this module importable with zero side effects
+    # (it is imported by append_receipt_internals/payload.py at module scope).
+    from ndjson_io import iter_ndjson  # noqa: PLC0415
+
+    for record in iter_ndjson(path):
+        yield read_receipt(record, current_version=current_version)
+
+
+def read_receipts(
+    path: PathLike,
+    *,
+    current_version: int = CURRENT_SCHEMA_VERSION,
+) -> List[Dict[str, Any]]:
+    """Eager list form of :func:`iter_receipts` (torn-tail-safe, non-writing)."""
+    return list(iter_receipts(path, current_version=current_version))
+
+
+__all__ = [
+    "CURRENT_SCHEMA_VERSION",
+    "ABSENT_SCHEMA_VERSION",
+    "SCHEMA_MIGRATIONS",
+    "ReceiptSchemaTooNewError",
+    "ReceiptSchemaVersionError",
+    "ReceiptSchemaMigrationMissingError",
+    "receipt_schema_version",
+    "read_receipt",
+    "iter_receipts",
+    "read_receipts",
+]

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -48,6 +48,7 @@ if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
 from dispatch_identity import validate_receipt_kind  # noqa: E402
+from ledger_schema_version import CURRENT_SCHEMA_VERSION  # noqa: E402
 
 
 def _utc_now_iso() -> str:
@@ -60,7 +61,10 @@ def _utc_now_iso() -> str:
 # status; always ``task_complete``), not caller data. ``ReceiptV2.__post_init__``
 # forces these constants so a future emit site cannot bypass them by stamping a
 # non-v2 receipt or a different event_type.
-RECEIPT_V2_SCHEMA_VERSION = 2
+# Sourced from ledger_schema_version.CURRENT_SCHEMA_VERSION so the receipt
+# shape's stamp and the reader's migration ladder share ONE version constant
+# (bump there, not here — see ledger_schema_version.py).
+RECEIPT_V2_SCHEMA_VERSION = CURRENT_SCHEMA_VERSION
 RECEIPT_V2_EVENT_TYPE = "task_complete"
 
 

--- a/tests/test_ledger_schema_version.py
+++ b/tests/test_ledger_schema_version.py
@@ -1,0 +1,198 @@
+"""test_ledger_schema_version.py — direction-aware receipt-schema version reader.
+
+Covers scripts/lib/ledger_schema_version.py, the read-side discipline for a
+mixed-version append-only receipt ledger (ADR-005, ADR-035):
+
+  - NEWER schema than the reader knows -> refuse loudly (ReceiptSchemaTooNewError)
+  - OLDER schema -> convert in memory and read on, never write the conversion back
+  - schema_version ABSENT -> oldest generation (version 0), not an error, convert
+  - a read round never touches the ledger bytes (hash + mtime unchanged)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+import ledger_schema_version as lsv
+from ledger_schema_version import (
+    ABSENT_SCHEMA_VERSION,
+    CURRENT_SCHEMA_VERSION,
+    ReceiptSchemaMigrationMissingError,
+    ReceiptSchemaTooNewError,
+    ReceiptSchemaVersionError,
+    iter_receipts,
+    read_receipt,
+    read_receipts,
+    receipt_schema_version,
+)
+
+
+def _write_ledger(path: Path, records: list[dict]) -> Path:
+    """Write records as compact NDJSON lines (the ledger writer's separators)."""
+    path.write_text(
+        "".join(json.dumps(r, separators=(",", ":")) + "\n" for r in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# version resolution
+# ---------------------------------------------------------------------------
+
+def test_absent_schema_version_is_version_zero():
+    assert receipt_schema_version({}) == ABSENT_SCHEMA_VERSION
+    assert receipt_schema_version({"dispatch_id": "d"}) == ABSENT_SCHEMA_VERSION
+    assert receipt_schema_version({"schema_version": None}) == ABSENT_SCHEMA_VERSION
+    assert ABSENT_SCHEMA_VERSION == 0
+
+
+def test_schema_version_parses_int_and_int_string():
+    assert receipt_schema_version({"schema_version": 2}) == 2
+    assert receipt_schema_version({"schema_version": "2"}) == 2
+
+
+def test_non_numeric_schema_version_raises_loudly():
+    with pytest.raises(ReceiptSchemaVersionError, match="not an integer"):
+        receipt_schema_version({"schema_version": "abc"})
+    with pytest.raises(ReceiptSchemaVersionError, match="not an integer"):
+        read_receipt({"schema_version": "abc"})
+
+
+# ---------------------------------------------------------------------------
+# the four dispatch requirements
+# ---------------------------------------------------------------------------
+
+def test_newer_schema_refuses_loudly():
+    """A receipt stamped newer than the reader's CURRENT refuses, never guesses."""
+    receipt = {"schema_version": CURRENT_SCHEMA_VERSION + 1, "dispatch_id": "d"}
+    with pytest.raises(ReceiptSchemaTooNewError, match="newer"):
+        read_receipt(receipt)
+
+
+def test_older_schema_converts_in_memory():
+    """v1 -> current: stamp bumps and the legacy ``event`` alias promotes to
+    ``event_type`` (non-lossy — ``event`` is retained, history is not rewritten)."""
+    receipt = {"schema_version": 1, "dispatch_id": "d", "event": "task_complete"}
+    out = read_receipt(receipt)
+    assert out["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert out["event_type"] == "task_complete"
+    assert out["event"] == "task_complete"  # retained, not deleted
+
+
+def test_missing_schema_version_counts_as_version_zero():
+    """A receipt with no schema_version is the oldest generation: not an error,
+    and it converts the full ladder (0 -> 1 -> current)."""
+    receipt = {"dispatch_id": "d", "event": "task_complete"}
+    assert receipt_schema_version(receipt) == 0
+    out = read_receipt(receipt)
+    assert out["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert out["event_type"] == "task_complete"
+
+
+def test_reading_a_ledger_writes_nothing_back(tmp_path):
+    """Hash + mtime of a mixed-version ledger are byte-identical after a full
+    read round — the in-memory conversion is never persisted on read."""
+    path = tmp_path / "t0_receipts.ndjson"
+    records = [
+        {"dispatch_id": "d-0", "event": "task_complete"},  # v0 (absent stamp)
+        {"schema_version": 1, "dispatch_id": "d-1", "event": "task_complete"},  # v1
+        {"schema_version": 2, "dispatch_id": "d-2", "event_type": "task_complete"},  # v2
+    ]
+    _write_ledger(path, records)
+
+    before_bytes = path.read_bytes()
+    before_hash = hashlib.sha256(before_bytes).hexdigest()
+    before_mtime = path.stat().st_mtime_ns
+
+    converted = read_receipts(path)
+
+    assert len(converted) == 3
+    assert all(r["schema_version"] == CURRENT_SCHEMA_VERSION for r in converted)
+    assert path.read_bytes() == before_bytes
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before_hash
+    assert path.stat().st_mtime_ns == before_mtime
+
+
+# ---------------------------------------------------------------------------
+# purity + robustness
+# ---------------------------------------------------------------------------
+
+def test_read_receipt_never_mutates_its_input():
+    receipt = {"schema_version": 1, "dispatch_id": "d", "event": "task_complete"}
+    snapshot = dict(receipt)
+    out = read_receipt(receipt)
+    assert receipt == snapshot  # input untouched
+    assert out is not receipt
+    assert out["schema_version"] == CURRENT_SCHEMA_VERSION
+
+
+def test_equal_version_reads_as_a_copy():
+    receipt = {"schema_version": 2, "dispatch_id": "d", "event_type": "task_complete"}
+    out = read_receipt(receipt)
+    assert out == receipt
+    assert out is not receipt  # always a new dict, never the caller's
+
+
+def test_missing_migration_step_raises(monkeypatch):
+    """A gap in the ladder (no 1 -> 2 step) refuses instead of silently
+    returning a half-converted receipt."""
+    monkeypatch.delitem(lsv.SCHEMA_MIGRATIONS, 1)
+    with pytest.raises(ReceiptSchemaMigrationMissingError, match="no migration registered"):
+        read_receipt({"schema_version": 0, "dispatch_id": "d"})
+
+
+def test_non_dict_receipt_raises_type_error():
+    with pytest.raises(TypeError, match="must be a dict"):
+        read_receipt(["not", "a", "dict"])  # type: ignore[arg-type]
+
+
+def test_iter_receipts_streams_and_converts(tmp_path):
+    path = tmp_path / "t0_receipts.ndjson"
+    _write_ledger(
+        path,
+        [
+            {"dispatch_id": "d-0", "event": "task_complete"},  # v0
+            {"schema_version": 2, "dispatch_id": "d-1", "event_type": "task_complete"},  # v2
+        ],
+    )
+    out = list(iter_receipts(path))
+    assert len(out) == 2
+    assert all(r["schema_version"] == CURRENT_SCHEMA_VERSION for r in out)
+    assert out[0]["event_type"] == "task_complete"
+
+
+def test_read_receipts_skips_torn_tail(tmp_path):
+    """Built on ndjson_io: a partial final line from a crash mid-append is
+    skipped, not raised, and the good records still convert."""
+    path = tmp_path / "t0_receipts.ndjson"
+    good = [{"schema_version": 2, "dispatch_id": "d-0", "event_type": "task_complete"}]
+    _write_ledger(
+        path,
+        [
+            good[0],
+        ],
+    )
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write('{"schema_version": 2, "dispatch_id": "d-1", "par')  # torn
+    assert read_receipts(path) == good
+
+
+# ---------------------------------------------------------------------------
+# constant centralization (write path and reader share ONE source)
+# ---------------------------------------------------------------------------
+
+def test_write_path_and_reader_share_one_version_constant():
+    """receipt_schema (Path 1) and payload.py (Path 2) both stamp from
+    CURRENT_SCHEMA_VERSION — one bump site, monotonic everywhere."""
+    from receipt_schema import RECEIPT_V2_SCHEMA_VERSION  # noqa: E402
+
+    assert RECEIPT_V2_SCHEMA_VERSION == CURRENT_SCHEMA_VERSION
+    assert CURRENT_SCHEMA_VERSION == 2  # ADR-035 cutover value


### PR DESCRIPTION
## Summary

Closes the read-side gap for a mixed-version append-only receipt ledger (ADR-005, ADR-035). The write side already stamps a monotonic `schema_version` on every new receipt; this PR centralizes that stamp and adds a direction-aware reader.

## What changed

- **`scripts/lib/ledger_schema_version.py`** (new): single `CURRENT_SCHEMA_VERSION = 2` constant plus a pure, deterministic reader.
  - receipt with **newer** schema than the reader knows -> refuse loudly (`ReceiptSchemaTooNewError`)
  - receipt with **older** schema -> convert in memory and read on; the conversion is **never** written back at read time (only lands on disk when the receipt is re-emitted through the normal write path)
  - receipt **without** `schema_version` -> oldest generation (version 0), not an error, convert
  - migration ladder `0 -> 1 -> 2` runs per-line and is pure (new dict, input never mutated)
- **`scripts/lib/receipt_schema.py`** + **`scripts/lib/append_receipt_internals/payload.py`**: both stamp sites now source the version from `CURRENT_SCHEMA_VERSION` (one bump site instead of two hardcoded `2`s).
- **`tests/test_ledger_schema_version.py`** (new): 14 tests covering the four required behaviours plus robustness.

## Migration path (no rewrite)

The existing ~27,772 mixed-version lines are never rewritten (ADR-005 append-only). The in-memory conversion in `read_receipt` / `iter_receipts` / `read_receipts` is the migration: lazy, per-line, durable only when a line is re-emitted.

## Verification

- **Own ledger census** — `wc -l` on `~/.vnx-data/vnx-dev/state/t0_receipts.ndjson`: **27,772 lines**; **2,168** receipts with no `status` key; **49** with empty-string `status`. The earlier "2,217 statusless" figure counts falsy status (absent OR empty): 2,168 + 49 = 2,217. The 27,751 -> 27,772 delta is append-only growth (+21 lines since the dispatch snapshot), not a discrepancy.
- **Four tests targeted green** — `tests/test_ledger_schema_version.py` (14 passed), plus direct neighbours `test_receipt_schema.py`, `test_ndjson_io.py`, `test_append_receipt*.py`, `test_receipt_v2_pr5_schema_cutover.py` (205 passed).
- **Read writes nothing back** — full `read_receipts()` over the real 27,772-line ledger streamed all records with zero `too_new` raises; ledger sha256 (`9435497d…`) and mtime were byte-identical before and after.

## Non-goal

Status-value vocabulary cleanup (20 distinct statuses) is explicitly out of scope — that is the separate `ledger-vocab-generated` track, so the two changes do not interleave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)