### PR TITLE
feat(dispatch): separate delivery vs reporting observability on provider lane

### DIFF
--- a/scripts/lib/failure_classification.py
+++ b/scripts/lib/failure_classification.py
@@ -8,6 +8,14 @@ completion, a model error, and a timeout all produce the same silent receipt.
 This module gives every failure path a structured classification so an operator
 can tell them apart without tailing log files.
 
+Taxonomy ownership (dispatch 20260816-p10b-provider-observability): THIS module
+owns the receipt-facing failure taxonomy — the ``failure_class`` /
+``failure_reason`` pair stamped on a dispatch receipt. ``failure_classifier.py``
+carries a DIFFERENT, non-overlapping taxonomy (delivery-code → retryable
+mapping for the tmux lane's release_on_delivery_failure) and references this
+module as the owner of the receipt-facing concern; it must not re-derive or
+duplicate these categories.
+
 Categories
 ----------
 auth_rejected    — HTTP 401/403 from the provider endpoint (proxy, API, etc.)

--- a/scripts/lib/failure_classifier.py
+++ b/scripts/lib/failure_classifier.py
@@ -5,6 +5,13 @@ VNX Failure Classifier — Structured failure classification for delivery failur
 Classifies delivery failure reasons into actionable categories so T0 can
 deterministically decide whether to retry, reroute, or escalate.
 
+Taxonomy ownership (dispatch 20260816-p10b-provider-observability): this module
+carries the DELIVERY-code taxonomy (delivery-code → retryable mapping), distinct
+from the receipt-facing failure taxonomy owned by ``failure_classification.py``
+(the ``failure_class`` / ``failure_reason`` pair stamped on a dispatch receipt).
+Do NOT add receipt-facing failure classes here, and do NOT re-derive
+``failure_classification`` categories here — reference that module instead.
+
 Classification taxonomy:
   - invalid_skill:           Skill not found or misconfigured (non-retryable)
   - stale_lease:             Lease generation mismatch / expired (retryable)

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -100,6 +100,7 @@ def emit_dispatch_receipt(
     deadline_seconds: Optional[int] = None,
     failure_reason: Optional[str] = None,
     failure_class: Optional[str] = None,
+    delivery_state: Optional[str] = None,
     role_applied: Optional[bool] = None,
     role_tier: Optional[str] = None,
     role_not_applied_reason: Optional[str] = None,
@@ -195,6 +196,13 @@ def emit_dispatch_receipt(
     reason instead of a silent "(no error captured)" log line. Conditionally
     stamped (omitted on success).
 
+    ``delivery_state``: dispatch 20260816-p10b-provider-observability — one of
+    ``session_ready`` | ``submit_failed`` | ``deliver_failed`` |
+    ``delivery_refused``, making delivery and reporting separately observable
+    on the receipt (mirrors the tmux lane's sentinels). Conditionally stamped
+    (None omits) so lanes that do not yet compute it keep a byte-identical
+    receipt shape.
+
     ``permission_posture`` / ``permission_profile`` / ``permission_allow_
     pattern_count``: OI-864 — the ACTUAL spawn-time permission posture
     (``"blanket-skip"`` | ``"scoped-allowlist"`` | ``"attached-interactive"``),
@@ -289,6 +297,7 @@ def emit_dispatch_receipt(
         deadline_seconds=deadline_seconds,
         failure_reason=failure_reason,
         failure_class=failure_class,
+        delivery_state=delivery_state,
         role_applied=role_applied,
         role_tier=role_tier,
         role_not_applied_reason=role_not_applied_reason,

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -37,6 +37,27 @@ from dispatch_identity import (  # single canonical sentinel (dispatch-20260804-
 
 _EX_USAGE = 64  # sysexits.h EX_USAGE
 
+# Delivery-state taxonomy (dispatch 20260816-p10b-provider-observability).
+# Mirrors the tmux lane's delivery sentinels so the PROVIDER lane's delivery
+# and reporting are separately observable in the receipt ledger (not just on
+# stdout). Four distinguishable states, each a named string stamped on the
+# receipt's ``delivery_state`` field:
+#   session_ready    — delivered AND reported (status=success)
+#   submit_failed    — delivered but nothing reported (status=failure/timeout:
+#                      the worker was launched but produced no report)
+#   deliver_failed   — never delivered (spawn boundary failed: returncode
+#                      126/127 = binary missing / cannot execute)
+#   delivery_refused — refused for delivery (pre-flight gate: constraint
+#                      violation, missing key, model-resolution failure,
+#                      claude-not-a-provider reject, delegation reject)
+# The failure REASON on the receipt stays in failure_reason/failure_class via
+# failure_classification.py (the single receipt-facing failure taxonomy) —
+# delivery_state is orthogonal to it, never a third taxonomy.
+_DELIVERY_STATE_SESSION_READY = "session_ready"
+_DELIVERY_STATE_SUBMIT_FAILED = "submit_failed"
+_DELIVERY_STATE_DELIVER_FAILED = "deliver_failed"
+_DELIVERY_STATE_DELIVERY_REFUSED = "delivery_refused"
+
 # ADR-012 worker-permission enforcement flag (default OFF). Imported defensively
 # so provider_dispatch remains importable even if worker_permissions is missing.
 #
@@ -659,6 +680,29 @@ def _event_store_safety_net(event_store: Any, args: argparse.Namespace) -> None:
         )
 
 
+def _derive_delivery_state(status: str, result: Any) -> str:
+    """Map a spawn outcome to one of the four provider-lane delivery states.
+
+    success → session_ready (delivered and reported). blocked → delivery_refused
+    (refused before delivery). failure/timeout → deliver_failed when the spawn
+    boundary itself failed (returncode 126/127 = binary missing / cannot
+    execute), otherwise submit_failed (delivered but nothing reported).
+
+    "Delivered" is NOT derived from whether the process lives — it is derived
+    from the spawn boundary: a returned result with any returncode other than
+    126/127 means the worker was launched, so a non-success outcome is a submit
+    failure, not a delivery failure.
+    """
+    if status == "success":
+        return _DELIVERY_STATE_SESSION_READY
+    if status == "blocked":
+        return _DELIVERY_STATE_DELIVERY_REFUSED
+    returncode = getattr(result, "returncode", None)
+    if returncode in (126, 127):
+        return _DELIVERY_STATE_DELIVER_FAILED
+    return _DELIVERY_STATE_SUBMIT_FAILED
+
+
 def _emit_governance(
     args: argparse.Namespace,
     provider: str,
@@ -834,6 +878,12 @@ def _emit_governance(
         )
         _toolcall_signals = {}
 
+    # Delivery-state (dispatch 20260816-p10b-provider-observability): derive
+    # the four-way delivery/reporting state from status + spawn returncode so
+    # the receipt distinguishes "never delivered" from "delivered but nothing
+    # reported" without consulting the door log.
+    _delivery_state = _derive_delivery_state(status, result)
+
     for attempt in range(_EMIT_MAX_RETRIES):
         try:
             # OI-866: classify failure so the receipt carries a distinguishable
@@ -960,6 +1010,7 @@ def _emit_governance(
                 deadline_seconds=getattr(args, "deadline_seconds", None),
                 failure_reason=_fail_reason,
                 failure_class=_fail_class,
+                delivery_state=_delivery_state,
             )
             print(f"Receipt: {receipt_path}", file=sys.stderr)
             break
@@ -1144,23 +1195,50 @@ def _constraint_via_for_provider(provider: str, sub_provider: "str | None") -> "
     return None
 
 
-def _emit_constraint_failure_receipt(
+def _emit_refusal_receipt(
     args: argparse.Namespace,
     provider: str,
     model: str,
     failure_reason: str,
+    *,
+    delivery_state: str = _DELIVERY_STATE_DELIVERY_REFUSED,
+    status: str = "blocked",
 ) -> None:
-    """Record fail-closed pre-flight failures before any provider spawn."""
+    """Record a pre-flight refusal (or delivery-boundary failure) to the ledger.
+
+    Every provider-lane refusal and delivery-boundary failure must land in
+    t0_receipts.ndjson — not just stdout — so the four delivery states are
+    distinguishable by reading storage alone (dispatch
+    20260816-p10b-provider-observability). Covers the fail-closed gates that
+    never reach a spawn result: constraint violation, missing API key,
+    model-resolution failure, claude-not-a-provider reject, and delegation
+    reject (all delivery_refused), plus the main-level uncaught spawn exception
+    (deliver_failed, status=failure).
+
+    failure_class is derived via failure_classification.classify_failure_safe —
+    the single receipt-facing failure taxonomy — never a third taxonomy.
+    """
+    from failure_classification import classify_failure_safe  # noqa: PLC0415
+
     state_dir = _resolve_state_dir()
     receipt_path = state_dir / "t0_receipts.ndjson"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    _classification = classify_failure_safe(
+        status=status,
+        error=failure_reason,
+        provider=provider,
+        dispatch_id=args.dispatch_id,
+    )
     receipt = {
         "dispatch_id": args.dispatch_id,
         "terminal_id": args.terminal_id,
         "provider": provider,
         "model": model,
-        "status": "failure",
+        "status": status,
+        "delivery_state": delivery_state,
+        "failure_class": _classification.get("failure_class") or "unknown",
         "completion_pct": 0,
         "risk": 0.0,
         "duration_seconds": 0.0,
@@ -2057,6 +2135,13 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
             f"litellm:{base_sub} requires {required_key} env var",
             file=sys.stderr,
         )
+        try:
+            _emit_refusal_receipt(
+                args, args.provider, getattr(args, "model", None) or base_sub or "litellm",
+                f"litellm:{base_sub} requires {required_key} env var (missing)",
+            )
+        except Exception as _ref_exc:
+            logger.error("_dispatch_litellm: refusal receipt failed dispatch=%s: %s", args.dispatch_id, _ref_exc)
         return _EX_USAGE
 
     env_model = os.environ.get("VNX_LITELLM_MODEL", "")
@@ -2217,6 +2302,13 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
     except KimiModelResolutionError as _model_exc:
         logger.error("_dispatch_kimi: model resolution failed for %r: %s", explicit_model, _model_exc)
         print(f"_dispatch_kimi: model resolution failed: {_model_exc}", file=sys.stderr)
+        try:
+            _emit_refusal_receipt(
+                args, "kimi", explicit_model or "kimi",
+                f"kimi model resolution failed: {_model_exc}",
+            )
+        except Exception as _ref_exc:
+            logger.error("_dispatch_kimi: refusal receipt failed dispatch=%s: %s", args.dispatch_id, _ref_exc)
         return 1
     enriched_instruction = _enrich_instruction(args)
     # Isolation + (bench) seed materialization. Fail-loud by design, never a
@@ -2699,7 +2791,13 @@ def main(argv: list[str] | None = None) -> int:
             raise
         model = _constraint_model_for_provider(args, provider)
         failure_reason = f"constraint violation: {exc}"
-        _emit_constraint_failure_receipt(args, provider, model, failure_reason)
+        try:
+            _emit_refusal_receipt(args, provider, model, failure_reason)
+        except Exception as _ref_exc:
+            logger.error(
+                "provider_dispatch: refusal receipt failed for constraint violation dispatch=%s: %s",
+                args.dispatch_id, _ref_exc,
+            )
         print(f"provider_dispatch: constraint violation - {exc}", file=sys.stderr)
         return 1
 
@@ -2718,6 +2816,16 @@ def main(argv: list[str] | None = None) -> int:
                 ".vnx-attest/allowed_signers trust anchor found.",
                 file=sys.stderr,
             )
+            try:
+                _emit_refusal_receipt(
+                    args, provider, getattr(args, "model", None) or "unknown",
+                    "VNX_SIGNED_DELEGATION=1 but no .vnx-attest/allowed_signers trust anchor found",
+                )
+            except Exception as _ref_exc:
+                logger.error(
+                    "provider_dispatch: refusal receipt failed for delegation reject dispatch=%s: %s",
+                    args.dispatch_id, _ref_exc,
+                )
             return 1
         _ctx = _dm.DispatchContext(
             project_id=_resolve_data_dir().name,
@@ -2737,6 +2845,16 @@ def main(argv: list[str] | None = None) -> int:
                 f"[provider_dispatch] REJECT: signed-delegation gate failed: {_reason}",
                 file=sys.stderr,
             )
+            try:
+                _emit_refusal_receipt(
+                    args, provider, getattr(args, "model", None) or "unknown",
+                    f"signed-delegation gate failed: {_reason}",
+                )
+            except Exception as _ref_exc:
+                logger.error(
+                    "provider_dispatch: refusal receipt failed for delegation reject dispatch=%s: %s",
+                    args.dispatch_id, _ref_exc,
+                )
             return 1
         if _recorded_mandate:
             args.mandate_id = _recorded_mandate
@@ -2745,65 +2863,99 @@ def main(argv: list[str] | None = None) -> int:
                 args.dispatch_id, _recorded_mandate,
             )
 
-    if provider == "claude":
-        # Benchmark exemption: the measurement harness is exempt from the single-entry
-        # door (it dispatches lanes directly; PR-12 plan). When the operator has
-        # explicitly authorized `claude -p` for the benchmark (VNX_BENCH_CLAUDE_HEADLESS=1)
-        # AND we are in benchmark seed-materialize mode, route claude through the governed
-        # materialized-cell `claude -p` path instead of rejecting to the door.
-        if (
-            os.environ.get("VNX_BENCH_SEED_MATERIALIZE") == "1"
-            and os.environ.get("VNX_BENCH_CLAUDE_HEADLESS") == "1"
-        ):
-            return _dispatch_claude(args)
-        # PR-5: claude is not a provider-lane provider. The single-entry door owns
-        # all Claude routing. Silent headless auto-selection via provider_dispatch is
-        # removed — use DispatchSpec with allow_headless=true through the door instead.
-        print(
-            "[provider_dispatch] REJECT: 'claude' is not a provider-lane provider. "
-            "Claude dispatches route via the single-entry dispatch door. "
-            "Use 'vnx dispatch <pending-id>' (VNX_SINGLE_ENTRY_DISPATCH=1) or "
-            "'python3 scripts/lib/dispatch_cli.py --spec-file <path>'. "
-            "For headless/api-billed runs set allow_headless=true in the DispatchSpec.",
-            file=sys.stderr,
+    try:
+        if provider == "claude":
+            # Benchmark exemption: the measurement harness is exempt from the single-entry
+            # door (it dispatches lanes directly; PR-12 plan). When the operator has
+            # explicitly authorized `claude -p` for the benchmark (VNX_BENCH_CLAUDE_HEADLESS=1)
+            # AND we are in benchmark seed-materialize mode, route claude through the governed
+            # materialized-cell `claude -p` path instead of rejecting to the door.
+            if (
+                os.environ.get("VNX_BENCH_SEED_MATERIALIZE") == "1"
+                and os.environ.get("VNX_BENCH_CLAUDE_HEADLESS") == "1"
+            ):
+                return _dispatch_claude(args)
+            # PR-5: claude is not a provider-lane provider. The single-entry door owns
+            # all Claude routing. Silent headless auto-selection via provider_dispatch is
+            # removed — use DispatchSpec with allow_headless=true through the door instead.
+            print(
+                "[provider_dispatch] REJECT: 'claude' is not a provider-lane provider. "
+                "Claude dispatches route via the single-entry dispatch door. "
+                "Use 'vnx dispatch <pending-id>' (VNX_SINGLE_ENTRY_DISPATCH=1) or "
+                "'python3 scripts/lib/dispatch_cli.py --spec-file <path>'. "
+                "For headless/api-billed runs set allow_headless=true in the DispatchSpec.",
+                file=sys.stderr,
+            )
+            try:
+                _emit_refusal_receipt(
+                    args, "claude", getattr(args, "model", None) or "claude",
+                    "claude is not a provider-lane provider (route via the single-entry dispatch door)",
+                )
+            except Exception as _ref_exc:
+                logger.error(
+                    "provider_dispatch: refusal receipt failed for claude reject dispatch=%s: %s",
+                    args.dispatch_id, _ref_exc,
+                )
+            return _EX_USAGE
+
+        if provider == "codex":
+            _envelope_on = os.environ.get("VNX_UNIFIED_ENVELOPE") == "1"
+            _envelope_lanes = [
+                lane.strip()
+                for lane in (os.environ.get("VNX_UNIFIED_ENVELOPE_LANES") or "").split(",")
+                if lane.strip()
+            ]
+            if _envelope_on and "codex" in _envelope_lanes:
+                return _dispatch_codex_via_envelope(args)
+            return _dispatch_codex(args)
+
+        if provider == "gemini":
+            return _dispatch_gemini(args)
+
+        if provider == "kimi":
+            return _dispatch_kimi(args)
+
+        if provider == "deepseek-harness":
+            return _dispatch_deepseek_harness(args)
+
+        if provider == "glm-harness":
+            return _dispatch_glm_harness(args)
+
+        if provider == "local-gemma":
+            return _dispatch_local_gemma(args)
+
+        if provider.startswith("litellm:") or provider == "litellm":
+            return _dispatch_litellm(args)
+
+        # Unknown literal — argparse-style error (exit code 2).
+        parser.error(
+            f"Unknown provider '{provider}'. "
+            "Accepted values: claude, codex, gemini, kimi, litellm:<model>."
         )
-        return _EX_USAGE
-
-    if provider == "codex":
-        _envelope_on = os.environ.get("VNX_UNIFIED_ENVELOPE") == "1"
-        _envelope_lanes = [
-            lane.strip()
-            for lane in (os.environ.get("VNX_UNIFIED_ENVELOPE_LANES") or "").split(",")
-            if lane.strip()
-        ]
-        if _envelope_on and "codex" in _envelope_lanes:
-            return _dispatch_codex_via_envelope(args)
-        return _dispatch_codex(args)
-
-    if provider == "gemini":
-        return _dispatch_gemini(args)
-
-    if provider == "kimi":
-        return _dispatch_kimi(args)
-
-    if provider == "deepseek-harness":
-        return _dispatch_deepseek_harness(args)
-
-    if provider == "glm-harness":
-        return _dispatch_glm_harness(args)
-
-    if provider == "local-gemma":
-        return _dispatch_local_gemma(args)
-
-    if provider.startswith("litellm:") or provider == "litellm":
-        return _dispatch_litellm(args)
-
-    # Unknown literal — argparse-style error (exit code 2).
-    parser.error(
-        f"Unknown provider '{provider}'. "
-        "Accepted values: claude, codex, gemini, kimi, litellm:<model>."
-    )
-    return 2  # unreachable; parser.error() exits
+        return 2  # unreachable; parser.error() exits
+    except Exception as _spawn_exc:
+        # An uncaught spawn exception means the worker was never delivered a
+        # result — record it as deliver_failed (not delivered) so the receipt
+        # ledger distinguishes it from submit_failed (delivered, no report)
+        # without consulting the door log (dispatch
+        # 20260816-p10b-provider-observability).
+        logger.exception(
+            "provider_dispatch: uncaught spawn exception dispatch=%s provider=%s",
+            args.dispatch_id, provider,
+        )
+        try:
+            _emit_refusal_receipt(
+                args, provider, getattr(args, "model", None) or "unknown",
+                f"uncaught spawn exception: {_spawn_exc!r}",
+                delivery_state=_DELIVERY_STATE_DELIVER_FAILED,
+                status="failure",
+            )
+        except Exception as _ref_exc:
+            logger.error(
+                "provider_dispatch: refusal receipt failed for uncaught exception dispatch=%s: %s",
+                args.dispatch_id, _ref_exc,
+            )
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -131,6 +131,14 @@ class ReceiptV2:
     # timeout, model_error, unknown). failure_reason is the human-readable detail.
     failure_reason: Optional[str] = None
     failure_class: Optional[str] = None
+    # dispatch 20260816-p10b-provider-observability: delivery-state field.
+    # Orthogonal to failure_class — one of the closed set
+    # session_ready | submit_failed | deliver_failed | delivery_refused,
+    # mirroring the tmux lane's deliver_failed/submit_failed/session_ready
+    # sentinels plus a provider-lane-only delivery_refused for pre-flight
+    # refusals. Conditionally stamped (None omits) so lanes that do not yet
+    # compute it keep a byte-identical receipt shape.
+    delivery_state: Optional[str] = None
     # Deterministic role-applied control (dispatch-20260801-w10): stamped by the
     # provider/envelope GOVERN paths after the deterministic check that the
     # resolved role source's content actually reached the assembled final prompt.
@@ -236,6 +244,8 @@ class ReceiptV2:
             receipt["failure_reason"] = self.failure_reason
         if self.failure_class is not None:
             receipt["failure_class"] = self.failure_class
+        if self.delivery_state is not None:
+            receipt["delivery_state"] = self.delivery_state
         if self.role_applied is not None:
             receipt["role_applied"] = self.role_applied
         if self.role_tier is not None:

--- a/tests/test_provider_delivery_observability.py
+++ b/tests/test_provider_delivery_observability.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""test_provider_delivery_observability.py — provider-lane delivery-state receipts.
+
+dispatch 20260816-p10b-provider-observability: delivery and reporting must be
+separately observable on the PROVIDER lane. This module verifies the four
+delivery states land in the receipt ledger (not just stdout):
+
+  session_ready    — delivered AND reported (status=success)
+  submit_failed    — delivered but nothing reported (status=failure/timeout)
+  deliver_failed   — never delivered (spawn boundary returncode 126/127, or an
+                     uncaught spawn exception in main())
+  delivery_refused — refused for delivery (pre-flight gate: constraint
+                     violation, missing key, model-resolution failure,
+                     claude-not-a-provider reject, delegation reject)
+
+Plus a constructed death case (invalid key -> 401/402 provider error, no real
+credits) proving the stored state is readable from t0_receipts.ndjson alone,
+without consulting the door log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+import provider_dispatch as pd
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_args(**overrides) -> argparse.Namespace:
+    defaults = dict(
+        dispatch_id="delivery-test-001",
+        terminal_id="T1",
+        pr_id=None,
+        instruction="Reply OK.",
+        model="deepseek-v4-pro",
+        provider="deepseek-harness",
+        role="backend-developer",
+        project_id="test-proj",
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class _FakeResult:
+    """Minimal spawn result carrying only what _emit_governance reads."""
+
+    def __init__(self, *, error=None, completion_text=None, timed_out=False,
+                 returncode=None, token_usage=None, session_id=None):
+        self.error = error
+        self.completion_text = completion_text
+        self.timed_out = timed_out
+        self.returncode = returncode
+        self.token_usage = token_usage if token_usage is not None else {"input": 0, "output": 0}
+        self.session_id = session_id
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _read_receipts(state_dir: Path) -> list[dict]:
+    receipt_file = state_dir / "t0_receipts.ndjson"
+    assert receipt_file.exists(), f"expected receipt ledger at {receipt_file}"
+    lines = [ln for ln in receipt_file.read_text().splitlines() if ln.strip()]
+    assert lines, "receipt ledger must be non-empty"
+    return [json.loads(ln) for ln in lines]
+
+
+def _find_dispatch(receipts: list[dict], dispatch_id: str) -> dict:
+    matching = [r for r in receipts if r.get("dispatch_id") == dispatch_id]
+    assert len(matching) == 1, f"expected exactly 1 receipt for {dispatch_id}, got {len(matching)}"
+    return matching[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. _derive_delivery_state: the four states
+# ---------------------------------------------------------------------------
+
+class TestDeriveDeliveryState:
+    def test_success_is_session_ready(self):
+        assert pd._derive_delivery_state("success", _FakeResult(returncode=0)) == "session_ready"
+
+    def test_blocked_is_delivery_refused(self):
+        assert pd._derive_delivery_state("blocked", _FakeResult(returncode=64)) == "delivery_refused"
+
+    def test_returncode_126_is_deliver_failed(self):
+        assert pd._derive_delivery_state("failure", _FakeResult(returncode=126)) == "deliver_failed"
+
+    def test_returncode_127_is_deliver_failed(self):
+        assert pd._derive_delivery_state("failure", _FakeResult(returncode=127)) == "deliver_failed"
+
+    def test_failure_with_normal_returncode_is_submit_failed(self):
+        assert pd._derive_delivery_state("failure", _FakeResult(returncode=1)) == "submit_failed"
+
+    def test_timeout_is_submit_failed(self):
+        assert pd._derive_delivery_state("timeout", _FakeResult(timed_out=True)) == "submit_failed"
+
+
+# ---------------------------------------------------------------------------
+# 2. _emit_governance stamps the derived delivery_state onto the receipt
+# ---------------------------------------------------------------------------
+
+class TestEmitGovernanceDeliveryState:
+    def _emit(self, status, result):
+        args = _make_args()
+        with (
+            patch("provider_costs.emit_provider_cost", return_value=None),
+            patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/r.ndjson")) as mock_receipt,
+            patch("governance_emit.emit_unified_report", return_value=Path("/tmp/report.md")),
+        ):
+            pd._emit_governance(
+                args, args.provider, args.model, result, _now(), _now(), status,
+            )
+        return mock_receipt.call_args.kwargs
+
+    def test_success_stamps_session_ready(self):
+        kwargs = self._emit("success", _FakeResult(returncode=0))
+        assert kwargs["delivery_state"] == "session_ready"
+
+    def test_blocked_stamps_delivery_refused(self):
+        kwargs = self._emit("blocked", _FakeResult(returncode=64))
+        assert kwargs["delivery_state"] == "delivery_refused"
+
+    def test_returncode_127_stamps_deliver_failed(self):
+        kwargs = self._emit("failure", _FakeResult(returncode=127))
+        assert kwargs["delivery_state"] == "deliver_failed"
+
+    def test_normal_failure_stamps_submit_failed(self):
+        kwargs = self._emit("failure", _FakeResult(returncode=1, error="some error"))
+        assert kwargs["delivery_state"] == "submit_failed"
+
+
+# ---------------------------------------------------------------------------
+# 3. _emit_refusal_receipt writes delivery_refused to storage
+# ---------------------------------------------------------------------------
+
+class TestRefusalReceiptStorage:
+    def test_refusal_lands_in_ledger_not_just_stdout(self, tmp_path):
+        state_dir = tmp_path / "state"
+        args = _make_args(dispatch_id="refusal-001")
+
+        with patch.dict(
+            "os.environ",
+            {"VNX_STATE_DIR": str(state_dir), "VNX_DATA_DIR_EXPLICIT": "1"},
+            clear=False,
+        ):
+            pd._emit_refusal_receipt(args, "claude", "sonnet", "claude is not a provider-lane provider")
+
+        r = _find_dispatch(_read_receipts(state_dir), "refusal-001")
+        assert r["delivery_state"] == "delivery_refused"
+        assert r["status"] == "blocked"
+        assert "claude is not a provider-lane provider" in r["failure_reason"]
+        assert r["failure_class"], "failure_class must be stamped (reuse of the receipt taxonomy)"
+
+    def test_refusal_derive_deliver_failed_override(self, tmp_path):
+        state_dir = tmp_path / "state"
+        args = _make_args(dispatch_id="refusal-002")
+
+        with patch.dict(
+            "os.environ",
+            {"VNX_STATE_DIR": str(state_dir), "VNX_DATA_DIR_EXPLICIT": "1"},
+            clear=False,
+        ):
+            pd._emit_refusal_receipt(
+                args, "deepseek-harness", "deepseek-v4-pro",
+                "uncaught spawn exception: RuntimeError('boom')",
+                delivery_state=pd._DELIVERY_STATE_DELIVER_FAILED,
+                status="failure",
+            )
+
+        r = _find_dispatch(_read_receipts(state_dir), "refusal-002")
+        assert r["delivery_state"] == "deliver_failed"
+        assert r["status"] == "failure"
+
+
+# ---------------------------------------------------------------------------
+# 4. Constructed death case: invalid key -> 401/402, stored state readable
+#    WITHOUT the door log.
+# ---------------------------------------------------------------------------
+
+class TestDeathCaseStoredStateReadableWithoutDoorLog:
+    """A provider dispatch failing on quota/auth via an invalid key (no real
+    credits, no real subprocess) must leave a receipt whose delivery_state,
+    failure_class, and failure_reason are self-contained in t0_receipts.ndjson."""
+
+    def _run_death_case(self, tmp_path, dispatch_id, error_text):
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        args = _make_args(dispatch_id=dispatch_id)
+        result = _FakeResult(returncode=1, error=error_text, completion_text=None)
+
+        with patch.dict(
+            "os.environ",
+            {
+                "VNX_STATE_DIR": str(state_dir),
+                "VNX_DATA_DIR": str(data_dir),
+                "VNX_DATA_DIR_EXPLICIT": "1",
+            },
+            clear=False,
+        ), patch("provider_costs.emit_provider_cost", return_value=None):
+            pd._emit_governance(
+                args, "deepseek-harness", "deepseek-v4-pro",
+                result, _now(), _now(), "failure",
+            )
+
+        return _find_dispatch(_read_receipts(state_dir), dispatch_id)
+
+    def test_auth_error_stored_state(self, tmp_path):
+        r = self._run_death_case(
+            tmp_path, "death-auth-001",
+            "API Error: 401 Unauthorized - invalid API key",
+        )
+        assert r["status"] == "failure"
+        assert r["delivery_state"] == "submit_failed"
+        assert r["failure_class"] == "auth_rejected"
+        # The reason is readable from the receipt alone (no door log needed).
+        assert "401" in r["failure_reason"] or "invalid API key" in r["failure_reason"]
+
+    def test_quota_error_stored_state(self, tmp_path):
+        r = self._run_death_case(
+            tmp_path, "death-quota-001",
+            "API Error: 402 Insufficient Balance",
+        )
+        assert r["status"] == "failure"
+        assert r["delivery_state"] == "submit_failed"
+        assert r["failure_class"] == "credit_exhausted"
+        assert "credit" in r["failure_reason"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 5. main() catches an uncaught spawn exception and records deliver_failed
+# ---------------------------------------------------------------------------
+
+class TestMainUncaughtDeliverFailed:
+    def test_uncaught_spawn_exception_writes_deliver_failed(self, tmp_path):
+        state_dir = tmp_path / "state"
+        with patch.dict(
+            "os.environ",
+            {"VNX_STATE_DIR": str(state_dir), "VNX_DATA_DIR_EXPLICIT": "1"},
+            clear=False,
+        ), patch.object(pd, "_check_constraints", return_value=[]), \
+           patch.object(pd, "_dispatch_gemini", side_effect=RuntimeError("spawn exploded")):
+            rc = pd.main([
+                "--provider", "gemini",
+                "--terminal-id", "T1",
+                "--dispatch-id", "deliver-failed-001",
+                "--instruction", "noop",
+            ])
+
+        assert rc == 1
+        r = _find_dispatch(_read_receipts(state_dir), "deliver-failed-001")
+        assert r["delivery_state"] == "deliver_failed"
+        assert r["status"] == "failure"
+        assert "spawn exploded" in r["failure_reason"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Wat

De provider-lane maakte levering en rapportage niet apart waarneembaar. Elke niet-succes-uitkomst landde als `status=failure` (of niets), zodat "niet geleverd", "geleverd maar niets gerapporteerd" en "geweigerd voor levering" in het grootboek niet te onderscheiden waren zonder de deur-log te lezen.

## Wat er verandert

Een nieuw `delivery_state`-veld op het provider-lane receipt, met vier onderscheidbare toestanden die in de OPSLAG landen (niet alleen stdout):

- `session_ready` — geleverd én gerapporteerd (`status=success`)
- `submit_failed` — geleverd maar niets gerapporteerd (`status=failure/timeout`)
- `deliver_failed` — nooit geleverd (spawn-boundary returncode 126/127, of een oncaught spawn-exception in `main()`)
- `delivery_refused` — geweigerd vóór levering (constraint-violation, missende key, model-resolutie-fout, claude-reject, delegation-reject)

"Geleverd" wordt NIET afgeleid uit "proces leeft": het wordt afgeleid uit de spawn-boundary (elke returncode anders dan 126/127 = de worker is gelanceerd).

Weigerpaden die voorheen niets schreven (claude-reject, kimi model-resolutie, litellm missende key, delegation-reject) schrijven nu een `delivery_refused`-receipt. Een oncaught spawn-exception in `main()` schrijft een `deliver_failed`-receipt.

## Taxonomy-eigenaarschap

`failure_classification.py` is de eigenaar van de receipt-facing failure-taxonomy (`failure_class`/`failure_reason`). `failure_classifier.py` draagt een andere, niet-overlappende taxonomy (delivery-code → retryable) en verwijst nu naar de eigenaar in plaats van te dupliceren. Geen derde taxonomy geïntroduceerd — `delivery_state` is orthogonaal aan `failure_class`.

## Verificatie

- `grep -cE "deliver_failed|submit_failed|session_ready|sentinel"` provider-lane: 7 → 20. tmux-lane ongewijzigd op 39 (niets toegevoegd aan de tmux-lane).
- Nieuw `tests/test_provider_delivery_observability.py` (15 tests) dekt de vier toestanden + een geconstrueerd sterfgeval (ongeldige key → 401/402, geen echte credits) dat de opgeslagen toestand uit `t0_receipts.ndjson` leest zonder de deur-log.
- Targettests groen: `test_failure_classification.py`, `test_receipt_schema.py`, `test_failclass_registry.py`, `test_receipt_v2_pr_b2_wiring.py`, `test_provider_deadline_passthrough.py` (100+ pass).
- Twee pre-existing roods op HEAD (niet door deze PR): `test_provider_dispatch_entry.py::test_litellm_routes_to_dispatch_litellm` (constraint `model-not-in-current-registry`) en `test_provider_dispatch_deepseek_harness.py::test_handler_missing_key_emits_governance_receipt` (MagicMock niet JSON-serializable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)