### PR TITLE
feat(analyzer): distinguish deep-analysis failure modes from a bare zero (OI-1258)

### DIFF
--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -430,6 +430,8 @@ CREATE TABLE IF NOT EXISTS nightly_digests (
     digest_date DATE NOT NULL UNIQUE,
     sessions_analyzed INTEGER DEFAULT 0,
     deep_analyzed INTEGER DEFAULT 0,
+    deep_attempts INTEGER DEFAULT 0,
+    deep_failures INTEGER DEFAULT 0,
     new_suggestions INTEGER DEFAULT 0,
     total_tokens_used INTEGER DEFAULT 0,
     digest_markdown TEXT NOT NULL,

--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -432,6 +432,7 @@ CREATE TABLE IF NOT EXISTS nightly_digests (
     deep_analyzed INTEGER DEFAULT 0,
     deep_attempts INTEGER DEFAULT 0,
     deep_failures INTEGER DEFAULT 0,
+    deep_config_skips INTEGER DEFAULT 0,
     new_suggestions INTEGER DEFAULT 0,
     total_tokens_used INTEGER DEFAULT 0,
     digest_markdown TEXT NOT NULL,

--- a/scripts/conversation_analyzer.py
+++ b/scripts/conversation_analyzer.py
@@ -72,15 +72,21 @@ def main():
         # exit code, so a night where the whole pipeline failed still reported
         # launchd status 0 — the silent-failure pattern this chain exists to catch.
         if fail_closed_exit_code(stats):
-            log("ERROR", f"All sessions failed ({stats.errors} errors, 0 analyzed); returning non-zero exit")
+            if stats.deep_attempts > 0 and stats.deep_failures >= stats.deep_attempts:
+                run_error = (f"deep analysis failed on all {stats.deep_attempts} attempts")
+            else:
+                run_error = f"all sessions failed ({stats.errors} errors, 0 analyzed)"
+            log("ERROR", f"{run_error}; returning non-zero exit")
             run_status = "fail"
-            run_error = f"all sessions failed ({stats.errors} errors, 0 analyzed)"
             rc = 1
     finally:
         analyzer.close()
         try:
             from health_beacon import HealthBeacon
             details = {"max_sessions": args.max_sessions, "dry_run": args.dry_run}
+            if stats is not None:
+                details["deep_attempts"] = stats.deep_attempts
+                details["deep_failures"] = stats.deep_failures
             if run_error:
                 details["error"] = run_error
             HealthBeacon(

--- a/scripts/conversation_analyzer/deep_analyzer.py
+++ b/scripts/conversation_analyzer/deep_analyzer.py
@@ -24,28 +24,40 @@ from provider_spawns.deepseek_harness_spawn import (
 
 
 @dataclass(frozen=True)
-class ClaudeOutcome:
-    """Result of one ``claude`` CLI invocation, with the failure mode explicit.
+class LLMOutcome:
+    """Result of one LLM-invocation attempt, with the failure mode explicit.
 
     ``status`` is one of:
-      - ``ok``          — CLI succeeded (rc 0) and produced usable text
-      - ``empty``       — CLI succeeded (rc 0) but produced no usable text
-      - ``missing_cli`` — claude binary absent from PATH (FileNotFoundError)
-      - ``cli_failed``  — claude exited non-zero (``returncode`` + ``stderr``)
-      - ``timeout``     — claude exceeded the 90s deadline
-      - ``error``       — any other unexpected exception
+      - ``ok``           — call succeeded and produced usable text
+      - ``empty``        — call succeeded (rc 0) but produced no usable text
+      - ``missing_cli``  — claude binary absent from PATH (FileNotFoundError)
+      - ``cli_failed``   — claude exited non-zero (``returncode`` + ``stderr``)
+      - ``timeout``      — call exceeded its deadline
+      - ``error``        — any other unexpected exception
+      - ``config_skip``  — no invocation was ever made: a config gap (missing
+                           API key, unreachable/unconfigured Ollama) refused
+                           the attempt before any subprocess started
 
     ``text`` carries the assistant output for ``ok`` (and the raw stdout for
-    ``empty``, kept for diagnostics). A caller can tell all six apart without
-    parsing logs — the gap the old ``Optional[str]`` return left open, where a
-    missing CLI, a crashed CLI, and a successful-but-empty run all collapsed to
-    ``None`` (OI-1258).
+    ``empty``, kept for diagnostics). A caller can tell every mode apart
+    without parsing logs — the gap the old ``Optional[str]`` return left open,
+    where a missing CLI, a crashed CLI, and a successful-but-empty run all
+    collapsed to ``None`` (OI-1258).
+
+    ``attempted`` is derived from ``status``: every status reflects a real
+    invocation that fired except ``config_skip``, which by definition never
+    started one. This is what distinguishes a failed attempt from a skipped
+    one (fix1585-r2): a config gap must not count as "tried and failed".
     """
 
     status: str
     text: Optional[str] = None
     returncode: Optional[int] = None
     stderr: str = ""
+
+    @property
+    def attempted(self) -> bool:
+        return self.status != "config_skip"
 
 
 class DeepAnalyzer:
@@ -73,6 +85,11 @@ class DeepAnalyzer:
         # digest counter spans claude, deepseek-harness, and ollama paths.
         self.deep_attempts = 0
         self.deep_failures = 0
+        # fix1585-r2: sessions where every candidate strategy refused before
+        # invoking anything (missing DEEPSEEK_API_KEY, no usable Ollama model
+        # or server) — a config gap, not a failed attempt. Kept separate from
+        # ``deep_attempts``/``deep_failures`` so it never fail-closes the run.
+        self.deep_config_skips = 0
 
     SYSTEM_PROMPT = """You are a VNX orchestration system analyst. Analyze this Claude Code session summary and extract actionable improvement suggestions.
 
@@ -119,29 +136,32 @@ Respond with valid JSON:
         prompt = f"{self.SYSTEM_PROMPT}\n\n## Session Summary\n\n{summary}"
 
         result_text = None
-        # ``attempted`` records whether an LLM was actually invoked this
-        # session. It stays False for the billing-guard skip (no LLM called),
-        # so a deliberate skip never counts as a failed attempt.
-        attempted = False
+        # ``any_attempted`` records whether an LLM was actually invoked this
+        # session — derived from each candidate's own LLMOutcome.attempted,
+        # not from which branch was merely tried. A config gap (missing
+        # DEEPSEEK_API_KEY, no usable Ollama model/server) refuses before any
+        # subprocess starts, so it must never flip this to True (fix1585-r2).
+        any_attempted = False
 
         # deepseek-harness: own-key auth via the claude CLI driving DeepSeek's
         # Anthropic-compatible endpoint.  Fails closed when DEEPSEEK_API_KEY is
         # unset — never falls back to the OAuth subscription (constraint
         # deepseek-harness-subscription-blocked).
         if LLM_STRATEGY == "deepseek-harness":
-            attempted = True
-            result_text = self._try_deepseek_harness(prompt)
+            outcome = self._try_deepseek_harness(prompt)
+            any_attempted = any_attempted or outcome.attempted
+            result_text = outcome.text if outcome.status == "ok" else None
         # Billing guard: in "auto" mode, refuse the claude path when the
         # session backlog exceeds the threshold. "claude-only" bypasses
         # the guard — the operator explicitly opted in to metered spend.
         elif LLM_STRATEGY == "claude-only":
-            attempted = True
             outcome = self._try_claude_max(prompt)
+            any_attempted = any_attempted or outcome.attempted
             result_text = outcome.text if outcome.status == "ok" else None
         elif LLM_STRATEGY == "auto":
             if self._session_backlog <= AUTO_CLAUSE_MAX_SESSIONS:
-                attempted = True
                 outcome = self._try_claude_max(prompt)
+                any_attempted = any_attempted or outcome.attempted
                 result_text = outcome.text if outcome.status == "ok" else None
             else:
                 if self._session_backlog > 0:
@@ -152,23 +172,31 @@ Respond with valid JSON:
                         f"Use VNX_ANALYZER_LLM=claude-only to override.")
 
         if result_text is None and LLM_STRATEGY in ("auto", "ollama-only"):
-            attempted = True
-            result_text = self._try_ollama(prompt)
+            outcome = self._try_ollama(prompt)
+            any_attempted = any_attempted or outcome.attempted
+            result_text = outcome.text if outcome.status == "ok" else None
 
-        if attempted:
+        if any_attempted:
             self.deep_attempts += 1
+        else:
+            # No candidate strategy ever invoked an LLM this session — every
+            # branch that ran refused on a config gap. That is a skipped
+            # attempt, not a failed one (fix1585-r2).
+            self.deep_config_skips += 1
 
         if result_text is None:
-            if attempted:
+            if any_attempted:
                 self.deep_failures += 1
-            log("WARNING", "No LLM available for deep analysis")
+                log("WARNING", "No LLM available for deep analysis")
             return None
 
         parsed = self._parse_response(result_text)
-        if parsed is None:
-            # The LLM answered but nothing parseable came back — an attempt
-            # that produced no usable result, distinct from a hard failure.
+        if parsed is None or "suggestions" not in parsed:
+            # The LLM answered but nothing parseable — or no "suggestions"
+            # key — came back: an attempt that produced no usable result,
+            # distinct from a hard failure but still not success.
             self.deep_failures += 1
+            return None
         return parsed
 
     @classmethod
@@ -271,7 +299,7 @@ Respond with valid JSON:
         return "\n".join(lines)
 
     @staticmethod
-    def _try_claude_max(prompt: str) -> ClaudeOutcome:
+    def _try_claude_max(prompt: str) -> LLMOutcome:
         try:
             result = subprocess.run(
                 ["claude", "-p", "--output-format", "json", "--max-turns", "1"],
@@ -285,20 +313,20 @@ Respond with valid JSON:
             # profile, so this is a distinct failure from a binary that runs
             # and then errors out (OI-1258).
             log("ERROR", "Claude CLI not found on PATH")
-            return ClaudeOutcome("missing_cli")
+            return LLMOutcome("missing_cli")
         except subprocess.TimeoutExpired:
             log("ERROR", "Claude CLI timed out after 90s")
-            return ClaudeOutcome("timeout")
+            return LLMOutcome("timeout")
         except Exception as e:
             log("ERROR", f"Claude CLI error: {e}")
-            return ClaudeOutcome("error", stderr=str(e))
+            return LLMOutcome("error", stderr=str(e))
 
         if result.returncode != 0:
             snippet = (result.stderr or "").strip()[:200]
             log("ERROR",
                 f"Claude CLI failed (rc={result.returncode}): {snippet}")
-            return ClaudeOutcome("cli_failed",
-                                 returncode=result.returncode, stderr=snippet)
+            return LLMOutcome("cli_failed",
+                              returncode=result.returncode, stderr=snippet)
 
         try:
             output = json.loads(result.stdout)
@@ -308,19 +336,21 @@ Respond with valid JSON:
 
         if not (text or "").strip():
             log("ERROR", "Claude CLI succeeded (rc=0) but produced no usable text")
-            return ClaudeOutcome("empty", text=result.stdout)
+            return LLMOutcome("empty", text=result.stdout)
 
-        return ClaudeOutcome("ok", text=text)
+        return LLMOutcome("ok", text=text)
 
     @staticmethod
-    def _try_deepseek_harness(prompt: str) -> Optional[str]:
+    def _try_deepseek_harness(prompt: str) -> LLMOutcome:
         """Run deep analysis via the claude CLI driving DeepSeek's Anthropic-compatible endpoint.
 
         Uses the measured-safe key-auth recipe from
         ``provider_spawns.deepseek_harness_spawn``: own ``DEEPSEEK_API_KEY``,
         ``ANTHROPIC_AUTH_TOKEN`` bearer, telemetry suppressed.  Fails closed
         when no own key is available — never falls back to the OAuth
-        subscription (constraint deepseek-harness-subscription-blocked).
+        subscription (constraint deepseek-harness-subscription-blocked). A
+        missing key is a ``config_skip``, not an attempt: no subprocess is
+        ever started (fix1585-r2).
 
         Model is ``VNX_ANALYZER_DEEPSEEK_MODEL`` (default ``deepseek-v4-flash``).
         """
@@ -330,7 +360,7 @@ Respond with valid JSON:
                 f"{DEEPSEEK_API_KEY_ENV} not set; "
                 f"deepseek-harness requires own API key (account safety — "
                 f"the lane must never ride the OAuth subscription)")
-            return None
+            return LLMOutcome("config_skip")
 
         harness_env = build_harness_env(api_key)
         # Override model to the analyzer-specific default (flash, not pro).
@@ -352,28 +382,37 @@ Respond with valid JSON:
                 env=child_env,
             )
             if result.returncode != 0:
+                snippet = (result.stderr or "").strip()[:200]
                 log("WARNING", f"DeepSeek harness failed (rc={result.returncode}): "
-                               f"{result.stderr[:200]}")
-                return None
+                               f"{snippet}")
+                return LLMOutcome("cli_failed",
+                                  returncode=result.returncode, stderr=snippet)
             try:
                 output = json.loads(result.stdout)
-                return output.get("result", result.stdout)
+                text = output.get("result", result.stdout)
             except json.JSONDecodeError:
-                return result.stdout
+                text = result.stdout
+            if not (text or "").strip():
+                return LLMOutcome("empty", text=result.stdout)
+            return LLMOutcome("ok", text=text)
         except FileNotFoundError:
             log("INFO", "Claude CLI not found for deepseek-harness")
-            return None
+            return LLMOutcome("missing_cli")
         except subprocess.TimeoutExpired:
             log("WARNING", "DeepSeek harness timed out (120s)")
-            return None
+            return LLMOutcome("timeout")
         except Exception as e:
             log("WARNING", f"DeepSeek harness error: {e}")
-            return None
+            return LLMOutcome("error", stderr=str(e))
 
     @classmethod
-    def _try_ollama(cls, prompt: str) -> Optional[str]:
+    def _try_ollama(cls, prompt: str) -> LLMOutcome:
         if not cls._probe_ollama():
-            return None
+            # The probe already logs the specific reason (unreachable server,
+            # zero models, or the configured model missing) — no subprocess-
+            # equivalent call was ever issued, so this is a config_skip, not
+            # an attempted-and-failed call (fix1585-r2).
+            return LLMOutcome("config_skip")
         try:
             import urllib.request
             payload = json.dumps({
@@ -390,10 +429,14 @@ Respond with valid JSON:
             )
             with urllib.request.urlopen(req, timeout=120) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
-                return body.get("response", "")
+                text = body.get("response", "")
         except Exception as e:
             log("INFO", f"Ollama not available: {e}")
-            return None
+            return LLMOutcome("error", stderr=str(e))
+
+        if not (text or "").strip():
+            return LLMOutcome("empty", text=text)
+        return LLMOutcome("ok", text=text)
 
     @staticmethod
     def _parse_response(text: str) -> Optional[dict]:

--- a/scripts/conversation_analyzer/deep_analyzer.py
+++ b/scripts/conversation_analyzer/deep_analyzer.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -22,6 +23,31 @@ from provider_spawns.deepseek_harness_spawn import (
 )
 
 
+@dataclass(frozen=True)
+class ClaudeOutcome:
+    """Result of one ``claude`` CLI invocation, with the failure mode explicit.
+
+    ``status`` is one of:
+      - ``ok``          — CLI succeeded (rc 0) and produced usable text
+      - ``empty``       — CLI succeeded (rc 0) but produced no usable text
+      - ``missing_cli`` — claude binary absent from PATH (FileNotFoundError)
+      - ``cli_failed``  — claude exited non-zero (``returncode`` + ``stderr``)
+      - ``timeout``     — claude exceeded the 90s deadline
+      - ``error``       — any other unexpected exception
+
+    ``text`` carries the assistant output for ``ok`` (and the raw stdout for
+    ``empty``, kept for diagnostics). A caller can tell all six apart without
+    parsing logs — the gap the old ``Optional[str]`` return left open, where a
+    missing CLI, a crashed CLI, and a successful-but-empty run all collapsed to
+    ``None`` (OI-1258).
+    """
+
+    status: str
+    text: Optional[str] = None
+    returncode: Optional[int] = None
+    stderr: str = ""
+
+
 class DeepAnalyzer:
     """LLM-based deep analysis of flagged sessions."""
 
@@ -36,6 +62,17 @@ class DeepAnalyzer:
     # Claude-auto guard: set by the runner before processing sessions to
     # inform the billing guard of the backlog size.
     _session_backlog: int = 0
+
+    def __init__(self) -> None:
+        # OI-1258: per-run attempt accounting, distinct from the success-only
+        # ``sessions_deep`` counter. ``deep_attempts`` counts sessions where an
+        # LLM was actually invoked; ``deep_failures`` counts those that produced
+        # no usable result. Together they make a ``deep_analyzed=0`` digest
+        # interpretable: 0 attempts ("nothing was tried") vs N attempts with N
+        # failures ("everything failed"). Strategy-agnostic on purpose — the
+        # digest counter spans claude, deepseek-harness, and ollama paths.
+        self.deep_attempts = 0
+        self.deep_failures = 0
 
     SYSTEM_PROMPT = """You are a VNX orchestration system analyst. Analyze this Claude Code session summary and extract actionable improvement suggestions.
 
@@ -82,21 +119,30 @@ Respond with valid JSON:
         prompt = f"{self.SYSTEM_PROMPT}\n\n## Session Summary\n\n{summary}"
 
         result_text = None
+        # ``attempted`` records whether an LLM was actually invoked this
+        # session. It stays False for the billing-guard skip (no LLM called),
+        # so a deliberate skip never counts as a failed attempt.
+        attempted = False
 
         # deepseek-harness: own-key auth via the claude CLI driving DeepSeek's
         # Anthropic-compatible endpoint.  Fails closed when DEEPSEEK_API_KEY is
         # unset — never falls back to the OAuth subscription (constraint
         # deepseek-harness-subscription-blocked).
         if LLM_STRATEGY == "deepseek-harness":
+            attempted = True
             result_text = self._try_deepseek_harness(prompt)
         # Billing guard: in "auto" mode, refuse the claude path when the
         # session backlog exceeds the threshold. "claude-only" bypasses
         # the guard — the operator explicitly opted in to metered spend.
         elif LLM_STRATEGY == "claude-only":
-            result_text = self._try_claude_max(prompt)
+            attempted = True
+            outcome = self._try_claude_max(prompt)
+            result_text = outcome.text if outcome.status == "ok" else None
         elif LLM_STRATEGY == "auto":
             if self._session_backlog <= AUTO_CLAUSE_MAX_SESSIONS:
-                result_text = self._try_claude_max(prompt)
+                attempted = True
+                outcome = self._try_claude_max(prompt)
+                result_text = outcome.text if outcome.status == "ok" else None
             else:
                 if self._session_backlog > 0:
                     log("WARNING",
@@ -106,13 +152,24 @@ Respond with valid JSON:
                         f"Use VNX_ANALYZER_LLM=claude-only to override.")
 
         if result_text is None and LLM_STRATEGY in ("auto", "ollama-only"):
+            attempted = True
             result_text = self._try_ollama(prompt)
 
+        if attempted:
+            self.deep_attempts += 1
+
         if result_text is None:
+            if attempted:
+                self.deep_failures += 1
             log("WARNING", "No LLM available for deep analysis")
             return None
 
-        return self._parse_response(result_text)
+        parsed = self._parse_response(result_text)
+        if parsed is None:
+            # The LLM answered but nothing parseable came back — an attempt
+            # that produced no usable result, distinct from a hard failure.
+            self.deep_failures += 1
+        return parsed
 
     @classmethod
     def set_session_backlog(cls, count: int):
@@ -214,7 +271,7 @@ Respond with valid JSON:
         return "\n".join(lines)
 
     @staticmethod
-    def _try_claude_max(prompt: str) -> Optional[str]:
+    def _try_claude_max(prompt: str) -> ClaudeOutcome:
         try:
             result = subprocess.run(
                 ["claude", "-p", "--output-format", "json", "--max-turns", "1"],
@@ -223,23 +280,37 @@ Respond with valid JSON:
                 text=True,
                 timeout=90,
             )
-            if result.returncode != 0:
-                log("WARNING", f"Claude CLI failed: {result.stderr[:200]}")
-                return None
-            try:
-                output = json.loads(result.stdout)
-                return output.get("result", result.stdout)
-            except json.JSONDecodeError:
-                return result.stdout
         except FileNotFoundError:
-            log("INFO", "Claude CLI not found")
-            return None
+            # The binary is absent from PATH — a launchd job inherits no shell
+            # profile, so this is a distinct failure from a binary that runs
+            # and then errors out (OI-1258).
+            log("ERROR", "Claude CLI not found on PATH")
+            return ClaudeOutcome("missing_cli")
         except subprocess.TimeoutExpired:
-            log("WARNING", "Claude CLI timed out")
-            return None
+            log("ERROR", "Claude CLI timed out after 90s")
+            return ClaudeOutcome("timeout")
         except Exception as e:
-            log("WARNING", f"Claude CLI error: {e}")
-            return None
+            log("ERROR", f"Claude CLI error: {e}")
+            return ClaudeOutcome("error", stderr=str(e))
+
+        if result.returncode != 0:
+            snippet = (result.stderr or "").strip()[:200]
+            log("ERROR",
+                f"Claude CLI failed (rc={result.returncode}): {snippet}")
+            return ClaudeOutcome("cli_failed",
+                                 returncode=result.returncode, stderr=snippet)
+
+        try:
+            output = json.loads(result.stdout)
+            text = output.get("result", result.stdout)
+        except json.JSONDecodeError:
+            text = result.stdout
+
+        if not (text or "").strip():
+            log("ERROR", "Claude CLI succeeded (rc=0) but produced no usable text")
+            return ClaudeOutcome("empty", text=result.stdout)
+
+        return ClaudeOutcome("ok", text=text)
 
     @staticmethod
     def _try_deepseek_harness(prompt: str) -> Optional[str]:

--- a/scripts/conversation_analyzer/generator.py
+++ b/scripts/conversation_analyzer/generator.py
@@ -19,6 +19,7 @@ class DigestGenerator:
             "## Samenvatting",
             f"- **{run_stats.sessions_analyzed}** sessies geanalyseerd",
             f"- **{run_stats.sessions_deep}** sessies diep geanalyseerd (LLM)",
+            f"- **{run_stats.deep_attempts}** diepte-pogingen, **{run_stats.deep_failures}** zonder bruikbaar resultaat",
             f"- **{len(run_stats.suggestions)}** nieuwe verbeter-suggesties",
             f"- **{run_stats.total_tokens:,}** output tokens totaal",
             "",

--- a/scripts/conversation_analyzer/models.py
+++ b/scripts/conversation_analyzer/models.py
@@ -134,6 +134,8 @@ class SessionFlags:
 class RunStats:
     sessions_analyzed: int = 0
     sessions_deep: int = 0
+    deep_attempts: int = 0
+    deep_failures: int = 0
     total_tokens: int = 0
     errors: int = 0
     skipped: int = 0
@@ -141,7 +143,7 @@ class RunStats:
 
 
 def fail_closed_exit_code(stats: "RunStats | None") -> int:
-    """Return a non-zero exit code when the run failed closed (OI-862).
+    """Return a non-zero exit code when the run failed closed (OI-862, OI-1258).
 
     A run whose every session errored is a failed run and must not exit 0:
     the per-session exception handler in the runner already counted the
@@ -149,7 +151,17 @@ def fail_closed_exit_code(stats: "RunStats | None") -> int:
     session would otherwise report launchd status 0 — the same silent-failure
     pattern this chain exists to catch. Partial runs (some sessions analyzed)
     stay green so a single session hiccup does not alarm the nightly job.
+
+    OI-1258 adds the deep-analysis half of the same failure: a run that
+    attempted deep analysis on N sessions and produced no usable result on
+    any of them also exits non-zero. Without it, a night where every deep
+    call failed read as "deep_analyzed=0" — indistinguishable from "nothing
+    was tried" — and launchd stayed green.
     """
-    if stats is not None and stats.errors > 0 and stats.sessions_analyzed == 0:
+    if stats is None:
+        return 0
+    if stats.errors > 0 and stats.sessions_analyzed == 0:
+        return 1
+    if stats.deep_attempts > 0 and stats.deep_failures >= stats.deep_attempts:
         return 1
     return 0

--- a/scripts/conversation_analyzer/models.py
+++ b/scripts/conversation_analyzer/models.py
@@ -136,6 +136,7 @@ class RunStats:
     sessions_deep: int = 0
     deep_attempts: int = 0
     deep_failures: int = 0
+    deep_config_skips: int = 0
     total_tokens: int = 0
     errors: int = 0
     skipped: int = 0

--- a/scripts/conversation_analyzer/runner.py
+++ b/scripts/conversation_analyzer/runner.py
@@ -275,11 +275,13 @@ class ConversationAnalyzer:
         cur.execute("""
             INSERT OR REPLACE INTO nightly_digests (
                 digest_date, sessions_analyzed, deep_analyzed,
+                deep_attempts, deep_failures,
                 new_suggestions, total_tokens_used,
                 digest_markdown, digest_path
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             run_date, stats.sessions_analyzed, stats.sessions_deep,
+            stats.deep_attempts, stats.deep_failures,
             len(stats.suggestions), stats.total_tokens,
             markdown, str(digest_path),
         ))
@@ -312,6 +314,12 @@ class ConversationAnalyzer:
             log("ANALYZE", f"[{i}/{len(sessions)}] {jsonl_path.parent.name}/{jsonl_path.name}")
             deep_remaining = self._process_one_session(
                 jsonl_path, dry_run, deep_remaining, stats, session_rows)
+
+        # OI-1258: copy the analyzer's per-run attempt accounting into the run
+        # stats so the digest, DB row, and fail-closed exit code all see the
+        # attempts/failures alongside the success-only ``sessions_deep``.
+        stats.deep_attempts = self.deep.deep_attempts
+        stats.deep_failures = self.deep.deep_failures
 
         if not dry_run:
             self._finalize_run(stats, session_rows, run_date)
@@ -360,6 +368,8 @@ class ConversationAnalyzer:
         print(f"{'=' * 70}{Colors.RESET}\n")
         print(f"Sessions Analyzed: {stats.sessions_analyzed}")
         print(f"Deep Analyzed:     {stats.sessions_deep}")
+        print(f"Deep Attempts:     {stats.deep_attempts}")
+        print(f"Deep Failures:     {stats.deep_failures}")
         print(f"Suggestions:       {len(stats.suggestions)}")
         print(f"Total Tokens:      {stats.total_tokens:,}")
         print(f"Errors:            {stats.errors}")

--- a/scripts/conversation_analyzer/runner.py
+++ b/scripts/conversation_analyzer/runner.py
@@ -275,13 +275,13 @@ class ConversationAnalyzer:
         cur.execute("""
             INSERT OR REPLACE INTO nightly_digests (
                 digest_date, sessions_analyzed, deep_analyzed,
-                deep_attempts, deep_failures,
+                deep_attempts, deep_failures, deep_config_skips,
                 new_suggestions, total_tokens_used,
                 digest_markdown, digest_path
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             run_date, stats.sessions_analyzed, stats.sessions_deep,
-            stats.deep_attempts, stats.deep_failures,
+            stats.deep_attempts, stats.deep_failures, stats.deep_config_skips,
             len(stats.suggestions), stats.total_tokens,
             markdown, str(digest_path),
         ))
@@ -320,6 +320,7 @@ class ConversationAnalyzer:
         # attempts/failures alongside the success-only ``sessions_deep``.
         stats.deep_attempts = self.deep.deep_attempts
         stats.deep_failures = self.deep.deep_failures
+        stats.deep_config_skips = self.deep.deep_config_skips
 
         if not dry_run:
             self._finalize_run(stats, session_rows, run_date)
@@ -370,6 +371,7 @@ class ConversationAnalyzer:
         print(f"Deep Analyzed:     {stats.sessions_deep}")
         print(f"Deep Attempts:     {stats.deep_attempts}")
         print(f"Deep Failures:     {stats.deep_failures}")
+        print(f"Deep Config Skips: {stats.deep_config_skips}")
         print(f"Suggestions:       {len(stats.suggestions)}")
         print(f"Total Tokens:      {stats.total_tokens:,}")
         print(f"Errors:            {stats.errors}")

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -29,7 +29,7 @@ from db_backup_rotation import parse_backup_keep, rotate_backups_safe
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 29
+HIGHEST_QI_VERSION = 30
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -1600,6 +1600,25 @@ def _migrate_v29(conn: sqlite3.Connection) -> None:
         log('INFO', f'Backfilled project_id for {null_count} legacy session_analytics rows')
 
 
+def _migrate_v30(conn: sqlite3.Connection) -> None:
+    """V30: nightly_digests deep_attempts + deep_failures columns (OI-1258).
+
+    The digest recorded only ``deep_analyzed`` — a success-only count. A digest
+    of ``deep_analyzed=0`` was uninterpretable: it read as "nothing was tried"
+    but could equally mean "N attempts, all failed". Add the attempt and
+    failure counts so a zero success count can be read against its cause.
+    """
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(nightly_digests)").fetchall()}
+    if "deep_attempts" not in cols:
+        conn.execute(
+            "ALTER TABLE nightly_digests ADD COLUMN deep_attempts INTEGER DEFAULT 0"
+        )
+    if "deep_failures" not in cols:
+        conn.execute(
+            "ALTER TABLE nightly_digests ADD COLUMN deep_failures INTEGER DEFAULT 0"
+        )
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -1631,6 +1650,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     27: _migrate_v27,
     28: _migrate_v28,
     29: _migrate_v29,
+    30: _migrate_v30,
 }
 
 

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -29,7 +29,7 @@ from db_backup_rotation import parse_backup_keep, rotate_backups_safe
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 30
+HIGHEST_QI_VERSION = 31
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -1619,6 +1619,22 @@ def _migrate_v30(conn: sqlite3.Connection) -> None:
         )
 
 
+def _migrate_v31(conn: sqlite3.Connection) -> None:
+    """V31: nightly_digests deep_config_skips column (fix1585-r2).
+
+    A config gap (missing DEEPSEEK_API_KEY, missing/unavailable ollama model,
+    unreachable ollama server) was previously indistinguishable from a real
+    failed attempt — it folded into ``deep_attempts``/``deep_failures`` and
+    fail-closed the nightly run over nothing that was ever tried. This column
+    lets a config-gap night be told apart from a genuine deep-analysis failure.
+    """
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(nightly_digests)").fetchall()}
+    if "deep_config_skips" not in cols:
+        conn.execute(
+            "ALTER TABLE nightly_digests ADD COLUMN deep_config_skips INTEGER DEFAULT 0"
+        )
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -1651,6 +1667,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     28: _migrate_v28,
     29: _migrate_v29,
     30: _migrate_v30,
+    31: _migrate_v31,
 }
 
 

--- a/tests/test_conversation_analyzer.py
+++ b/tests/test_conversation_analyzer.py
@@ -118,6 +118,7 @@ def _create_schema(conn: sqlite3.Connection):
             deep_analyzed INTEGER DEFAULT 0,
             deep_attempts INTEGER DEFAULT 0,
             deep_failures INTEGER DEFAULT 0,
+            deep_config_skips INTEGER DEFAULT 0,
             new_suggestions INTEGER DEFAULT 0,
             total_tokens_used INTEGER DEFAULT 0,
             digest_markdown TEXT NOT NULL,
@@ -391,13 +392,13 @@ class TestDeepAnalyzer:
 # Phase 3a: _try_claude_max outcome classification (OI-1258)
 # ---------------------------------------------------------------------------
 
-class TestClaudeOutcome:
+class TestLLMOutcome:
     """``_try_claude_max`` must return a distinct outcome per failure mode.
 
     The old ``Optional[str]`` return collapsed four different situations —
     missing CLI, crashed CLI, successful-but-empty, and successful-with-result —
     into a single ``None``. Each test below asserts a different
-    ``ClaudeOutcome.status`` so a caller can tell them apart without parsing logs.
+    ``LLMOutcome.status`` so a caller can tell them apart without parsing logs.
     """
 
     @staticmethod
@@ -416,6 +417,10 @@ class TestClaudeOutcome:
         outcome = self._run_outcome(side_effect=FileNotFoundError())
         assert outcome.status == "missing_cli"
         assert outcome.text is None
+        # A missing binary is a real invocation attempt (subprocess.run WAS
+        # called) that happened to fail — distinct from config_skip, where no
+        # call is ever made.
+        assert outcome.attempted is True
 
     def test_nonzero_rc_returns_cli_failed_with_rc_and_stderr(self):
         outcome = self._run_outcome(returncode=2, stderr="boom: something broke")
@@ -450,9 +455,16 @@ class TestClaudeOutcome:
         assert outcome.status == "error"
         assert "disk full" in outcome.stderr
 
+    def test_config_skip_status_is_not_attempted(self):
+        """``config_skip`` is the one status where no invocation ever fired."""
+        from conversation_analyzer.deep_analyzer import LLMOutcome
+        outcome = LLMOutcome("config_skip")
+        assert outcome.attempted is False
+
 
 class TestDeepAnalyzerCounter:
-    """``deep_attempts``/``deep_failures`` track invoked-vs-failed deep analysis."""
+    """``deep_attempts``/``deep_failures``/``deep_config_skips`` track
+    invoked-vs-failed-vs-never-invoked deep analysis (fix1585-r2)."""
 
     @staticmethod
     def _analyze_with_claude(outcome):
@@ -478,31 +490,153 @@ class TestDeepAnalyzerCounter:
             os.unlink(jsonl_path)
 
     def test_failed_attempt_counts_attempt_and_failure(self):
-        from conversation_analyzer.deep_analyzer import ClaudeOutcome
-        analyzer, result = self._analyze_with_claude(ClaudeOutcome("missing_cli"))
+        from conversation_analyzer.deep_analyzer import LLMOutcome
+        analyzer, result = self._analyze_with_claude(LLMOutcome("missing_cli"))
         assert result is None
         assert analyzer.deep_attempts == 1
         assert analyzer.deep_failures == 1
+        assert analyzer.deep_config_skips == 0
 
     def test_successful_attempt_counts_attempt_no_failure(self):
-        from conversation_analyzer.deep_analyzer import ClaudeOutcome
+        from conversation_analyzer.deep_analyzer import LLMOutcome
         analyzer, result = self._analyze_with_claude(
-            ClaudeOutcome("ok", text='{"suggestions":[]}')
+            LLMOutcome("ok", text='{"suggestions":[]}')
         )
         assert result is not None
         assert analyzer.deep_attempts == 1
         assert analyzer.deep_failures == 0
+        assert analyzer.deep_config_skips == 0
 
     def test_parseable_but_empty_result_counts_failure(self):
         # LLM answered but returned no parseable JSON — an attempt that
         # produced nothing usable, distinct from a hard CLI failure.
-        from conversation_analyzer.deep_analyzer import ClaudeOutcome
+        from conversation_analyzer.deep_analyzer import LLMOutcome
         analyzer, result = self._analyze_with_claude(
-            ClaudeOutcome("ok", text="no json here")
+            LLMOutcome("ok", text="no json here")
         )
         assert result is None
         assert analyzer.deep_attempts == 1
         assert analyzer.deep_failures == 1
+        assert analyzer.deep_config_skips == 0
+
+    def test_json_without_suggestions_key_counts_as_failure_not_success(self):
+        """A JSON reply that parses but lacks 'suggestions' is a silent-zero
+        on the other side of the same bug (advisory point, fix1585-r2): it
+        must count as a failed attempt, not slip through as a usable result."""
+        from conversation_analyzer.deep_analyzer import LLMOutcome
+        analyzer, result = self._analyze_with_claude(
+            LLMOutcome("ok", text='{"patterns": ["foo"], "bottlenecks": []}')
+        )
+        assert result is None
+        assert analyzer.deep_attempts == 1
+        assert analyzer.deep_failures == 1
+        assert analyzer.deep_config_skips == 0
+
+    def test_deepseek_harness_missing_key_is_config_skip_not_attempt(self):
+        """Live bug (fix1585-r2): deepseek-harness without DEEPSEEK_API_KEY
+        must not count as an attempted-and-failed session. This drives the
+        REAL ``_try_deepseek_harness`` production code (not a hand-built
+        outcome) so the test fails if the production skip check regresses —
+        it feeds the writing side, not a value invented on the checking side.
+        """
+        import conversation_analyzer.deep_analyzer as da_module
+
+        analyzer = DeepAnalyzer()
+        metrics = SessionMetrics(session_id="deepseek-nokey-test",
+                                  total_output_tokens=5000, tool_calls_total=20)
+        flags = SessionFlags()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write('{"type":"user","message":{"role":"user","content":"test"}}\n')
+            f.flush()
+            jsonl_path = Path(f.name)
+
+        try:
+            with patch.object(DeepAnalyzer, '_build_session_summary',
+                              return_value='test summary'), \
+                 patch.object(da_module, 'LLM_STRATEGY', 'deepseek-harness'), \
+                 patch.dict(da_module.os.environ, {}, clear=True):
+                result = analyzer.analyze_session(jsonl_path, metrics, flags)
+        finally:
+            os.unlink(jsonl_path)
+
+        assert result is None
+        assert analyzer.deep_attempts == 0, (
+            "a missing API key never started a subprocess — it must not "
+            "count as an attempt"
+        )
+        assert analyzer.deep_failures == 0, (
+            "no attempt was made, so there is nothing to count as a failure"
+        )
+        assert analyzer.deep_config_skips == 1
+
+    def test_ollama_probe_failure_is_config_skip_not_attempt(self):
+        """Live bug (fix1585-r2): ollama-only with a missing/wrong model (or
+        an unreachable server) must not count as an attempted-and-failed
+        session. Drives the REAL ``_try_ollama`` production code; only the
+        network-dependent probe is stubbed (no real Ollama server in CI) —
+        the config_skip classification itself is the production code path.
+        """
+        import conversation_analyzer.deep_analyzer as da_module
+
+        analyzer = DeepAnalyzer()
+        metrics = SessionMetrics(session_id="ollama-noprobe-test",
+                                  total_output_tokens=5000, tool_calls_total=20)
+        flags = SessionFlags()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write('{"type":"user","message":{"role":"user","content":"test"}}\n')
+            f.flush()
+            jsonl_path = Path(f.name)
+
+        try:
+            with patch.object(DeepAnalyzer, '_build_session_summary',
+                              return_value='test summary'), \
+                 patch.object(da_module, 'LLM_STRATEGY', 'ollama-only'), \
+                 patch.object(DeepAnalyzer, '_probe_ollama', return_value=False):
+                result = analyzer.analyze_session(jsonl_path, metrics, flags)
+        finally:
+            os.unlink(jsonl_path)
+
+        assert result is None
+        assert analyzer.deep_attempts == 0, (
+            "a failed probe never issued the generate call — it must not "
+            "count as an attempt"
+        )
+        assert analyzer.deep_failures == 0
+        assert analyzer.deep_config_skips == 1
+
+    def test_config_skip_run_stays_green_on_fail_closed_exit_code(self):
+        """The end-to-end point of fix1585-r2: a run where every flagged
+        session hit a config gap must not fail-close the nightly job. Feeds
+        fail_closed_exit_code with counters produced by the real
+        analyze_session() call above, not hand-crafted RunStats."""
+        from conversation_analyzer import fail_closed_exit_code, RunStats
+        import conversation_analyzer.deep_analyzer as da_module
+
+        analyzer = DeepAnalyzer()
+        metrics = SessionMetrics(session_id="deepseek-nokey-rc-test",
+                                  total_output_tokens=5000, tool_calls_total=20)
+        flags = SessionFlags()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write('{"type":"user","message":{"role":"user","content":"test"}}\n')
+            f.flush()
+            jsonl_path = Path(f.name)
+
+        try:
+            with patch.object(DeepAnalyzer, '_build_session_summary',
+                              return_value='test summary'), \
+                 patch.object(da_module, 'LLM_STRATEGY', 'deepseek-harness'), \
+                 patch.dict(da_module.os.environ, {}, clear=True):
+                analyzer.analyze_session(jsonl_path, metrics, flags)
+        finally:
+            os.unlink(jsonl_path)
+
+        stats = RunStats(sessions_analyzed=1, deep_attempts=analyzer.deep_attempts,
+                         deep_failures=analyzer.deep_failures,
+                         deep_config_skips=analyzer.deep_config_skips)
+        assert fail_closed_exit_code(stats) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -514,6 +648,7 @@ class TestDeepAnalyzerStrategy:
     def test_deepseek_harness_strategy_skips_claude_and_ollama(self):
         """LLM_STRATEGY=deepseek-harness calls only the harness path, not claude or ollama."""
         import conversation_analyzer.deep_analyzer as da_module
+        from conversation_analyzer.deep_analyzer import LLMOutcome
 
         analyzer = DeepAnalyzer()
         metrics = SessionMetrics(session_id="strat-test", total_output_tokens=5000,
@@ -530,7 +665,7 @@ class TestDeepAnalyzerStrategy:
             with patch.object(DeepAnalyzer, '_build_session_summary',
                               return_value='test summary'), \
                  patch.object(DeepAnalyzer, '_try_deepseek_harness',
-                              return_value=mock_result) as mock_harness, \
+                              return_value=LLMOutcome("ok", text=mock_result)) as mock_harness, \
                  patch.object(DeepAnalyzer, '_try_claude_max') as mock_claude, \
                  patch.object(DeepAnalyzer, '_try_ollama') as mock_ollama, \
                  patch.object(da_module, 'LLM_STRATEGY', 'deepseek-harness'):
@@ -542,11 +677,14 @@ class TestDeepAnalyzerStrategy:
                 mock_harness.assert_called_once()
                 mock_claude.assert_not_called()
                 mock_ollama.assert_not_called()
+                assert analyzer.deep_attempts == 1
+                assert analyzer.deep_config_skips == 0
         finally:
             os.unlink(jsonl_path)
 
     def test_deepseek_harness_fail_closed_without_key(self):
-        """_try_deepseek_harness returns None when DEEPSEEK_API_KEY is unset."""
+        """_try_deepseek_harness returns a config_skip outcome (no subprocess
+        started) when DEEPSEEK_API_KEY is unset."""
         # Consumer-namespace patch: the method reads os.environ at call time
         # inside deep_analyzer.py, so we patch os.environ in that module's
         # namespace to ensure the method sees the empty key.
@@ -554,7 +692,8 @@ class TestDeepAnalyzerStrategy:
 
         with patch.dict(da_module.os.environ, {}, clear=True):
             result = DeepAnalyzer._try_deepseek_harness("test prompt")
-            assert result is None
+            assert result.status == "config_skip"
+            assert result.attempted is False
 
     def test_deepseek_harness_model_default(self):
         """VNX_ANALYZER_DEEPSEEK_MODEL defaults to deepseek-v4-flash."""
@@ -564,6 +703,7 @@ class TestDeepAnalyzerStrategy:
     def test_ollama_only_strategy_still_works(self):
         """LLM_STRATEGY=ollama-only (default) still dispatches correctly (no regression)."""
         import conversation_analyzer.deep_analyzer as da_module
+        from conversation_analyzer.deep_analyzer import LLMOutcome
 
         analyzer = DeepAnalyzer()
         metrics = SessionMetrics(session_id="ollama-test", total_output_tokens=5000,
@@ -579,7 +719,7 @@ class TestDeepAnalyzerStrategy:
             with patch.object(DeepAnalyzer, '_build_session_summary',
                               return_value='test summary'), \
                  patch.object(DeepAnalyzer, '_try_ollama',
-                              return_value='{"result":"ok"}') as mock_ollama, \
+                              return_value=LLMOutcome("ok", text='{"suggestions":[]}')) as mock_ollama, \
                  patch.object(DeepAnalyzer, '_try_claude_max') as mock_claude, \
                  patch.object(DeepAnalyzer, '_try_deepseek_harness') as mock_harness, \
                  patch.object(da_module, 'LLM_STRATEGY', 'ollama-only'):
@@ -590,6 +730,8 @@ class TestDeepAnalyzerStrategy:
                 mock_ollama.assert_called_once()
                 mock_claude.assert_not_called()
                 mock_harness.assert_not_called()
+                assert analyzer.deep_attempts == 1
+                assert analyzer.deep_config_skips == 0
         finally:
             os.unlink(jsonl_path)
 
@@ -786,7 +928,7 @@ class TestDigestGenerator:
         analyzer.conn = conn
 
         stats = RunStats(sessions_analyzed=5, sessions_deep=1, deep_attempts=4,
-                         deep_failures=3, total_tokens=10000)
+                         deep_failures=3, deep_config_skips=2, total_tokens=10000)
         md = "# Test Digest"
 
         with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as f:
@@ -802,9 +944,82 @@ class TestDigestGenerator:
         assert row["deep_analyzed"] == 1
         assert row["deep_attempts"] == 4
         assert row["deep_failures"] == 3
+        assert row["deep_config_skips"] == 2
         assert row["digest_markdown"] == "# Test Digest"
         conn.close()
         os.unlink(digest_path)
+
+
+# ---------------------------------------------------------------------------
+# ConversationAnalyzer.run() production wiring (advisory, fix1585-r2)
+# ---------------------------------------------------------------------------
+
+class TestRunCopiesDeepCountersIntoStats:
+    """runner.py's ``run()`` copies ``self.deep.deep_attempts`` /
+    ``deep_failures`` / ``deep_config_skips`` into ``stats`` after the
+    session loop (runner.py ~321-323). Nothing else exercises that specific
+    copy: ``DeepAnalyzer``'s counters are covered in isolation above, and
+    ``RunStats``/``_store_digest`` are covered by constructing ``RunStats``
+    directly. Deleting those three lines would leave every other test in
+    this file green while the digest, DB row, and fail-closed exit code
+    silently went back to reading 0/0/0 forever. This pins the wiring
+    itself.
+    """
+
+    def test_run_copies_deep_counters_from_analyzer_to_stats(self):
+        analyzer = ConversationAnalyzer.__new__(ConversationAnalyzer)
+        analyzer.deep = DeepAnalyzer()
+        # Simulate attempts/failures/config-skips having accumulated during
+        # session processing, without needing a real LLM call.
+        analyzer.deep.deep_attempts = 3
+        analyzer.deep.deep_failures = 2
+        analyzer.deep.deep_config_skips = 5
+
+        def _fake_process_one_session(jsonl_path, dry_run, deep_remaining,
+                                      stats, session_rows):
+            stats.sessions_analyzed += 1
+            return deep_remaining
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_session = Path(tmpdir) / "fake.jsonl"
+            with patch.object(ConversationAnalyzer, 'find_unanalyzed_sessions',
+                              return_value=[fake_session]), \
+                 patch.object(ConversationAnalyzer, '_process_one_session',
+                              side_effect=_fake_process_one_session), \
+                 patch.object(ConversationAnalyzer, '_finalize_run'):
+                stats = analyzer.run(max_sessions=1, deep_budget=1)
+
+        assert stats.deep_attempts == 3
+        assert stats.deep_failures == 2
+        assert stats.deep_config_skips == 5
+
+    def test_run_with_zero_deep_activity_leaves_stats_at_zero(self):
+        """Control case: sessions were processed but none triggered deep
+        analysis -> the copy still runs and leaves all three counters at 0
+        (not unset/None). Uses the same processed-session path as the
+        non-zero case above so the early ``if not sessions: return stats``
+        short-circuit in run() (which never reaches the copy at all) isn't
+        mistaken for coverage of the wiring."""
+        analyzer = ConversationAnalyzer.__new__(ConversationAnalyzer)
+        analyzer.deep = DeepAnalyzer()
+
+        def _fake_process_one_session(jsonl_path, dry_run, deep_remaining,
+                                      stats, session_rows):
+            stats.sessions_analyzed += 1
+            return deep_remaining
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_session = Path(tmpdir) / "fake.jsonl"
+            with patch.object(ConversationAnalyzer, 'find_unanalyzed_sessions',
+                              return_value=[fake_session]), \
+                 patch.object(ConversationAnalyzer, '_process_one_session',
+                              side_effect=_fake_process_one_session), \
+                 patch.object(ConversationAnalyzer, '_finalize_run'):
+                stats = analyzer.run(max_sessions=1, deep_budget=1)
+
+        assert stats.deep_attempts == 0
+        assert stats.deep_failures == 0
+        assert stats.deep_config_skips == 0
 
 
 # ---------------------------------------------------------------------------
@@ -1642,6 +1857,28 @@ class TestFailClosedExitCode:
         # Deep failure does not need errors/sessions to be zero to fail closed.
         assert fail_closed_exit_code(
             RunStats(errors=0, sessions_analyzed=50, deep_attempts=20, deep_failures=20)
+        ) == 1
+
+    def test_fail_closed_config_skip_night_stays_green(self):
+        """A run where every flagged session hit a configuration gap (no API
+        key, no model, unreachable lane) must not fail-close (fix1585-r2).
+
+        Before the fix, ``deep_attempts`` was incremented the moment a
+        strategy branch was entered — including a pure config-gap
+        short-circuit — so a 20-session config-gap night reported
+        ``deep_attempts=20, deep_failures=20`` and fail-closed the nightly
+        job over a problem no attempt was ever made to solve. With the fix,
+        those 20 sessions land in ``deep_config_skips`` instead and
+        ``deep_attempts`` stays 0.
+        """
+        from conversation_analyzer import fail_closed_exit_code, RunStats
+        assert fail_closed_exit_code(
+            RunStats(deep_attempts=0, deep_failures=0, deep_config_skips=20)
+        ) == 0
+        # Mixed run: some genuine attempts failed alongside config skips ->
+        # still fails closed on the genuine failures.
+        assert fail_closed_exit_code(
+            RunStats(deep_attempts=5, deep_failures=5, deep_config_skips=15)
         ) == 1
 
     def test_main_returns_nonzero_when_all_sessions_fail(self):

--- a/tests/test_conversation_analyzer.py
+++ b/tests/test_conversation_analyzer.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -115,6 +116,8 @@ def _create_schema(conn: sqlite3.Connection):
             digest_date DATE NOT NULL UNIQUE,
             sessions_analyzed INTEGER DEFAULT 0,
             deep_analyzed INTEGER DEFAULT 0,
+            deep_attempts INTEGER DEFAULT 0,
+            deep_failures INTEGER DEFAULT 0,
             new_suggestions INTEGER DEFAULT 0,
             total_tokens_used INTEGER DEFAULT 0,
             digest_markdown TEXT NOT NULL,
@@ -382,6 +385,124 @@ class TestDeepAnalyzer:
         metrics = SessionMetrics(total_output_tokens=5000, tool_calls_total=20)
         flags = SessionFlags()
         assert analyzer.should_deep_analyze(metrics, flags) is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: _try_claude_max outcome classification (OI-1258)
+# ---------------------------------------------------------------------------
+
+class TestClaudeOutcome:
+    """``_try_claude_max`` must return a distinct outcome per failure mode.
+
+    The old ``Optional[str]`` return collapsed four different situations —
+    missing CLI, crashed CLI, successful-but-empty, and successful-with-result —
+    into a single ``None``. Each test below asserts a different
+    ``ClaudeOutcome.status`` so a caller can tell them apart without parsing logs.
+    """
+
+    @staticmethod
+    def _run_outcome(side_effect=None, returncode=0, stdout="", stderr=""):
+        import conversation_analyzer.deep_analyzer as da_module
+
+        if side_effect is not None:
+            patcher = patch.object(da_module.subprocess, "run", side_effect=side_effect)
+        else:
+            fake = SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+            patcher = patch.object(da_module.subprocess, "run", return_value=fake)
+        with patcher:
+            return DeepAnalyzer._try_claude_max("test prompt")
+
+    def test_missing_cli_returns_missing_cli_outcome(self):
+        outcome = self._run_outcome(side_effect=FileNotFoundError())
+        assert outcome.status == "missing_cli"
+        assert outcome.text is None
+
+    def test_nonzero_rc_returns_cli_failed_with_rc_and_stderr(self):
+        outcome = self._run_outcome(returncode=2, stderr="boom: something broke")
+        assert outcome.status == "cli_failed"
+        assert outcome.returncode == 2
+        assert "boom" in outcome.stderr
+
+    def test_success_empty_output_returns_empty_outcome(self):
+        outcome = self._run_outcome(returncode=0, stdout="")
+        assert outcome.status == "empty"
+        assert outcome.text == ""
+
+    def test_success_with_result_returns_ok_outcome(self):
+        outcome = self._run_outcome(returncode=0, stdout='{"result": "hello world"}')
+        assert outcome.status == "ok"
+        assert outcome.text == "hello world"
+
+    def test_raw_stdout_without_json_returns_ok_outcome(self):
+        outcome = self._run_outcome(returncode=0, stdout="plain text answer")
+        assert outcome.status == "ok"
+        assert outcome.text == "plain text answer"
+
+    def test_timeout_returns_timeout_outcome(self):
+        import conversation_analyzer.deep_analyzer as da_module
+        outcome = self._run_outcome(
+            side_effect=da_module.subprocess.TimeoutExpired(cmd=["claude"], timeout=90)
+        )
+        assert outcome.status == "timeout"
+
+    def test_unexpected_exception_returns_error_outcome(self):
+        outcome = self._run_outcome(side_effect=RuntimeError("disk full"))
+        assert outcome.status == "error"
+        assert "disk full" in outcome.stderr
+
+
+class TestDeepAnalyzerCounter:
+    """``deep_attempts``/``deep_failures`` track invoked-vs-failed deep analysis."""
+
+    @staticmethod
+    def _analyze_with_claude(outcome):
+        import conversation_analyzer.deep_analyzer as da_module
+
+        analyzer = DeepAnalyzer()
+        metrics = SessionMetrics(session_id="counter-test", total_output_tokens=5000,
+                                  tool_calls_total=20)
+        flags = SessionFlags()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write('{"type":"user","message":{"role":"user","content":"test"}}\n')
+            f.flush()
+            jsonl_path = Path(f.name)
+
+        try:
+            with patch.object(DeepAnalyzer, '_build_session_summary',
+                              return_value='test summary'), \
+                 patch.object(DeepAnalyzer, '_try_claude_max', return_value=outcome), \
+                 patch.object(da_module, 'LLM_STRATEGY', 'claude-only'):
+                return analyzer, analyzer.analyze_session(jsonl_path, metrics, flags)
+        finally:
+            os.unlink(jsonl_path)
+
+    def test_failed_attempt_counts_attempt_and_failure(self):
+        from conversation_analyzer.deep_analyzer import ClaudeOutcome
+        analyzer, result = self._analyze_with_claude(ClaudeOutcome("missing_cli"))
+        assert result is None
+        assert analyzer.deep_attempts == 1
+        assert analyzer.deep_failures == 1
+
+    def test_successful_attempt_counts_attempt_no_failure(self):
+        from conversation_analyzer.deep_analyzer import ClaudeOutcome
+        analyzer, result = self._analyze_with_claude(
+            ClaudeOutcome("ok", text='{"suggestions":[]}')
+        )
+        assert result is not None
+        assert analyzer.deep_attempts == 1
+        assert analyzer.deep_failures == 0
+
+    def test_parseable_but_empty_result_counts_failure(self):
+        # LLM answered but returned no parseable JSON — an attempt that
+        # produced nothing usable, distinct from a hard CLI failure.
+        from conversation_analyzer.deep_analyzer import ClaudeOutcome
+        analyzer, result = self._analyze_with_claude(
+            ClaudeOutcome("ok", text="no json here")
+        )
+        assert result is None
+        assert analyzer.deep_attempts == 1
+        assert analyzer.deep_failures == 1
 
 
 # ---------------------------------------------------------------------------
@@ -664,7 +785,8 @@ class TestDigestGenerator:
         analyzer = ConversationAnalyzer.__new__(ConversationAnalyzer)
         analyzer.conn = conn
 
-        stats = RunStats(sessions_analyzed=5, sessions_deep=1, total_tokens=10000)
+        stats = RunStats(sessions_analyzed=5, sessions_deep=1, deep_attempts=4,
+                         deep_failures=3, total_tokens=10000)
         md = "# Test Digest"
 
         with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as f:
@@ -677,6 +799,9 @@ class TestDigestGenerator:
         row = cur.fetchone()
         assert row is not None
         assert row["sessions_analyzed"] == 5
+        assert row["deep_analyzed"] == 1
+        assert row["deep_attempts"] == 4
+        assert row["deep_failures"] == 3
         assert row["digest_markdown"] == "# Test Digest"
         conn.close()
         os.unlink(digest_path)
@@ -1504,6 +1629,20 @@ class TestFailClosedExitCode:
         assert fail_closed_exit_code(RunStats(errors=0, sessions_analyzed=3)) == 0
         # Defensive: None stats (no run executed) -> zero.
         assert fail_closed_exit_code(None) == 0
+
+    def test_fail_closed_deep_analysis_all_failed(self):
+        """Every deep attempt failed -> non-zero (the OI-1258 case)."""
+        from conversation_analyzer import fail_closed_exit_code, RunStats
+        # 20 attempts, 20 failures -> the silent deep_analyzed=0 night.
+        assert fail_closed_exit_code(RunStats(deep_attempts=20, deep_failures=20)) == 1
+        # Partial deep failure stays green (some sessions did produce a result).
+        assert fail_closed_exit_code(RunStats(deep_attempts=20, deep_failures=5)) == 0
+        # No attempts -> zero (nothing was tried; not a failure).
+        assert fail_closed_exit_code(RunStats(deep_attempts=0, deep_failures=0)) == 0
+        # Deep failure does not need errors/sessions to be zero to fail closed.
+        assert fail_closed_exit_code(
+            RunStats(errors=0, sessions_analyzed=50, deep_attempts=20, deep_failures=20)
+        ) == 1
 
     def test_main_returns_nonzero_when_all_sessions_fail(self):
         """``conversation_analyzer.py`` exits non-zero when every session failed."""

--- a/tests/test_quality_db_dream_migration.py
+++ b/tests/test_quality_db_dream_migration.py
@@ -219,3 +219,56 @@ class TestDreamMigrationV20:
         conn.close()
 
         assert row is not None, "existing dream_cycles row must survive re-migration"
+
+
+class TestNightlyDigestsV30:
+    """V30: nightly_digests gains deep_attempts + deep_failures (OI-1258)."""
+
+    def test_bootstrap_adds_deep_attempts_and_deep_failures(self, tmp_path):
+        """A fresh bootstrap carries both new digest columns."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(nightly_digests)").fetchall()}
+        conn.close()
+
+        assert "deep_attempts" in cols
+        assert "deep_failures" in cols
+
+    def test_v30_adds_columns_to_existing_digest_table(self, tmp_path):
+        """_migrate_v30 backfills the columns on a pre-v30 digest table."""
+        db_path = tmp_path / "upgrade.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE nightly_digests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                digest_date DATE NOT NULL UNIQUE,
+                sessions_analyzed INTEGER DEFAULT 0,
+                deep_analyzed INTEGER DEFAULT 0,
+                new_suggestions INTEGER DEFAULT 0,
+                total_tokens_used INTEGER DEFAULT 0,
+                digest_markdown TEXT NOT NULL,
+                digest_path TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+        """)
+        conn.execute(
+            "INSERT INTO nightly_digests (digest_date, digest_markdown) "
+            "VALUES ('2026-06-15', '# old digest')"
+        )
+        conn.commit()
+
+        quality_db_init._migrate_v30(conn)
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(nightly_digests)").fetchall()}
+        assert "deep_attempts" in cols
+        assert "deep_failures" in cols
+
+        # Existing rows survive with the DEFAULT backfill of 0.
+        row = conn.execute(
+            "SELECT deep_attempts, deep_failures FROM nightly_digests "
+            "WHERE digest_date = '2026-06-15'"
+        ).fetchone()
+        assert row == (0, 0)
+        conn.close()

--- a/tests/test_quality_db_dream_migration.py
+++ b/tests/test_quality_db_dream_migration.py
@@ -272,3 +272,74 @@ class TestNightlyDigestsV30:
         ).fetchone()
         assert row == (0, 0)
         conn.close()
+
+
+class TestNightlyDigestsV31:
+    """V31: nightly_digests gains deep_config_skips (fix1585-r2).
+
+    A config gap (missing DEEPSEEK_API_KEY, missing/unavailable ollama model,
+    unreachable ollama server) was previously folded into deep_attempts /
+    deep_failures, reading as "N attempts, all failed" and fail-closing the
+    nightly run over nothing that was ever tried. This third column lets a
+    config-gap night be told apart from a genuine deep-analysis failure.
+    """
+
+    def test_bootstrap_adds_deep_config_skips(self, tmp_path):
+        """A fresh bootstrap carries the new digest column."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(nightly_digests)").fetchall()}
+        conn.close()
+
+        assert "deep_config_skips" in cols
+
+    def test_v31_adds_column_to_existing_digest_table(self, tmp_path):
+        """_migrate_v31 backfills the column on a pre-v31 digest table."""
+        db_path = tmp_path / "upgrade.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE nightly_digests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                digest_date DATE NOT NULL UNIQUE,
+                sessions_analyzed INTEGER DEFAULT 0,
+                deep_analyzed INTEGER DEFAULT 0,
+                deep_attempts INTEGER DEFAULT 0,
+                deep_failures INTEGER DEFAULT 0,
+                new_suggestions INTEGER DEFAULT 0,
+                total_tokens_used INTEGER DEFAULT 0,
+                digest_markdown TEXT NOT NULL,
+                digest_path TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+        """)
+        conn.execute(
+            "INSERT INTO nightly_digests (digest_date, digest_markdown) "
+            "VALUES ('2026-06-15', '# old digest')"
+        )
+        conn.commit()
+
+        quality_db_init._migrate_v31(conn)
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(nightly_digests)").fetchall()}
+        assert "deep_config_skips" in cols
+
+        # Existing rows survive with the DEFAULT backfill of 0.
+        row = conn.execute(
+            "SELECT deep_config_skips FROM nightly_digests "
+            "WHERE digest_date = '2026-06-15'"
+        ).fetchone()
+        assert row == (0,)
+        conn.close()
+
+    def test_user_version_reaches_31(self, tmp_path):
+        """PRAGMA user_version equals HIGHEST_QI_VERSION (31) after bootstrap."""
+        db_path = tmp_path / "quality_intelligence.db"
+        _bootstrap(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        version = schema_migration.get_user_version(conn)
+        conn.close()
+
+        assert version == quality_db_init.HIGHEST_QI_VERSION == 31


### PR DESCRIPTION
## Wat

`nightly_digests.deep_analyzed` is een succes-only teller. Een digest van `deep_analyzed=0` leest als "er is niks geprobeerd", terwijl het feitelijk "N pogingen, allemaal mislukt" betekent. Het verschil bestond niet in de code.

## Meting (vooraf)

- `nightly_digests` over 2026-06-01 .. 2026-08-16: 40 digests, 1950 sessies, **20 deep_analyzed totaal**. Vanaf ~2026-07-30 staat er elke dag `deep_analyzed=0` (50 sessies/dag).
- Huidige strategie: `VNX_ANALYZER_LLM` unset -> default `ollama-only`. `_try_claude_max` wordt dus NU niet aangeroepen; de huidige `deep_analyzed=0` is het ollama-pad dat faalt (`probe_health: produces_crap` in `events/dream/launchd.out.log`).
- Log grep `~/.vnx-data/vnx-dev/state/nightly_pipeline.log`: `"Claude CLI failed"` = **12** hits (2026-06-01, WARNING, lege stderr); `"Claude CLI not found"` = **407** hits (2026-06-02 04:08+).
- launchd plist `com.vnx.auto-dream` (PATH-snapshot 2026-07-31 23:09) bevat `/Users/vincentvandeth/.local/bin`; `claude` v2.1.233 is daar NU bereikbaar.

## Wijziging

1. **Uitkomsten onderscheidbaar**: `_try_claude_max` retourneert een `ClaudeOutcome` (`ok`/`empty`/`missing_cli`/`cli_failed`/`timeout`/`error`) in plaats van `Optional[str]`. `cli_failed` draagt returncode + stderr-snippet. Falen logt op ERROR, niet WARNING.
2. **Teller vertelt de waarheid**: `DeepAnalyzer` telt `deep_attempts`/`deep_failures` per run, strategie-agnostisch. `RunStats`, digest-markdown en `nightly_digests` (migratie v30) dragen beide naast `deep_analyzed`.
3. **Een fout is geen waarschuwing**: `fail_closed_exit_code` faalt nu ook closed als elke diepte-poging zonder bruikbaar resultaat eindigde (`deep_attempts>0 and deep_failures>=deep_attempts`). De nightly job verlaat dan non-zero en de HealthBeacon krijgt `deep_attempts`/`deep_failures` in de details. Gekozen plek: de bestaande fail-closed-keten (exit code + HealthBeacon), geen nieuw alarmsysteem.

## Tests

16 nieuwe/bijgewerkte tests: 4 vereiste claude-uitkomsten (missing CLI, non-zero rc, empty, result) + timeout/error, teller-trackings, fail-closed deep-failure, v30-migratie. Alle groen. Twee pre-existente failures in `test_conversation_analyzer.py` (memory-suggestions) en drie in `test_schema_init_view_ordering.py` staan ook rood op kale HEAD (geen regressie).

Dispatch-ID: 20260816-staart-s3-dream-failure-visible