### PR TITLE
fix(orphan-sweep): make tmux session listing fail-open for worktree reap (OI-1286)

### DIFF
--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -19,7 +19,14 @@ runtime objects persist forever:
    (``tmux_worktree.classify_path`` + ``reap``): a DIRTY worktree is MARKED
    (``git worktree lock`` with a reason) and NEVER deleted; clean/committed/
    pushed are removed exactly as teardown would, including process-group and
-   leftover-process cleanup. Uncommitted work is never silently deleted.
+   leftover-process cleanup. Uncommitted work is never silently deleted. The
+   session listing that decides which worktrees still have a live session is
+   itself tri-state (OI-1286): a real empty listing (tmux running, no server
+   because zero sessions exist — rc=1 with "no server running" in stderr) is
+   read as "zero sessions" and the sweep proceeds; an UNMEASURABLE listing
+   (tmux not installed, the runner raised, or an unrecognized non-zero exit)
+   is never read as "zero sessions" — it records an error and skips the
+   worktree reap for this entire run instead of guessing.
 
 3. **``dispatches/active/<id>/manifest.json``** — the subprocess lane's active
    manifests. Delegated to :mod:`crash_recovery_sweep`, which already recovers
@@ -36,6 +43,9 @@ Safety (both requirements from the dispatch):
     ``--current-dispatch``) fences that id off from all three kinds, because a
     live dispatch can be driven under a liveness signal this module cannot see
     (e.g. a harness that named its tmux session differently from ``vnx-<id>``).
+    The tmux session LISTING itself is fail-open too: when it cannot be taken
+    at all, no worktree is reaped this run, not just the ones whose id happens
+    to appear in a (possibly empty-because-broken) listing.
 """
 from __future__ import annotations
 
@@ -141,11 +151,23 @@ def _run_tmux(args: list[str], timeout: int = 10) -> tuple[int, str, str]:
         return (1, "", str(exc))
 
 
-def _real_list_sessions() -> list[str]:
-    rc, out, _ = _run_tmux(["list-sessions", "-F", "#{session_name}"])
-    if rc != 0:
+def _real_list_sessions() -> "list[str] | None":
+    """List tmux session names; tri-state on failure (OI-1286).
+
+    Returns the real listing on success. On a non-zero exit, tmux's own
+    "no server running" (rc=1, that phrase in stderr) is a genuinely empty
+    listing — zero sessions really exist — and returns ``[]``. Every other
+    non-zero outcome (tmux not installed, the runner raising OSError/
+    TimeoutExpired, or any other unrecognized rc) was never actually
+    measured and returns ``None``. Callers must not collapse ``None`` into
+    ``[]``: that is exactly the "cannot measure" == "dead" bug this fixes.
+    """
+    rc, out, err = _run_tmux(["list-sessions", "-F", "#{session_name}"])
+    if rc == 0:
+        return [line.strip() for line in out.splitlines() if line.strip()]
+    if "no server running" in (err or "").lower():
         return []
-    return [line.strip() for line in out.splitlines() if line.strip()]
+    return None
 
 
 def _real_probe_liveness(session: str, pid_alive: Callable[[Optional[int]], bool]) -> "bool | None":
@@ -202,7 +224,7 @@ def sweep(
     current_dispatch_id: Optional[str] = None,
     max_orphans: int = DEFAULT_MAX_ORPHANS,
     dry_run: bool = False,
-    list_sessions: Optional[Callable[[], list[str]]] = None,
+    list_sessions: Optional[Callable[[], "list[str] | None"]] = None,
     probe_liveness: Optional[Callable[[str], "bool | None"]] = None,
     kill_session: Optional[Callable[[str], bool]] = None,
     pid_alive: Optional[Callable[[Optional[int]], bool]] = None,
@@ -227,6 +249,11 @@ def sweep(
         list_sessions / probe_liveness / kill_session / pid_alive:
                             Injectable backends (defaults to real tmux/os).
                             Tests override them; production never does.
+                            ``list_sessions`` returning ``None`` means the
+                            listing was not measurable this run (OI-1286):
+                            kind-1 sees no sessions and kind-2 reaps nothing,
+                            with an error recorded in the result instead of
+                            treating "cannot measure" as "zero sessions".
 
     Returns:
         :class:`OrphanSweepResult` — per-object failures are recorded in
@@ -257,7 +284,25 @@ def sweep(
     # OR it is the protected invoking dispatch.
     surviving_ids: set[str] = set(protected)
 
-    for name in sorted(list_fn()):
+    sessions = list_fn()
+    listing_unmeasurable = sessions is None
+    if listing_unmeasurable:
+        sessions = []
+        result.errors.append({
+            "kind": "tmux",
+            "error": (
+                "tmux session listing was not measurable this run (tmux "
+                "missing, the runner raised, or an unrecognized non-zero "
+                "exit) — worktree reap skipped entirely so 'cannot measure' "
+                "is never read as 'zero sessions'"
+            ),
+        })
+        logger.warning(
+            "orphan_sweep: tmux session listing unmeasurable — skipping "
+            "worktree reap this run (fail-open)"
+        )
+
+    for name in sorted(sessions):
         m = _SESSION_RE.match(name)
         if not m:
             continue
@@ -306,7 +351,7 @@ def sweep(
                 continue
             wid = m.group("id")
             result.worktrees_scanned.append(str(entry))
-            if wid in surviving_ids:
+            if listing_unmeasurable or wid in surviving_ids:
                 result.worktrees_skipped_live.append(str(entry))
                 continue
             branch = f"dispatch/{wid}"

--- a/tests/test_orphan_sweep_fail_open.py
+++ b/tests/test_orphan_sweep_fail_open.py
@@ -1,0 +1,221 @@
+"""tests/test_orphan_sweep_fail_open.py — OI-1286 fail-closed listing regression tests.
+
+``orphan_sweep._real_list_sessions()`` collapses EVERY non-zero ``tmux
+list-sessions`` outcome to an empty list: tmux not installed, an
+OSError/TimeoutExpired from the runner, AND a legitimate "no server running"
+(real zero sessions) all read as ``[]``, indistinguishable from each other.
+``sweep()`` then treats that empty list as "no tmux sessions exist" and
+proceeds to reap every non-protected worktree it finds under
+``.vnx-data/worktrees/`` — even though the listing was never actually taken.
+
+The module docstring's fail-open promise ("'cannot measure' is never read as
+'dead'") does not hold for this path. These tests pin the two directions the
+eventual fix must satisfy without collapsing into each other:
+
+  * NOT MEASURABLE (tmux missing; OSError/TimeoutExpired from the runner) ->
+    worktrees must be LEFT ALONE and an error must land in the result. RED on
+    main: today they get reaped and no error is recorded.
+  * REALLY ZERO (rc=1, stderr contains "no server running") -> sweep proceeds
+    exactly as it does today. GREEN on main and must stay green after any
+    fix — the regression guard against a fix that fails closed too broadly.
+
+Per the dispatch: ``list_sessions`` is NOT injected here. Injecting it would
+bypass ``_real_list_sessions`` entirely and test nothing about the defect.
+Instead the process boundary is stubbed: ``shutil.which`` and the tmux runner
+(``orphan_sweep._adapter_run_tmux``, i.e. ``tmux_adapter._run_tmux``) — the
+real ``_real_list_sessions`` runs in every test below.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+# Unconditional inserts (mirrors test_orphan_sweep.py): scripts/lib is
+# frequently ALREADY on sys.path (installed package + conftest), so a
+# `not in sys.path` guard would skip the front-insert and leave scripts/ ahead,
+# resolving `orphan_sweep` to the CLI instead of the lib module.
+sys.path.insert(0, str(_SCRIPT_DIR))
+sys.path.insert(0, str(_SCRIPT_DIR / "lib"))
+
+import orphan_sweep as osweep  # noqa: E402  (the lib module)
+import tmux_worktree  # noqa: E402
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Pin runtime dirs to a per-test tmp tree; clear the current-dispatch fence.
+
+    Mirrors ``tests/test_orphan_sweep.py::env``. The current-dispatch fence
+    (``VNX_CURRENT_DISPATCH_ID``) is exported by the dispatch worker and
+    inherited by pytest, so it must be cleared here or the default would
+    protect a real dispatch id in every test.
+    """
+    data_dir = tmp_path / ".vnx-data"
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / "unified_reports"
+    active = data_dir / "dispatches" / "active"
+    for d in (data_dir, state_dir, reports_dir, active):
+        d.mkdir(parents=True)
+    keys = (
+        "VNX_DATA_DIR", "VNX_DATA_DIR_EXPLICIT", "VNX_STATE_DIR",
+        "VNX_REPORTS_DIR", "VNX_PROJECT_ID", "VNX_CURRENT_DISPATCH_ID",
+    )
+    orig = {k: os.environ.get(k) for k in keys}
+    os.environ["VNX_DATA_DIR"] = str(data_dir)
+    os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
+    os.environ["VNX_STATE_DIR"] = str(state_dir)
+    os.environ["VNX_REPORTS_DIR"] = str(reports_dir)
+    os.environ["VNX_PROJECT_ID"] = "vnx-dev"
+    os.environ.pop("VNX_CURRENT_DISPATCH_ID", None)
+    yield data_dir
+    for k, v in orig.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    """Bare origin + local clone with an initial commit (mirrors test_tmux_worktree)."""
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", str(bare), str(local)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    (local / "README.md").write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    return local
+
+
+def _alloc(local: Path, dispatch_id: str) -> tmux_worktree.WorktreeHandle:
+    return tmux_worktree.allocate(dispatch_id, repo_root=local)
+
+
+# ---------------------------------------------------------------------------
+# Direction 1 — NOT MEASURABLE: worktrees must be left alone, error recorded.
+# RED on main: today these get silently reaped, no error recorded.
+# ---------------------------------------------------------------------------
+
+def test_tmux_not_installed_worktree_survives_and_is_errored(env, tmp_path, monkeypatch):
+    """rc=127 'tmux not found' is unmeasurable, not 'zero sessions' — must not reap."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "no-tmux-1")
+    assert handle.path.is_dir()
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: None)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert handle.path.is_dir(), (
+        "worktree was reaped even though the tmux listing was never "
+        "measurable (tmux not installed) — fail-open contract violated"
+    )
+    assert str(handle.path) not in res.worktrees_removed
+    assert res.errors, (
+        "an unmeasurable tmux listing must surface as an error in the "
+        "result, not pass silently as 'zero sessions'"
+    )
+
+
+def test_tmux_runner_oserror_worktree_survives_and_is_errored(env, tmp_path, monkeypatch):
+    """An OSError from the tmux runner is unmeasurable, not 'zero sessions' — must not reap."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "runner-oserror-1")
+    assert handle.path.is_dir()
+
+    def fake_run_tmux(*args, **kwargs):
+        raise OSError("Resource temporarily unavailable")
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: "/usr/local/bin/tmux")
+    monkeypatch.setattr(osweep, "_adapter_run_tmux", fake_run_tmux)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert handle.path.is_dir(), (
+        "worktree was reaped even though the tmux runner raised OSError — "
+        "fail-open contract violated"
+    )
+    assert str(handle.path) not in res.worktrees_removed
+    assert res.errors, (
+        "a tmux runner OSError must surface as an error in the result, "
+        "not pass silently as 'zero sessions'"
+    )
+
+
+def test_tmux_runner_timeout_worktree_survives_and_is_errored(env, tmp_path, monkeypatch):
+    """A TimeoutExpired from the tmux runner is unmeasurable, not 'zero sessions' — must not reap."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "runner-timeout-1")
+    assert handle.path.is_dir()
+
+    def fake_run_tmux(*args, timeout=10, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["tmux", "list-sessions"], timeout=timeout)
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: "/usr/local/bin/tmux")
+    monkeypatch.setattr(osweep, "_adapter_run_tmux", fake_run_tmux)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert handle.path.is_dir(), (
+        "worktree was reaped even though the tmux runner raised "
+        "TimeoutExpired — fail-open contract violated"
+    )
+    assert str(handle.path) not in res.worktrees_removed
+    assert res.errors, (
+        "a tmux runner TimeoutExpired must surface as an error in the "
+        "result, not pass silently as 'zero sessions'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direction 2 — REALLY ZERO: rc=1 "no server running" is a real empty listing.
+# GREEN on main; must stay green — regression guard against an over-eager
+# fail-closed fix that also fences off a legitimately empty listing.
+# ---------------------------------------------------------------------------
+
+def test_no_server_running_is_real_zero_sessions_worktree_still_reaped(env, tmp_path, monkeypatch):
+    """rc=1 with 'no server running' in stderr means truly zero sessions — sweep proceeds."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "no-server-1")
+
+    def fake_run_tmux(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=("tmux", *args),
+            returncode=1,
+            stdout="",
+            stderr="no server running on /tmp/tmux-501/default",
+        )
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: "/usr/local/bin/tmux")
+    monkeypatch.setattr(osweep, "_adapter_run_tmux", fake_run_tmux)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert str(handle.path) in res.worktrees_removed
+    assert not handle.path.exists()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

`orphan_sweep._real_list_sessions()` collapsed every non-zero `tmux
list-sessions` outcome — tmux not installed, an OSError/TimeoutExpired from
the runner, AND a legitimate "no server running" (real zero sessions) — to
the same empty list. `sweep()` then treated that empty list as "no tmux
sessions exist" and proceeded to reap every non-protected worktree, even
though the listing was never actually taken. The module docstring's
fail-open promise ("'cannot measure' is never read as 'dead'") did not hold
for the worktree kind.

This replaces PR #1597 (test-only): that PR added the RED regression test
without a fix. This PR cherry-picks that same test commit unchanged and adds
the fix on top.

## Changes

- `scripts/lib/orphan_sweep.py`:
  - `_real_list_sessions()` now returns `list[str] | None` — a real listing
    (including a genuinely empty one, detected via tmux's own "no server
    running" text in stderr) returns a list; every other non-zero outcome
    (missing binary, runner exception, unrecognized rc) returns `None`.
  - `sweep()` treats `None` as "not measurable": it records an error in
    `result.errors` and skips the worktree reap for kind 2 entirely this
    run, instead of guessing based on an empty-because-broken listing. The
    real "no server running" path is untouched and still proceeds exactly
    as before.
  - Updated the module docstring and `sweep()`'s `list_sessions` doc to
    describe the tri-state contract.
- `tests/test_orphan_sweep_fail_open.py` (cherry-picked unchanged from
  `dispatch/20260817-oi1286-test`, commit `a7701efb`): the RED regression
  test this PR turns green.

## Verification

Baseline (before the fix, right after cherry-picking the test commit):

```
$ python3 -m pytest tests/test_orphan_sweep_fail_open.py -v
tests/test_orphan_sweep_fail_open.py::test_tmux_not_installed_worktree_survives_and_is_errored FAILED
tests/test_orphan_sweep_fail_open.py::test_tmux_runner_oserror_worktree_survives_and_is_errored FAILED
tests/test_orphan_sweep_fail_open.py::test_tmux_runner_timeout_worktree_survives_and_is_errored FAILED
tests/test_orphan_sweep_fail_open.py::test_no_server_running_is_real_zero_sessions_worktree_still_reaped PASSED
=================== 3 failed, 1 passed in 1.68s ===================
```

After the fix:

```
$ python3 -m pytest tests/test_orphan_sweep_fail_open.py -v
tests/test_orphan_sweep_fail_open.py::test_tmux_not_installed_worktree_survives_and_is_errored PASSED
tests/test_orphan_sweep_fail_open.py::test_tmux_runner_oserror_worktree_survives_and_is_errored PASSED
tests/test_orphan_sweep_fail_open.py::test_tmux_runner_timeout_worktree_survives_and_is_errored PASSED
tests/test_orphan_sweep_fail_open.py::test_no_server_running_is_real_zero_sessions_worktree_still_reaped PASSED
=================== 4 passed in 1.01s ===================
```

Existing suite unaffected:

```
$ python3 -m pytest tests/test_orphan_sweep.py -v
=================== 13 passed in 1.86s ===================
```

`git diff --stat HEAD~1..HEAD` on the fix commit (`fed75ce0`) touches only
`scripts/lib/orphan_sweep.py` — the test file is not in this commit, it
came in unchanged via cherry-pick from the test-writer's commit `ff9219d1`.

## Test plan

- [x] `tests/test_orphan_sweep_fail_open.py` — 4 passed (was 3 failed, 1 passed)
- [x] `tests/test_orphan_sweep.py` — 13 passed (no regression)