### PR TITLE
fix(orphan-sweep): pin the tri-state tmux discriminator to real tmux, not a stubbed string (OI-1286)

### DIFF
--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -19,7 +19,14 @@ runtime objects persist forever:
    (``tmux_worktree.classify_path`` + ``reap``): a DIRTY worktree is MARKED
    (``git worktree lock`` with a reason) and NEVER deleted; clean/committed/
    pushed are removed exactly as teardown would, including process-group and
-   leftover-process cleanup. Uncommitted work is never silently deleted.
+   leftover-process cleanup. Uncommitted work is never silently deleted. The
+   session listing that decides which worktrees still have a live session is
+   itself tri-state (OI-1286): a real empty listing (tmux running, no server
+   because zero sessions exist — rc=1 with "no server running" in stderr) is
+   read as "zero sessions" and the sweep proceeds; an UNMEASURABLE listing
+   (tmux not installed, the runner raised, or an unrecognized non-zero exit)
+   is never read as "zero sessions" — it records an error and skips the
+   worktree reap for this entire run instead of guessing.
 
 3. **``dispatches/active/<id>/manifest.json``** — the subprocess lane's active
    manifests. Delegated to :mod:`crash_recovery_sweep`, which already recovers
@@ -36,6 +43,9 @@ Safety (both requirements from the dispatch):
     ``--current-dispatch``) fences that id off from all three kinds, because a
     live dispatch can be driven under a liveness signal this module cannot see
     (e.g. a harness that named its tmux session differently from ``vnx-<id>``).
+    The tmux session LISTING itself is fail-open too: when it cannot be taken
+    at all, no worktree is reaped this run, not just the ones whose id happens
+    to appear in a (possibly empty-because-broken) listing.
 """
 from __future__ import annotations
 
@@ -141,11 +151,23 @@ def _run_tmux(args: list[str], timeout: int = 10) -> tuple[int, str, str]:
         return (1, "", str(exc))
 
 
-def _real_list_sessions() -> list[str]:
-    rc, out, _ = _run_tmux(["list-sessions", "-F", "#{session_name}"])
-    if rc != 0:
+def _real_list_sessions() -> "list[str] | None":
+    """List tmux session names; tri-state on failure (OI-1286).
+
+    Returns the real listing on success. On a non-zero exit, tmux's own
+    "no server running" (rc=1, that phrase in stderr) is a genuinely empty
+    listing — zero sessions really exist — and returns ``[]``. Every other
+    non-zero outcome (tmux not installed, the runner raising OSError/
+    TimeoutExpired, or any other unrecognized rc) was never actually
+    measured and returns ``None``. Callers must not collapse ``None`` into
+    ``[]``: that is exactly the "cannot measure" == "dead" bug this fixes.
+    """
+    rc, out, err = _run_tmux(["list-sessions", "-F", "#{session_name}"])
+    if rc == 0:
+        return [line.strip() for line in out.splitlines() if line.strip()]
+    if "no server running" in (err or "").lower():
         return []
-    return [line.strip() for line in out.splitlines() if line.strip()]
+    return None
 
 
 def _real_probe_liveness(session: str, pid_alive: Callable[[Optional[int]], bool]) -> "bool | None":
@@ -202,7 +224,7 @@ def sweep(
     current_dispatch_id: Optional[str] = None,
     max_orphans: int = DEFAULT_MAX_ORPHANS,
     dry_run: bool = False,
-    list_sessions: Optional[Callable[[], list[str]]] = None,
+    list_sessions: Optional[Callable[[], "list[str] | None"]] = None,
     probe_liveness: Optional[Callable[[str], "bool | None"]] = None,
     kill_session: Optional[Callable[[str], bool]] = None,
     pid_alive: Optional[Callable[[Optional[int]], bool]] = None,
@@ -227,6 +249,11 @@ def sweep(
         list_sessions / probe_liveness / kill_session / pid_alive:
                             Injectable backends (defaults to real tmux/os).
                             Tests override them; production never does.
+                            ``list_sessions`` returning ``None`` means the
+                            listing was not measurable this run (OI-1286):
+                            kind-1 sees no sessions and kind-2 reaps nothing,
+                            with an error recorded in the result instead of
+                            treating "cannot measure" as "zero sessions".
 
     Returns:
         :class:`OrphanSweepResult` — per-object failures are recorded in
@@ -257,7 +284,25 @@ def sweep(
     # OR it is the protected invoking dispatch.
     surviving_ids: set[str] = set(protected)
 
-    for name in sorted(list_fn()):
+    sessions = list_fn()
+    listing_unmeasurable = sessions is None
+    if listing_unmeasurable:
+        sessions = []
+        result.errors.append({
+            "kind": "tmux",
+            "error": (
+                "tmux session listing was not measurable this run (tmux "
+                "missing, the runner raised, or an unrecognized non-zero "
+                "exit) — worktree reap skipped entirely so 'cannot measure' "
+                "is never read as 'zero sessions'"
+            ),
+        })
+        logger.warning(
+            "orphan_sweep: tmux session listing unmeasurable — skipping "
+            "worktree reap this run (fail-open)"
+        )
+
+    for name in sorted(sessions):
         m = _SESSION_RE.match(name)
         if not m:
             continue
@@ -306,7 +351,7 @@ def sweep(
                 continue
             wid = m.group("id")
             result.worktrees_scanned.append(str(entry))
-            if wid in surviving_ids:
+            if listing_unmeasurable or wid in surviving_ids:
                 result.worktrees_skipped_live.append(str(entry))
                 continue
             branch = f"dispatch/{wid}"

--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -22,11 +22,14 @@ runtime objects persist forever:
    leftover-process cleanup. Uncommitted work is never silently deleted. The
    session listing that decides which worktrees still have a live session is
    itself tri-state (OI-1286): a real empty listing (tmux running, no server
-   because zero sessions exist — rc=1 with "no server running" in stderr) is
-   read as "zero sessions" and the sweep proceeds; an UNMEASURABLE listing
-   (tmux not installed, the runner raised, or an unrecognized non-zero exit)
-   is never read as "zero sessions" — it records an error and skips the
-   worktree reap for this entire run instead of guessing.
+   because zero sessions exist — rc=1 with either "no server running" in
+   stderr, or a connect failure against a socket that does not exist on disk,
+   e.g. tmux 3.5a's "error connecting to <path> (No such file or
+   directory)") is read as "zero sessions" and the sweep proceeds; an
+   UNMEASURABLE listing (tmux not installed, the runner raised, a connect
+   failure against a socket that DOES exist, or an unrecognized non-zero
+   exit) is never read as "zero sessions" — it records an error and skips
+   the worktree reap for this entire run instead of guessing.
 
 3. **``dispatches/active/<id>/manifest.json``** — the subprocess lane's active
    manifests. Delegated to :mod:`crash_recovery_sweep`, which already recovers
@@ -154,18 +157,33 @@ def _run_tmux(args: list[str], timeout: int = 10) -> tuple[int, str, str]:
 def _real_list_sessions() -> "list[str] | None":
     """List tmux session names; tri-state on failure (OI-1286).
 
-    Returns the real listing on success. On a non-zero exit, tmux's own
-    "no server running" (rc=1, that phrase in stderr) is a genuinely empty
-    listing — zero sessions really exist — and returns ``[]``. Every other
-    non-zero outcome (tmux not installed, the runner raising OSError/
-    TimeoutExpired, or any other unrecognized rc) was never actually
-    measured and returns ``None``. Callers must not collapse ``None`` into
-    ``[]``: that is exactly the "cannot measure" == "dead" bug this fixes.
+    Returns the real listing on success. On a non-zero exit, two stderr
+    shapes both mean "no server is listening on this socket, so there are
+    genuinely zero sessions" and return ``[]``:
+
+      * the classic phrasing, "no server running" (older/other tmux builds);
+      * a connect failure against a socket that does not exist on disk —
+        tmux 3.5a on macOS emits ``error connecting to <path> (No such file
+        or directory)`` for this case instead of the classic phrase (that is
+        exactly the OI-1286 scenario: a restarted host, or a worker using a
+        different ``TMUX_TMPDIR``, where no socket was ever created).
+
+    Every other non-zero outcome (tmux not installed, the runner raising
+    OSError/TimeoutExpired, a connect failure against a socket that DOES
+    exist — e.g. a permission error or a protocol mismatch — or any other
+    unrecognized rc) was never actually measured and returns ``None``.
+    Callers must not collapse ``None`` into ``[]``: that is exactly the
+    "cannot measure" == "dead" bug this fixes. The "no such file" check is
+    what keeps that distinction real: a missing socket is a measurement, a
+    socket you can't reach is not.
     """
     rc, out, err = _run_tmux(["list-sessions", "-F", "#{session_name}"])
     if rc == 0:
         return [line.strip() for line in out.splitlines() if line.strip()]
-    if "no server running" in (err or "").lower():
+    err_lower = (err or "").lower()
+    if "no server running" in err_lower:
+        return []
+    if "error connecting to" in err_lower and "no such file or directory" in err_lower:
         return []
     return None
 

--- a/tests/test_orphan_sweep_fail_open.py
+++ b/tests/test_orphan_sweep_fail_open.py
@@ -29,8 +29,10 @@ real ``_real_list_sessions`` runs in every test below.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -189,6 +191,47 @@ def test_tmux_runner_timeout_worktree_survives_and_is_errored(env, tmp_path, mon
     )
 
 
+def test_unrecognized_nonzero_rc_worktree_survives_and_is_errored(env, tmp_path, monkeypatch):
+    """A plain non-zero rc whose stderr is neither empty nor about a missing
+    socket (e.g. a permission error or protocol mismatch on a socket that
+    DOES exist) is unmeasurable, not 'zero sessions' — must not reap.
+
+    This is the branch between the two fenced cases: rc=0 (real listing) and
+    the two recognized "genuinely zero sessions" stderr shapes. Anything else
+    non-zero must stay None. Modeled on a real tmux 3.5a stderr measured
+    against an unreadable-but-existing socket file: "error connecting to
+    <path> (Socket operation on non-socket)" — "error connecting to" is
+    present (like the real no-socket case) but "no such file or directory"
+    is not, so this must NOT be read as zero sessions.
+    """
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "unknown-stderr-1")
+    assert handle.path.is_dir()
+
+    def fake_run_tmux(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=("tmux", *args),
+            returncode=1,
+            stdout="",
+            stderr="error connecting to /tmp/xyz/tmux-501/default (Socket operation on non-socket)",
+        )
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: "/usr/local/bin/tmux")
+    monkeypatch.setattr(osweep, "_adapter_run_tmux", fake_run_tmux)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert handle.path.is_dir(), (
+        "worktree was reaped even though the tmux listing returned an "
+        "unrecognized non-zero rc — fail-open contract violated"
+    )
+    assert str(handle.path) not in res.worktrees_removed
+    assert res.errors, (
+        "an unrecognized non-zero rc must surface as an error in the "
+        "result, not pass silently as 'zero sessions'"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Direction 2 — REALLY ZERO: rc=1 "no server running" is a real empty listing.
 # GREEN on main; must stay green — regression guard against an over-eager
@@ -215,6 +258,41 @@ def test_no_server_running_is_real_zero_sessions_worktree_still_reaped(env, tmp_
 
     assert str(handle.path) in res.worktrees_removed
     assert not handle.path.exists()
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux binary not installed")
+def test_real_tmux_empty_socket_dir_reads_as_real_zero_sessions(monkeypatch):
+    """Pin the discriminator against the ACTUAL tmux binary, not a stubbed
+    string (the review finding on PR #1601): point ``TMUX_TMPDIR`` at a fresh,
+    empty directory (no socket ever created there) and confirm the real
+    stderr is read as genuinely zero sessions.
+
+    Measured on this machine, tmux 3.5a / macOS: this scenario does NOT
+    produce "no server running" — it produces ``error connecting to <path>
+    (No such file or directory)``. A discriminator that only recognizes the
+    classic phrase reads this as unmeasurable and skips the worktree reap in
+    exactly the restarted-host / different-TMUX_TMPDIR scenario OI-1286
+    exists for. This test gets its stderr from the binary itself; it must
+    never hardcode the expected phrase into the fixture.
+    """
+    with tempfile.TemporaryDirectory(dir="/tmp") as empty_socket_dir:
+        monkeypatch.setenv("TMUX_TMPDIR", empty_socket_dir)
+        monkeypatch.delenv("TMUX", raising=False)
+
+        rc, out, err = osweep._run_tmux(["list-sessions", "-F", "#{session_name}"])
+        assert rc != 0, (
+            f"expected the real tmux binary to fail to connect against an "
+            f"empty, freshly-created TMUX_TMPDIR (no socket present) — got "
+            f"rc=0, out={out!r}. If tmux now succeeds here the premise of "
+            f"this test no longer holds."
+        )
+
+        sessions = osweep._real_list_sessions()
+
+    assert sessions == [], (
+        f"real tmux binary against an empty TMUX_TMPDIR must be read as "
+        f"genuinely zero sessions, got {sessions!r} (rc={rc}, stderr={err!r})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_orphan_sweep_fail_open.py
+++ b/tests/test_orphan_sweep_fail_open.py
@@ -1,0 +1,221 @@
+"""tests/test_orphan_sweep_fail_open.py — OI-1286 fail-closed listing regression tests.
+
+``orphan_sweep._real_list_sessions()`` collapses EVERY non-zero ``tmux
+list-sessions`` outcome to an empty list: tmux not installed, an
+OSError/TimeoutExpired from the runner, AND a legitimate "no server running"
+(real zero sessions) all read as ``[]``, indistinguishable from each other.
+``sweep()`` then treats that empty list as "no tmux sessions exist" and
+proceeds to reap every non-protected worktree it finds under
+``.vnx-data/worktrees/`` — even though the listing was never actually taken.
+
+The module docstring's fail-open promise ("'cannot measure' is never read as
+'dead'") does not hold for this path. These tests pin the two directions the
+eventual fix must satisfy without collapsing into each other:
+
+  * NOT MEASURABLE (tmux missing; OSError/TimeoutExpired from the runner) ->
+    worktrees must be LEFT ALONE and an error must land in the result. RED on
+    main: today they get reaped and no error is recorded.
+  * REALLY ZERO (rc=1, stderr contains "no server running") -> sweep proceeds
+    exactly as it does today. GREEN on main and must stay green after any
+    fix — the regression guard against a fix that fails closed too broadly.
+
+Per the dispatch: ``list_sessions`` is NOT injected here. Injecting it would
+bypass ``_real_list_sessions`` entirely and test nothing about the defect.
+Instead the process boundary is stubbed: ``shutil.which`` and the tmux runner
+(``orphan_sweep._adapter_run_tmux``, i.e. ``tmux_adapter._run_tmux``) — the
+real ``_real_list_sessions`` runs in every test below.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+# Unconditional inserts (mirrors test_orphan_sweep.py): scripts/lib is
+# frequently ALREADY on sys.path (installed package + conftest), so a
+# `not in sys.path` guard would skip the front-insert and leave scripts/ ahead,
+# resolving `orphan_sweep` to the CLI instead of the lib module.
+sys.path.insert(0, str(_SCRIPT_DIR))
+sys.path.insert(0, str(_SCRIPT_DIR / "lib"))
+
+import orphan_sweep as osweep  # noqa: E402  (the lib module)
+import tmux_worktree  # noqa: E402
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Pin runtime dirs to a per-test tmp tree; clear the current-dispatch fence.
+
+    Mirrors ``tests/test_orphan_sweep.py::env``. The current-dispatch fence
+    (``VNX_CURRENT_DISPATCH_ID``) is exported by the dispatch worker and
+    inherited by pytest, so it must be cleared here or the default would
+    protect a real dispatch id in every test.
+    """
+    data_dir = tmp_path / ".vnx-data"
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / "unified_reports"
+    active = data_dir / "dispatches" / "active"
+    for d in (data_dir, state_dir, reports_dir, active):
+        d.mkdir(parents=True)
+    keys = (
+        "VNX_DATA_DIR", "VNX_DATA_DIR_EXPLICIT", "VNX_STATE_DIR",
+        "VNX_REPORTS_DIR", "VNX_PROJECT_ID", "VNX_CURRENT_DISPATCH_ID",
+    )
+    orig = {k: os.environ.get(k) for k in keys}
+    os.environ["VNX_DATA_DIR"] = str(data_dir)
+    os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
+    os.environ["VNX_STATE_DIR"] = str(state_dir)
+    os.environ["VNX_REPORTS_DIR"] = str(reports_dir)
+    os.environ["VNX_PROJECT_ID"] = "vnx-dev"
+    os.environ.pop("VNX_CURRENT_DISPATCH_ID", None)
+    yield data_dir
+    for k, v in orig.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    """Bare origin + local clone with an initial commit (mirrors test_tmux_worktree)."""
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", str(bare), str(local)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    (local / "README.md").write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    return local
+
+
+def _alloc(local: Path, dispatch_id: str) -> tmux_worktree.WorktreeHandle:
+    return tmux_worktree.allocate(dispatch_id, repo_root=local)
+
+
+# ---------------------------------------------------------------------------
+# Direction 1 — NOT MEASURABLE: worktrees must be left alone, error recorded.
+# RED on main: today these get silently reaped, no error recorded.
+# ---------------------------------------------------------------------------
+
+def test_tmux_not_installed_worktree_survives_and_is_errored(env, tmp_path, monkeypatch):
+    """rc=127 'tmux not found' is unmeasurable, not 'zero sessions' — must not reap."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "no-tmux-1")
+    assert handle.path.is_dir()
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: None)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert handle.path.is_dir(), (
+        "worktree was reaped even though the tmux listing was never "
+        "measurable (tmux not installed) — fail-open contract violated"
+    )
+    assert str(handle.path) not in res.worktrees_removed
+    assert res.errors, (
+        "an unmeasurable tmux listing must surface as an error in the "
+        "result, not pass silently as 'zero sessions'"
+    )
+
+
+def test_tmux_runner_oserror_worktree_survives_and_is_errored(env, tmp_path, monkeypatch):
+    """An OSError from the tmux runner is unmeasurable, not 'zero sessions' — must not reap."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "runner-oserror-1")
+    assert handle.path.is_dir()
+
+    def fake_run_tmux(*args, **kwargs):
+        raise OSError("Resource temporarily unavailable")
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: "/usr/local/bin/tmux")
+    monkeypatch.setattr(osweep, "_adapter_run_tmux", fake_run_tmux)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert handle.path.is_dir(), (
+        "worktree was reaped even though the tmux runner raised OSError — "
+        "fail-open contract violated"
+    )
+    assert str(handle.path) not in res.worktrees_removed
+    assert res.errors, (
+        "a tmux runner OSError must surface as an error in the result, "
+        "not pass silently as 'zero sessions'"
+    )
+
+
+def test_tmux_runner_timeout_worktree_survives_and_is_errored(env, tmp_path, monkeypatch):
+    """A TimeoutExpired from the tmux runner is unmeasurable, not 'zero sessions' — must not reap."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "runner-timeout-1")
+    assert handle.path.is_dir()
+
+    def fake_run_tmux(*args, timeout=10, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["tmux", "list-sessions"], timeout=timeout)
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: "/usr/local/bin/tmux")
+    monkeypatch.setattr(osweep, "_adapter_run_tmux", fake_run_tmux)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert handle.path.is_dir(), (
+        "worktree was reaped even though the tmux runner raised "
+        "TimeoutExpired — fail-open contract violated"
+    )
+    assert str(handle.path) not in res.worktrees_removed
+    assert res.errors, (
+        "a tmux runner TimeoutExpired must surface as an error in the "
+        "result, not pass silently as 'zero sessions'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direction 2 — REALLY ZERO: rc=1 "no server running" is a real empty listing.
+# GREEN on main; must stay green — regression guard against an over-eager
+# fail-closed fix that also fences off a legitimately empty listing.
+# ---------------------------------------------------------------------------
+
+def test_no_server_running_is_real_zero_sessions_worktree_still_reaped(env, tmp_path, monkeypatch):
+    """rc=1 with 'no server running' in stderr means truly zero sessions — sweep proceeds."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "no-server-1")
+
+    def fake_run_tmux(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=("tmux", *args),
+            returncode=1,
+            stdout="",
+            stderr="no server running on /tmp/tmux-501/default",
+        )
+
+    monkeypatch.setattr(osweep.shutil, "which", lambda name: "/usr/local/bin/tmux")
+    monkeypatch.setattr(osweep, "_adapter_run_tmux", fake_run_tmux)
+
+    res = osweep.sweep(repo_root=local, data_dir=env)
+
+    assert str(handle.path) in res.worktrees_removed
+    assert not handle.path.exists()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Replaces #1601, which was rejected. That PR's fail-open fix for
`_real_list_sessions()` was correct in shape (rc=0 → real listing,
"cannot measure" → `None`, "no server running" → `[]`) but the
discriminator only recognized the classic `"no server running"` stderr
phrase, and its regression test fed that exact string into the fixture
itself — confirming the discriminator agrees with its own assumption,
not that it matches reality.

Measured against the real `tmux 3.5a` binary on macOS:

```
$ tmux -V
tmux 3.5a

$ mkdir -p /tmp/leeg && env -u TMUX TMUX_TMPDIR=/tmp/leeg tmux list-sessions
error connecting to /private/tmp/leeg/tmux-501/default (No such file or directory)
rc=1
```

No `"no server running"` anywhere. That means the exact scenario
OI-1286 exists for — a restarted host, or a worker using a different
`TMUX_TMPDIR` than the sweep — fell into the `None` ("unmeasurable")
branch and silently skipped the worktree reap.

## Changes

- `scripts/lib/orphan_sweep.py` — `_real_list_sessions()` now also
  recognizes a connect failure against a **socket that does not exist
  on disk** (`"error connecting to"` + `"no such file or directory"`
  in stderr) as genuinely zero sessions, alongside the classic `"no
  server running"` phrase. Every other non-zero outcome — tmux
  missing, the runner raising, a connect failure against a socket that
  **does** exist (permission error, protocol mismatch), or any other
  unrecognized rc — stays `None`. Docstrings (module + function)
  updated to describe both recognized shapes.
- `tests/test_orphan_sweep_fail_open.py`:
  - Added `test_real_tmux_empty_socket_dir_reads_as_real_zero_sessions`
    — points `TMUX_TMPDIR` at a fresh empty dir and reads the real
    stderr tmux produces (`skipif` when `tmux` isn't installed). Never
    hardcodes the expected phrase into the fixture.
  - Added `test_unrecognized_nonzero_rc_worktree_survives_and_is_errored`
    — the missing "ordinary non-zero rc, unrecognized stderr" branch
    flagged in the prior review, modeled on a real tmux stderr for an
    existing-but-unreachable socket (`"Socket operation on non-socket"`).
  - Left the existing stubbed tests (tmux missing, OSError,
    TimeoutExpired, and the stubbed "no server running" regression
    guard) untouched — they cover the unmeasurable side and the
    classic-phrase side correctly.

## Verification

Real binary measurement (this machine):
```
$ tmux -V
tmux 3.5a
$ python3 -c "..."   # empty TMUX_TMPDIR, TMUX unset
rc: 1
stderr: 'error connecting to /private/tmp/tmpk718yjce/tmux-501/default (No such file or directory)\n'
```

RED → GREEN proof (scoped stash of only `orphan_sweep.py`, discriminator reverted to #1601's version, tests re-run, then restored):
```
$ git stash push -- scripts/lib/orphan_sweep.py
$ python3 -m pytest tests/test_orphan_sweep_fail_open.py -v
...
FAILED tests/test_orphan_sweep_fail_open.py::test_real_tmux_empty_socket_dir_reads_as_real_zero_sessions
AssertionError: ... got None (rc=1, stderr='error connecting to ... (No such file or directory)\n')
1 failed, 5 passed

$ git stash pop
$ python3 -m pytest tests/test_orphan_sweep_fail_open.py -v
6 passed
```

Full targeted suites, both green:
```
$ python3 -m pytest tests/test_orphan_sweep_fail_open.py -v
6 passed in 0.96s

$ python3 -m pytest tests/test_orphan_sweep.py -v
13 passed in 1.62s
```

## Test plan

- [x] `pytest tests/test_orphan_sweep_fail_open.py -v` — 6 passed
- [x] `pytest tests/test_orphan_sweep.py -v` — 13 passed (unchanged from main)
- [x] RED-with-old-discriminator / GREEN-with-new confirmed via scoped stash
- [x] Real tmux 3.5a binary measured directly, not assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)