### PR TITLE
feat(governance): pin PR merge to the head the gates approved

### DIFF
--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -19,6 +19,13 @@ for this PR (see ``_run_review_gate`` ->
 ``contract_hash``/``report_path``, or a verdict contradicting its report is a
 refusal. The same ``--override-reason`` valve applies with a mandatory reason.
 
+Merge pinning (OI-1264): the merge is pinned to the exact head the gates
+approved. ``_run_ci_gate`` establishes the head SHA, and ``_do_merge`` passes
+it as ``gh pr merge --match-head-commit <sha>`` so ``gh`` refuses to merge any
+other commit. A push to the branch after the gates ran moves the head, and the
+merge is then refused with a "gates must re-run" message instead of silently
+merging a commit the gates never saw.
+
 Usage:
     python3 scripts/pr_merge.py --pr 123
     python3 scripts/pr_merge.py --pr 123 --dispatch-id 20260526-gov2-something
@@ -303,16 +310,58 @@ def _run_review_gate(
     return gate, pr_data
 
 
-def _do_merge(pr_number: int, method: str) -> tuple[bool, str]:
-    """Execute gh pr merge and return (success, error_message)."""
+_HEAD_MOVED_MARKERS = (
+    "head branch is not up to date",
+    "head branch was modified",
+    "head was modified",
+    "head changed",
+    "head has changed",
+)
+
+
+def _is_head_moved_refusal(output: str) -> bool:
+    """True when a failed ``gh pr merge`` refusal signals the PR head moved.
+
+    ``gh`` surfaces the GitHub server's refusal text verbatim and has no stable
+    exit-code vocabulary for a ``--match-head-commit`` mismatch, so this matches
+    the phrasings GitHub emits when the head no longer equals the pinned commit.
+    A non-match falls through to the raw error, never to a silent pass.
+    """
+    low = (output or "").lower()
+    return any(marker in low for marker in _HEAD_MOVED_MARKERS)
+
+
+def _head_moved_refusal_message(pr_number: int, head_sha: str, raw: str) -> str:
+    """Explain a head-moved refusal as the gates working, not a crash."""
+    return (
+        f"merge van PR #{pr_number} geweigerd: de head van de branch is "
+        f"verschoven na de goedkeuring (goedgekeurd op {head_sha}). "
+        "Er is na de CI-/review-gate naar de branch gepusht; de gates moeten "
+        "opnieuw draaien op de nieuwe head voordat deze PR gemerged mag worden. "
+        f"gh: {raw}"
+    )
+
+
+def _do_merge(pr_number: int, method: str, head_sha: str = "") -> tuple[bool, str]:
+    """Execute gh pr merge pinned to the approved head and return (success, error).
+
+    ``head_sha`` is the exact commit the CI and review gates approved. It is
+    passed as ``--match-head-commit`` so ``gh`` refuses to merge any other
+    commit: a push to the branch after the gates ran moves the head, and the
+    merge must then be refused (so the gates re-run) rather than silently merged.
+    A head-moved refusal is reported as that — the system working — not as a
+    generic ``gh`` failure.
+    """
     method_flag = f"--{method}"
-    result = _gh([
-        "pr", "merge", str(pr_number),
-        method_flag, "--auto",
-    ])
+    args = ["pr", "merge", str(pr_number), method_flag, "--auto"]
+    if head_sha:
+        args += ["--match-head-commit", head_sha]
+    result = _gh(args)
     if result.returncode != 0:
-        msg = (result.stderr or result.stdout or "gh pr merge failed").strip()
-        return False, msg
+        raw = (result.stderr or result.stdout or "gh pr merge failed").strip()
+        if head_sha and _is_head_moved_refusal(raw):
+            return False, _head_moved_refusal_message(pr_number, head_sha, raw)
+        return False, raw
     return True, ""
 
 
@@ -383,8 +432,16 @@ def merge_pr(
     merge_method: str = "squash",
     dry_run: bool = False,
     receipts_file: Optional[str] = None,
+    head_sha: str = "",
 ) -> Dict[str, Any]:
     """Merge a PR and emit audit trail.
+
+    ``head_sha`` is the exact commit the gates approved; it is threaded into
+    ``gh pr merge --match-head-commit`` so the merge refuses any other commit.
+    It is established once by ``_run_ci_gate`` and must not be re-fetched here
+    (a second fetch would be a second source for the same identity). Empty
+    (default) preserves the pre-pinning behavior for callers that never ran a
+    gate.
 
     Returns a dict with keys: success, pr_number, dispatch_id, merge_method,
     pr_title, branch, receipt_status, register_ok, error.
@@ -426,8 +483,8 @@ def merge_pr(
             print(f"[dry-run] dispatch_id: {dispatch_id}")
         return result
 
-    # Execute the merge
-    ok, err = _do_merge(pr_number, merge_method)
+    # Execute the merge, pinned to the head the gates approved.
+    ok, err = _do_merge(pr_number, merge_method, head_sha)
     if not ok:
         result["error"] = err
         print(f"ERROR: gh pr merge failed for #{pr_number}: {err}", file=sys.stderr)
@@ -493,7 +550,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     method = args.merge_method or "squash"
 
     # ── Merge gate: VNX CI conclusion=success for the exact PR head ──────
-    gate, _ = _run_ci_gate(args.pr, override_reason=args.override_reason)
+    gate, pr_data = _run_ci_gate(args.pr, override_reason=args.override_reason)
     if gate["verdict"] != "GO":
         if args.json:
             print(json.dumps({
@@ -528,11 +585,16 @@ def main(argv: Optional[list[str]] = None) -> int:
     else:
         print(f"Review gate: {review_gate['message']}")
 
+    # The head SHA the gates approved is established once in _run_ci_gate; the
+    # merge is pinned to it (--match-head-commit) so a post-gate push is refused.
+    head_sha = (pr_data or {}).get("headRefOid") or ""
+
     result = merge_pr(
         pr_number=args.pr,
         dispatch_id=args.dispatch_id or "",
         merge_method=method,
         dry_run=args.dry_run,
+        head_sha=head_sha,
     )
 
     if args.json:

--- a/tests/test_file_scope_overlap.py
+++ b/tests/test_file_scope_overlap.py
@@ -189,7 +189,7 @@ def test_merge_pr_surfaces_overlap_warning(monkeypatch):
 
     monkeypatch.setattr(pr_merge, "_query_pr",
                         lambda pr: {"title": "fix: t", "headRefName": "dispatch/merging"})
-    monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method: (True, ""))
+    monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method, *a, **k: (True, ""))
     monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "ok"})
     monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **kw: True)
     monkeypatch.setattr(
@@ -206,7 +206,7 @@ def test_merge_pr_overlap_check_failure_does_not_block(monkeypatch):
 
     monkeypatch.setattr(pr_merge, "_query_pr",
                         lambda pr: {"title": "fix: t", "headRefName": "dispatch/merging"})
-    monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method: (True, ""))
+    monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method, *a, **k: (True, ""))
     monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "ok"})
     monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **kw: True)
 

--- a/tests/test_pr_merge_dual_scheme.py
+++ b/tests/test_pr_merge_dual_scheme.py
@@ -125,7 +125,7 @@ class TestMergePrDualScheme:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
             n, "chore(hygiene): remove dead code (PR-HYG-1)", "feat/hyg-1-dead-code"
         ))
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         result = pr_merge.merge_pr(pr_number=668, receipts_file=str(receipts_path))
@@ -146,7 +146,7 @@ class TestMergePrDualScheme:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
             n, "docs(readme): update installation instructions", "feat/docs-readme"
         ))
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         result = pr_merge.merge_pr(pr_number=674, receipts_file=str(receipts_path))
@@ -169,7 +169,7 @@ class TestMergePrDualScheme:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
             n, "fix: hotfix with no label", "fix/hotfix"
         ))
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         pr_merge.merge_pr(pr_number=999, receipts_file=str(receipts_path))
@@ -185,7 +185,7 @@ class TestMergePrDualScheme:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
             n, "feat: implement schema versioning (PR-42)", "feat/schema-versioning"
         ))
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         pr_merge.merge_pr(pr_number=642, receipts_file=str(receipts_path))
@@ -201,7 +201,7 @@ class TestMergePrDualScheme:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: self._make_pr_data(
             n, "feat(trace): fix traceability gap (PR-B-TRACE)", "feat/trace-gap-fix"
         ))
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         pr_merge.merge_pr(

--- a/tests/test_pr_merge_match_head.py
+++ b/tests/test_pr_merge_match_head.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Tests for the merge-pinning fix (OI-1264): the merge is pinned to the head
+the gates approved.
+
+Before this fix, ``_run_ci_gate`` verified the CI against a specific head SHA
+and ``_run_review_gate`` verified the review-gate result on the same commit,
+but ``_do_merge`` ran ``gh pr merge --auto`` with no ``--match-head-commit``.
+In the ``--auto`` wait window a push to the branch moved the head, and ``gh``
+then merged a different commit than the one the gates had approved.
+
+These tests pin two guarantees:
+
+  - ``gh pr merge`` is invoked with ``--match-head-commit`` carrying the SAME
+    sha the CI gate approved — the sha is threaded from the gate's established
+    source (``_run_ci_gate``'s ``pr_data``), not re-fetched or fed by the test
+    to both sides.
+  - a shifted head is a refused merge with a clear "the gates must re-run"
+    message, not a generic ``gh`` failure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+
+
+SHA = "b" * 40
+
+
+def _go_gate(**kw):
+    gate = {
+        "verdict": "GO",
+        "message": "VNX CI geslaagd op bbbbbbbbbbbb",
+        "ci_conclusion": "success",
+        "ran_on_sha": True,
+        "head_sha": SHA,
+        "ci_run_id": 1,
+        "workflow_name": "VNX CI",
+        "overridden": False,
+        "override_reason": None,
+    }
+    gate.update(kw)
+    return gate
+
+
+def _ok_merge_result():
+    return {
+        "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
+        "pr_title": "", "branch": "", "receipt_status": None, "register_ok": False,
+        "error": "", "dry_run": True, "overlaps": [],
+    }
+
+
+class TestMergePinnedToApprovedHead:
+    def test_merge_receives_the_sha_the_ci_gate_approved(self, monkeypatch, capsys):
+        """The sha the merge is pinned to is the one the CI gate approved.
+
+        The sha is injected exactly once (through ``_query_pr``). The real
+        ``_run_ci_gate`` extracts ``headRefOid`` and hands it to
+        ``check_ci_run_for_head``; ``main()`` threads that same value down to
+        ``merge_pr``. Asserting both destinations equal proves herkomst (the
+        value flowed through the real threading), not a value this test fed to
+        both sides.
+        """
+        pr_data = {"number": 5, "headRefOid": SHA, "headRefName": "feature/x", "title": "fix: x"}
+        gate_seen = {}
+        merge_seen = {}
+
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: pr_data)
+
+        def fake_check(project_root, *, branch, head_sha, override_reason=None):
+            gate_seen["head_sha"] = head_sha
+            return _go_gate(head_sha=head_sha)
+
+        monkeypatch.setattr(pr_merge, "check_ci_run_for_head", fake_check)
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (_go_gate(), None))
+
+        def fake_merge(**kw):
+            merge_seen["head_sha"] = kw.get("head_sha")
+            return _ok_merge_result()
+
+        monkeypatch.setattr(pr_merge, "merge_pr", fake_merge)
+
+        rc = pr_merge.main(["--pr", "5", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert gate_seen["head_sha"] == SHA
+        assert merge_seen["head_sha"] == SHA
+        assert merge_seen["head_sha"] == gate_seen["head_sha"]
+
+    def test_do_merge_adds_match_head_commit_flag(self, monkeypatch):
+        """``gh pr merge`` is invoked with ``--match-head-commit <sha>``."""
+        seen = {}
+        ok_run = subprocess.CompletedProcess(["gh"], 0, stdout="", stderr="")
+
+        def fake_gh(args, **k):
+            seen["args"] = list(args)
+            return ok_run
+
+        monkeypatch.setattr(pr_merge, "_gh", fake_gh)
+
+        ok, err = pr_merge._do_merge(5, "squash", head_sha=SHA)
+
+        assert ok is True
+        assert err == ""
+        assert seen["args"] == [
+            "pr", "merge", "5", "--squash", "--auto", "--match-head-commit", SHA,
+        ]
+
+    def test_do_merge_without_head_sha_omits_flag(self, monkeypatch):
+        """Without a pinned head the flag is omitted (backward compatible)."""
+        seen = {}
+        ok_run = subprocess.CompletedProcess(["gh"], 0, stdout="", stderr="")
+
+        def fake_gh(args, **k):
+            seen["args"] = list(args)
+            return ok_run
+
+        monkeypatch.setattr(pr_merge, "_gh", fake_gh)
+
+        ok, _ = pr_merge._do_merge(5, "squash", head_sha="")
+
+        assert ok is True
+        assert "--match-head-commit" not in seen["args"]
+
+
+class TestHeadMovedRefusal:
+    def test_shifted_head_is_a_refused_merge_with_clear_message(self, monkeypatch):
+        """A shifted head -> refused merge with a "gates must re-run" message."""
+        raw = "the head branch is not up to date with the base branch"
+        failed = subprocess.CompletedProcess(["gh"], 1, stdout="", stderr=raw)
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: failed)
+
+        ok, err = pr_merge._do_merge(5, "squash", head_sha=SHA)
+
+        assert ok is False
+        assert "verschoven" in err
+        assert "opnieuw" in err
+        assert SHA in err
+        assert raw in err
+
+    def test_unrelated_failure_keeps_raw_error(self, monkeypatch):
+        """A non-head-moved failure is not mislabeled as a shifted head."""
+        raw = "Merge conflict: unable to merge"
+        failed = subprocess.CompletedProcess(["gh"], 1, stdout="", stderr=raw)
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: failed)
+
+        ok, err = pr_merge._do_merge(5, "squash", head_sha=SHA)
+
+        assert ok is False
+        assert err == raw
+        assert "verschoven" not in err

--- a/tests/test_pr_merge_receipt.py
+++ b/tests/test_pr_merge_receipt.py
@@ -88,7 +88,7 @@ class TestMergePrEmitsReceipt:
             "number": n, "title": "feat: test PR", "headRefName": "feature-branch",
             "state": "OPEN",
         })
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         result = pr_merge.merge_pr(
@@ -118,7 +118,7 @@ class TestMergePrEmitsReceipt:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
             "number": n, "title": "chore: cleanup", "headRefName": "chore-branch",
         })
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         pr_merge.merge_pr(pr_number=42, receipts_file=str(receipts_path))
@@ -137,7 +137,7 @@ class TestMergePrEmitsReceipt:
             "title": "refactor(receipt): extract mtime-calc python",
             "headRefName": "gov2-receipt-mtime",
         })
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         result = pr_merge.merge_pr(pr_number=648, receipts_file=str(receipts_path))
@@ -157,7 +157,7 @@ class TestMergePrEmitsReceipt:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
             "number": n, "title": "fix: hotfix", "headRefName": "hotfix-branch",
         })
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         result = pr_merge.merge_pr(pr_number=77, receipts_file=str(receipts_path))
@@ -175,7 +175,7 @@ class TestMergePrEmitsReceipt:
         query_called = []
         merge_called = []
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: query_called.append(n) or None)
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: merge_called.append((n, m)) or (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: merge_called.append((n, m)) or (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         result = pr_merge.merge_pr(pr_number=55, dry_run=True, receipts_file=str(receipts_path))
@@ -193,7 +193,7 @@ class TestMergePrEmitsReceipt:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
             "number": n, "title": "...", "headRefName": "...",
         })
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (False, "merge conflict"))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (False, "merge conflict"))
 
         receipts_path = vnx_env["receipts_path"]
         result = pr_merge.merge_pr(pr_number=33, receipts_file=str(receipts_path))
@@ -210,7 +210,7 @@ class TestMergePrEmitsReceipt:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
             "number": n, "title": "test", "headRefName": "branch",
         })
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         pr_merge.merge_pr(pr_number=11, receipts_file=str(receipts_path))
@@ -230,7 +230,7 @@ class TestEmitRegisterEvent:
         monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
             "number": n, "title": "test register", "headRefName": "reg-branch",
         })
-        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m: (True, ""))
+        monkeypatch.setattr(pr_merge, "_do_merge", lambda n, m, *a, **k: (True, ""))
 
         receipts_path = vnx_env["receipts_path"]
         register_path = vnx_env["state_dir"] / "dispatch_register.ndjson"


### PR DESCRIPTION
## What

Fixes OI-1264: `_do_merge` ran `gh pr merge --auto` with no `--match-head-commit`, so a push during the auto wait window could merge a commit the CI and review gates never saw.

## Change

- Thread the head sha `_run_ci_gate` establishes into `_do_merge` and pass it as `gh pr merge --match-head-commit <sha>`. The sha is threaded from the gate's established source (`pr_data["headRefOid"]`), not re-fetched.
- A shifted head is now a refused merge with a clear "gates must re-run" message instead of a generic `gh` failure.

## Verification

- `python3 -m pytest tests/test_pr_merge_match_head.py tests/test_pr_merge_dual_scheme.py tests/test_pr_merge_receipt.py tests/test_pr_merge_ci_gate.py tests/test_pr_merge_review_gate.py tests/test_file_scope_overlap.py -q` -> 81 passed.
- New tests pin herkomst (sha flows from `_query_pr` through the real gate into the merge call) and cover the head-moved refusal and the backward-compatible no-pin case.

Dispatch-ID: 20260817-g2p5-matchhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)