### PR TITLE
feat(dispatch): resolve per-dispatch worktree in the headless writer

### DIFF
--- a/scripts/lib/headless_dispatch_writer.py
+++ b/scripts/lib/headless_dispatch_writer.py
@@ -15,6 +15,9 @@ Design invariants:
   - Role validation checks .claude/skills/<role>/ directory existence.
   - dispatch.json is written atomically to pending/<dispatch_id>/dispatch.json.
   - created_at is always a UTC ISO-8601 timestamp.
+  - The per-dispatch worktree is resolved via dispatch_worktree_isolation
+    BEFORE writing: the worker branches inside that worktree, never the main
+    checkout, and the resolution is fail-closed (no main-checkout fallback).
 """
 
 from __future__ import annotations
@@ -114,6 +117,18 @@ class DispatchValidationError(ValueError):
     """Raised when dispatch parameters fail validation."""
 
 
+class DispatchWorktreeError(RuntimeError):
+    """Raised when the dispatch worktree cannot be resolved (fail-closed).
+
+    The headless worker must operate inside the per-dispatch worktree the door
+    created, never the main checkout.  When that worktree cannot be resolved —
+    unresolvable project root, unresolvable base_ref, occupancy conflict, or
+    identity mismatch — the writer refuses outright.  There is no fallback to
+    the main checkout; a silent fallback is the exact defect this exists to
+    remove.
+    """
+
+
 # ---------------------------------------------------------------------------
 # generate_dispatch_id
 # ---------------------------------------------------------------------------
@@ -132,6 +147,47 @@ def generate_dispatch_id(prefix: str, track: str) -> str:
     date_part = now.strftime("%Y%m%d")
     time_part = now.strftime("%H%M%S")
     return f"{date_part}-{time_part}-{prefix}-{track}"
+
+
+# ---------------------------------------------------------------------------
+# dispatch worktree resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_dispatch_worktree(
+    dispatch_id: str,
+    *,
+    project_root: Optional[Path] = None,
+) -> "tuple[Path, str]":
+    """Resolve/create the per-dispatch worktree and return ``(path, branch)``.
+
+    Uses the single canonical mechanism — ``dispatch_worktree_isolation`` —
+    already shared by the tmux and provider lanes, so the headless writer does
+    not build a second worktree mechanism beside it.  ``create_dispatch_worktree``
+    creates or re-enters the worktree at
+    ``<project_root>/.vnx-data/worktrees/dispatch-<safe_id>`` on branch
+    ``dispatch/<safe_id>`` and acquires the OI-1232 occupancy lock; the identity
+    is then verified so a wrong-identity hand-out fails loud instead of running
+    on the wrong tree.
+
+    Fail-closed: any failure raises :class:`DispatchWorktreeError`.  The writer
+    refuses and does NOT fall back to the main checkout.
+    """
+    from dispatch_worktree_isolation import (  # noqa: PLC0415
+        _sanitize_dispatch_id,
+        create_dispatch_worktree,
+        resolve_consumer_project_root,
+        verify_worktree_identity,
+    )
+    root = Path(project_root) if project_root is not None else resolve_consumer_project_root()
+    try:
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=root)
+        claim = verify_worktree_identity(dispatch_id, wt_path, project_root=root)
+    except Exception as exc:
+        raise DispatchWorktreeError(
+            f"cannot resolve the dispatch worktree for {dispatch_id!r}: {exc}"
+        ) from exc
+    branch = claim.get("branch") or f"dispatch/{_sanitize_dispatch_id(dispatch_id)}"
+    return Path(wt_path), branch
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +225,8 @@ def write_dispatch(
         parent_dispatch: Optional parent dispatch ID for chaining.
         feature:         Optional feature tag (e.g. F42).
         branch:          Optional git branch the worker should operate on.
+                         Defaults to the dispatch worktree's branch
+                         (``dispatch/<safe_id>``) when not provided.
         context_files:   Optional list of file paths to include as context.
 
     Returns:
@@ -176,6 +234,9 @@ def write_dispatch(
 
     Raises:
         DispatchValidationError: If terminal, track, or role validation fails.
+        DispatchWorktreeError:   If the dispatch worktree cannot be resolved;
+                                 the dispatch is refused (no main-checkout
+                                 fallback).
     """
     # --- validate terminal ---
     if terminal not in VALID_TERMINALS:
@@ -203,6 +264,12 @@ def write_dispatch(
         # Skills dir not found — skip role validation rather than hard-fail
         pass
 
+    # --- resolve/create the dispatch worktree (fail-closed) ---
+    # The worker must operate inside this worktree, not the main checkout.
+    # A failure here refuses the dispatch outright — no fallback to the main
+    # checkout, which is the exact behavior this exists to remove.
+    worktree_path, resolved_branch = _resolve_dispatch_worktree(dispatch_id)
+
     # --- resolve dispatch directory ---
     dispatch_base = _dispatch_dir()
     pending_dir = dispatch_base / "pending" / dispatch_id
@@ -221,7 +288,8 @@ def write_dispatch(
         "pr_id": pr_id,
         "parent_dispatch": parent_dispatch,
         "feature": feature,
-        "branch": branch,
+        "branch": branch or resolved_branch,
+        "worktree_path": str(worktree_path),
         "instruction": instruction,
         "context_files": context_files or [],
         "created_at": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/tests/test_decision_executor.py
+++ b/tests/test_decision_executor.py
@@ -129,6 +129,16 @@ class TestExecuteDispatchWritesPending:
 
         monkeypatch.setattr(headless_dispatch_writer, "_dispatch_dir", lambda: dispatches_dir)
         monkeypatch.setattr(headless_dispatch_writer, "_skills_dir", lambda: skills_dir)
+        # No git repo in tmp_path: stub the fail-closed worktree resolution so
+        # the writer can run without creating a real worktree.
+        monkeypatch.setattr(
+            headless_dispatch_writer,
+            "_resolve_dispatch_worktree",
+            lambda dispatch_id, **kw: (
+                tmp_path / "worktree" / dispatch_id,
+                f"dispatch/{dispatch_id}",
+            ),
+        )
 
         reset_cycle_counter()
 
@@ -191,6 +201,15 @@ class TestMaxDispatchesEnforced:
 
         monkeypatch.setattr(headless_dispatch_writer, "_dispatch_dir", lambda: dispatches_dir)
         monkeypatch.setattr(headless_dispatch_writer, "_skills_dir", lambda: skills_dir)
+        # No git repo in tmp_path: stub the fail-closed worktree resolution.
+        monkeypatch.setattr(
+            headless_dispatch_writer,
+            "_resolve_dispatch_worktree",
+            lambda dispatch_id, **kw: (
+                tmp_path / "worktree" / dispatch_id,
+                f"dispatch/{dispatch_id}",
+            ),
+        )
 
         state_dir = tmp_path / "state"
         state_dir.mkdir()

--- a/tests/test_headless_dispatch_writer_worktree.py
+++ b/tests/test_headless_dispatch_writer_worktree.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Tests for worktree handling in headless_dispatch_writer.
+
+The headless worker must operate in the per-dispatch worktree the door created
+for it, and branch there — never the main checkout.  Three deliverables, each
+covered by a test class below:
+
+1. The worker branches in the worktree, not the main checkout — ``write_dispatch``
+   stamps ``worktree_path`` + the worktree's branch into ``dispatch.json``, and
+   ``_resolve_dispatch_worktree`` really does land on ``dispatch/<safe_id>``
+   while the main checkout stays on ``main``.
+
+2. The OI-1232 occupancy lock is taken (via ``create_dispatch_worktree``) and
+   released (via ``remove_dispatch_worktree``) — the writer adds no lock of its
+   own and no timeout-based cleanup.
+
+3. An unresolvable worktree refuses the dispatch — fail-closed, no fallback to
+   the main checkout (the exact behavior this work removes).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parents[1] / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_worktree_isolation  # noqa: E402
+import headless_dispatch_writer  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _set_shared_claim_dir(monkeypatch, tmp_path: Path) -> Path:
+    """Point the claim registry + occupancy lock at a shared temp state root."""
+    data_dir = tmp_path / "shared-data"
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(data_dir / "state"))
+    return data_dir
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    """Create a real git repo on branch main with one committed seed file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "wt-test@vnx"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "VNX WT Test"], check=True
+    )
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True)
+    return repo
+
+
+def _flock_is_held(lock_path: Path) -> bool:
+    """True when a fresh open file description cannot take the exclusive flock.
+
+    flock() locks are per open-file-description, so a second ``open()`` from the
+    same process is treated independently and denied while the lock is held.
+    """
+    fh = open(lock_path, "a")
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fh, fcntl.LOCK_UN)
+        return False
+    except BlockingIOError:
+        return True
+    finally:
+        fh.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. The worker branches in the worktree, not the main checkout
+# ---------------------------------------------------------------------------
+
+class TestWriteDispatchStampsWorktree:
+    def test_payload_carries_worktree_path_and_branch_not_main(self, tmp_path, monkeypatch):
+        """write_dispatch stamps the worktree path + branch, not the main branch."""
+        dispatches_dir = tmp_path / "dispatches"
+        (dispatches_dir / "pending").mkdir(parents=True)
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "backend-developer").mkdir(parents=True)
+
+        fake_root = tmp_path / "consumer-root"
+        fake_root.mkdir()
+        fake_wt = fake_root / ".vnx-data" / "worktrees" / "dispatch-20260816-p7-stamp"
+        fake_wt.mkdir(parents=True)
+
+        monkeypatch.setattr(headless_dispatch_writer, "_dispatch_dir", lambda: dispatches_dir)
+        monkeypatch.setattr(headless_dispatch_writer, "_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr(
+            dispatch_worktree_isolation, "resolve_consumer_project_root", lambda: fake_root
+        )
+        monkeypatch.setattr(
+            dispatch_worktree_isolation,
+            "create_dispatch_worktree",
+            lambda dispatch_id, **kw: fake_wt,
+        )
+        monkeypatch.setattr(
+            dispatch_worktree_isolation,
+            "verify_worktree_identity",
+            lambda dispatch_id, wt_path, **kw: {
+                "dispatch_id": dispatch_id,
+                "worktree_path": str(fake_wt),
+                "branch": "dispatch/20260816-p7-stamp",
+            },
+        )
+
+        path = headless_dispatch_writer.write_dispatch(
+            dispatch_id="20260816-p7-stamp",
+            terminal="T1",
+            track="A",
+            role="backend-developer",
+            instruction="the worker must branch in the worktree",
+        )
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["worktree_path"] == str(fake_wt), (
+            "dispatch.json must carry the worktree path so the worker runs there"
+        )
+        assert payload["branch"] == "dispatch/20260816-p7-stamp", (
+            "dispatch.json must carry the worktree branch, not the main branch"
+        )
+        assert payload["branch"] != "main"
+
+
+class TestWorkerBranchesInWorktreeNotMain:
+    def test_resolve_lands_on_dispatch_branch_and_main_stays_main(self, tmp_path, monkeypatch):
+        """_resolve_dispatch_worktree checks out dispatch/<safe_id>; main is untouched."""
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+
+        dispatch_id = "20260816-p7-real-wt"
+        wt_path, branch = headless_dispatch_writer._resolve_dispatch_worktree(
+            dispatch_id, project_root=repo
+        )
+
+        assert branch == "dispatch/20260816-p7-real-wt"
+        assert wt_path.exists()
+
+        wt_branch = subprocess.run(
+            ["git", "-C", str(wt_path), "branch", "--show-current"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert wt_branch == "dispatch/20260816-p7-real-wt", (
+            f"worker checkout must be the worktree branch, got {wt_branch!r}"
+        )
+
+        main_branch = subprocess.run(
+            ["git", "-C", str(repo), "branch", "--show-current"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert main_branch == "main", (
+            f"main checkout must stay on main, got {main_branch!r}"
+        )
+
+        dispatch_worktree_isolation.remove_dispatch_worktree(dispatch_id, project_root=repo)
+
+
+# ---------------------------------------------------------------------------
+# 2. The OI-1232 occupancy lock is taken and released
+# ---------------------------------------------------------------------------
+
+class TestOccupancyLockTakenAndReleased:
+    def test_lock_held_after_resolve_and_released_after_remove(self, tmp_path, monkeypatch):
+        """create_dispatch_worktree holds the lock; remove_dispatch_worktree releases it."""
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+
+        dispatch_id = "20260816-p7-lock"
+        headless_dispatch_writer._resolve_dispatch_worktree(dispatch_id, project_root=repo)
+
+        safe_id = dispatch_worktree_isolation._sanitize_dispatch_id(dispatch_id)
+        lock_path = dispatch_worktree_isolation._occupancy_lock_path(safe_id, repo)
+
+        # Taken: a fresh open file description cannot acquire the exclusive lock.
+        assert _flock_is_held(lock_path) is True, (
+            "occupancy lock must be held after the worktree is resolved"
+        )
+
+        dispatch_worktree_isolation.remove_dispatch_worktree(dispatch_id, project_root=repo)
+
+        # Released: the canonical teardown released it.
+        assert _flock_is_held(lock_path) is False, (
+            "occupancy lock must be released after remove_dispatch_worktree"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. An unresolvable worktree refuses the dispatch (fail-closed)
+# ---------------------------------------------------------------------------
+
+class TestUnresolvableWorktreeRefuses:
+    def test_write_dispatch_refuses_and_writes_nothing(self, tmp_path, monkeypatch):
+        """A failed worktree resolution refuses the dispatch with no partial write."""
+        dispatches_dir = tmp_path / "dispatches"
+        (dispatches_dir / "pending").mkdir(parents=True)
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "backend-developer").mkdir(parents=True)
+        fake_root = tmp_path / "consumer-root"
+        fake_root.mkdir()
+
+        def refuse_create(dispatch_id, **kw):
+            raise RuntimeError("cannot resolve base_ref 'origin/main'")
+
+        monkeypatch.setattr(headless_dispatch_writer, "_dispatch_dir", lambda: dispatches_dir)
+        monkeypatch.setattr(headless_dispatch_writer, "_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr(
+            dispatch_worktree_isolation, "resolve_consumer_project_root", lambda: fake_root
+        )
+        monkeypatch.setattr(
+            dispatch_worktree_isolation, "create_dispatch_worktree", refuse_create
+        )
+
+        with pytest.raises(headless_dispatch_writer.DispatchWorktreeError):
+            headless_dispatch_writer.write_dispatch(
+                dispatch_id="20260816-p7-refuse",
+                terminal="T1",
+                track="A",
+                role="backend-developer",
+                instruction="must refuse — no fallback to main checkout",
+            )
+
+        # Fail-closed: no pending dir, no dispatch.json written.
+        assert list((dispatches_dir / "pending").iterdir()) == [], (
+            "an unresolvable worktree must refuse before writing any dispatch.json"
+        )

--- a/tests/test_w5c_misc_cleanups.py
+++ b/tests/test_w5c_misc_cleanups.py
@@ -295,13 +295,23 @@ class TestHeadlessDispatchWriterDocumented:
             f"Module docstring must document consumers; got: {doc[:200]!r}"
         )
 
-    def test_write_dispatch_returns_path(self, tmp_path):
+    def test_write_dispatch_returns_path(self, tmp_path, monkeypatch):
         """write_dispatch creates pending/<id>/dispatch.json and returns its path."""
         import headless_dispatch_writer as hdw
 
         dispatch_id = hdw.generate_dispatch_id("test-w5c", "B")
         import os
         os.environ["VNX_DISPATCH_DIR"] = str(tmp_path / "dispatches")
+        # The writer resolves a per-dispatch worktree before writing; stub that
+        # resolution so this unit test never touches a real git worktree.
+        monkeypatch.setattr(
+            hdw,
+            "_resolve_dispatch_worktree",
+            lambda dispatch_id, **kw: (
+                tmp_path / "worktree" / dispatch_id,
+                f"dispatch/{dispatch_id}",
+            ),
+        )
 
         path = hdw.write_dispatch(
             dispatch_id=dispatch_id,


### PR DESCRIPTION
## Wat

`headless_dispatch_writer.write_dispatch` had zero worktree handling. The door creates a dispatch worktree, but the headless worker branched in the MAIN checkout, and the worktree was reaped while that work sat uncommitted there.

This makes the headless writer resolve the per-dispatch worktree **before** writing `dispatch.json`, so the worker branches inside the worktree the door created instead of the main checkout.

## Wat er verandert

1. `_resolve_dispatch_worktree()` in `scripts/lib/headless_dispatch_writer.py` — reuses the single canonical `dispatch_worktree_isolation` mechanism (the same one the tmux/provider lanes use), not a second one beside it. It calls `create_dispatch_worktree` (which carries the OI-1232 occupancy lock) + `verify_worktree_identity`, then returns `(worktree_path, branch)`.
2. `write_dispatch` stamps `worktree_path` + `branch` (`dispatch/<safe_id>`) into `dispatch.json`.
3. **Fail-closed** — an unresolvable worktree (bad project root, bad base_ref, occupancy conflict, identity mismatch) raises `DispatchWorktreeError` and refuses the dispatch. No fallback to the main checkout.
4. **Occupancy lock uit #1569 gebruikt**, geen eigen variant, geen timeout-based opruiming.

## Bewijs

- `grep -c "worktree" scripts/lib/headless_dispatch_writer.py`: **0 → 24**
- Runtime proof — main checkout stays on `main` while the resolved worktree lands on `dispatch/<id>`:
  - worker `git rev-parse --show-toplevel` → `<repo>/.vnx-data/worktrees/dispatch-<id>`
  - worker `git branch --show-current` → `dispatch/<id>`
  - main `git branch --show-current` → `main` (before AND after)
- Targeted tests green: `test_headless_dispatch_writer_worktree.py` (4 new), `test_decision_executor.py`, `test_headless_dispatch_project_id.py`, `test_w5c_misc_cleanups.py`, `test_agent_dispatch.py` = **65 passed**.

## Niet gedaan (bewust)

- `wave7_models.yaml` niet aangeraakt — de drie rungs blijven op `tmux_interactive` tot deze voorwaarde gemerged + geverifieerd is.

Dispatch-ID: 20260816-p7-headless-worktree-ds

🤖 Generated with [Claude Code](https://claude.com/claude-code)