### PR TITLE
fix(dispatch): thread DispatchPath.access through the tmux-lane wire (OI-1271)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -36,6 +36,7 @@ from dispatch_spec import (  # noqa: E402
     Provider,
     Reject,
     ValidatedSpec,
+    WRITE_GRANTING_PATH_ACCESS,
     validate,
     write_paths,
 )
@@ -1826,17 +1827,34 @@ def _dispatch_path_wire_entry(dp: DispatchPath) -> str:
     READ_WRITE. The receiving parser already understands the ``path:access``
     suffix form; only the sender was missing it.
 
-    READ_WRITE (``DispatchPath``'s own default) is emitted as a bare path,
-    unchanged from before this fix: that keeps every existing caller that
-    never declares ``access`` byte-for-byte identical on the wire, which
-    matters beyond this module — ``benchmark_worker_isolation.materialize_benchmark_seed``
-    and ``TmuxInteractiveDispatch._scope_note`` both consume this same list
-    and treat an entry as a literal repo-relative path, not a
-    ``path:access`` pair. Only a path that actually restricts or narrows
-    access (READ/WRITE/CREATE) needs the explicit suffix to survive the
-    trip.
+    Only READ gets the ``:access`` suffix. WRITE, READ_WRITE, and CREATE
+    (every member of WRITE_GRANTING_PATH_ACCESS) are all emitted as a bare
+    path. This is a deliberate minimal-wire-change choice, not an
+    oversight: ``resolve_dispatch_write_scope`` treats WRITE, READ_WRITE,
+    and CREATE identically, and a suffix-less entry already parses to
+    READ_WRITE — itself write-granting — so tagging WRITE or CREATE changes
+    nothing about the resulting write scope. READ is the only access value
+    that narrows anything, so it is the only one worth the suffix. The
+    membership check against WRITE_GRANTING_PATH_ACCESS (rather than an
+    equality check against PathAccess.READ) keeps this function deriving
+    "which access values need no suffix" from the same single source of
+    truth ``worker_permissions`` already imports for "which access values
+    mean write", instead of redeclaring the inverse.
+
+    That restraint matters beyond this module: ``benchmark_worker_isolation.
+    materialize_benchmark_seed`` and ``TmuxInteractiveDispatch._scope_note``
+    both consume this same list and treat every entry as a literal
+    repo-relative path, not a ``path:access`` pair — neither strips a
+    suffix. Suffixing WRITE/CREATE for no enforcement benefit would only add
+    a way to break those two consumers the day a caller declares
+    ``access=write``/``access=create`` on a path that also flows through
+    them; today no caller does (only READ and the READ_WRITE default are
+    used anywhere in this codebase). Keeping the wire form byte-for-byte
+    unchanged for every access value except the one that actually needs it
+    is the same reasoning the original OI-1271 fix already applied to
+    READ_WRITE, carried through consistently instead of stopping short.
     """
-    if dp.access == PathAccess.READ_WRITE:
+    if dp.access in WRITE_GRANTING_PATH_ACCESS:
         return str(dp.path)
     return f"{dp.path}:{dp.access.value}"
 

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1815,6 +1815,32 @@ def build_runtime_snapshot(
 # Lane executors
 # ---------------------------------------------------------------------------
 
+def _dispatch_path_wire_entry(dp: DispatchPath) -> str:
+    """Encode one DispatchPath for the tmux-lane ``--dispatch-paths`` wire format.
+
+    OI-1271: dispatch_cli previously handed the lane bare ``str(dp.path)``
+    strings, so ``DispatchPath.access`` never reached
+    ``worker_permissions.resolve_dispatch_write_scope`` — a path declared
+    ``access=read`` landed in the worker's write scope anyway, because
+    ``_parse_dispatch_path_entry`` defaults a suffix-less entry to
+    READ_WRITE. The receiving parser already understands the ``path:access``
+    suffix form; only the sender was missing it.
+
+    READ_WRITE (``DispatchPath``'s own default) is emitted as a bare path,
+    unchanged from before this fix: that keeps every existing caller that
+    never declares ``access`` byte-for-byte identical on the wire, which
+    matters beyond this module — ``benchmark_worker_isolation.materialize_benchmark_seed``
+    and ``TmuxInteractiveDispatch._scope_note`` both consume this same list
+    and treat an entry as a literal repo-relative path, not a
+    ``path:access`` pair. Only a path that actually restricts or narrows
+    access (READ/WRITE/CREATE) needs the explicit suffix to survive the
+    trip.
+    """
+    if dp.access == PathAccess.READ_WRITE:
+        return str(dp.path)
+    return f"{dp.path}:{dp.access.value}"
+
+
 def _execute_claude(
     plan: ExecutionPlan,
     permit: ExecutionPermit,
@@ -1865,7 +1891,7 @@ def _execute_claude(
         plan.dispatch_id,
         role=role,
         model=plan.model,
-        dispatch_paths=[str(dp.path) for dp in plan.dispatch_paths],
+        dispatch_paths=[_dispatch_path_wire_entry(dp) for dp in plan.dispatch_paths],
         deadline_seconds=plan.deadline_seconds,
         base_ref=plan.base_ref,
         isolated_worktree=True,

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -119,15 +119,34 @@ def write_paths(paths: "tuple[DispatchPath, ...]") -> list[str]:
     ``PathAccess.READ`` entry is excluded (see WRITE_GRANTING_PATH_ACCESS);
     everything else is included.
 
-    Not yet wired to the tmux-lane ``--dispatch-paths`` CLI surface
-    (``scripts/lib/worker_permissions.resolve_dispatch_write_scope``, which
-    enforces the write-scope narrowing this function's output is meant to
-    feed): that surface currently carries plain path strings sourced from
-    ``dispatch_cli.py``/``dispatch_bridge.py`` (the single-entry dispatch
-    door's staging/bridge layer), which are outside this change's file
-    boundary. Once that bridge threads typed ``DispatchPath`` objects
-    through instead of bare strings, it should call this function rather
-    than re-deriving which access values mean "write".
+    This function's own caller is door-time classification, not wire
+    encoding: ``dispatch_cli._spec_is_writing`` calls ``write_paths()`` to
+    decide whether a dispatch is "writing" (and therefore needs a review
+    gate) — it only needs to know whether the write-granting subset is
+    non-empty, so the filtered, stripped-to-bare-string return shape is
+    exactly what it wants.
+
+    OI-1271 wired ``DispatchPath.access`` onto the tmux-lane
+    ``--dispatch-paths`` CLI surface, but not by routing through this
+    function. The sending side is ``dispatch_cli._dispatch_path_wire_entry``,
+    called once per ``DispatchPath`` while building the ``dispatch_paths``
+    kwarg for ``TmuxInteractiveDispatch.dispatch``; the receiving side is
+    ``worker_permissions._parse_dispatch_path_entry``, which reads each wire
+    entry back into a ``(path, access)`` pair for
+    ``worker_permissions.resolve_dispatch_write_scope``. That bridge cannot
+    call ``write_paths()``: the wire needs every declared path present, each
+    carrying its own access, because two other consumers of the same list —
+    ``benchmark_worker_isolation.materialize_benchmark_seed`` and
+    ``TmuxInteractiveDispatch._scope_note`` — read every entry as a literal
+    repo-relative path, and a pre-filtered, write-only subset would silently
+    drop the read-only paths they still need to see.
+    ``_dispatch_path_wire_entry`` instead re-derives write-intent per path
+    against ``WRITE_GRANTING_PATH_ACCESS`` directly — the same frozenset
+    this function already consults, and the same one ``worker_permissions``
+    imports (as ``WRITE_GRANTING_ACCESS``) for the receiving side — so
+    "which access values mean write" still has one source of truth even
+    though door-time classification and wire encoding evaluate it through
+    two independent call paths rather than one calling the other.
     """
     return [str(dp.path) for dp in paths if dp.access in WRITE_GRANTING_PATH_ACCESS]
 

--- a/tests/test_dispatch_path_access_provenance.py
+++ b/tests/test_dispatch_path_access_provenance.py
@@ -1,0 +1,209 @@
+"""test_dispatch_path_access_provenance.py — OI-1271: access=read becomes a write grant.
+
+The spec knows a per-path access right (``DispatchPath.access``), and
+``worker_permissions.resolve_dispatch_write_scope`` knows how to honour it — but
+the single-entry door drops the right on the floor before the tmux lane ever
+sees it. ``dispatch_cli.py:1868`` builds the ``dispatch_paths`` kwarg for
+``TmuxInteractiveDispatch.dispatch`` as ``[str(dp.path) for dp in
+plan.dispatch_paths]``: plain path strings, no ``access`` anywhere. Downstream,
+``worker_permissions._parse_dispatch_path_entry`` treats a bare string (no
+``:access`` suffix) as ``PathAccess.READ_WRITE`` — so a path the spec declared
+``access=read`` silently becomes writable once it reaches the worker-scope
+enforcement hook.
+
+This is a HERKOMST test, not a parser test: it never hand-writes a
+``"path:read"`` string and asserts the parser reads it back correctly (that
+already works and is not the bug). Instead it captures what the door actually
+hands to ``TmuxInteractiveDispatch.dispatch`` — by monkeypatching that method
+and recording its kwargs — for a spec whose ``DispatchPath`` carries
+``access=read``, and only then feeds that captured, door-produced value into
+``resolve_dispatch_write_scope``. The assertion hangs off the real call chain
+(``dispatch_cli._execute_claude`` -> ``TmuxInteractiveDispatch.dispatch`` ->
+``worker_permissions.resolve_dispatch_write_scope``), not off a value the test
+itself typed in.
+
+Every test in this file exercises ``dispatch_cli._execute_claude`` on
+unmodified production code. ``test_read_access_path_...`` and
+``test_mixed_access_paths_...`` are RED on origin/main (the defect); the
+``read_write`` regression test is GREEN on main today and must stay GREEN
+once the fix lands, since it is the proof the fix has not narrowed anything
+that used to work.
+"""
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import sys
+from pathlib import Path, PurePosixPath
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_cli import _execute_claude
+from dispatch_internal import issue_permit
+from dispatch_plan import ExecutionPlan
+from dispatch_spec import DispatchPath, Isolation, PathAccess, Provider
+from worker_permissions import resolve_dispatch_write_scope
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_instruction_file(tmp_path: Path, text: str = "# OI-1271 provenance test\n") -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text(text, encoding="utf-8")
+    return f
+
+
+def _make_plan(tmp_path: Path, dispatch_paths: "tuple[DispatchPath, ...]") -> ExecutionPlan:
+    """A valid claude-lane plan carrying *dispatch_paths* with a matching instruction sha256.
+
+    Mirrors ``_make_mcp_plan`` in test_requires_mcp_propagation.py — the same
+    ``_execute_claude`` call shape, just varying ``dispatch_paths`` instead of
+    ``requires_mcp``.
+    """
+    ifile = _fake_instruction_file(tmp_path)
+    sha = hashlib.sha256(ifile.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+    return ExecutionPlan(
+        dispatch_id="oi1271-exec-001",
+        project_id="vnx-dev",
+        provider=Provider.CLAUDE,
+        model="sonnet",
+        lane="claude_tmux_subscription",
+        adapter="tmux_claude",
+        target_id="ephemeral",
+        billing="subscription",
+        serialization_class="claude-tmux",
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="verify_strict",
+        deadline_seconds=3600,
+        base_ref="origin/main",
+        dispatch_paths=dispatch_paths,
+        instruction_file=ifile,
+        route_reason="D11,D3,D1,D2,D4,D5,D6,D7,D8,D9,D10,D12",
+        instruction_sha256=sha,
+    )
+
+
+def _capture_door_forwarded_dispatch_paths(tmp_path: Path, dispatch_paths: "tuple[DispatchPath, ...]") -> "list[str]":
+    """Drive the real door path (_execute_claude -> TmuxInteractiveDispatch.dispatch)
+    and return exactly what the door handed the tmux lane as ``dispatch_paths``.
+
+    This is the HERKOMST capture point: whatever list comes back here is what
+    line 1868 of dispatch_cli.py actually produced, not a string the test wrote.
+    """
+    plan = _make_plan(tmp_path, dispatch_paths)
+    permit = issue_permit(plan)
+    with patch(
+        "tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch",
+        return_value=MagicMock(success=True),
+    ) as mock_dispatch:
+        _execute_claude(plan, permit, state_dir=tmp_path / "state", data_dir=tmp_path)
+    mock_dispatch.assert_called_once()
+    _, kwargs = mock_dispatch.call_args
+    assert "dispatch_paths" in kwargs
+    return kwargs["dispatch_paths"]
+
+
+def _is_in_write_scope(file_path: str, write_scope: "list[str] | None") -> bool:
+    if write_scope is None:
+        return True
+    return any(fnmatch.fnmatch(file_path, scope) for scope in write_scope)
+
+
+# ---------------------------------------------------------------------------
+# The defect: access=read does not survive the door -> lane -> write-scope chain
+# ---------------------------------------------------------------------------
+
+class TestReadAccessPathLosesItsRestrictionAtTheDoor:
+    def test_read_access_path_excluded_from_door_forwarded_write_scope(self, tmp_path: Path) -> None:
+        """A DispatchPath declared access=read must not end up write-scoped.
+
+        RED on main: dispatch_cli.py:1868 builds dispatch_paths as bare
+        ``str(dp.path)`` strings, so the captured value the door hands the
+        lane carries no access information at all. Fed into
+        resolve_dispatch_write_scope, a bare string defaults to READ_WRITE
+        (worker_permissions._parse_dispatch_path_entry), so the read-only
+        path incorrectly lands in the resulting write scope and this
+        assertion fails.
+        """
+        read_path = "scripts/lib/secret_module.py"
+        dispatch_paths = (
+            DispatchPath(PurePosixPath(read_path), access=PathAccess.READ),
+        )
+
+        captured = _capture_door_forwarded_dispatch_paths(tmp_path, dispatch_paths)
+        write_scope = resolve_dispatch_write_scope(captured)
+
+        assert not _is_in_write_scope(read_path, write_scope), (
+            f"access=read path {read_path!r} must not be write-scoped, but the door-forwarded "
+            f"dispatch_paths {captured!r} resolved to write_scope {write_scope!r} which includes it "
+            "(OI-1271: dispatch_cli.py:1868 drops DispatchPath.access before handing dispatch_paths "
+            "to TmuxInteractiveDispatch.dispatch)"
+        )
+
+    def test_mixed_access_paths_write_scope_reflects_only_write_granting_paths(self, tmp_path: Path) -> None:
+        """A dispatch declaring BOTH a read and a read_write path must only write-scope the latter.
+
+        RED on main for the same reason as above — pulls the full chain
+        (door -> lane kwargs -> resolve_dispatch_write_scope) through a
+        realistic mixed-access spec instead of a single-path one, so the
+        selectivity itself (not just "empty vs non-empty") is under test.
+        """
+        read_path = "scripts/lib/secret_module.py"
+        write_path = "scripts/lib/build_module.py"
+        dispatch_paths = (
+            DispatchPath(PurePosixPath(read_path), access=PathAccess.READ),
+            DispatchPath(PurePosixPath(write_path), access=PathAccess.READ_WRITE),
+        )
+
+        captured = _capture_door_forwarded_dispatch_paths(tmp_path, dispatch_paths)
+        write_scope = resolve_dispatch_write_scope(captured)
+
+        assert _is_in_write_scope(write_path, write_scope), (
+            f"access=read_write path {write_path!r} must remain write-scoped; got write_scope {write_scope!r}"
+        )
+        assert not _is_in_write_scope(read_path, write_scope), (
+            f"access=read path {read_path!r} must not be write-scoped alongside a read_write sibling, but "
+            f"door-forwarded dispatch_paths {captured!r} resolved to write_scope {write_scope!r} which includes it"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression net — read_write must keep working. GREEN on main, stays GREEN.
+# ---------------------------------------------------------------------------
+
+class TestReadWriteAccessPathRegressionNet:
+    def test_read_write_access_path_included_in_door_forwarded_write_scope(self, tmp_path: Path) -> None:
+        """A DispatchPath declared access=read_write must remain write-scoped end-to-end.
+
+        GREEN on main today: a bare path string defaults to READ_WRITE in
+        worker_permissions._parse_dispatch_path_entry, so this already
+        passes by coincidence of the very default the defect exploits. It
+        must keep passing once the fix threads real access through, so the
+        fix is proven not to have narrowed a legitimately write-granted path.
+        """
+        write_path = "scripts/lib/build_module.py"
+        dispatch_paths = (
+            DispatchPath(PurePosixPath(write_path), access=PathAccess.READ_WRITE),
+        )
+
+        captured = _capture_door_forwarded_dispatch_paths(tmp_path, dispatch_paths)
+        write_scope = resolve_dispatch_write_scope(captured)
+
+        assert _is_in_write_scope(write_path, write_scope), (
+            f"access=read_write path {write_path!r} must be write-scoped; got captured={captured!r}, "
+            f"write_scope={write_scope!r}"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_dispatch_path_wire_format.py
+++ b/tests/test_dispatch_path_wire_format.py
@@ -1,0 +1,85 @@
+"""test_dispatch_path_wire_format.py — pins dispatch_cli._dispatch_path_wire_entry's wire form.
+
+OI-1271 review (PR #1602 replacement): the fix threads DispatchPath.access onto
+the tmux-lane ``--dispatch-paths`` wire via ``_dispatch_path_wire_entry``, but no
+test pinned the actual string each PathAccess value produces. The two review
+points this file closes:
+
+  * "byte-for-byte identical for READ_WRITE" was an unverified claim in the
+    original commit message, not a test assertion.
+  * WRITE and CREATE had no test of their own at all.
+
+This test is deliberately about the WIRE STRING, not about write-scope
+resolution (test_dispatch_path_access_provenance.py already covers the
+door -> lane -> resolve_dispatch_write_scope chain end to end). Pinning the
+exact string here means the chosen wire form — only READ gets a ``:access``
+suffix, WRITE/READ_WRITE/CREATE stay bare paths — cannot silently drift back
+to suffixing everything (or nothing) without a red test.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_cli import _dispatch_path_wire_entry
+from dispatch_spec import DispatchPath, PathAccess
+
+
+# ---------------------------------------------------------------------------
+# One row per PathAccess value — the closed set has exactly four members.
+# ---------------------------------------------------------------------------
+
+WIRE_FORM_CASES = [
+    pytest.param(PathAccess.READ, "scripts/lib/secret_module.py:read", id="read"),
+    pytest.param(PathAccess.WRITE, "scripts/lib/secret_module.py", id="write"),
+    pytest.param(PathAccess.READ_WRITE, "scripts/lib/secret_module.py", id="read_write"),
+    pytest.param(PathAccess.CREATE, "scripts/lib/secret_module.py", id="create"),
+]
+
+
+class TestDispatchPathWireEntry:
+    @pytest.mark.parametrize("access, expected_wire_string", WIRE_FORM_CASES)
+    def test_wire_string_per_access_value(
+        self, access: PathAccess, expected_wire_string: str
+    ) -> None:
+        dp = DispatchPath(PurePosixPath("scripts/lib/secret_module.py"), access=access)
+
+        assert _dispatch_path_wire_entry(dp) == expected_wire_string
+
+    def test_all_four_path_access_values_are_covered(self) -> None:
+        """Fail loud if PathAccess ever grows/shrinks without this test noticing."""
+        covered = {case.values[0] for case in WIRE_FORM_CASES}
+
+        assert covered == set(PathAccess), (
+            f"WIRE_FORM_CASES covers {sorted(a.value for a in covered)} but "
+            f"PathAccess has {sorted(a.value for a in PathAccess)} — add/remove a "
+            "case so every access value stays pinned"
+        )
+
+    def test_only_read_gets_a_suffix(self) -> None:
+        """Cross-check the four rows above against the write-granting/narrowing split.
+
+        READ is the only PathAccess value that is NOT in WRITE_GRANTING_PATH_ACCESS
+        (see dispatch_spec.py) — it is also the only one that gets a wire suffix.
+        This test fails if that correspondence is ever broken in either direction,
+        independent of the exact string each case above pins.
+        """
+        from dispatch_spec import WRITE_GRANTING_PATH_ACCESS
+
+        for access in PathAccess:
+            dp = DispatchPath(PurePosixPath("some/path.py"), access=access)
+            wire = _dispatch_path_wire_entry(dp)
+            has_suffix = wire != "some/path.py"
+
+            assert has_suffix == (access not in WRITE_GRANTING_PATH_ACCESS), (
+                f"{access!r}: wire form {wire!r} suffix presence ({has_suffix}) "
+                f"disagrees with WRITE_GRANTING_PATH_ACCESS membership"
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Supersedes #1602 (branch `dispatch/20260817-oi1271-fix`). That PR was
inhouds-goedgekeurd door twee lezers uit verschillende modelfamilies, geen
blockers, maar twee review-punten bleven open. This PR carries over its
test and fix commits unmodified and adds the two follow-up changes on top.

- OI-1271 fix (unchanged, cherry-picked): `dispatch_cli._execute_claude`
  built the tmux lane's `dispatch_paths` kwarg as bare `str(dp.path)`
  strings, dropping `DispatchPath.access` before it reached
  `worker_permissions.resolve_dispatch_write_scope`. A path declared
  `access=read` landed in the worker's write scope anyway.
- Review point 1: `dispatch_spec.write_paths()`'s docstring said the
  tmux-lane wire was "not yet wired" to `DispatchPath.access` — stale as of
  this fix. Rewritten to describe the actual bridge and why `write_paths()`
  itself is never its encoder.
- Review point 2: `_dispatch_path_wire_entry()` suffixed READ, WRITE, and
  CREATE alike. `resolve_dispatch_write_scope` treats WRITE, READ_WRITE,
  and CREATE identically (all write-granting; a bare entry already
  defaults to READ_WRITE), so suffixing WRITE/CREATE changed no
  enforcement outcome while adding needless risk for the two literal-path
  consumers (`benchmark_worker_isolation.materialize_benchmark_seed`,
  `TmuxInteractiveDispatch._scope_note`). Narrowed to: only READ gets a
  suffix, decided via `WRITE_GRANTING_PATH_ACCESS` membership rather than
  a hardcoded equality check.

## Changes

- `scripts/lib/dispatch_cli.py` — `_dispatch_path_wire_entry()` now emits
  a `:access` suffix only for `PathAccess.READ` (via
  `WRITE_GRANTING_PATH_ACCESS` membership, not a `PathAccess.READ_WRITE`
  equality check); `WRITE_GRANTING_PATH_ACCESS` added to the
  `dispatch_spec` import; docstring rewritten to explain the choice.
- `scripts/lib/dispatch_spec.py` — `write_paths()` docstring rewritten:
  describes the real OI-1271 bridge
  (`dispatch_cli._dispatch_path_wire_entry` ->
  `TmuxInteractiveDispatch.dispatch` ->
  `worker_permissions._parse_dispatch_path_entry` ->
  `resolve_dispatch_write_scope`) and why `write_paths()` is not its
  encoder.
- `tests/test_dispatch_path_wire_format.py` (new) — pins the wire string
  for all four `PathAccess` values plus a membership cross-check against
  `WRITE_GRANTING_PATH_ACCESS`.
- `tests/test_dispatch_path_access_provenance.py` — cherry-picked
  unchanged from the superseded branch, not modified in this PR.

## Verification

```
$ python3 -m pytest tests/test_dispatch_path_access_provenance.py -q
...                                                                      [100%]
3 passed in 0.26s

$ python3 -m pytest tests/test_dispatch_path_wire_format.py -v
tests/test_dispatch_path_wire_format.py::TestDispatchPathWireEntry::test_wire_string_per_access_value[read] PASSED
tests/test_dispatch_path_wire_format.py::TestDispatchPathWireEntry::test_wire_string_per_access_value[write] PASSED
tests/test_dispatch_path_wire_format.py::TestDispatchPathWireEntry::test_wire_string_per_access_value[read_write] PASSED
tests/test_dispatch_path_wire_format.py::TestDispatchPathWireEntry::test_wire_string_per_access_value[create] PASSED
tests/test_dispatch_path_wire_format.py::TestDispatchPathWireEntry::test_all_four_path_access_values_are_covered PASSED
tests/test_dispatch_path_wire_format.py::TestDispatchPathWireEntry::test_only_read_gets_a_suffix PASSED
6 passed in 0.16s

$ python3 -m pytest tests/test_dispatch_cli.py tests/test_dispatch_spec.py tests/test_worker_permissions.py tests/test_worker_permissions_merge.py tests/test_worker_permissions_role_scope.py -q
373 passed in 6.46s
```

`git diff --stat` confirms `tests/test_dispatch_path_access_provenance.py`
is untouched by this PR (identical to the cherry-picked commit).

## Test plan

- [x] `tests/test_dispatch_path_access_provenance.py` green (3, cherry-picked, untouched)
- [x] New `tests/test_dispatch_path_wire_format.py` green (6)
- [x] `test_dispatch_cli.py` + `test_dispatch_spec.py` + `test_worker_permissions*.py` green (373)

🤖 Generated with [Claude Code](https://claude.com/claude-code)