### PR TITLE
fix(smart-router): fail loud on constraint-blocked models in routing recommendations (OI-1255)

### DIFF
--- a/scripts/benchmark/analyze_results.py
+++ b/scripts/benchmark/analyze_results.py
@@ -30,6 +30,12 @@ RESULTS_DIR = BENCHMARK_DIR / "results"
 CLAUDEDOCS_DIR = REPO_ROOT / "claudedocs"
 ROUTING_OUTPUT = REPO_ROOT / "scripts" / "lib" / "providers" / "routing_recommendations.yaml"
 
+# scripts/lib is importable in the test suite via tests/conftest.py; add it here
+# so the CLI path can validate model ids against the constraint SSOT as well.
+_LIB_DIR = REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
 
 def load_results(results_dir: Path) -> List[Dict]:
     records = []
@@ -201,6 +207,44 @@ def render_markdown_report(records: List[Dict], summary: Dict, pareto: List[Dict
     return "\n".join(lines)
 
 
+def validate_routing_models(routing: Dict) -> None:
+    """Fail loud when the generated recommendations name a constraint-blocked model.
+
+    The results dir keeps legacy benchmark records (e.g. glm-5-1 field-test
+    JSONs); passing their model_ids straight through would regenerate a
+    routing_recommendations.yaml that recommends models the dispatch door
+    refuses (deprecated-glm-models admits only glm-5.2 — OI-1255). The router
+    already rejects such a file at load (BlockedRecommendationError); this
+    guard surfaces the same drift at GENERATION time, with the offending
+    model ids named, instead of letting the file be written first.
+    """
+    from smart_router import parse_route_model_id  # noqa: PLC0415
+    from providers.constraint_enforcer import (  # noqa: PLC0415
+        blocking_model_violations as _blocking_model_violations,
+    )
+
+    blocked: List[str] = []
+    for task_id, entries in (routing.get("routing_by_task") or {}).items():
+        for entry in entries:
+            model_id = str((entry or {}).get("model_id") or "")
+            if not model_id:
+                continue
+            provider, model = parse_route_model_id(model_id)
+            violations = _blocking_model_violations(provider=provider, model=model)
+            if violations:
+                codes = ", ".join(sorted({v.code for v in violations}))
+                blocked.append(f"{model_id!r} (task {task_id!r}, constraint(s): {codes})")
+    if blocked:
+        raise ValueError(
+            "analyze_results: refusing to write routing_recommendations.yaml — "
+            "benchmark results contain constraint-blocked model(s): "
+            + "; ".join(blocked)
+            + ". Remove/refresh those result files or admit the model in "
+            "provider_constraints.yaml; writing the file would recommend a model "
+            "the dispatch door refuses (OI-1255)."
+        )
+
+
 def _atomic_write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".tmp")
@@ -227,6 +271,7 @@ def main() -> int:
     summary = build_task_summary(records)
     pareto = build_pareto_frontier(records)
     routing = build_routing_recommendations(summary)
+    validate_routing_models(routing)
     report_md = render_markdown_report(records, summary, pareto)
 
     report_path = output_dir / "benchmark-model-comparison.md"

--- a/scripts/benchmark/export_routing_matrix.py
+++ b/scripts/benchmark/export_routing_matrix.py
@@ -68,8 +68,14 @@ LANE = {
     "codex-gpt-5-5": ("codex-gpt-5-5", "codex-cli"),
     "codex-gpt-5-4": ("codex-gpt-5-4", "codex-cli"),
     "kimi-k2-7-code": ("kimi-k2-7-code", "kimi-cli"),
-    "glm-5-2": ("glm-5-2", "flat-runner"),
-    "glm-5-2-harness": ("glm-5-2", "claude-harness"),
+    # LANE keys stay in the benchmark's dash spelling (they match lane_id in the
+    # raw.csv files); the EMITTED model_id is the canonical wave7_models.yaml
+    # registry key (dot form). Emitting the dash form would produce a file the
+    # constraint layer refuses: deprecated-glm-models admits only glm-5.2, and
+    # its alias match is exact (no dot/dash fold), so smart_router's load-time
+    # validation (OI-1255) rejects dash-form entries as blocked.
+    "glm-5-2": ("glm-5.2", "flat-runner"),
+    "glm-5-2-harness": ("glm-5.2", "claude-harness"),
     "deepseek-v4-flash-harness": ("deepseek-v4-flash", "claude-harness"),
     "deepseek-v4-pro-harness": ("deepseek-v4-pro", "claude-harness"),
     # kimi-k2-6 deliberately dropped (superseded by kimi-k2-7-code)

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -628,6 +628,57 @@ def _get_enforcer() -> ConstraintEnforcer:
     return _enforcer
 
 
+def _model_policy_constraint_ids(constraints: list[dict[str, Any]]) -> frozenset[str]:
+    """Ids of constraints that gate on MODEL IDENTITY, derived from the SSOT.
+
+    A constraint qualifies when it is blocking, cannot be env-overridden, and
+    its required_route/forbidden_route carries a ``model`` key. Constraints
+    keyed on via/role/env (e.g. deepseek-harness-subscription-blocked, which
+    only bites when DEEPSEEK_API_KEY is absent) are runtime-route policy, not
+    model identity, and are excluded — a config file naming a model must never
+    be judged by whether a secret happens to be present in this shell.
+    """
+    ids: set[str] = set()
+    for constraint in constraints:
+        if str(constraint.get("audit_severity") or "") != "blocking":
+            continue
+        if bool(constraint.get("override_allowed", False)):
+            continue
+        route = constraint.get("required_route") or constraint.get("forbidden_route") or {}
+        if isinstance(route, Mapping) and route.get("model") is not None:
+            ids.add(str(constraint.get("id") or constraint.get("code") or "unknown"))
+    return frozenset(ids)
+
+
+def blocking_model_violations(
+    *,
+    provider: Optional[str] = None,
+    sub_provider: Optional[str] = None,
+    model: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> list[ConstraintViolation]:
+    """Blocking, non-overridable violations from MODEL-IDENTITY constraints only.
+
+    This is the config-load-time view of the constraint SSOT: it answers "is
+    this model one the dispatch layer would refuse?" without the runtime axes
+    (via/role/env) that check_constraints also weighs. Callers that load a
+    model list from a file (smart_router's routing_recommendations.yaml, the
+    benchmark export generators) use this to FAIL LOUD when a blocked model
+    (e.g. a deprecated GLM version under deprecated-glm-models) lands in a
+    recommendations file, instead of silently filtering it and hiding the
+    drift (OI-1255).
+    """
+    enforcer = _get_enforcer()
+    policy_ids = _model_policy_constraint_ids(enforcer._constraints)
+    violations = enforcer.check_constraints(
+        provider=provider, sub_provider=sub_provider, model=model, env=env,
+    )
+    return [
+        v for v in violations
+        if v.severity == "blocking" and v.code in policy_ids
+    ]
+
+
 def check_constraints(**kwargs: Any) -> list[ConstraintViolation]:
     return _get_enforcer().check_constraints(**kwargs)
 

--- a/scripts/lib/providers/routing_recommendations.yaml
+++ b/scripts/lib/providers/routing_recommendations.yaml
@@ -5,6 +5,17 @@
 # current (claude-sonnet-5, claude-opus-4-8, glm-5-2) on 2026-07-22 per operator mandate,
 # WITHOUT a re-benchmark. Every remapped entry carries an inline "# remapped ..." comment.
 # Treat all scores here as a snapshot pending refresh — see track bench-v2-model-refresh.
+#
+# 2026-08-16 (dispatch 20260816-staart-s2-glm5-registry, OI-1255):
+# - Removed all five `glm-5` (base, Feb 2026) candidate entries: deprecated-glm-models in
+#   provider_constraints.yaml (operator directive 2026-08-03) blocks every GLM except glm-5.2,
+#   so these recommendations named a model the dispatch door refuses.
+# - Renamed `glm-5-2` (benchmark-lane dash spelling) to the canonical registry key `glm-5.2`
+#   (wave7_models.yaml). The dash spelling fails the deprecated-glm-models exact-alias match
+#   and was silently filtered out of every decide() result alongside the genuinely blocked glm-5.
+# - smart_router now validates every candidate against the blocking model-identity constraints
+#   at load and raises BlockedRecommendationError on a blocked entry. A regeneration that
+#   reintroduces a blocked model (analyze_results.py over legacy results) fails loud there.
 routing_by_task:
   01_code_generation:
     candidates:
@@ -56,7 +67,7 @@ routing_by_task:
       avg_duration_seconds: 160.6
       launch_success_rate: 0.61
       n: 33
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: claude-harness
       composite_score: 8.15
       quality_tier: 3
@@ -64,14 +75,6 @@ routing_by_task:
       avg_duration_seconds: 197.3
       launch_success_rate: 1.0
       n: 3
-    - model_id: glm-5
-      runner: flat-runner
-      composite_score: 6.75
-      quality_tier: 2
-      cost_usd_per_call: 0.0578
-      avg_duration_seconds: 106.8
-      launch_success_rate: 0.65
-      n: 28
     - model_id: kimi-k2-7-code
       runner: kimi-cli
       composite_score: 6.5
@@ -80,7 +83,7 @@ routing_by_task:
       avg_duration_seconds: 161.9
       launch_success_rate: 0.77
       n: 46
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: flat-runner
       composite_score: 5.92
       quality_tier: 2
@@ -88,7 +91,7 @@ routing_by_task:
       avg_duration_seconds: 281.3
       launch_success_rate: 0.61
       n: 30
-    - model_id: glm-5-2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
+    - model_id: glm-5.2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
       runner: flat-runner
       composite_score: 4.83
       quality_tier: 1
@@ -114,7 +117,7 @@ routing_by_task:
       n: 25
   02_code_review:
     candidates:
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: claude-harness
       composite_score: 8.7
       quality_tier: 3
@@ -178,7 +181,7 @@ routing_by_task:
       avg_duration_seconds: 303.7
       launch_success_rate: 1.0
       n: 6
-    - model_id: glm-5-2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
+    - model_id: glm-5.2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
       runner: flat-runner
       composite_score: 7.82
       quality_tier: 3
@@ -186,15 +189,7 @@ routing_by_task:
       avg_duration_seconds: 247.8
       launch_success_rate: 1.0
       n: 6
-    - model_id: glm-5
-      runner: flat-runner
-      composite_score: 7.67
-      quality_tier: 3
-      cost_usd_per_call: 0.4682
-      avg_duration_seconds: 138.8
-      launch_success_rate: 1.0
-      n: 6
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: flat-runner
       composite_score: 5.9
       quality_tier: 2
@@ -285,15 +280,7 @@ routing_by_task:
       avg_duration_seconds: 97.2
       launch_success_rate: 0.88
       n: 15
-    - model_id: glm-5
-      runner: flat-runner
-      composite_score: 5.67
-      quality_tier: 2
-      cost_usd_per_call: 0.0067
-      avg_duration_seconds: 25.7
-      launch_success_rate: 0.94
-      n: 17
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: flat-runner
       composite_score: 5.62
       quality_tier: 2
@@ -301,7 +288,7 @@ routing_by_task:
       avg_duration_seconds: 68.1
       launch_success_rate: 1.0
       n: 18
-    - model_id: glm-5-2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
+    - model_id: glm-5.2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
       runner: flat-runner
       composite_score: 5.26
       quality_tier: 2
@@ -317,7 +304,7 @@ routing_by_task:
       avg_duration_seconds: 73.1
       launch_success_rate: 1.0
       n: 13
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: claude-harness
       composite_score: 4.63
       quality_tier: 1
@@ -375,7 +362,7 @@ routing_by_task:
       avg_duration_seconds: 76.7
       launch_success_rate: 0.42
       n: 11
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: claude-harness
       composite_score: 8.86
       quality_tier: 3
@@ -383,15 +370,7 @@ routing_by_task:
       avg_duration_seconds: 161.5
       launch_success_rate: 0.75
       n: 3
-    - model_id: glm-5
-      runner: flat-runner
-      composite_score: 8.28
-      quality_tier: 3
-      cost_usd_per_call: 0.0156
-      avg_duration_seconds: 99.9
-      launch_success_rate: 0.65
-      n: 11
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: flat-runner
       composite_score: 7.61
       quality_tier: 3
@@ -399,7 +378,7 @@ routing_by_task:
       avg_duration_seconds: 149.3
       launch_success_rate: 0.43
       n: 9
-    - model_id: glm-5-2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
+    - model_id: glm-5.2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
       runner: flat-runner
       composite_score: 6.76
       quality_tier: 2
@@ -434,7 +413,7 @@ routing_by_task:
     min_quality_tier: 2
   06_design:
     candidates:
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: claude-harness
       composite_score: 8.9
       quality_tier: 3
@@ -498,15 +477,7 @@ routing_by_task:
       avg_duration_seconds: 500.9
       launch_success_rate: 1.0
       n: 2
-    - model_id: glm-5
-      runner: flat-runner
-      composite_score: 8.59
-      quality_tier: 3
-      cost_usd_per_call: null
-      avg_duration_seconds: 645.6
-      launch_success_rate: 1.0
-      n: 2
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: flat-runner
       composite_score: 5.87
       quality_tier: 2
@@ -514,7 +485,7 @@ routing_by_task:
       avg_duration_seconds: 203.8
       launch_success_rate: 1.0
       n: 2
-    - model_id: glm-5-2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
+    - model_id: glm-5.2  # remapped 2026-07-22 from glm-5-1 (inherited score, not re-benchmarked)
       runner: flat-runner
       composite_score: 4.05
       quality_tier: 1
@@ -574,7 +545,7 @@ routing_by_task:
       avg_duration_seconds: 250.0
       launch_success_rate: 1.0
       n: 0
-    - model_id: glm-5-2
+    - model_id: glm-5.2
       runner: claude-harness
       composite_score: 7.5
       quality_tier: 3

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -236,6 +236,52 @@ def classify_task(
 # Composite score at or below which a model is considered incapable for the task class.
 _INCAPABLE_SCORE_FLOOR = 1.0
 
+
+class BlockedRecommendationError(ValueError):
+    """A routing_recommendations.yaml candidate names a model the constraints block.
+
+    Raised at load time (fail loud, OI-1255): a recommendations file is a COPY
+    of model identity that can decay (glm-5 was recommended in five places
+    while provider_constraints.yaml `deprecated-glm-models` blocked it). A
+    silent filter would hide the next case exactly the way that one was hidden,
+    so the router refuses the file instead.
+    """
+
+
+def _validate_candidates_not_blocked(
+    task_class: str,
+    candidates: List[RouteCandidate],
+    *,
+    env: Optional[Dict] = None,
+    source: Optional[Path] = None,
+) -> None:
+    """Fail loud when a candidate model violates a blocking model-identity constraint.
+
+    Every entry parsed from the recommendations file is checked against the
+    constraint SSOT (provider_constraints.yaml) via
+    providers.constraint_enforcer.blocking_model_violations — the same
+    allowlist the dispatch door enforces (e.g. deprecated-glm-models admits
+    only glm-5.2 for zai). Runtime-route constraints (via/role/env-keyed) are
+    deliberately NOT checked here: they are decide()'s per-dispatch filter,
+    not a verdict on the model itself.
+    """
+    from providers.constraint_enforcer import (  # noqa: PLC0415
+        blocking_model_violations as _blocking_model_violations,
+    )
+
+    for candidate in candidates:
+        provider, model = parse_route_model_id(candidate.model_id)
+        violations = _blocking_model_violations(provider=provider, model=model, env=env)
+        if violations:
+            codes = ", ".join(sorted({v.code for v in violations}))
+            raise BlockedRecommendationError(
+                f"routing_recommendations candidate {candidate.model_id!r} in task class "
+                f"{task_class!r} is blocked by constraint(s) [{codes}] "
+                f"(source: {source or _RECOMMENDATIONS_PATH}): {violations[0].message} "
+                f"Remove the entry or admit the model in provider_constraints.yaml — "
+                f"the router fails loud instead of silently dropping the candidate (OI-1255)."
+            )
+
 # Operator-chosen capability threshold (2026-06-28): a model scoring at/above this clears the
 # "capable enough" bar and competes on COST; models below it are ranked by capability instead, so a
 # cheap-but-weak model can never beat a much stronger one. On the 0-10 composite scale, 7.0 = solidly
@@ -328,6 +374,11 @@ def _load_recommendations(
     models below the threshold are ranked by capability descending. When costs are all None (no
     wave7 data), every above-bar candidate ties on cost and the order collapses to score-descending
     — identical to the pre-cost-aware behaviour.
+
+    Every parsed candidate is validated against the blocking model-identity
+    constraints (provider_constraints.yaml) and the load raises
+    BlockedRecommendationError on the first blocked model — a recommendations
+    file carrying a deprecated model is a hard error, never a silent skip.
     """
     from cost_loader import enrich_candidates as _enrich  # noqa: PLC0415
 
@@ -377,6 +428,10 @@ def _load_recommendations(
                 cost_tier=cost_tier,
                 quality_tier=qt,
             ))
+        # OI-1255: reject the whole file loudly when any entry names a model
+        # the constraint SSOT blocks — BEFORE enrichment/sorting, so a blocked
+        # model can never reach a caller even as a filtered-out tail entry.
+        _validate_candidates_not_blocked(task_class, candidates, source=yaml_path)
         _enrich(candidates)
         if min_qt is not None:
             candidates = [c for c in candidates if (c.quality_tier or 0) >= min_qt]

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -309,6 +309,53 @@ def test_analyze_results_writes_yaml_recommendations(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
+# validate_routing_models — OI-1255 generation-time guard
+#
+# The results dir keeps legacy records (glm-5-1 field tests). Passing those
+# model_ids straight into routing_recommendations.yaml would regenerate the
+# exact drift this dispatch removed: the router recommending a model the
+# dispatch door refuses. The guard must fail loud BEFORE the file is written.
+# ---------------------------------------------------------------------------
+
+def test_validate_routing_models_allows_current_models():
+    """Current registry models (incl. the one allowed GLM) pass the guard."""
+    routing = {"routing_by_task": {"01_alpha": [
+        {"model_id": "claude-sonnet-5"},
+        {"model_id": "deepseek-v4-pro"},
+        {"model_id": "glm-5.2"},
+        {"model_id": "kimi-k2-7-code"},
+    ]}}
+    analyze_results.validate_routing_models(routing)  # must not raise
+
+
+@pytest.mark.parametrize("blocked", ["glm-5", "glm-5.1", "glm-5-1", "glm-4.5", "glm-4.6"])
+def test_validate_routing_models_blocks_deprecated_glm(blocked):
+    routing = {"routing_by_task": {"01_alpha": [{"model_id": blocked}]}}
+    with pytest.raises(ValueError, match="deprecated-glm-models"):
+        analyze_results.validate_routing_models(routing)
+
+
+def test_analyze_results_main_refuses_to_write_blocked_routing(tmp_path: Path, monkeypatch):
+    """End-to-end: main() fails loud and writes NO routing file when the
+    aggregated results carry a deprecated GLM model (the legacy glm-5-1
+    field-test records in scripts/benchmark/results are the live case)."""
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    record = _make_result_record("glm-5-1", "01_alpha", 0.001, 8)
+    (results_dir / "glm-5-1__01_alpha.json").write_text(json.dumps(record))
+    routing_out = tmp_path / "routing.yaml"
+    monkeypatch.setattr(
+        sys, "argv",
+        ["analyze_results.py", "--results-dir", str(results_dir),
+         "--output-dir", str(tmp_path / "claudedocs")],
+    )
+    with patch.object(analyze_results, "ROUTING_OUTPUT", routing_out):
+        with pytest.raises(ValueError, match="constraint-blocked"):
+            analyze_results.main()
+    assert not routing_out.exists()
+
+
+# ---------------------------------------------------------------------------
 # test_pareto_frontier
 # ---------------------------------------------------------------------------
 

--- a/tests/test_constraint_enforcer.py
+++ b/tests/test_constraint_enforcer.py
@@ -30,6 +30,7 @@ from providers.constraint_enforcer import (
     ConstraintEnforcer,
     ConstraintViolationError,
     HardConstraintViolation,
+    blocking_model_violations,
     check_constraints,
 )
 
@@ -641,3 +642,52 @@ class TestRegistryKeyNormalization:
         )
         blocking = [v for v in violations if v.severity == "blocking"]
         assert not blocking, f"unexpected blocking violations: {blocking}"
+
+
+# ---------------------------------------------------------------------------
+# blocking_model_violations — config-load-time view (OI-1255)
+#
+# smart_router and the benchmark export generators use this helper to fail loud
+# when a model list names a model the dispatch door refuses. It isolates the
+# model-identity axis of the constraint SSOT: blocking, non-overridable
+# constraints keyed on `model` (currently exactly deprecated-glm-models).
+# ---------------------------------------------------------------------------
+
+class TestBlockingModelViolations:
+
+    @pytest.mark.parametrize("blocked", ["glm-5", "glm-5.1", "glm-4.5", "glm-4.6", "glm-5.3"])
+    def test_deprecated_glm_variants_flagged(self, blocked):
+        violations = blocking_model_violations(provider="litellm:zai", model=blocked, env={})
+        assert [v.code for v in violations] == ["deprecated-glm-models"]
+        assert all(v.severity == "blocking" for v in violations)
+
+    def test_glm_5_2_not_flagged(self):
+        assert blocking_model_violations(provider="litellm:zai", model="glm-5.2", env={}) == []
+
+    def test_glm_harness_alias_routes_to_zai_identity(self):
+        """The zai allowlist covers every provider string routing to zai (OI-1217)."""
+        violations = blocking_model_violations(provider="glm-harness", model="glm-5", env={})
+        assert [v.code for v in violations] == ["deprecated-glm-models"]
+
+    def test_env_keyed_deepseek_block_is_not_model_policy(self):
+        """deepseek-harness-subscription-blocked depends on DEEPSEEK_API_KEY being
+        absent — runtime-route policy, not model identity. It must NOT flag a
+        config-file model list even with an empty env."""
+        assert blocking_model_violations(
+            provider="litellm", sub_provider="deepseek", model="deepseek-v4-flash", env={},
+        ) == []
+
+    def test_non_glm_models_not_flagged(self):
+        for provider, model in (
+            ("claude", "sonnet"),
+            ("kimi", "kimi-k2-7-code"),
+            ("litellm", "codex-gpt-5-5"),
+        ):
+            assert blocking_model_violations(provider=provider, model=model, env={}) == []
+
+    def test_override_env_cannot_denylist_model_policy(self, monkeypatch):
+        """deprecated-glm-models has override_allowed: false — an env flag must
+        not whitewash a blocked model at config-load time either."""
+        monkeypatch.setenv("VNX_OVERRIDE_DEPRECATED_GLM_MODELS", "1")
+        violations = blocking_model_violations(provider="zai", model="glm-5")
+        assert [v.code for v in violations] == ["deprecated-glm-models"]

--- a/tests/test_smart_router.py
+++ b/tests/test_smart_router.py
@@ -15,6 +15,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
 from smart_router import (
+    BlockedRecommendationError,
     RouteCandidate,
     RouteDecision,
     classify_task,
@@ -486,3 +487,119 @@ class TestNullCostSortKey:
         assert decision.primary.model_id == "claude-sonnet-4-6"
         assert decision.primary.composite_score == 9.5
         assert decision.primary.model_id != "deepseek-v4-flash"
+
+
+# ---------------------------------------------------------------------------
+# Blocked-model load validation (OI-1255)
+#
+# routing_recommendations.yaml recommended glm-5 (base) in five places while
+# provider_constraints.yaml `deprecated-glm-models` blocks every GLM except
+# glm-5.2. decide() silently filtered those entries, so the drift was
+# invisible. The loader now fails loud instead: a blocked model anywhere in
+# the file raises BlockedRecommendationError.
+# ---------------------------------------------------------------------------
+
+def _single_candidate_yaml(tmp_path, model_id, task_class="01_code_generation"):
+    data = {
+        "routing_by_task": {
+            task_class: [
+                {"model_id": model_id, "composite_score": 8.0,
+                 "avg_duration_seconds": 100.0, "cost_usd_per_call": None},
+            ],
+        }
+    }
+    p = tmp_path / "routing_recommendations.yaml"
+    p.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+    return p
+
+
+class TestBlockedModelValidation:
+
+    @pytest.mark.parametrize("blocked", ["glm-5", "glm-5.1", "glm-4.5", "glm-4.6", "glm-5-1"])
+    def test_blocked_glm_model_fails_loud(self, tmp_path, blocked):
+        """A deprecated GLM variant in the file must raise, not be silently dropped."""
+        rec_path = _single_candidate_yaml(tmp_path, blocked)
+        with pytest.raises(BlockedRecommendationError, match="deprecated-glm-models"):
+            recommend("01_code_generation", recommendations_path=rec_path)
+
+    def test_error_names_model_task_class_and_source(self, tmp_path):
+        rec_path = _single_candidate_yaml(tmp_path, "glm-5", task_class="05_debugging")
+        with pytest.raises(BlockedRecommendationError) as excinfo:
+            _load_recommendations(rec_path)
+        msg = str(excinfo.value)
+        assert "glm-5" in msg
+        assert "05_debugging" in msg
+        assert str(rec_path) in msg
+        assert "deprecated-glm-models" in msg
+
+    def test_decide_also_fails_loud(self, tmp_path):
+        """decide() goes through the same loader, so it raises the same error."""
+        rec_path = _single_candidate_yaml(tmp_path, "glm-5")
+        with pytest.raises(BlockedRecommendationError):
+            decide("implement a new module", recommendations_path=rec_path)
+
+    def test_glm_5_2_remains_a_valid_candidate(self, tmp_path):
+        """The one allowed GLM version loads and ranks normally."""
+        rec_path = _single_candidate_yaml(tmp_path, "glm-5.2")
+        candidates = recommend("01_code_generation", recommendations_path=rec_path)
+        assert [c.model_id for c in candidates] == ["glm-5.2"]
+        decision = decide("implement a new module", recommendations_path=rec_path)
+        assert decision.primary is not None
+        assert decision.primary.model_id == "glm-5.2"
+        assert decision.constraints_applied == []
+
+    def test_non_glm_candidates_unaffected(self, tmp_path):
+        """Non-GLM models keep passing validation, incl. env-keyed deepseek lanes
+        (deepseek-harness-subscription-blocked is runtime-route policy, not model
+        identity, so it must NOT fail the load even with no DEEPSEEK_API_KEY)."""
+        data = {
+            "routing_by_task": {
+                "01_code_generation": [
+                    {"model_id": "claude-sonnet-5", "composite_score": 9.0,
+                     "avg_duration_seconds": 100.0, "cost_usd_per_call": None},
+                    {"model_id": "deepseek-v4-flash", "composite_score": 8.0,
+                     "avg_duration_seconds": 100.0, "cost_usd_per_call": None},
+                    {"model_id": "kimi-k2-7-code", "composite_score": 7.0,
+                     "avg_duration_seconds": 100.0, "cost_usd_per_call": None},
+                    {"model_id": "codex-gpt-5-5", "composite_score": 6.0,
+                     "avg_duration_seconds": 100.0, "cost_usd_per_call": None},
+                ],
+            }
+        }
+        rec_path = tmp_path / "routing_recommendations.yaml"
+        rec_path.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+        candidates = recommend("01_code_generation", recommendations_path=rec_path)
+        assert len(candidates) == 4
+
+    def test_real_yaml_has_no_blocked_candidates(self):
+        """The shipped file passes its own validation and names no deprecated GLM."""
+        recs = _load_recommendations()  # raises BlockedRecommendationError if violated
+        all_ids = [c.model_id for cands in recs.values() for c in cands]
+        assert "glm-5" not in all_ids
+        assert "glm-5.1" not in all_ids
+        assert "glm-5-1" not in all_ids
+        assert "glm-4.5" not in all_ids
+        assert "glm-4.6" not in all_ids
+        # The allowed GLM is still recommended (canonical registry spelling).
+        assert "glm-5.2" in all_ids
+
+    def test_real_yaml_glm_5_2_survives_decide_constraint_filter(self):
+        """End-to-end: a GLM-capable task class can surface glm-5.2 from decide().
+
+        Before the canonical-spelling fix, the dash-form glm-5-2 entries were
+        caught by the same deprecated-glm-models filter as the genuinely
+        blocked glm-5, so GLM could never be recommended at all.
+        """
+        from smart_router import _filter_by_constraints
+
+        recs = _load_recommendations()
+        glm_classes = [
+            tc for tc, cands in recs.items()
+            if any(c.model_id == "glm-5.2" for c in cands)
+        ]
+        assert glm_classes, "expected at least one task class recommending glm-5.2"
+        for tc in glm_classes:
+            allowed, _applied = _filter_by_constraints(recs[tc], env={})
+            assert any(c.model_id == "glm-5.2" for c in allowed), (
+                f"glm-5.2 must survive the constraint filter for {tc}"
+            )

--- a/tests/test_smart_router_cost_aware.py
+++ b/tests/test_smart_router_cost_aware.py
@@ -218,7 +218,11 @@ class TestRecommendCostAware:
             "03_refactoring": [
                 {"model_id": "claude-sonnet-4-6", "composite_score": 8.5,
                  "avg_duration_seconds": 209.0, "cost_usd_per_call": None},
-                {"model_id": "glm-5-1", "composite_score": 1.0,
+                # codex-gpt-5-4 stands in as the incapable cheap model: the
+                # previous fixture used glm-5-1, which is a deprecated GLM
+                # version — since OI-1255 a blocked model in a recommendations
+                # file raises BlockedRecommendationError at load by design.
+                {"model_id": "codex-gpt-5-4", "composite_score": 1.0,
                  "avg_duration_seconds": 0.85, "cost_usd_per_call": 0.000001},
             ],
         }
@@ -226,9 +230,9 @@ class TestRecommendCostAware:
         candidates = recommend("03_refactoring", recommendations_path=rec_path)
 
         assert len(candidates) == 2
-        # sonnet (capable, score=8.5) must beat glm-5-1 (incapable, score=1.0) despite glm being cheaper
+        # sonnet (capable, score=8.5) must beat codex-gpt-5-4 (incapable, score=1.0) despite codex being cheaper
         assert candidates[0].model_id == "claude-sonnet-4-6"
-        assert candidates[1].model_id == "glm-5-1"
+        assert candidates[1].model_id == "codex-gpt-5-4"
 
     def test_null_costs_preserve_score_order(self, tmp_path):
         """When all costs are null, sort falls back to score descending."""
@@ -276,7 +280,10 @@ class TestDecideCostAware:
                  "avg_duration_seconds": 209.0, "cost_usd_per_call": None},
                 {"model_id": "deepseek-v4-flash", "composite_score": 8.5,
                  "avg_duration_seconds": 19.0, "cost_usd_per_call": None},
-                {"model_id": "glm-5-1", "composite_score": 1.0,
+                # codex-gpt-5-4 replaces the former glm-5-1 fixture entry:
+                # glm-5-1 is blocked by deprecated-glm-models and now fails
+                # loud at load (OI-1255) instead of ranking as a candidate.
+                {"model_id": "codex-gpt-5-4", "composite_score": 1.0,
                  "avg_duration_seconds": 0.85, "cost_usd_per_call": None},
             ],
         }


### PR DESCRIPTION
## Summary

`routing_recommendations.yaml` recommended `glm-5` (base, Feb 2026) in five places while `deprecated-glm-models` in `provider_constraints.yaml` (operator directive 2026-08-03) blocks every GLM except `glm-5.2`. `decide()` silently filtered those entries, so the drift was invisible. Worse: the dash-spelled `glm-5-2` entries were caught by the same exact-alias allowlist match, so GLM could **never** surface from `decide()` at all.

## What changed

- **`scripts/lib/providers/constraint_enforcer.py`** — new public `blocking_model_violations()`: the config-load-time view of the constraint SSOT. Only blocking, non-overridable constraints keyed on `model` count (currently exactly `deprecated-glm-models`); via/role/env-keyed runtime policy (e.g. the DEEPSEEK_API_KEY-dependent deepseek block) is deliberately excluded.
- **`scripts/lib/smart_router.py`** — `_load_recommendations()` validates every parsed candidate and raises `BlockedRecommendationError` naming model, task class, constraint and source file. A blocked model in the file is a hard error, never a silent skip.
- **`scripts/lib/providers/routing_recommendations.yaml`** — the five `glm-5` entries removed; `glm-5-2` renamed to the canonical registry spelling `glm-5.2`; provenance header updated.
- **`scripts/benchmark/export_routing_matrix.py`** — `LANE` now emits canonical `glm-5.2` (lane keys stay dash-form to match raw.csv `lane_id`s).
- **`scripts/benchmark/analyze_results.py`** — `validate_routing_models()` refuses to write a routing file containing constraint-blocked models, so the legacy `glm-5-1` result records can no longer regenerate the drift on the next benchmark export.

## Verification

- `grep -c 'model_id: glm-5$' scripts/lib/providers/routing_recommendations.yaml` → `0` (was `5`)
- `recommend('06_design')` no longer lists `glm-5`; `decide()` for GLM-bearing classes reports `constraints: []` (nothing silently filtered anymore) and `glm-5.2` survives the constraint filter end-to-end.
- `python3 scripts/benchmark/analyze_results.py` over the real legacy results dir now exits 1 with `ValueError` naming all seven `glm-5-1` occurrences instead of writing a poisoned file.
- Targeted tests + direct neighbors: **445 passed, 1 skipped, 3 failed** — the 3 failures (`test_pr10_provider_string_canon.py::TestDeepseekHarnessRegistryKey` ×2, `test_wiring_completeness.py::TestSmartRouterRouteWiring::test_provider_dispatch_auto_route_calls_smart_router_route`) fail identically on the clean tree (verified via `git stash`); they are pre-existing and unrelated.

Dispatch-ID: 20260816-staart-s2-glm5-registry