### PR TITLE
feat(ledger): consolidate receipt status vocab into one generated source

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -243,6 +243,24 @@ jobs:
             -p no:cacheprovider \
             --basetemp=/tmp/vnx_pytest_safe
 
+      - name: Status vocabulary drift guard
+        run: |
+          set -euo pipefail
+          # Fail CI if any module hard-codes its own copy of the completion-
+          # outcome status vocabulary (FAILURE_STATUSES | SUCCESS_STATUSES).
+          # event_outcome_semantics._STATUS_VOCABULARY is the single source; a
+          # second collection drawn entirely from it is a drifting copy. See
+          # dispatch/20260816-p9-ledger-vocab-ds.
+          python3 "$GITHUB_WORKSPACE/scripts/check_status_vocab_drift.py"
+
+      - name: Run status vocabulary drift guard unit tests
+        run: |
+          set -euo pipefail
+          pytest -q \
+            "$GITHUB_WORKSPACE/tests/test_status_vocab_drift.py" \
+            -p no:cacheprovider \
+            --basetemp=/tmp/vnx_pytest_safe
+
   trace-token-check:
     name: Trace Token Validation
     runs-on: ubuntu-latest

--- a/scripts/check_status_vocab_drift.py
+++ b/scripts/check_status_vocab_drift.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""CI drift check: the receipt completion-status vocabulary has one source.
+
+``event_outcome_semantics._STATUS_VOCABULARY`` is the single generated source
+for the completion-outcome status vocabulary. Any OTHER module that hard-codes
+its own module-level set/frozenset of status literals drawn entirely from the
+canonical ``FAILURE_STATUSES | SUCCESS_STATUSES`` is a drifting copy and fails
+this check.
+
+Why AST, not import: reading source files means the check runs in CI without
+executing repo code, and it catches a copy the moment it is written (before a
+new canonical literal is even added and drift becomes observable at runtime).
+
+A module-level name is in scope when it contains ``STATUS`` and is assigned a
+set/frozenset literal with at least two string elements, all of which are in
+the canonical outcome set. A single-literal constant or a name without
+``STATUS`` is not a collection worth flagging; a set that contains even one
+non-canonical literal is a DIFFERENT vocabulary (e.g. the review-verdict
+``pass``/``fail`` set), not a copy of this one.
+
+Exit 0 when clean, 1 when a drifting copy is found. Importable for tests via
+``find_hardcoded_outcome_vocab(repo_root)``.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_SCRIPTS_LIB = _SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(_SCRIPTS_LIB))
+
+from event_outcome_semantics import FAILURE_STATUSES, SUCCESS_STATUSES  # noqa: E402
+
+_CANONICAL = FAILURE_STATUSES | SUCCESS_STATUSES
+
+# Known constants whose own module-level STATUS set is a legitimately-distinct
+# vocabulary, not a copy of the completion-outcome vocabulary. Keyed by
+# (basename, name) — not by whole file — so a future drifting copy added to
+# one of these files is still caught. Each reason names the semantic the
+# constant actually serves, so the allow-list documents itself rather than
+# silently swallowing a real copy.
+_ALLOWLIST = {
+    # ADR-035 §3.1 review-verdict completion-claim vocabulary: "is a success
+    # status" for gate verdicts, a narrower claim than the completion-outcome
+    # vocabulary (it deliberately omits "ok"). Not an outcome classification.
+    ("receipt_verdict.py", "SUCCESS_STATUSES"):
+        "ADR-035 review-verdict completion-claim vocabulary, omits 'ok'",
+    # Shares receipt_verdict's completion-claim set; phantom_guard uses it to
+    # decide whether a completion claim is even eligible for scrutiny.
+    ("phantom_guard.py", "COMPLETION_STATUSES"):
+        "mirrors receipt_verdict completion-claim vocabulary",
+    # _AUTHORITATIVE_STATUSES = {done, failed} is the receipt-dedup authority
+    # tier (authored > synthesized), not an outcome classification.
+    ("dispatch_govern.py", "_AUTHORITATIVE_STATUSES"):
+        "receipt-dedup authority tier (done/failed)",
+}
+
+
+@dataclass
+class Violation:
+    path: str
+    line: int
+    name: str
+    literals: List[str]
+
+
+def _iter_module_level_assignments(tree: ast.Module):
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    yield target.id, node.value, node.lineno
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            yield node.target.id, node.value, node.lineno
+
+
+def _string_elements(node) -> List[str]:
+    """Return string literal elements of a set/frozenset literal, else []."""
+    inner = None
+    if isinstance(node, ast.Set):
+        inner = node.elts
+    elif (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "frozenset"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Set)
+    ):
+        inner = node.args[0].elts
+    if inner is None:
+        return []
+    literals: List[str] = []
+    for elt in inner:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            literals.append(elt.value)
+    return literals
+
+
+def find_hardcoded_outcome_vocab(repo_root: Path) -> List[Violation]:
+    """Scan scripts/ for hard-coded copies of the completion-outcome vocabulary."""
+    violations: List[Violation] = []
+    scripts_root = repo_root / "scripts"
+    if not scripts_root.is_dir():
+        return violations
+
+    for py_file in sorted(scripts_root.rglob("*.py")):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+
+        for name, value, lineno in _iter_module_level_assignments(tree):
+            if "STATUS" not in name.upper():
+                continue
+            if (py_file.name, name) in _ALLOWLIST:
+                continue
+            literals = _string_elements(value)
+            if len(literals) < 2:
+                continue
+            if all(lit in _CANONICAL for lit in literals):
+                violations.append(
+                    Violation(
+                        path=str(py_file.relative_to(repo_root)),
+                        line=lineno,
+                        name=name,
+                        literals=sorted(literals),
+                    )
+                )
+    return violations
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    violations = find_hardcoded_outcome_vocab(repo_root)
+    if not violations:
+        print("check_status_vocab_drift: clean — no hard-coded outcome vocab copies")
+        return 0
+
+    print(
+        "check_status_vocab_drift: FAILED — hard-coded copies of the completion-"
+        "outcome vocabulary found. Import event_outcome_semantics instead."
+    )
+    for v in violations:
+        print(f"  {v.path}:{v.line} {v.name} = {sorted(v.literals)}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -50,6 +50,12 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
 # Single canonical sentinel — imported from dispatch_identity (dispatch-20260804-190000).
 from dispatch_identity import _IDENTITY_UNRESOLVED
 
+# Canonical receipt status vocabulary (single generated source). The govern
+# step derives its declared-failure set from it instead of hand-copying the
+# literals, so it cannot drift from report_to_receipt_converter's terminal
+# classification.
+from event_outcome_semantics import FAILURE_STATUSES
+
 # The plan-gate's own role — a worker report ending in a ```vnx-plan-verdict``` fence.
 _PLAN_REVIEWER_ROLE = "plan-reviewer"
 
@@ -381,14 +387,13 @@ def _split_yaml_frontmatter(text: str) -> "tuple[dict, str]":
 
 # OI-1202: terminal-failure statuses a worker report can DECLARE (bold
 # ``**Status**: value`` in the body, or a ``status`` key in YAML frontmatter).
-# Mirrors report_to_receipt_converter's ``_TERMINAL_FAILURE_STATUSES`` plus the
-# other failure-shaped literals, so a 4-heading report that declares failure
-# (e.g. worker_heartbeat's heartbeat_killed / worker_process_gone reports) is
-# never re-labeled "done" by the lane-synthesized fallback.
-_DECLARED_FAILURE_STATUSES = frozenset({
-    "failed", "failure", "heartbeat_killed", "error", "blocked", "timeout",
-    "contract_invalid",
-})
+# Derived from the canonical FAILURE_STATUSES (event_outcome_semantics) plus
+# "timeout" — the one literal dispatch_govern treats as failure-shaped that the
+# canonical completion vocabulary deliberately keeps as ignorable. A 4-heading
+# report that declares any of these (e.g. worker_heartbeat's heartbeat_killed /
+# worker_process_gone reports) is never re-labeled "done" by the
+# lane-synthesized fallback.
+_DECLARED_FAILURE_STATUSES = FAILURE_STATUSES | frozenset({"timeout"})
 
 # Bold-field shape the worker_heartbeat failure reports use ("**Status**: failed").
 _STATUS_BOLD_RE = re.compile(r"\*\*Status\*\*\s*:\s*([^\n]+)", re.IGNORECASE)

--- a/scripts/lib/event_outcome_semantics.py
+++ b/scripts/lib/event_outcome_semantics.py
@@ -37,17 +37,70 @@ from typing import Optional
 # The union of every status literal seen across the write paths that emit
 # these event_types: ReceiptV2 (event_type forced to "task_complete",
 # governance_emit.py), SynthesizedLaneReceipt (event_type
-# "subprocess_completion", dispatch_govern.ensure_receipt — status "done" for
+# "subprocess_completion", dispatch_govern.ensure_receipt, status "done" for
 # an authored non-failing report, "failed" otherwise), and the legacy
 # report_to_receipt_converter / codex-variant emit sites ("failure" is a
 # distinct literal from "failed", not a typo — different call sites use each).
 #
+# _STATUS_VOCABULARY is the single generated source. FAILURE_STATUSES,
+# SUCCESS_STATUSES, and IGNORABLE_STATUSES below are DERIVED from it (never
+# hand-copied), and the write-side converter resolves a report's declared
+# status against it via resolve_status_category(). A new status literal is
+# added here exactly once, with its category; there is no second list to keep
+# in sync, and scripts/check_status_vocab_drift.py fails CI on any module that
+# hard-codes its own copy.
+#
+# The five historical differences vs the converter's old hand-copied sets are
+# resolved here per value:
+#   - "ok"               -> success (a report declaring ok is a success claim)
+#   - "" (empty)         -> REMOVED from success: absence is not a success
+#                           claim (resolve_status_category returns "no_signal")
+#   - "blocked"          -> failure (a blocked completion is a governed failure)
+#   - "contract_invalid" -> failure (already canonical; the converter missed it)
+#   - "heartbeat_killed" -> failure (the converter's defensive literal; a
+#                           heartbeat-kill report is failure-shaped by design)
+#
 # "timeout" is deliberately NOT a failure status here: a completion-family
 # receipt carrying literal status="timeout" is a separate, pre-existing
 # carve-out (kept as-is by this consolidation, not part of the OI-1148 fix).
+# It is still listed as ignorable so the write-side refuses nothing the
+# read-side already tolerated.
 # ---------------------------------------------------------------------------
-FAILURE_STATUSES = frozenset({"failed", "failure", "error", "blocked", "contract_invalid"})
-SUCCESS_STATUSES = frozenset({"success", "completed", "complete", "ok", "done", ""})
+_STATUS_VOCABULARY = {
+    # governed failure literals
+    "failed": "failure",
+    "failure": "failure",
+    "error": "failure",
+    "blocked": "failure",
+    "contract_invalid": "failure",
+    "heartbeat_killed": "failure",
+    # governed success literals
+    "success": "success",
+    "completed": "success",
+    "complete": "success",
+    "ok": "success",
+    "done": "success",
+    # explicitly ignorable literals (pending/neutral, no outcome signal)
+    "timeout": "ignorable",
+    "no_confirmation": "ignorable",
+    "unknown": "ignorable",
+    "in_progress": "ignorable",
+    "guard_error": "ignorable",
+    "no_ready_pr": "ignorable",
+    "not_configured": "ignorable",
+    "not_executable": "ignorable",
+    "requested": "ignorable",
+}
+
+FAILURE_STATUSES = frozenset(
+    status for status, category in _STATUS_VOCABULARY.items() if category == "failure"
+)
+SUCCESS_STATUSES = frozenset(
+    status for status, category in _STATUS_VOCABULARY.items() if category == "success"
+)
+IGNORABLE_STATUSES = frozenset(
+    status for status, category in _STATUS_VOCABULARY.items() if category == "ignorable"
+)
 
 # event_types whose own status field uses the FAILURE_STATUSES/SUCCESS_STATUSES
 # vocab above to signal outcome.
@@ -100,10 +153,50 @@ def is_governed_failure(event_type: Optional[str], status: Optional[str]) -> boo
     return classify_event_outcome(event_type, status) == "failure"
 
 
+class UnknownStatusError(ValueError):
+    """A report declared a status literal outside the canonical vocabulary.
+
+    Raised by resolve_status_category() so the write-side converter refuses a
+    report instead of silently treating an unknown literal as a non-terminal
+    status (which would let a typo or a new, unvetted literal slip through as
+    a quiet success/no-signal receipt).
+    """
+
+
+def resolve_status_category(status: Optional[str]) -> str:
+    """Resolve a normalized status literal to its canonical category (strict).
+
+    The write-side (report_to_receipt_converter) uses this to refuse a report
+    whose declared status is not in the canonical vocabulary. The read-side
+    (classify_event_outcome) stays tolerant by design; only the write path is
+    fail-closed, because the write path is where a new literal enters the
+    ledger.
+
+    Returns one of:
+      "failure"   -- the status is a governed failure literal.
+      "success"   -- the status is a governed success literal.
+      "ignorable" -- the status is in the vocabulary but carries no outcome
+                     signal (pending/neutral literals the ledger tolerates).
+      "no_signal" -- the status is empty/absent (NOT a success claim).
+
+    Raises UnknownStatusError for any other literal.
+    """
+    st = (status or "").strip().lower()
+    if not st:
+        return "no_signal"
+    category = _STATUS_VOCABULARY.get(st)
+    if category is None:
+        raise UnknownStatusError(f"unknown status literal: {status!r}")
+    return category
+
+
 __all__ = [
     "FAILURE_STATUSES",
     "SUCCESS_STATUSES",
+    "IGNORABLE_STATUSES",
     "COMPLETION_EVENT_TYPES",
+    "UnknownStatusError",
     "classify_event_outcome",
     "is_governed_failure",
+    "resolve_status_category",
 ]

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -46,6 +46,10 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 from dispatch_identity import _IDENTITY_UNRESOLVED  # single canonical sentinel (dispatch-20260804-190000)
+# Canonical receipt status vocabulary (single generated source). The converter
+# no longer carries its own hand-copied terminal-status sets; it resolves every
+# declared status through resolve_status_category() below.
+from event_outcome_semantics import UnknownStatusError, resolve_status_category
 
 _LIB_DIR = Path(__file__).resolve().parent
 _SCRIPTS_DIR = _LIB_DIR.parent  # scripts/ — append_receipt.py lives here
@@ -587,18 +591,16 @@ def _resolve_report_provider_model(
     return provider, model
 
 
-# Terminal success statuses that trigger fail-closed validation (OI-1035 et al.).
-# Any report claiming one of these statuses must pass all three fail-closed
-# checks before a success receipt is written.  Reports with other statuses
-# (e.g. "unknown", absent) keep the pre-existing contract-invalid semantics.
-_TERMINAL_SUCCESS_STATUSES = frozenset({"success", "done", "complete", "completed"})
-
-# Terminal failure statuses (OI-1130).  A report that DECLARES itself failed
-# (e.g. the heartbeat-kill report from worker_heartbeat.
-# build_heartbeat_failure_report, which stamps ``Status: failed`` +
-# ``Failure-Reason: heartbeat_killed``) must produce a task_failed receipt —
-# never a task_complete that downstream tooling reads as a normal completion.
-_TERMINAL_FAILURE_STATUSES = frozenset({"failed", "failure", "heartbeat_killed"})
+# Terminal-status classification is no longer a hand-copied pair of frozensets.
+# build_receipt_from_report() resolves every declared status through
+# event_outcome_semantics.resolve_status_category() — the single generated
+# vocabulary — so the converter cannot drift from the canonical outcome sets.
+#
+#   "success"       -> fail-closed validation (OI-1035 et al.) must all pass
+#   "failure"       -> task_failed receipt (OI-1130), never a task_complete
+#   "ignorable"     -> no outcome signal, keeps pre-existing contract semantics
+#   "no_signal"     -> empty/absent status, keeps pre-existing contract semantics
+#   anything else   -> refused as task_failed with failure_reason="unknown_status"
 
 
 def _check_branch_on_origin(dispatch_id: str) -> bool:
@@ -883,7 +885,33 @@ def build_receipt_from_report(
     # "contract_invalid" bucket (which received 96 hits in 7 days and is
     # invisible to any alarm).
     status_raw = (merged.get("status") or "").strip().lower()
-    is_terminal_success = status_raw in _TERMINAL_SUCCESS_STATUSES
+    try:
+        status_category = resolve_status_category(status_raw)
+    except UnknownStatusError:
+        # Fail-closed on the vocabulary itself: a status literal outside the
+        # canonical list is refused as a failure, never adopted as a quiet
+        # no-signal receipt. A new literal must enter the canonical vocabulary
+        # first; an unknown one is evidence of a typo or an unvetted emitter.
+        logger.warning(
+            "report_to_receipt_converter: unknown status dispatch=%s status=%r: refusing",
+            dispatch_id, status_raw,
+        )
+        receipt_out: Dict[str, Any] = {
+            **base,
+            "event_type": "task_failed",
+            "status": "failed",
+            "failure_reason": "unknown_status",
+            "unknown_status": status_raw,
+        }
+        if ambiguous_report:
+            receipt_out["ambiguous_report_path"] = True
+            receipt_out["report_path_candidates"] = [
+                {"path": str(c), "size": resolved.candidate_sizes[str(c)]}
+                for c in resolved.candidates_found
+            ] if resolved is not None else []
+        return receipt_out
+
+    is_terminal_success = status_category == "success"
 
     if is_terminal_success:
         fail_closed_violations = _run_fail_closed_checks(
@@ -916,7 +944,7 @@ def build_receipt_from_report(
     # success, detectable only by reading the Summary prose.  Declared failure
     # outranks contract violations: an explicit failure signal must never
     # degrade into the low-visibility contract_invalid bucket.
-    if status_raw in _TERMINAL_FAILURE_STATUSES:
+    if status_category == "failure":
         receipt_out: Dict[str, Any] = {
             **base,
             "event_type": "task_failed",

--- a/tests/test_append_receipt_register_emit.py
+++ b/tests/test_append_receipt_register_emit.py
@@ -800,14 +800,13 @@ def test_confidence_legacy_event_field(ar):
     assert captured[0]["outcome"] == "success"
 
 
-def test_confidence_task_complete_empty_status_yields_success(ar):
-    """task_complete with empty status ('' in SUCCESS_STATUSES) → outcome='success'."""
+def test_confidence_task_complete_empty_status_skips(ar):
+    """task_complete with empty status → no outcome signal ('' no longer success)."""
     captured = []
     receipt = _make_receipt("task_complete", dispatch_id="CONF-011", terminal="T1")
     # no status field → str(receipt.get("status", "")).lower() == ""
     _run_confidence_update(ar, receipt, captured)
-    assert len(captured) == 1
-    assert captured[0]["outcome"] == "success"
+    assert len(captured) == 0
 
 
 # ── Tests: CQS timing — open_items_created set AFTER enrichment ───────────────

--- a/tests/test_event_outcome_semantics.py
+++ b/tests/test_event_outcome_semantics.py
@@ -14,14 +14,19 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
 
 from event_outcome_semantics import (  # noqa: E402
     COMPLETION_EVENT_TYPES,
     FAILURE_STATUSES,
+    IGNORABLE_STATUSES,
     SUCCESS_STATUSES,
+    UnknownStatusError,
     classify_event_outcome,
     is_governed_failure,
+    resolve_status_category,
 )
 
 
@@ -180,3 +185,70 @@ def test_done_is_in_success_statuses():
 def test_failure_and_failed_are_distinct_entries_in_failure_statuses():
     assert "failed" in FAILURE_STATUSES
     assert "failure" in FAILURE_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# Single generated vocabulary — the five historical differences, resolved
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_killed_is_a_failure_literal():
+    assert "heartbeat_killed" in FAILURE_STATUSES
+    assert classify_event_outcome("task_complete", "heartbeat_killed") == "failure"
+
+
+def test_empty_status_is_no_longer_success():
+    assert "" not in SUCCESS_STATUSES
+    assert classify_event_outcome("task_complete", "") is None
+
+
+def test_ignorable_statuses_carry_no_outcome_signal():
+    for status in IGNORABLE_STATUSES:
+        assert classify_event_outcome("task_complete", status) is None, status
+
+
+# ---------------------------------------------------------------------------
+# resolve_status_category — the strict write-side resolver
+# ---------------------------------------------------------------------------
+
+def test_resolve_status_category_maps_success_literals():
+    for status in SUCCESS_STATUSES:
+        assert resolve_status_category(status) == "success", status
+
+
+def test_resolve_status_category_maps_failure_literals():
+    for status in FAILURE_STATUSES:
+        assert resolve_status_category(status) == "failure", status
+
+
+def test_resolve_status_category_maps_ignorable_literals():
+    for status in IGNORABLE_STATUSES:
+        assert resolve_status_category(status) == "ignorable", status
+
+
+def test_resolve_status_category_empty_is_no_signal():
+    assert resolve_status_category("") == "no_signal"
+    assert resolve_status_category(None) == "no_signal"
+    assert resolve_status_category("   ") == "no_signal"
+
+
+def test_resolve_status_category_unknown_raises():
+    with pytest.raises(UnknownStatusError):
+        resolve_status_category("bogus")
+    with pytest.raises(UnknownStatusError):
+        resolve_status_category("successful")  # near-miss, not a literal
+
+
+def test_resolve_status_category_is_case_insensitive():
+    assert resolve_status_category("FAILED") == "failure"
+    assert resolve_status_category(" Done ") == "success"
+
+
+def test_vocabulary_sets_are_disjoint_and_complete():
+    assert not (FAILURE_STATUSES & SUCCESS_STATUSES)
+    assert not (FAILURE_STATUSES & IGNORABLE_STATUSES)
+    assert not (SUCCESS_STATUSES & IGNORABLE_STATUSES)
+    # every vocabulary key lands in exactly one derived set
+    from event_outcome_semantics import _STATUS_VOCABULARY
+    assert set(_STATUS_VOCABULARY) == (
+        FAILURE_STATUSES | SUCCESS_STATUSES | IGNORABLE_STATUSES
+    )

--- a/tests/test_outcome_vocab_sync.py
+++ b/tests/test_outcome_vocab_sync.py
@@ -16,9 +16,11 @@ This file contains:
   B) A cross-module consistency test that imports all four FAILURE sets and verifies
      they are identical, so any future divergence fails CI structurally.
   B2) Cross-module SUCCESS_STATUSES structural tests (drain/digest/payload).
-      Documented payload-specific additions: "" (empty string as success for
-      the confidence-scoring path — drain carries it too; digest omits it, which
-      is an existing documented difference between the two consumers).
+      The canonical success set (payload imports it from event_outcome_semantics)
+      is {success, completed, complete, ok, done}. Empty status ("") was removed
+      from canonical success — absence is not a success claim. drain still
+      carries "" as a documented read-side classifier tolerance this
+      consolidation leaves untouched; digest omits it.
   C) Semantic checks: the `failures_direct` branch in receipt_classifier is
      tested to fire immediately for a `contract_invalid` receipt and to
      queue for batch for a success receipt.
@@ -358,17 +360,19 @@ def _get_payload_success_statuses() -> FrozenSet[str]:
 
 # Documented structural differences in SUCCESS_STATUSES across modules:
 #
-#   digest omits "":
-#     weekly_digest classifies receipts that passed event-type gating; an empty
-#     status string is not meaningful in that context so the digest excludes it.
-#     drain and payload include "" (drain: upstream classifier; payload: empty
-#     status on a task_complete receipt treated conservatively as success).
+#   empty status ("") is NOT canonical success:
+#     event_outcome_semantics dropped "" from SUCCESS_STATUSES — absence is not
+#     a success claim (resolve_status_category returns "no_signal"). drain still
+#     carries "" as a pre-existing read-side classifier tolerance this
+#     consolidation leaves untouched (check_active_drain is a read-side
+#     consumer, not the write path the consolidation governs). digest omits ""
+#     because an empty status is not meaningful after event-type gating.
 #
 # The canonical core that ALL three must carry:
 _SUCCESS_CORE = frozenset({"success", "completed", "complete", "ok", "done"})
 
-# payload-specific addition documented above (drain also has it):
-_PAYLOAD_SUCCESS_OWN_ADDITIONS: FrozenSet[str] = frozenset({""})
+# drain-known extra vs canonical (documented acceptable difference):
+_DRAIN_SUCCESS_KNOWN_EXTRA: FrozenSet[str] = frozenset({""})
 # digest-known omissions vs drain (documented acceptable gap):
 _DIGEST_SUCCESS_KNOWN_OMISSIONS: FrozenSet[str] = frozenset({""})
 
@@ -376,20 +380,33 @@ _DIGEST_SUCCESS_KNOWN_OMISSIONS: FrozenSet[str] = frozenset({""})
 class TestSuccessVocabCrossModuleSync:
     """Structural drift tests between SUCCESS_STATUSES sets in drain / digest / payload.
 
-    The canonical reference is check_active_drain.SUCCESS_STATUSES.
-    - payload must contain all drain entries (drain also has "" so payload matches drain).
-    - digest may omit "" (documented acceptable difference).
+    The canonical reference is payload.SUCCESS_STATUSES (imported from
+    event_outcome_semantics, the single generated source). It is exactly the
+    core {success, completed, complete, ok, done}.
+    - drain may carry "" as a documented extra (read-side classifier tolerance).
+    - digest omits "" (documented acceptable difference).
     - All three must contain the common core.
     """
 
-    def test_payload_success_set_matches_drain(self):
-        """After adding 'done', payload.SUCCESS_STATUSES must equal drain.SUCCESS_STATUSES."""
-        drain = _get_drain_success_statuses()
+    def test_payload_success_set_is_the_canonical_core(self):
+        """payload.SUCCESS_STATUSES is exactly the canonical core (no "")."""
         payload = _get_payload_success_statuses()
-        assert payload == drain, (
-            f"payload.SUCCESS_STATUSES diverged from check_active_drain.SUCCESS_STATUSES.\n"
-            f"  drain only  : {drain - payload}\n"
-            f"  payload only: {payload - drain}"
+        assert payload == _SUCCESS_CORE, (
+            f"payload.SUCCESS_STATUSES must be exactly the canonical success core.\n"
+            f"  expected: {sorted(_SUCCESS_CORE)}\n"
+            f"  actual  : {sorted(payload)}"
+        )
+
+    def test_drain_success_carries_only_empty_as_extra(self):
+        """drain may differ from canonical only by the documented "" extra."""
+        drain = _get_drain_success_statuses()
+        assert drain - _SUCCESS_CORE == _DRAIN_SUCCESS_KNOWN_EXTRA, (
+            f"check_active_drain.SUCCESS_STATUSES has an undocumented extra vs canonical core:\n"
+            f"  drain only: {sorted(drain - _SUCCESS_CORE)}"
+        )
+        assert _SUCCESS_CORE - drain == frozenset(), (
+            f"check_active_drain.SUCCESS_STATUSES is missing canonical core entries: "
+            f"{sorted(_SUCCESS_CORE - drain)}"
         )
 
     def test_payload_success_contains_done(self):

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -271,6 +271,74 @@ class TestBuildReceiptFromReport:
         assert receipt["status"] == "failed"
 
 
+class TestStatusVocabularyFailClosed:
+    """The converter resolves declared status against the single canonical
+    vocabulary (event_outcome_semantics), so it cannot drift from the outcome
+    sets. Unknown status refuses; ignorable status passes through; and the
+    converter's classification agrees with the canonical resolver for every
+    vocabulary literal.
+    """
+
+    def _receipt_for_status(self, tmp_path: Path, status: str) -> dict:
+        p = tmp_path / f"20260816-vocab-{status or 'empty'}.md"
+        _write_frontmatter_report(p, "20260816-vocab", status=status)
+        return build_receipt_from_report(p, p.read_text(encoding="utf-8"))
+
+    def test_unknown_status_refuses_as_task_failed(self, tmp_path):
+        receipt = self._receipt_for_status(tmp_path, "bogus")
+        assert receipt is not None
+        assert receipt["event_type"] == "task_failed"
+        assert receipt["status"] == "failed"
+        assert receipt["failure_reason"] == "unknown_status"
+        assert receipt["unknown_status"] == "bogus"
+
+    def test_ignorable_status_passes_through(self, tmp_path):
+        receipt = self._receipt_for_status(tmp_path, "in_progress")
+        assert receipt is not None
+        assert receipt["event_type"] == "task_complete"
+        assert receipt["status"] == "in_progress"
+
+    def test_classification_agrees_with_canonical(self, tmp_path, monkeypatch):
+        import report_to_receipt_converter as rtc
+        from event_outcome_semantics import (
+            FAILURE_STATUSES,
+            IGNORABLE_STATUSES,
+            SUCCESS_STATUSES,
+            resolve_status_category,
+        )
+        monkeypatch.setattr(rtc, "_check_branch_on_origin", lambda _did: True)
+
+        for status in sorted(FAILURE_STATUSES):
+            receipt = self._receipt_for_status(tmp_path, status)
+            assert receipt["event_type"] == "task_failed", (status, receipt)
+            assert receipt["status"] == "failed", (status, receipt)
+            assert resolve_status_category(status) == "failure"
+
+        for status in sorted(SUCCESS_STATUSES):
+            receipt = self._receipt_for_status(tmp_path, status)
+            assert receipt["event_type"] == "task_complete", (status, receipt)
+            assert receipt["status"] == status, (status, receipt)
+            assert resolve_status_category(status) == "success"
+
+        for status in sorted(IGNORABLE_STATUSES):
+            receipt = self._receipt_for_status(tmp_path, status)
+            assert receipt["event_type"] == "task_complete", (status, receipt)
+            assert receipt["status"] == status, (status, receipt)
+            assert resolve_status_category(status) == "ignorable"
+
+    def test_empty_status_is_no_signal_not_success(self, tmp_path):
+        # An empty status passes through as a no-signal task_complete (write-side
+        # behavior unchanged) but resolves to "no_signal", never "success", so
+        # the read side no longer books absence as a success.
+        from event_outcome_semantics import resolve_status_category
+
+        receipt = self._receipt_for_status(tmp_path, "")
+        assert receipt is not None
+        assert receipt["event_type"] == "task_complete"
+        assert receipt["status"] == ""
+        assert resolve_status_category("") == "no_signal"
+
+
 # ---------------------------------------------------------------------------
 # Part 3: convert_report_to_receipt() — single-file conversion
 # ---------------------------------------------------------------------------

--- a/tests/test_status_vocab_drift.py
+++ b/tests/test_status_vocab_drift.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_status_vocab_drift.py — the CI drift check.
+
+The ledger-vocab consolidation's CI guard: a second hard-coded
+completion-outcome status collection in the repo must fail the drift check.
+These tests prove the scanner (1) is clean on the real tree, (2) catches a
+planted copy, (3) does not false-positive on a distinct vocabulary, and (4)
+that the converter reads the canonical vocabulary instead of keeping its own
+copy.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from check_status_vocab_drift import find_hardcoded_outcome_vocab  # noqa: E402
+
+
+def test_real_tree_has_no_hardcoded_outcome_vocab_copy():
+    violations = find_hardcoded_outcome_vocab(VNX_ROOT)
+    assert violations == [], (
+        "found hard-coded copies of the completion-outcome vocabulary:\n"
+        + "\n".join(f"  {v.path}:{v.line} {v.name} = {v.literals}" for v in violations)
+    )
+
+
+def test_planted_second_collection_is_detected(tmp_path):
+    (tmp_path / "scripts" / "lib").mkdir(parents=True)
+    planted = tmp_path / "scripts" / "lib" / "planted_copy.py"
+    planted.write_text(
+        "_TERMINAL_SUCCESS_STATUSES = frozenset({'success', 'done', 'complete', 'completed'})\n"
+        "_TERMINAL_FAILURE_STATUSES = frozenset({'failed', 'failure', 'heartbeat_killed'})\n",
+        encoding="utf-8",
+    )
+    violations = find_hardcoded_outcome_vocab(tmp_path)
+    names = {v.name for v in violations}
+    assert "_TERMINAL_SUCCESS_STATUSES" in names, names
+    assert "_TERMINAL_FAILURE_STATUSES" in names, names
+
+
+def test_distinct_vocabulary_is_not_flagged(tmp_path):
+    (tmp_path / "scripts" / "lib").mkdir(parents=True)
+    (tmp_path / "scripts" / "lib" / "distinct.py").write_text(
+        "REVIEW_VERDICT_STATUSES = frozenset({'pass', 'fail', 'pending'})\n",
+        encoding="utf-8",
+    )
+    assert find_hardcoded_outcome_vocab(tmp_path) == []
+
+
+def test_converter_reads_canonical_not_own_copy():
+    src = (LIB_DIR / "report_to_receipt_converter.py").read_text(encoding="utf-8")
+    # No terminal-status hand-copy remains.
+    assert "_TERMINAL_SUCCESS_STATUSES" not in src
+    assert "_TERMINAL_FAILURE_STATUSES" not in src
+    # It delegates every declared status to the canonical resolver.
+    assert "from event_outcome_semantics import UnknownStatusError, resolve_status_category" in src
+    assert "resolve_status_category(status_raw)" in src
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Consolidates the receipt completion-status vocabulary into a single generated source and adds a CI drift check plus fail-closed refusal for unknown literals.

The measured problem: 21 distinct status values across ~27,776 ledger receipts, with two disagreeing vocabularies:
- `event_outcome_semantics.py` (canonical): `FAILURE_STATUSES = {failed, failure, error, blocked, contract_invalid}`, `SUCCESS_STATUSES = {success, completed, complete, ok, done, ""}`
- `report_to_receipt_converter.py` (own copy): `_TERMINAL_SUCCESS_STATUSES = {success, done, complete, completed}`, `_TERMINAL_FAILURE_STATUSES = {failed, failure, heartbeat_killed}`

## Changes

1. **Single generated vocabulary** — `event_outcome_semantics._STATUS_VOCABULARY` (dict: literal -> category) is now the one source; `FAILURE_STATUSES`, `SUCCESS_STATUSES`, and `IGNORABLE_STATUSES` are derived from it by generator expression. `report_to_receipt_converter` and `dispatch_govern` resolve status against it instead of hand-copied frozensets.
2. **Five historical differences resolved per value** (not unioned):
   - `ok` -> success (declaring ok is a success claim)
   - `""` -> removed from success (absence is not a success claim; empty resolves to `no_signal`)
   - `blocked` -> failure (a blocked completion is a governed failure)
   - `contract_invalid` -> failure (already canonical; the converter missed it)
   - `heartbeat_killed` -> failure (heartbeat-kill reports are failure-shaped by design)
3. **Unknown status refuses by default** — `resolve_status_category()` raises `UnknownStatusError`; the converter turns it into a `task_failed` receipt with `failure_reason=unknown_status`. Ignorable literals (`timeout`, `no_confirmation`, `unknown`, `in_progress`, `guard_error`, `no_ready_pr`, `not_configured`, `not_executable`, `requested`) are explicitly opt-in and carry no outcome signal.
4. **CI drift check** — `scripts/check_status_vocab_drift.py` (AST scan) + a `vnx-ci.yml` step fail CI if any module hard-codes its own copy of the outcome vocabulary. Allow-list keyed by `(basename, name)` for legitimately distinct vocabularies (`receipt_verdict.SUCCESS_STATUSES`, `phantom_guard.COMPLETION_STATUSES`, `dispatch_govern._AUTHORITATIVE_STATUSES`).
5. **Tests** — two paths classify the same receipt identically; unknown value refuses; ignorable value passes; CI check finds a planted second collection.

## Verification

Targeted tests green: 389 passed across the touched files and their direct neighbors (`test_status_vocab_drift`, `test_event_outcome_semantics`, `test_outcome_vocab_sync`, `test_append_receipt_register_emit`, `test_report_to_receipt_converter`, `test_dispatch_govern`, `test_outcome_signals`, `test_payload_exception_handling`). The drift check is clean on the real tree and fails (exit 1) on a planted second collection.

Non-goals preserved: the ledger is not rewritten; the 27,776 receipts are not normalized (append-only); the ledger version number is a separate parallel track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)