### PR TITLE
feat(dispatch): thread spec role through the provider-lane spawn

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -2162,7 +2162,10 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
 
         with serialize_lane(plan.serialization_class, dispatch_id=vspec.spec.dispatch_id):
             if plan.lane == "provider":
-                result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+                result = run_envelope_plan(
+                    plan, permit, state_dir=state_dir, data_dir=data_dir,
+                    role=vspec.spec.role,
+                )
                 if result.status != "success":
                     # Fail-loud: the door must never swallow a provider-lane failure into a
                     # bare exit code — the caller (bin/vnx dispatch) prints nothing else.

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -416,6 +416,7 @@ def run_envelope_plan(
     *,
     state_dir: Path,
     data_dir: Path,
+    role: Optional[str] = None,
 ) -> EnvelopeResult:
     """Execute a validated ExecutionPlan for the provider lane.
 
@@ -476,7 +477,9 @@ def run_envelope_plan(
         provider=plan.provider.value,
         model=plan.model,
         instruction=instruction,
-        role=plan.role,  # F2 (codex): carry the role so the phantom-guard review-exemption applies
+        role=role,  # mirror run_envelope_headless_plan: thread the spec role so the worker
+        # resolves it (not the code-worker fallback); still feeds the F2 codex
+        # phantom-guard review-exemption.
         pr_id=plan.pr_id,
         state_dir=state_dir,
         data_dir=data_dir,
@@ -587,7 +590,7 @@ def run_envelope_plan(
     _phantom_diff: Optional[str] = None
     try:
         start = datetime.now(timezone.utc)
-        result = ProviderAdapter().run(plan, enriched_spec.instruction, cwd=wt_path)
+        result = ProviderAdapter().run(plan, enriched_spec.instruction, cwd=wt_path, role=role)
         end = datetime.now(timezone.utc)
         # F1 (codex): capture the worker's diff BEFORE the teardown below —
         # remove_dispatch_worktree deletes both the worktree and the local dispatch/<id>

--- a/scripts/lib/envelope_adapters_provider.py
+++ b/scripts/lib/envelope_adapters_provider.py
@@ -160,6 +160,7 @@ class ProviderAdapter:
         *,
         event_writer: Optional[Callable] = None,
         cwd: Optional[Path] = None,
+        role: Optional[str] = None,
     ) -> _AdapterResult:
         from dispatch_spec import Provider  # noqa: PLC0415
         from provider_dispatch import (  # noqa: PLC0415
@@ -181,7 +182,14 @@ class ProviderAdapter:
         # each spawn's extra_env. Without it, every provider-lane worker resolves to
         # the restrictive code-worker fallback in pretooluse_worker_scope_enforce.py
         # even when the spec carried a genuine role.
-        role_env = _worker_role_env(plan.role)
+        # OI-1231/OI-1244: the same role must ALSO reach the spawn-side scope-args
+        # builder (subprocess_adapter._build_worker_scope_args ->
+        # resolve_worker_profile) via spawn_claude(role=...) for the harness lanes
+        # (deepseek/glm). The explicit ``role`` param (threaded from
+        # run_envelope_plan) wins; plan.role stays the backward-compatible source
+        # when the caller did not pass one.
+        effective_role = role if role is not None else plan.role
+        role_env = _worker_role_env(effective_role)
 
         # ---- codex ----
         if pv == Provider.CODEX:
@@ -209,7 +217,9 @@ class ProviderAdapter:
 
         # ---- kimi ----
         if pv == Provider.KIMI:
-            return self._run_kimi(plan, instruction, event_writer=event_writer, cwd=cwd)
+            return self._run_kimi(
+                plan, instruction, event_writer=event_writer, cwd=cwd, role=effective_role
+            )
 
         # ---- gemini ----
         if pv == Provider.GEMINI:
@@ -291,6 +301,7 @@ class ProviderAdapter:
                     event_writer=event_writer,
                     extra_env=role_env,
                     cwd=cwd,
+                    role=effective_role,
                     total_deadline=float(plan.deadline_seconds),
                 )
             except BrokenPipeError as exc:
@@ -360,6 +371,7 @@ class ProviderAdapter:
                     event_writer=event_writer,
                     extra_env=role_env,
                     cwd=cwd,
+                    role=effective_role,
                     total_deadline=float(plan.deadline_seconds),
                 )
             except BrokenPipeError as exc:
@@ -419,7 +431,7 @@ class ProviderAdapter:
             result = spawn_local_gemma(
                 instruction=instruction,
                 model=canonical_model,
-                role=plan.role,
+                role=effective_role,
                 deadline_seconds=300,
                 dispatch_id=plan.dispatch_id,
                 project_id="vnx-dev",
@@ -471,6 +483,7 @@ class ProviderAdapter:
         *,
         event_writer: Optional[Callable] = None,
         cwd: Optional[Path] = None,
+        role: Optional[str] = None,
     ) -> _AdapterResult:
         """Kimi spawn branch, extracted from run() (OI-709 function-size gate).
 
@@ -503,7 +516,7 @@ class ProviderAdapter:
                 dispatch_id=plan.dispatch_id,
                 terminal_id=plan.target_id,
                 event_writer=event_writer,
-                extra_env=_worker_role_env(plan.role),
+                extra_env=_worker_role_env(role),
                 cwd=cwd,
                 # worker-provider-kimi-flip (20260723): honor the spec's staged deadline
                 # instead of spawn_kimi's own hardcoded 900s default — a caller staging a

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -317,6 +317,11 @@ def test_provider_routes_to_envelope(mock_envelope, mock_snapshot, tmp_path):
     assert plan_arg.lane == "provider"
     assert plan_arg.provider == Provider.CODEX
 
+    # OI-1231/OI-1244: the door threads the spec's role into run_envelope_plan
+    # (mirroring _execute_claude / _execute_claude_headless) so the provider lane
+    # resolves it on the spawn side instead of the code-worker fallback.
+    assert kwargs["role"] == "backend-developer"
+
     # Permit must be valid (issued by issue_permit for this plan)
     from dispatch_internal import require_permit
     # Should not raise — a valid permit for the correct plan

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -741,7 +741,7 @@ class TestEnvelopeWorktreeIsolation:
 
         adapter_calls: list = []
 
-        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
+        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
             adapter_calls.append({"cwd": cwd})
             return _fake_adapter_success()
 
@@ -776,7 +776,7 @@ class TestEnvelopeWorktreeIsolation:
         state_dir.mkdir()
         data_dir.mkdir()
 
-        def bad_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
+        def bad_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
             raise RuntimeError("spawn exploded")
 
         _fake_consumer_root = tmp_path / "consumer-root"
@@ -809,7 +809,7 @@ class TestEnvelopeWorktreeIsolation:
         def bad_create(dispatch_id, project_root=None):
             raise RuntimeError("no disk space")
 
-        def spy_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
+        def spy_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
             adapter_calls.append({"cwd": cwd})
             return _fake_adapter_success()
 

--- a/tests/test_envelope_provider_adapter_role_env.py
+++ b/tests/test_envelope_provider_adapter_role_env.py
@@ -179,3 +179,56 @@ def test_local_gemma_absent_role_is_none():
 
     mock_spawn.assert_called_once()
     assert mock_spawn.call_args.kwargs["role"] is None
+
+
+# ---------------------------------------------------------------------------
+# OI-1231/OI-1244: the spawn-side role channel (the part this dispatch adds).
+#
+# The OI-1215 fix above threads VNX_WORKER_ROLE (the worker-side env channel the
+# pretooluse hook reads). But the SPAWN-SIDE scope-args builder
+# (subprocess_adapter._build_worker_scope_args -> resolve_worker_profile) is what
+# actually logs ``resolve_worker_profile: role is None`` in the door output — and
+# it reads the ``role`` param of ``spawn_claude``, not VNX_WORKER_ROLE. The harness
+# spawns (deepseek/glm) forward their **kwargs to spawn_claude, so the adapter must
+# pass ``role=`` through them for the role to reach resolve_worker_profile at all.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("provider_key,spawn_path,model", [
+    ("deepseek-harness", "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness", "deepseek-v4-pro"),
+    ("glm-harness", "provider_spawns.glm_harness_spawn.spawn_glm_harness", "glm-5.2"),
+])
+def test_harness_spawn_receives_role_kwarg(provider_key, spawn_path, model):
+    """The harness spawns receive role= so spawn_claude can hand it to
+    resolve_worker_profile (spawn-side), not just the VNX_WORKER_ROLE env overlay."""
+    provider = Provider({
+        "deepseek-harness": "deepseek-harness",
+        "glm-harness": "glm-harness",
+    }[provider_key])
+    plan = _plan(provider, model=model)
+
+    with patch(spawn_path, return_value=_OkSpawnResult()) as mock_spawn:
+        ProviderAdapter().run(plan, "implement the change")
+
+    mock_spawn.assert_called_once()
+    assert mock_spawn.call_args.kwargs.get("role") == "research-analyst", (
+        f"{spawn_path} was not handed role=research-analyst: "
+        f"got {mock_spawn.call_args.kwargs.get('role')!r}"
+    )
+
+
+def test_explicit_role_wins_over_plan_role_for_harness():
+    """ProviderAdapter.run(role=...) must override plan.role on BOTH channels:
+    the spawn-side role= kwarg and the worker-side VNX_WORKER_ROLE env overlay."""
+    plan = _plan(Provider.DEEPSEEK_HARNESS, role="research-analyst")
+
+    with patch(
+        "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness",
+        return_value=_OkSpawnResult(),
+    ) as mock_spawn:
+        ProviderAdapter().run(plan, "implement the change", role="backend-developer")
+
+    mock_spawn.assert_called_once()
+    kwargs = mock_spawn.call_args.kwargs
+    assert kwargs.get("role") == "backend-developer"
+    assert kwargs.get("extra_env") == {"VNX_WORKER_ROLE": "backend-developer"}

--- a/tests/test_envelope_ringbuffer_teardown_oi902.py
+++ b/tests/test_envelope_ringbuffer_teardown_oi902.py
@@ -234,7 +234,7 @@ class TestEnvelopePlanEndTeardown:
         permit = issue_permit(plan)
         _fake_consumer_root = events_dir.parent / "consumer-root"
 
-        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
+        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
             # The SubprocessAdapter writes events internally for the harness lane.
             _write_events(events_dir, plan_arg.target_id, plan_arg.dispatch_id, n=15)
             return _AdapterResult(returncode=0, completion_text="done", status="success")


### PR DESCRIPTION
## Problem

The provider lane resolved every worker to the restrictive code-worker fallback. `run_envelope_plan` never passed the spec's role to the spawn, so `spawn_claude` received `role=None` and `resolve_worker_profile` logged `role is None` (`is_fallback=True`) even for dispatches with an explicit role (`research-analyst`, `backend-developer`, `system-architect`, `quality-engineer`).

The headless lane (`run_envelope_headless_plan`) already threads the role; the provider lane did not.

## Fix

Mirror `run_envelope_headless_plan`:

1. `run_envelope_plan` gains `role: Optional[str] = None`, in the same form as the headless function.
2. The door (`dispatch_cli.run_dispatch`) passes `role=vspec.spec.role`.
3. `ProviderAdapter.run` threads it to the deepseek/glm harness spawns (which forward `**kwargs` to `spawn_claude -> SubprocessAdapter.deliver -> _build_worker_scope_args -> resolve_worker_profile`). The existing `VNX_WORKER_ROLE` env channel (OI-1215) stays intact — no second channel.

`role=None` keeps the prior fallback; an explicit role now resolves.

## Verification

- Targeted tests green: 369 passed across touched files + direct neighbors.
- Before/after on the exact resolve path:
  - `resolve_worker_profile(None)` → `resolve_worker_profile: role is None — resolving to the restrictive code-worker fallback (is_fallback=True)` → `role='code-worker'`.
  - `resolve_worker_profile("backend-developer")` → no warning, `role='backend-developer'`, `is_fallback=False`.
- End-to-end door-fire is post-merge (OI-1201: the dispatcher builds the worker argv with main-branch code).

## Open items

- OI-1231, OI-1244 (tracked in the dispatch).

Dispatch-ID: 20260816-p11-role-provider-lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)