### PR TITLE
fix(dispatch): refuse local-path git origins as project_id (OI-1253)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -378,10 +378,29 @@ def run(state_dir: Path, *, write: bool = True) -> Dict[str, Any]:
     }
 
 
-def _default_state_dir() -> Path:
-    from vnx_paths import ensure_env  # noqa: PLC0415
+class UnresolvableProjectError(RuntimeError):
+    """The runner cannot attribute its store to a project (no ``--state-dir``
+    and no resolvable project_id). Loud on purpose: proceeding would write
+    obligations to a fabricated or project-local store (OI-1253)."""
 
-    return Path(ensure_env()["VNX_STATE_DIR"])
+
+def _default_state_dir() -> Path:
+    import vnx_paths  # noqa: PLC0415
+
+    paths = vnx_paths.ensure_env()
+    project_root = Path(paths["PROJECT_ROOT"])
+    project_id = vnx_paths._resolve_state_project_id(project_root)
+    if project_id is None:
+        raise UnresolvableProjectError(
+            f"cannot resolve a project_id for project root {project_root}: "
+            "the store is unattributable, so obligations cannot be written "
+            "safely. A central install's git origin is not a project identity "
+            "(it may point at a release-time temp checkout). Pass --state-dir "
+            "(~/.vnx-data/<project_id>/state), or set VNX_PROJECT_ID / write a "
+            ".vnx-project-id marker for the project whose obligations this "
+            "runner fulfils."
+        )
+    return Path(paths["VNX_STATE_DIR"])
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -403,7 +422,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         format="%(name)s: %(levelname)s: %(message)s",
     )
 
-    state_dir = args.state_dir or _default_state_dir()
+    try:
+        state_dir = args.state_dir or _default_state_dir()
+    except UnresolvableProjectError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 20
     if not Path(state_dir).is_dir():
         print(f"ERROR: state dir not found: {state_dir}", file=sys.stderr)
         return 20

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -17,16 +17,23 @@ runner fulfils them:
      ``gate_recorder.record_not_executable`` writes both records with status
      ``not_executable`` plus a skip-rationale audit entry. Silence is not an
      end state.
-  4. If no PR exists yet the obligation stays ``pending`` — and the producer
-     freshness monitor (``review_gate_obligations`` producer) flags the gate
-     key once the oldest pending declaration exceeds cadence.
+  4. If no PR exists yet the obligation stays ``pending`` — a genuine wait for
+     a PR that has not been opened, which the producer freshness monitor
+     (``review_gate_obligations`` producer) flags per gate key once the oldest
+     pending declaration exceeds cadence.
+  5. If the PR cannot be resolved because the environment is wrong — the
+     project has no attributable GitHub ``owner/repo`` (no checkout registered
+     in ``~/.vnx/projects.json`` and no GitHub ``origin`` remote) — the
+     obligation is recorded in the distinct ``unresolvable`` status (a fault,
+     NOT a wait). It stays retryable for a bounded term and then escalates to
+     the loud terminal ``not_executable`` with ``reason=unresolvable_timeout``.
 
 Scheduling: launchd ``com.vnx.gate-obligation-runner.plist`` (StartInterval
 900s); also safe to run manually at any time — fulfilment is idempotent
 (terminal obligations are never re-run).
 
-Exit codes: 0 = no pending obligations remain after this run;
-11 = one or more obligations still pending (PR unresolved);
+Exit codes: 0 = no open obligations remain after this run;
+11 = one or more obligations still open (pending or unresolvable);
 20 = state dir / configuration error.
 """
 
@@ -36,10 +43,12 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -50,6 +59,7 @@ from gate_obligations import (  # noqa: E402
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
+    STATUS_UNRESOLVABLE,
     TERMINAL_STATUSES,
     iter_obligations,
     pr_number_from_pr_id,
@@ -59,6 +69,32 @@ from gate_obligations import (  # noqa: E402
 _LOG = logging.getLogger("gate_obligation_runner")
 
 _GH_TIMEOUT_SECONDS = 20
+
+# An obligation whose PR can't be resolved because the environment is wrong
+# (repo unattributable, no GitHub remote, gh unusable) is a config FAULT, not a
+# wait. It stays retryable in the distinct ``unresolvable`` status for a bounded
+# term, then escalates to the loud terminal ``not_executable``. 96 attempts at
+# the launchd 900s cadence ≈ 24h — the same window the producer-freshness
+# monitor uses before flagging a silently-pending gate key.
+_UNRESOLVABLE_ESCALATION_ATTEMPTS = 96
+
+# PR-resolution outcomes. The runner must tell "no PR yet" (a wait) apart from
+# "cannot resolve because the environment is wrong" (a fault) IN THE RECORD,
+# not only in a log line — a pending obligation that is actually misconfigured
+# reads as "not yet" forever and never alarms anyone (OI-1253 fix-forward).
+RESOLUTION_RESOLVED = "resolved"
+RESOLUTION_AWAITING = "awaiting"
+RESOLUTION_UNRESOLVABLE = "unresolvable"
+
+
+@dataclass
+class PrResolution:
+    """Outcome of resolving an obligation's PR number."""
+
+    status: str
+    pr_number: Optional[int] = None
+    owner_repo: Optional[str] = None
+    reason: Optional[str] = None
 
 
 def utc_now_iso() -> str:
@@ -96,13 +132,25 @@ def _pr_from_dispatch_metadata(state_dir: Path, dispatch_id: str) -> Optional[in
     return pr_number_from_pr_id(str(row[0]))
 
 
-def _gh_json(args: List[str]) -> Optional[Any]:
-    """Run a gh CLI command, returning parsed JSON or None on any failure."""
+def _gh_json(args: List[str], *, owner_repo: Optional[str] = None) -> Optional[Any]:
+    """Run a gh CLI command scoped to ``owner_repo``, returning parsed JSON.
+
+    ``owner_repo`` (``owner/repo``) is injected as ``--repo`` so the query never
+    depends on the ambient cwd. A central install's cwd is the install tree
+    whose ``origin`` is a release-time temp checkout; bare ``gh`` resolves that
+    as the repo and returns nothing, which read as an eternal "no PR yet"
+    instead of the misconfiguration it actually is (OI-1253 fix-forward).
+    Returns None on any failure (gh missing, timeout, non-zero exit, non-JSON).
+    """
     if shutil.which("gh") is None:
         return None
+    cmd = ["gh"]
+    if owner_repo:
+        cmd += ["--repo", owner_repo]
+    cmd += args
     try:
         proc = subprocess.run(
-            ["gh", *args],
+            cmd,
             capture_output=True, text=True, timeout=_GH_TIMEOUT_SECONDS, check=False,
         )
     except (subprocess.TimeoutExpired, OSError) as exc:
@@ -116,11 +164,12 @@ def _gh_json(args: List[str]) -> Optional[Any]:
         return None
 
 
-def _pr_from_github(dispatch_id: str) -> Optional[int]:
+def _pr_from_github(dispatch_id: str, owner_repo: str) -> Optional[int]:
     """Find the open/merged PR whose head branch is dispatch/<dispatch_id>."""
     data = _gh_json(
         ["pr", "list", "--state", "all", "--head", f"dispatch/{dispatch_id}",
-         "--json", "number", "--limit", "1"]
+         "--json", "number", "--limit", "1"],
+        owner_repo=owner_repo,
     )
     if isinstance(data, list) and data:
         number = data[0].get("number")
@@ -129,8 +178,11 @@ def _pr_from_github(dispatch_id: str) -> Optional[int]:
     return None
 
 
-def _branch_from_github(pr_number: int) -> Optional[str]:
-    data = _gh_json(["pr", "view", str(pr_number), "--json", "headRefName"])
+def _branch_from_github(pr_number: int, owner_repo: str) -> Optional[str]:
+    data = _gh_json(
+        ["pr", "view", str(pr_number), "--json", "headRefName"],
+        owner_repo=owner_repo,
+    )
     if isinstance(data, dict):
         branch = data.get("headRefName")
         if isinstance(branch, str) and branch.strip():
@@ -138,17 +190,155 @@ def _branch_from_github(pr_number: int) -> Optional[str]:
     return None
 
 
-def resolve_pr_number(state_dir: Path, record: Dict[str, Any]) -> Optional[int]:
-    """Resolve the obligation's PR number from every available source."""
+def _owner_repo_from_remote_url(url: str) -> Optional[str]:
+    """Derive ``owner/repo`` from a GitHub remote URL (https or ssh form).
+
+    Mirrors the regex in ``chain_origin_anchor._owner_repo_from_remote``; the
+    runner stays a lightweight stdlib script and must not import that module.
+    Returns None for any non-GitHub URL — including a local-filesystem origin,
+    which is a release/install artifact, never a project identity (OI-1253).
+    """
+    match = re.search(r"github\.com[:/]+([^/]+)/(.+?)(?:\.git)?/?$", url.strip())
+    if not match:
+        return None
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def _git_remote_origin(project_root: Path) -> Optional[str]:
+    """Return the ``origin`` remote URL for ``project_root``, or None."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(project_root), "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    return proc.stdout.strip()
+
+
+def _project_checkout_path(project_id: str) -> Optional[Path]:
+    """Resolve the project's checkout path from the operator registry.
+
+    ``~/.vnx/projects.json`` (vnx_identity schema v2) maps ``project_id`` →
+    ``path``. This is the cwd-independent link from a central-install runner's
+    store (``~/.vnx-data/<project_id>/state``) back to the actual checkout whose
+    ``origin`` remote is a real GitHub URL. Returns None when the id is not
+    registered or the path is gone.
+    """
+    if not project_id:
+        return None
+    try:
+        registry_path = Path("~/.vnx/projects.json").expanduser()
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    for entry in registry.get("projects", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("project_id") != project_id:
+            continue
+        raw_path = entry.get("path")
+        if not raw_path:
+            continue
+        try:
+            candidate = Path(raw_path).expanduser()
+        except (OSError, ValueError):
+            continue
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _resolve_github_owner_repo(state_dir: Path) -> Optional[str]:
+    """Resolve the GitHub ``owner/repo`` whose PRs this runner's obligations live in.
+
+    CWD-independent on purpose: ``gh`` must never infer the repo from the
+    ambient cwd, because a central install's cwd is the install tree (its origin
+    is a release-time temp checkout). Resolution order:
+
+      1. The checkout registered for the runner's project_id
+         (``~/.vnx/projects.json``) — its ``origin`` remote is the project's
+         real GitHub URL, even when the runner runs from ``$VNX_HOME``.
+      2. The current working directory — only as a convenience fallback for a
+         dev checkout run from within the repo. A local-path origin never
+         matches, so this fallback cannot fabricate an owner/repo from an
+         install's temp checkout.
+
+    Returns None when neither source yields a GitHub remote — the caller turns
+    that into the distinct, loud ``unresolvable`` state, never a silent wait.
+    """
+    import vnx_paths  # noqa: PLC0415
+
+    pid = (
+        vnx_paths.project_id_from_state_dir(state_dir)
+        or (os.environ.get("VNX_PROJECT_ID") or "").strip()
+    )
+    candidates: List[Path] = []
+    if pid:
+        checkout = _project_checkout_path(pid)
+        if checkout is not None:
+            candidates.append(checkout)
+    candidates.append(Path.cwd().resolve())
+
+    for root in candidates:
+        url = _git_remote_origin(root)
+        if not url:
+            continue
+        owner_repo = _owner_repo_from_remote_url(url)
+        if owner_repo:
+            return owner_repo
+    return None
+
+
+def resolve_pr_number(state_dir: Path, record: Dict[str, Any]) -> PrResolution:
+    """Resolve the obligation's PR number from every available source.
+
+    Returns a :class:`PrResolution` carrying one of three statuses so the caller
+    can record the distinction in the obligation's state:
+
+      - ``resolved``   — a PR number is known (record, dispatch metadata, GitHub).
+      - ``awaiting``   — the repo resolves and ``gh`` works, but no PR exists yet
+                         for the head branch: a genuine wait, stays ``pending``.
+      - ``unresolvable`` — the environment is wrong (no GitHub owner/repo, no
+                         checkout, gh missing): a fault, recorded distinctly.
+    """
     pr_number = record.get("pr_number")
     if isinstance(pr_number, int) and pr_number > 0:
-        return pr_number
+        return PrResolution(RESOLUTION_RESOLVED, pr_number=pr_number)
     dispatch_id = str(record.get("dispatch_id") or "")
     if not dispatch_id:
-        return None
-    return (
-        _pr_from_dispatch_metadata(state_dir, dispatch_id)
-        or _pr_from_github(dispatch_id)
+        return PrResolution(
+            RESOLUTION_UNRESOLVABLE,
+            reason="obligation has no dispatch_id to resolve a PR for",
+        )
+
+    from_metadata = _pr_from_dispatch_metadata(state_dir, dispatch_id)
+    if from_metadata:
+        return PrResolution(RESOLUTION_RESOLVED, pr_number=from_metadata)
+
+    owner_repo = _resolve_github_owner_repo(state_dir)
+    if not owner_repo:
+        return PrResolution(
+            RESOLUTION_UNRESOLVABLE,
+            reason=(
+                "cannot resolve a GitHub owner/repo for this runner: the "
+                "project checkout is not registered (~/.vnx/projects.json) and "
+                "no GitHub 'origin' remote resolves from the checkout or cwd. "
+                "gh would otherwise infer the repo from the ambient cwd, which "
+                "for a central install is a release-time temp checkout (OI-1253)"
+            ),
+        )
+    from_github = _pr_from_github(dispatch_id, owner_repo)
+    if from_github:
+        return PrResolution(
+            RESOLUTION_RESOLVED, pr_number=from_github, owner_repo=owner_repo,
+        )
+    return PrResolution(
+        RESOLUTION_AWAITING,
+        owner_repo=owner_repo,
+        reason=f"no PR yet for head branch dispatch/{dispatch_id}",
     )
 
 
@@ -241,15 +431,61 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
     attempts = int(record.get("attempts") or 0) + 1
     now = utc_now_iso()
 
-    pr_number = resolve_pr_number(state_dir, record)
-    if pr_number is None:
-        update_obligation(path, attempts=attempts, last_attempt_at=now)
+    resolution = resolve_pr_number(state_dir, record)
+
+    if resolution.status == RESOLUTION_UNRESOLVABLE:
+        # The environment is wrong (repo unattributable, gh unusable): a fault,
+        # not a wait. Record it in a state distinct from ``pending`` so a
+        # misconfigured obligation can never masquerade as "not yet". It stays
+        # retryable — the env may be fixed — until it crosses the escalation
+        # threshold, where it becomes the loud terminal not_executable.
+        update_obligation(
+            path,
+            status=STATUS_UNRESOLVABLE,
+            attempts=attempts,
+            last_attempt_at=now,
+            reason="unresolvable_repo",
+            reason_detail=resolution.reason,
+        )
+        outcome["action"] = "unresolvable"
+        outcome["detail"] = resolution.reason
+        if attempts >= _UNRESOLVABLE_ESCALATION_ATTEMPTS:
+            update_obligation(
+                path,
+                status=STATUS_NOT_EXECUTABLE,
+                attempts=attempts,
+                last_attempt_at=now,
+                resolved_at=now,
+                reason="unresolvable_timeout",
+                reason_detail=(
+                    f"PR unresolved after {attempts} attempts because the "
+                    f"environment is misconfigured: {resolution.reason}. Fix "
+                    "the project attribution (VNX_PROJECT_ID / "
+                    "~/.vnx/projects.json / the checkout's git origin remote) "
+                    "and reset this obligation to pending."
+                ),
+            )
+            outcome["action"] = "not_executable"
+        return outcome
+
+    if resolution.status == RESOLUTION_AWAITING:
+        # The repo resolves and gh works, but no PR exists yet for the head
+        # branch. A genuine wait: stays pending for the freshness monitor.
+        update_obligation(
+            path,
+            status=STATUS_PENDING,
+            attempts=attempts,
+            last_attempt_at=now,
+        )
         outcome["detail"] = "no PR resolvable yet — stays pending for the freshness monitor"
         return outcome
 
+    pr_number = resolution.pr_number
+    owner_repo = resolution.owner_repo or _resolve_github_owner_repo(state_dir)
+
     branch = (
         str(record.get("branch") or "").strip()
-        or (_branch_from_github(pr_number) or "")
+        or (_branch_from_github(pr_number, owner_repo) if owner_repo else "")
         or f"dispatch/{dispatch_id}"
     )
 
@@ -367,7 +603,7 @@ def run(state_dir: Path, *, write: bool = True) -> Dict[str, Any]:
             continue
         outcome = fulfill_obligation(state_dir, path, record)
         outcomes.append(outcome)
-        if outcome["action"] == "pending":
+        if outcome["action"] in ("pending", "unresolvable"):
             pending_after += 1
     return {
         "state_dir": str(state_dir),
@@ -375,6 +611,9 @@ def run(state_dir: Path, *, write: bool = True) -> Dict[str, Any]:
         "obligations_seen": len(obligations),
         "outcomes": outcomes,
         "pending_after": pending_after,
+        "unresolvable_after": sum(
+            1 for o in outcomes if o.get("action") == "unresolvable"
+        ),
     }
 
 

--- a/scripts/launchd/com.vnx.gate-obligation-runner.plist
+++ b/scripts/launchd/com.vnx.gate-obligation-runner.plist
@@ -14,22 +14,26 @@
     Also installable manually via reload_plist.sh:
       bash scripts/launchd/reload_plist.sh com.vnx.gate-obligation-runner
 
-    Exit 11 (obligations still pending) is captured into job_exits.ndjson by
+    Exit 11 (obligations still open) is captured into job_exits.ndjson by
     the producer-freshness monitor's launchd harvest; obligations pending
     longer than a day are flagged per gate key by the same monitor's
     review_gate_obligations producer.
 
-    Store is pinned explicitly via --state-dir (OI-1253): the central install's
-    git origin is a release-time temp checkout (e.g. /var/folders/.../checkout),
-    which must never drive store resolution. This runner fulfils the VNX
-    orchestration engine's own review-gate obligations, whose canonical store is
-    ~/.vnx-data/vnx-dev/state — so it is named explicitly rather than derived.
+    The store is NOT pinned by path. The job identifies its project via
+    VNX_PROJECT_ID (below), one instance per project; the runner then resolves
+    the store from that id and, independently, the GitHub owner/repo whose PRs
+    its obligations live in. A consumer installing this template for their own
+    project MUST set VNX_PROJECT_ID to their project id: vnx init substitutes
+    the ${VNX_PROJECT_ID} placeholder with the --project-id value, so manual
+    installs must edit it by hand. Hardcoding a store path here would make a
+    copied template run on the original project's obligations
+    (OI-1253 fix-forward).
   -->
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-c</string>
-    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/gate_obligation_runner.py --state-dir "$HOME/.vnx-data/vnx-dev/state"</string>
+    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/gate_obligation_runner.py</string>
   </array>
   <key>StartInterval</key>
   <integer>900</integer>
@@ -39,6 +43,8 @@
   <dict>
     <key>VNX_HOME</key>
     <string>${VNX_HOME}</string>
+    <key>VNX_PROJECT_ID</key>
+    <string>${VNX_PROJECT_ID}</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
   </dict>

--- a/scripts/launchd/com.vnx.gate-obligation-runner.plist
+++ b/scripts/launchd/com.vnx.gate-obligation-runner.plist
@@ -18,12 +18,18 @@
     the producer-freshness monitor's launchd harvest; obligations pending
     longer than a day are flagged per gate key by the same monitor's
     review_gate_obligations producer.
+
+    Store is pinned explicitly via --state-dir (OI-1253): the central install's
+    git origin is a release-time temp checkout (e.g. /var/folders/.../checkout),
+    which must never drive store resolution. This runner fulfils the VNX
+    orchestration engine's own review-gate obligations, whose canonical store is
+    ~/.vnx-data/vnx-dev/state — so it is named explicitly rather than derived.
   -->
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-c</string>
-    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/gate_obligation_runner.py</string>
+    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/gate_obligation_runner.py --state-dir "$HOME/.vnx-data/vnx-dev/state"</string>
   </array>
   <key>StartInterval</key>
   <integer>900</integer>

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -58,6 +58,11 @@ STATUS_PENDING = "pending"
 STATUS_FULFILLED = "fulfilled"
 STATUS_NOT_EXECUTABLE = "not_executable"
 STATUS_FAILED = "failed"
+# "unresolvable" is NOT terminal: the runner keeps retrying resolution while
+# the environment may be fixed. It is distinct from "pending" (a genuine wait
+# for a not-yet-opened PR) so a misconfigured obligation never reads as "not
+# yet" forever (OI-1253 fix-forward).
+STATUS_UNRESOLVABLE = "unresolvable"
 
 TERMINAL_STATUSES = frozenset({STATUS_FULFILLED, STATUS_NOT_EXECUTABLE, STATUS_FAILED})
 
@@ -216,6 +221,7 @@ __all__ = [
     "STATUS_FULFILLED",
     "STATUS_NOT_EXECUTABLE",
     "STATUS_FAILED",
+    "STATUS_UNRESOLVABLE",
     "TERMINAL_STATUSES",
     "obligations_dir",
     "obligation_path",

--- a/scripts/lib/producer_freshness.py
+++ b/scripts/lib/producer_freshness.py
@@ -208,8 +208,9 @@ def scan_gate_obligations(spec: Dict[str, Any], *, now: float) -> Dict[str, Opti
 
     Per-key ``last_seen`` semantics — declaration checked against evidence:
 
-      - if any obligation for the key is still ``pending``, last_seen = the
-        OLDEST pending declaration. A declared gate that produced no result
+      - if any obligation for the key is still open (``pending`` — waiting for a
+        not-yet-opened PR — or ``unresolvable`` — environment wrong), last_seen
+        = the OLDEST such declaration. A declared gate that produced no result
         within cadence then reads as stale: exactly the 2026-07-31 incident
         (nine dispatches declared codex_gate, zero ran, nothing noticed).
       - otherwise last_seen = the NEWEST terminal resolution (fulfilled /
@@ -236,7 +237,10 @@ def scan_gate_obligations(spec: Dict[str, Any], *, now: float) -> Dict[str, Opti
             raise ValueError(f"gate obligation {entry.name} is not a JSON object")
         key = str(record.get("gate") or entry.stem)
         status = record.get("status", "pending")
-        if status == "pending":
+        # "unresolvable" (env wrong, no attributable owner/repo) is a declared-
+        # but-unfulfilled state too — it must drive staleness exactly like
+        # "pending", never read as resolved evidence (OI-1253 fix-forward).
+        if status in ("pending", "unresolvable"):
             ts = _parse_ts(record.get("declared_at"))
             if ts is None:
                 ts = entry.stat().st_mtime

--- a/scripts/lib/project_root.py
+++ b/scripts/lib/project_root.py
@@ -6,6 +6,7 @@ state pollution. See upstream-fix issue Vinix24/vnx-orchestration#225.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import warnings
 from pathlib import Path
@@ -146,6 +147,28 @@ def resolve_dispatch_dir(caller_file: str | None = None) -> Path:
     return data / "dispatches"
 
 
+def is_local_path_origin(origin: str) -> bool:
+    """True when a git ``origin`` names a local filesystem path, not a project remote.
+
+    A git origin that is a local path (an absolute path, a ``~``-expanded path,
+    a Windows drive path, or a ``file://`` URL) is a checkout/install artifact
+    — e.g. the temp checkout dir ``vnx release publish`` passes as ``--source`` —
+    not a stable, shareable project identity. Such an origin must never yield a
+    project_id: an install map is not a project checkout (OI-1253).
+    """
+    expanded = os.path.expanduser(origin.strip())
+    if expanded.startswith("file://"):
+        return True
+    if expanded.startswith("~"):
+        return True
+    if re.match(r"^[A-Za-z]:[\\/]", expanded):
+        return True
+    try:
+        return Path(expanded).is_absolute()
+    except (OSError, ValueError):
+        return False
+
+
 def resolve_project_id(project_dir: str | Path | None = None) -> str:
     """Resolve the current project_id for tenant-scoped operations.
 
@@ -189,6 +212,8 @@ def resolve_project_id(project_dir: str | Path | None = None) -> str:
                 text=True,
             ).strip()
             if out:
+                if is_local_path_origin(out):
+                    continue
                 name = out.rstrip("/").split("/")[-1]
                 if name.endswith(".git"):
                     name = name[:-4]

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -25,6 +25,7 @@ if _lib not in _sys.path:
 from vnx_ids import PROJECT_ID_RE as _PROJECT_ID_RE
 
 import data_dir_guard
+from project_root import is_local_path_origin
 
 log = logging.getLogger(__name__)
 
@@ -294,6 +295,13 @@ def _project_id_from_git_remote(project_root: Path) -> Optional[str]:
     Scoped strictly to ``project_root`` — unlike ``project_root.resolve_project_id``
     this never consults the CWD, so resolving a bare repo does not leak a
     marker/id from wherever the caller happens to be running.
+
+    Only a real project remote (https/ssh/scp-style URL) is a valid identity
+    signal. A local-filesystem origin is refused: a central install or release
+    checkout whose origin points at a temp/dangling path must never fabricate a
+    project_id from its basename (OI-1253: the install's origin
+    ``/var/folders/.../checkout`` produced project_id ``checkout`` and made every
+    script resolve to the non-existent store ``~/.vnx-data/checkout``).
     """
     try:
         out = subprocess.check_output(
@@ -303,7 +311,7 @@ def _project_id_from_git_remote(project_root: Path) -> Optional[str]:
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return None
-    if not out:
+    if not out or is_local_path_origin(out):
         return None
     name = out.rstrip("/").split("/")[-1]
     if name.endswith(".git"):

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -522,6 +522,49 @@ class TestGateObligationRunnerInstall:
         assert any("load" in c for c in cmds), "launchctl load not called"
         assert any("list" in c for c in cmds), "launchctl list not called"
 
+    def test_install_substitutes_project_id(self, tmp_path, monkeypatch):
+        """vnx init must inject the project id into VNX_PROJECT_ID (OI-1253):
+        the job identifies its project via the env var, never a store path."""
+        from vnx_cli.commands import init_cmd
+
+        engine_root = tmp_path / "engine"
+        launchd_dir = engine_root / "scripts" / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / f"{self.PLIST_NAME}.plist").write_text(
+            '<?xml version="1.0"?><plist><dict>'
+            "<key>Label</key><string>com.vnx.gate-obligation-runner</string>"
+            "<key>EnvironmentVariables</key><dict>"
+            "<key>VNX_PROJECT_ID</key><string>${VNX_PROJECT_ID}</string>"
+            "</dict></dict></plist>",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(init_cmd._engine, "engine_root", lambda: engine_root)
+
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            m.stderr = ""
+            m.stdout = f"{self.PLIST_NAME}\n" if cmd == ["launchctl", "list"] else ""
+            return m
+
+        monkeypatch.setattr(init_cmd.subprocess, "run", fake_run)
+
+        result = init_cmd._install_gate_obligation_runner(
+            str(engine_root), project_id="vnx-dev",
+        )
+        assert result is True
+
+        dest = fake_home / "Library" / "LaunchAgents" / f"{self.PLIST_NAME}.plist"
+        content = dest.read_text(encoding="utf-8")
+        assert "${VNX_PROJECT_ID}" not in content, (
+            "The VNX_PROJECT_ID placeholder must be substituted at install"
+        )
+        assert "vnx-dev" in content, "The plist must carry the project id"
+
     def test_install_returns_false_when_template_missing(self, tmp_path, monkeypatch):
         from vnx_cli.commands import init_cmd
 

--- a/tests/test_gate_obligation_runner.py
+++ b/tests/test_gate_obligation_runner.py
@@ -11,6 +11,7 @@ message instead of writing to a fabricated or unattributable store.
 from __future__ import annotations
 
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -59,3 +60,143 @@ class TestDefaultStateDirGuard:
         rc = runner.main(["--state-dir", str(missing)])
         assert rc == 20
         assert "state dir not found" in capsys.readouterr().err
+
+
+class TestOwnerRepoFromRemoteUrl:
+    """``_owner_repo_from_remote_url`` accepts GitHub https/ssh forms and refuses
+    anything else, including a local-filesystem origin (OI-1253)."""
+
+    def test_https_url(self):
+        assert (
+            runner._owner_repo_from_remote_url(
+                "https://github.com/Vinix24/vnx-orchestration.git"
+            )
+            == "Vinix24/vnx-orchestration"
+        )
+
+    def test_ssh_url(self):
+        assert (
+            runner._owner_repo_from_remote_url(
+                "git@github.com:Vinix24/vnx-orchestration.git"
+            )
+            == "Vinix24/vnx-orchestration"
+        )
+
+    def test_no_trailing_git(self):
+        assert (
+            runner._owner_repo_from_remote_url(
+                "https://github.com/Vinix24/vnx-orchestration"
+            )
+            == "Vinix24/vnx-orchestration"
+        )
+
+    def test_local_filesystem_origin_refused(self):
+        assert (
+            runner._owner_repo_from_remote_url(
+                "/var/folders/ab/cd/T/vnx-checkout"
+            )
+            is None
+        )
+
+    def test_non_github_host_refused(self):
+        assert runner._owner_repo_from_remote_url("https://gitlab.com/foo/bar.git") is None
+
+
+class TestGhJsonRepoScoping:
+    """``gh`` must be told the repo explicitly, never infer it from the cwd."""
+
+    def test_injects_repo_flag_when_owner_repo_given(self, monkeypatch):
+        monkeypatch.setattr(runner.shutil, "which", lambda name: "/opt/homebrew/bin/gh")
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(returncode=0, stdout='{"number": 1}')
+
+        monkeypatch.setattr(runner.subprocess, "run", fake_run)
+        result = runner._gh_json(["pr", "list"], owner_repo="Vinix24/vnx-orchestration")
+        assert result == {"number": 1}
+        assert captured["cmd"] == [
+            "gh", "--repo", "Vinix24/vnx-orchestration", "pr", "list",
+        ]
+
+    def test_omits_repo_flag_when_none(self, monkeypatch):
+        monkeypatch.setattr(runner.shutil, "which", lambda name: "/opt/homebrew/bin/gh")
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(returncode=0, stdout='{"number": 1}')
+
+        monkeypatch.setattr(runner.subprocess, "run", fake_run)
+        runner._gh_json(["pr", "list"], owner_repo=None)
+        assert captured["cmd"] == ["gh", "pr", "list"]
+
+    def test_pr_from_github_requests_the_right_repo(self, monkeypatch):
+        captured = {}
+
+        def fake_gh_json(args, *, owner_repo=None):
+            captured["args"] = args
+            captured["owner_repo"] = owner_repo
+            return [{"number": 42}]
+
+        monkeypatch.setattr(runner, "_gh_json", fake_gh_json)
+        number = runner._pr_from_github("20260816-foo", "Vinix24/vnx-orchestration")
+        assert number == 42
+        assert captured["owner_repo"] == "Vinix24/vnx-orchestration"
+        assert "dispatch/20260816-foo" in captured["args"]
+
+
+class TestResolveGithubOwnerRepo:
+    """Repo identity must come from the project registry / checkout, not cwd."""
+
+    def test_resolves_from_registry_checkout_first(self, monkeypatch, tmp_path):
+        checkout = tmp_path / "vnx-orchestration"
+        checkout.mkdir()
+        monkeypatch.setattr(
+            vnx_paths, "project_id_from_state_dir", lambda state_dir: "vnx-dev",
+        )
+        monkeypatch.setattr(runner, "_project_checkout_path", lambda pid: checkout)
+
+        def fake_origin(root):
+            return "https://github.com/Vinix24/vnx-orchestration.git"
+
+        monkeypatch.setattr(runner, "_git_remote_origin", fake_origin)
+        assert (
+            runner._resolve_github_owner_repo(tmp_path / "state")
+            == "Vinix24/vnx-orchestration"
+        )
+
+    def test_cwd_fallback_returns_none_for_local_origin(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            vnx_paths, "project_id_from_state_dir", lambda state_dir: "",
+        )
+        monkeypatch.setattr(runner, "_project_checkout_path", lambda pid: None)
+        # A release-time temp checkout is a local-filesystem origin, never a
+        # GitHub identity: the fallback must NOT fabricate an owner/repo from it.
+        monkeypatch.setattr(
+            runner, "_git_remote_origin", lambda root: "/var/folders/ab/cd/T/checkout",
+        )
+        assert runner._resolve_github_owner_repo(tmp_path / "state") is None
+
+    def test_returns_none_when_no_remote_at_all(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            vnx_paths, "project_id_from_state_dir", lambda state_dir: "",
+        )
+        monkeypatch.setattr(runner, "_project_checkout_path", lambda pid: None)
+        monkeypatch.setattr(runner, "_git_remote_origin", lambda root: None)
+        assert runner._resolve_github_owner_repo(tmp_path / "state") is None
+
+
+class TestPlistHasNoHardcodedProject:
+    """The launchd template must pin NO project or store path (OI-1253)."""
+
+    PLIST = ROOT / "scripts" / "launchd" / "com.vnx.gate-obligation-runner.plist"
+
+    def test_template_has_no_hardcoded_project_or_store(self):
+        content = self.PLIST.read_text(encoding="utf-8")
+        assert "--state-dir" not in content
+        assert "vnx-dev" not in content
+        assert "~/.vnx-data" not in content
+        assert "VNX_PROJECT_ID" in content
+        assert "${VNX_PROJECT_ID}" in content

--- a/tests/test_gate_obligation_runner.py
+++ b/tests/test_gate_obligation_runner.py
@@ -1,0 +1,61 @@
+"""tests/test_gate_obligation_runner.py — OI-1253 runner store-resolution guard.
+
+The runner must never silently serve a store it cannot attribute to a project.
+A central install whose only identity signal was a release-time git origin
+resolves no project_id (the origin is refused by ``_project_id_from_git_remote``),
+and ``_resolve_state_root`` would otherwise fall back to a project-local dir
+under the immutable install. The runner must fail LOUD with an actionable
+message instead of writing to a fabricated or unattributable store.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import vnx_paths  # noqa: E402
+import gate_obligation_runner as runner  # noqa: E402
+
+
+class TestDefaultStateDirGuard:
+    """A runner without ``--state-dir`` must fail LOUD when project_id is None."""
+
+    def test_loud_when_project_id_unresolvable(self, monkeypatch):
+        monkeypatch.setattr(
+            vnx_paths, "_resolve_state_project_id", lambda project_root: None,
+        )
+        with pytest.raises(runner.UnresolvableProjectError) as excinfo:
+            runner._default_state_dir()
+        message = str(excinfo.value)
+        assert "--state-dir" in message
+        assert "VNX_PROJECT_ID" in message
+
+    def test_resolves_when_project_id_present(self, monkeypatch):
+        monkeypatch.setattr(
+            vnx_paths, "_resolve_state_project_id", lambda project_root: "vnx-dev",
+        )
+        state_dir = runner._default_state_dir()
+        assert state_dir.name == "state"
+
+    def test_main_returns_20_with_loud_error(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            vnx_paths, "_resolve_state_project_id", lambda project_root: None,
+        )
+        rc = runner.main([])
+        assert rc == 20
+        err = capsys.readouterr().err
+        assert "project_id" in err
+        assert "--state-dir" in err
+
+    def test_main_state_dir_missing_still_returns_20(self, tmp_path, capsys):
+        missing = tmp_path / "does-not-exist" / "state"
+        rc = runner.main(["--state-dir", str(missing)])
+        assert rc == 20
+        assert "state dir not found" in capsys.readouterr().err

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -42,6 +42,7 @@ from gate_obligations import (
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
+    STATUS_UNRESOLVABLE,
     obligation_path,
     pr_number_from_pr_id,
     register_obligation,
@@ -135,7 +136,8 @@ class _FakeManager:
 def _patch_manager(monkeypatch, manager: "_FakeManager") -> None:
     """Hermetic patch: no git, no gh, no real gate — only the fake manager."""
     monkeypatch.setattr(runner, "_build_manager", lambda state_dir: manager)
-    monkeypatch.setattr(runner, "_branch_from_github", lambda pr: None)
+    monkeypatch.setattr(runner, "_branch_from_github", lambda pr, owner_repo: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda state_dir: "Vinix24/vnx-orchestration")
     fake_rgm = types.ModuleType("review_gate_manager")
     fake_rgm._compute_changed_files = lambda branch: ["scripts/lib/foo.py"]
     monkeypatch.setitem(sys.modules, "review_gate_manager", fake_rgm)
@@ -321,21 +323,69 @@ def test_runner_gate_failure_is_loud_and_registered(tmp_path, monkeypatch):
     assert "gate_skip_rationale" in audit.read_text(encoding="utf-8")
 
 
-def test_runner_leaves_pending_when_pr_unresolvable(tmp_path, monkeypatch):
+def test_runner_leaves_pending_when_no_pr_yet(tmp_path, monkeypatch):
+    """Repo resolves and gh works, but no PR exists yet — a genuine WAIT, not a
+    fault. The obligation stays pending (OI-1253 fix-forward: this must not be
+    confused with the `unresolvable` env-wrong state)."""
     state_dir = _make_state_dir(tmp_path)
     register_obligation(
         state_dir, dispatch_id="20260731-oi876-no-pr", gate="codex_gate",
         project_id="vnx-dev",
     )
     monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
-    monkeypatch.setattr(runner, "_pr_from_github", lambda did: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
+    monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
 
     summary = runner.run(state_dir)
 
     assert summary["pending_after"] == 1
+    assert summary["unresolvable_after"] == 0
     record = _read_obligation(state_dir, "20260731-oi876-no-pr")
     assert record["status"] == STATUS_PENDING
     assert record["attempts"] == 1
+
+
+def test_runner_marks_unresolvable_when_repo_unattributable(tmp_path, monkeypatch):
+    """Env wrong (no attributable GitHub owner/repo) is a FAULT, recorded in the
+    distinct `unresolvable` status — never left as `pending`, which would read
+    as "not yet" forever (OI-1253 fix-forward)."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260816-s1fix-no-repo", gate="codex_gate",
+        project_id="vnx-dev",
+    )
+    monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: None)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 1
+    assert summary["unresolvable_after"] == 1
+    record = _read_obligation(state_dir, "20260816-s1fix-no-repo")
+    assert record["status"] == STATUS_UNRESOLVABLE
+    assert record["reason"] == "unresolvable_repo"
+    assert record["reason_detail"], "an unresolvable obligation must carry an actionable reason"
+
+
+def test_runner_escalates_unresolvable_to_not_executable_after_threshold(tmp_path, monkeypatch):
+    """An obligation that stays unresolvable past the bounded term escalates to
+    the loud terminal not_executable — it can never wait silently forever."""
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="20260816-s1fix-escalate", gate="codex_gate",
+        project_id="vnx-dev",
+    )
+    update_obligation(path, attempts=runner._UNRESOLVABLE_ESCALATION_ATTEMPTS - 1)
+    monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: None)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0, "escalated obligation is terminal, not still open"
+    record = _read_obligation(state_dir, "20260816-s1fix-escalate")
+    assert record["status"] == STATUS_NOT_EXECUTABLE
+    assert record["reason"] == "unresolvable_timeout"
+    assert "VNX_PROJECT_ID" in record["reason_detail"]
 
 
 def test_runner_never_refires_terminal_obligations(tmp_path, monkeypatch):

--- a/tests/test_oi897_bare_repo_data_dir.py
+++ b/tests/test_oi897_bare_repo_data_dir.py
@@ -32,6 +32,7 @@ for p in (LIB, ROOT):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
+import project_root  # noqa: E402
 import vnx_paths  # noqa: E402
 
 
@@ -163,3 +164,74 @@ class TestBareRepoHorizonList:
         result = _run_horizon_list(bare_repo, central_home)
         assert "VNXDataDirMismatchWarning" not in result.stderr
         assert "does not belong to project" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Unit: local-filesystem origins are not project identities (OI-1253)
+# ---------------------------------------------------------------------------
+
+def _repo_with_origin(tmp_path: Path, origin: str, name: str = "repo") -> Path:
+    """A git repo whose ``origin`` remote is set to ``origin`` (no clone needed —
+    ``git remote add`` does not validate local paths)."""
+    repo = tmp_path / name
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "remote", "add", "origin", origin], cwd=repo, check=True)
+    return repo
+
+
+class TestGitRemoteOriginRefusal:
+    """A central install's git origin is not a project identity.
+
+    The release route clones the install from a temp checkout dir
+    (``vnx release publish`` passes it as ``--source``), so the install's
+    ``origin`` is a dangling path like ``/var/folders/.../checkout``. Its
+    basename must never become a project_id — otherwise every script running
+    from the install resolves to the fabricated store ``~/.vnx-data/checkout``.
+    """
+
+    def test_temp_dir_origin_yields_no_project_id(self, tmp_path):
+        temp_origin = tmp_path / "vnx-release-nnksecu" / "checkout"
+        repo = _repo_with_origin(tmp_path, str(temp_origin), name="temp-repo")
+        assert vnx_paths._project_id_from_git_remote(repo) is None
+
+    def test_nonexistent_path_origin_yields_no_project_id(self, tmp_path):
+        gone = tmp_path / "gone" / "checkout"
+        repo = _repo_with_origin(tmp_path, str(gone), name="gone-repo")
+        assert vnx_paths._project_id_from_git_remote(repo) is None
+
+    def test_ssh_project_remote_still_resolves(self, tmp_path):
+        repo = _repo_with_origin(
+            tmp_path, "git@github.com:Vinix24/vnx-dev.git", name="ssh-repo",
+        )
+        assert vnx_paths._project_id_from_git_remote(repo) == "vnx-dev"
+
+    def test_https_project_remote_still_resolves(self, tmp_path):
+        repo = _repo_with_origin(
+            tmp_path, "https://github.com/Vinix24/seocrawler-v2.git", name="https-repo",
+        )
+        assert vnx_paths._project_id_from_git_remote(repo) == "seocrawler-v2"
+
+    def test_file_url_origin_yields_no_project_id(self, tmp_path):
+        repo = _repo_with_origin(
+            tmp_path, f"file://{tmp_path}/source/checkout", name="fileurl-repo",
+        )
+        assert vnx_paths._project_id_from_git_remote(repo) is None
+
+    def test_resolve_project_id_refuses_local_path_origin(self, tmp_path, monkeypatch):
+        """project_root.resolve_project_id (the data_dir_guard fallback) must
+        refuse the same local-path origin, not derive ``checkout``."""
+        temp_origin = tmp_path / "vnx-release-nnksecu" / "checkout"
+        repo = _repo_with_origin(tmp_path, str(temp_origin), name="pid-temp-repo")
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        monkeypatch.chdir(repo)
+        with pytest.raises(RuntimeError):
+            project_root.resolve_project_id()
+
+    def test_resolve_project_id_ssh_remote_still_resolves(self, tmp_path, monkeypatch):
+        repo = _repo_with_origin(
+            tmp_path, "git@github.com:Vinix24/vnx-dev.git", name="pid-ssh-repo",
+        )
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        monkeypatch.chdir(repo)
+        assert project_root.resolve_project_id() == "vnx-dev"

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -723,12 +723,15 @@ def vnx_init(args) -> int:
         return 1
 
 
-def _install_gate_obligation_runner(vnx_home: str) -> bool:
+def _install_gate_obligation_runner(vnx_home: str, project_id: str = "") -> bool:
     """Install the gate-obligation-runner launchd plist (OI-917).
 
     Reads the plist template from the engine root's scripts/launchd/ directory,
-    substitutes ``${VNX_HOME}`` with the resolved VNX home path, writes
-    atomically to ``~/Library/LaunchAgents/``, and loads via launchctl.
+    substitutes ``${VNX_HOME}`` with the resolved VNX home path and
+    ``${VNX_PROJECT_ID}`` with the project's id (OI-1253 fix-forward: the job
+    identifies its project via VNX_PROJECT_ID, one instance per project, never
+    via a hardcoded store path), writes atomically to ``~/Library/LaunchAgents/``,
+    and loads via launchctl.
 
     Returns True if the plist was installed or reloaded.
     Returns False if the template does not exist (not a VNX orchestration repo
@@ -776,6 +779,7 @@ def _install_gate_obligation_runner(vnx_home: str) -> bool:
 
     content = template.read_text(encoding="utf-8")
     content = content.replace("${VNX_HOME}", vnx_home)
+    content = content.replace("${VNX_PROJECT_ID}", project_id)
 
     fd, tmp_name = tempfile.mkstemp(dir=str(dest_dir), suffix=".tmp")
     try:
@@ -937,7 +941,9 @@ def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) ->
     print()
     print("Installing launchd agents...")
     try:
-        installed = _install_gate_obligation_runner(str(_engine.engine_root()))
+        installed = _install_gate_obligation_runner(
+            str(_engine.engine_root()), project_id=project_id
+        )
         if not installed:
             print("  skipped gate-obligation-runner (plist template not found)")
     except (OSError, RuntimeError) as exc:


### PR DESCRIPTION
## Wat er misging

De centrale VNX-install (`~/.vnx-system/current` → `versions/v1.5.0`) heeft een git-origin die naar een opgeruimde release-temp-checkout wijst:

```
/var/folders/q5/n9hzhbvx3zv05t09g426yblh0000gn/T/vnx-release-nnksecu_/checkout
```

`_project_id_from_git_remote` nam daarvan de basename en fabriceerde `project_id = "checkout"`. Daardoor resolveerde `gate_obligation_runner.py` `VNX_STATE_DIR=~/.vnx-data/checkout/state` (bestaat niet) en exit 20, elk kwartier.

## De fix

- **`project_root.is_local_path_origin()`** — nieuw shared helper: een lokale-pad-origin (absoluut pad, `~`, Windows-drive, `file://`) is geen project-identiteit.
- **`_project_id_from_git_remote`** en **`resolve_project_id`** weigeren beide zo'n origin. De tweede was een tweede, nog niet gefixt pad: de `data_dir_guard` riep `resolve_project_id()` aan en bleef zelfstandig "checkout" afleiden (spookwaarschuwing).
- **`gate_obligation_runner`** faalt nu LOUD (`UnresolvableProjectError`, exit 20) als er geen project_id resolveert, in plaats van stilletjes naar een project-lokale store te schrijven. Exit 20 treedt niet meer op om de "checkout"-reden.
- **plist-template** pint de store expliciet: `--state-dir "$HOME/.vnx-data/vnx-dev/state"`.

Collision-safety (`vnx_paths.py` `_resolve_state_root`) blijft intact: onoplosbaar project_id valt terug naar project-lokaal, nooit een gedeelde store.

## Bewijs (centrale install, launchd-env `env -i`)

Vóór: `project_id='checkout'`, `VNX_STATE_DIR=~/.vnx-data/checkout/state`.
Ná: `project_id=None`, `VNX_STATE_DIR=<install>/.vnx-data/state` (geen "checkout" meer). Runner zonder `--state-dir` → exit 20 met actie-melding; runner met `--state-dir ~/.vnx-data/vnx-dev/state` → exit 11 tegen de echte store.

## Tests

16 gerichte tests + 177 directe buren groen (1 pre-existing DeprecationWarning).

## Operatorstap (niet in deze PR)

De geïnstalleerde `~/Library/LaunchAgents/com.vnx.gate-obligation-runner.plist` moet dezelfde `--state-dir` toevoegen en herladen met `launchctl`. De repo-template is aangepast; de al geïnstalleerde plist is operatorwerk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)