### PR TITLE
test(failure-classification): red test for near-empty completion misclassified as unknown (OI-1333)

### DIFF
--- a/scripts/lib/failure_classification.py
+++ b/scripts/lib/failure_classification.py
@@ -79,6 +79,32 @@ CREDIT_EXHAUSTED_KEYWORDS = (
 _JSON_MESSAGE_RE = re.compile(r'"message"\s*:\s*"([^"]*)"')
 _MAX_DETAIL_LEN = 300
 
+# OI-1333: a completion that fails every keyword match above (credit/auth/
+# model_error) AND is this short cannot possibly carry the report contract —
+# report_body_contract.py requires >= 50 non-whitespace chars for the Summary
+# heading alone, before any of the other three required headings. Below this
+# floor, a non-report reply reads as a bare, uninformative fragment rather
+# than a legitimate short answer, so it belongs in `empty_completion`
+# (escalation: retry_same_tier) rather than `unknown` (no_climb).
+#
+# Measured 2026-08-18 against t0_receipts.ndjson (schema_version=2 dispatch
+# receipts) plus the on-disk report bodies each receipt's report_path points
+# to — 504 successful completions, 69 real (non-placeholder) failed ones:
+#   SUCCESS completions : n=504, min=262 chars (smallest legitimate report)
+#   FAILURE completions : n=69,  smallest genuinely-empty fragment observed
+#                          is 17 chars ("Request timed out", the measured
+#                          OI-1333 case, dispatch 20260817-d1592r3-pro);
+#                          the smallest short-but-NAMED unmatched error text
+#                          observed is 34 chars ("API Error: Content block
+#                          not found") — informative enough to stay `unknown`
+#                          per this module's own "never silently absorb a
+#                          named-but-unmatched error" policy (see module
+#                          docstring). Nothing was observed in [18, 33].
+# 25 sits in that unobserved gap: well clear of the 17-char measured floor,
+# well clear of the 34-char named-error floor, and an order of magnitude
+# below the smallest real success (262).
+_NEAR_EMPTY_COMPLETION_CHARS = 25
+
 
 def _extract_detail(text: Optional[str], max_len: int = _MAX_DETAIL_LEN) -> str:
     """Pull a bounded, human-readable detail out of raw error/completion text.
@@ -193,10 +219,25 @@ def classify_failure(
     if error:
         return {"failure_class": "unknown", "failure_reason": error}
 
-    # ── error absent but completion is non-empty (guaranteed by the
-    # empty_completion guard above) — surface the completion itself instead
-    # of a contentless "(no error captured)" placeholder; the provider's own
-    # words are on disk, even if they match no known pattern above.
+    # ── error absent, completion non-empty, too short to be a report ─────
+    # (OI-1333) A completion under the floor is not meaningfully different
+    # from an empty one — see _NEAR_EMPTY_COMPLETION_CHARS above for the
+    # measurement backing this boundary.
+    if len(completion) < _NEAR_EMPTY_COMPLETION_CHARS:
+        return {
+            "failure_class": "empty_completion",
+            "failure_reason": (
+                f"provider={provider} returned a near-empty completion "
+                f"({len(completion)} chars, below the "
+                f"{_NEAR_EMPTY_COMPLETION_CHARS}-char floor a report needs) "
+                f"with returncode={returncode}: {_extract_detail(completion)}"
+            ),
+        }
+
+    # ── error absent but completion is non-empty and long enough to be
+    # informative — surface the completion itself instead of a contentless
+    # "(no error captured)" placeholder; the provider's own words are on
+    # disk, even if they match no known pattern above.
     return {
         "failure_class": "unknown",
         "failure_reason": f"provider={provider} returncode={returncode}: {_extract_detail(completion)}",

--- a/tests/test_failclass_registry.py
+++ b/tests/test_failclass_registry.py
@@ -132,7 +132,33 @@ class TestClassifyFailure:
         """A failure with no `error` but a non-empty, unrecognized completion
         surfaces the completion's own content — dispatch 20260816-p9p10-
         failure-reason-root: the old contentless '(no error captured)'
-        placeholder discarded exactly this text even though it was on disk."""
+        placeholder discarded exactly this text even though it was on disk.
+
+        The fixture is a named-but-unmatched error text at the measured
+        34-char floor (OI-1333) — long enough to clear the near-empty-
+        completion threshold in _NEAR_EMPTY_COMPLETION_CHARS, so this stays
+        `unknown` rather than `empty_completion`."""
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error=None,
+            completion_text="API Error: Content block not found",
+            timed_out=False,
+            provider="mystery-provider",
+            returncode=1,
+        )
+        assert result["failure_class"] == "unknown"
+        assert result["failure_reason"] is not None
+        assert "API Error: Content block not found" in result["failure_reason"]
+        assert "no error captured" not in result["failure_reason"]
+
+    def test_empty_completion_when_completion_below_near_empty_floor(self):
+        """A failure with no `error` and a completion below the OI-1333
+        near-empty floor classifies as `empty_completion`, not `unknown` —
+        and the completion's own content still survives into failure_reason,
+        proving the near-empty branch doesn't discard content the way the
+        old '(no error captured)' placeholder used to."""
         from failure_classification import classify_failure
 
         result = classify_failure(
@@ -143,10 +169,9 @@ class TestClassifyFailure:
             provider="mystery-provider",
             returncode=1,
         )
-        assert result["failure_class"] == "unknown"
+        assert result["failure_class"] == "empty_completion"
         assert result["failure_reason"] is not None
         assert "some text" in result["failure_reason"]
-        assert "no error captured" not in result["failure_reason"]
 
     def test_success_returns_none_fields(self):
         """A success status returns None for both fields."""

--- a/tests/test_failure_classification.py
+++ b/tests/test_failure_classification.py
@@ -509,5 +509,121 @@ class TestDeliveryFailureClassification(unittest.TestCase):
         self.assertFalse(result["retryable"])
 
 
+# ---------------------------------------------------------------------------
+# TestNearEmptyCompletionMisclassifiedAsUnknown — OI-1333
+#
+# scripts/lib/failure_classification.py:132 only treats a FULLY empty
+# completion as `empty_completion` (`if not completion and error is None`).
+# Measured case, dispatch 20260817-d1592r3-pro: a deepseek-v4-pro review
+# dispatch ran 733s, spent 57,505 input / 1,937 output tokens, and returned a
+# 17-character completion. That completion cannot possibly be a report — the
+# envelope rejected it on the report contract (all four mandatory headings
+# absent) — yet classify_failure still calls it `unknown` because the
+# completion is merely non-empty rather than blank.
+#
+# The consequence sits one layer up: _ESCALATION_TABLE in
+# providers/smart_router/tier_routing.py maps `empty_completion` to
+# `retry_same_tier` but `unknown` to `no_climb`. The exact failure mode that
+# deserves a retry gets none. This class does not touch
+# failure_classification.py or tier_routing.py — it only proves the current
+# behavior is wrong and pins the two adjacent behaviors that must not
+# regress once the fix lands.
+# ---------------------------------------------------------------------------
+
+class TestNearEmptyCompletionMisclassifiedAsUnknown(unittest.TestCase):
+    """OI-1333: a vrijwel-lege completion (non-empty, but not a report) must
+    classify as `empty_completion`, not fall through to `unknown`."""
+
+    # The measured deepseek-v4-pro completion length (dispatch
+    # 20260817-d1592r3-pro) — demonstrably not a report: no headings, no
+    # structure, a single abrupt sentence fragment.
+    _NEAR_EMPTY_COMPLETION = "I cannot proceed."
+
+    _FULL_REPORT_COMPLETION = (
+        "## Summary\n"
+        "Fixed the empty completion misclassification bug so near-empty text "
+        "no longer falls through to the unknown bucket and misses a retry.\n\n"
+        "## Changes\n"
+        "Updated failure_classification.py to recognize a report-shaped "
+        "completion boundary.\n\n"
+        "## Verification\n"
+        "Ran the targeted pytest module; all cases green.\n\n"
+        "## Open Items\n"
+        "None\n"
+    )
+
+    def test_near_empty_completion_classifies_as_empty_completion(self):
+        """A short, demonstrably-not-a-report completion with no error must
+        classify as empty_completion, not unknown."""
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error=None,
+            completion_text=self._NEAR_EMPTY_COMPLETION,
+            timed_out=False,
+            provider="litellm:deepseek",
+            returncode=1,
+        )
+        self.assertEqual(result["failure_class"], "empty_completion")
+
+    def test_full_report_completion_is_not_classified_as_empty(self):
+        """A completion carrying all four mandatory report headings must NOT
+        be swept into empty_completion — this guards against a fix that
+        overshoots and starts treating legitimate output as empty. This test
+        passes today and must keep passing after the fix lands."""
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error=None,
+            completion_text=self._FULL_REPORT_COMPLETION,
+            timed_out=False,
+            provider="litellm:deepseek",
+            returncode=1,
+        )
+        self.assertNotEqual(result["failure_class"], "empty_completion")
+
+    def test_fully_empty_completion_still_classifies_as_empty_completion(self):
+        """The existing fully-blank branch is untouched by this bug — it
+        already passes today and must keep passing after the fix lands."""
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error=None,
+            completion_text="",
+            timed_out=False,
+            provider="litellm:deepseek",
+            returncode=0,
+        )
+        self.assertEqual(result["failure_class"], "empty_completion")
+
+    def test_near_empty_completion_escalates_as_retry_not_no_climb(self):
+        """The consequence, not just the label: feeding the near-empty
+        completion's failure_class through _ESCALATION_TABLE must yield
+        retry_same_tier — the same action a fully-empty completion gets.
+        Today it yields no_climb, the same as auth_rejected/unknown, so a
+        dispatch that deserves a retry gets none (measured: zero climbs
+        across 27,848 receipts)."""
+        from failure_classification import classify_failure
+        from providers.smart_router.tier_routing import escalate_tier
+
+        classification = classify_failure(
+            status="failure",
+            error=None,
+            completion_text=self._NEAR_EMPTY_COMPLETION,
+            timed_out=False,
+            provider="litellm:deepseek",
+            returncode=1,
+        )
+        escalation = escalate_tier(
+            "tier-mid",
+            "parent-dispatch-oi-1333",
+            failure_class=classification["failure_class"],
+        )
+        self.assertEqual(escalation.action, "retry_same_tier")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Adds a failing (red) test set to `tests/test_failure_classification.py` for OI-1333: `classify_failure()` in `scripts/lib/failure_classification.py` only treats a *fully* blank completion as `empty_completion` (line 132: `if not completion and error is None`). A short, non-blank, demonstrably-not-a-report completion falls through to `unknown` instead — measured on dispatch `20260817-d1592r3-pro`, a deepseek-v4-pro review that ran 733s, spent 57,505 input / 1,937 output tokens, and returned a 17-character completion the report contract correctly rejected (all four mandatory headings absent).

The consequence sits one layer up: `_ESCALATION_TABLE` in `scripts/lib/providers/smart_router/tier_routing.py` maps `empty_completion` → `retry_same_tier` but `unknown` → `no_climb`. The exact failure mode that deserves a retry gets none (measured: zero climbs across 27,848 receipts).

This PR is test-only, per the dispatch split: the fix lands in a separate PR/worker. No production source is touched.

## Changes
- `tests/test_failure_classification.py`: added `TestNearEmptyCompletionMisclassifiedAsUnknown` with 4 tests:
  1. `test_near_empty_completion_classifies_as_empty_completion` — a 17-char, demonstrably-non-report completion (`"I cannot proceed."`) with no error must classify as `empty_completion`, not `unknown`. **RED today.**
  2. `test_full_report_completion_is_not_classified_as_empty` — a completion carrying all four mandatory report headings must NOT be classified as `empty_completion` (guards against an overshooting fix). **Green today, must stay green.**
  3. `test_fully_empty_completion_still_classifies_as_empty_completion` — the existing fully-blank branch is untouched by this bug. **Green today, must stay green.**
  4. `test_near_empty_completion_escalates_as_retry_not_no_climb` — the consequence test: feeding the near-empty completion's `failure_class` through `escalate_tier()` must yield `retry_same_tier`, not `no_climb`. **RED today.**

No length threshold is asserted anywhere — only the two ends (17-char "cannot possibly be a report" text vs. a full four-heading report) are pinned, leaving the boundary itself for the fix-writer to design and justify.

## Verification
Ran locally on current `main` (this branch, before any fix lands):

```
$ python3 -m pytest tests/test_failure_classification.py -k TestNearEmptyCompletionMisclassifiedAsUnknown -v
...
tests/test_failure_classification.py::TestNearEmptyCompletionMisclassifiedAsUnknown::test_full_report_completion_is_not_classified_as_empty PASSED [ 25%]
tests/test_failure_classification.py::TestNearEmptyCompletionMisclassifiedAsUnknown::test_fully_empty_completion_still_classifies_as_empty_completion PASSED [ 50%]
tests/test_failure_classification.py::TestNearEmptyCompletionMisclassifiedAsUnknown::test_near_empty_completion_classifies_as_empty_completion FAILED [ 75%]
tests/test_failure_classification.py::TestNearEmptyCompletionMisclassifiedAsUnknown::test_near_empty_completion_escalates_as_retry_not_no_climb FAILED [100%]

FAILED ...::test_near_empty_completion_classifies_as_empty_completion - AssertionError: 'unknown' != 'empty_completion'
FAILED ...::test_near_empty_completion_escalates_as_retry_not_no_climb - AssertionError: 'no_climb' != 'retry_same_tier'
2 failed, 2 passed, 40 deselected in 0.28s
```

Full file (regression check on the other 42 pre-existing tests in this file):
```
$ python3 -m pytest tests/test_failure_classification.py -v
...
2 failed, 42 passed in 0.57s
```

Neighboring file that also covers `failure_classification.py` (no regressions):
```
$ python3 -m pytest tests/test_failclass_registry.py -q
48 passed in 1.11s
```

## Test plan
- [x] New tests fail on current `main` for the right reason (`unknown` vs `empty_completion`, `no_climb` vs `retry_same_tier`)
- [x] Two guard tests pass today and pin behavior the fix must not break
- [x] No source files touched (`scripts/lib/failure_classification.py`, `scripts/lib/providers/smart_router/tier_routing.py` read-only)
- [ ] Fix PR turns the 2 red tests green without breaking the 2 green guard tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Correctie op bovenstaande body (T0, 2026-08-19, vóór merge)

De body hierboven beschrijft alleen commit 1. De PR bevat sindsdien drie commits
en raakt wél productiecode. Twee claims hierboven zijn daarmee achterhaald:

- ~~"This PR is test-only ... No production source is touched"~~ — onjuist.
  `scripts/lib/failure_classification.py` is gewijzigd in commit `d2b2b450`.
- ~~"[x] No source files touched"~~ — onjuist, zie hierboven.
- De laatste checkbox ("Fix PR turns the 2 red tests green") is in deze PR
  afgehandeld in plaats van in een aparte PR.

### Werkelijke inhoud

| Commit | Wat |
|---|---|
| `b7b35769` | rode test voor OI-1333 (de vier tests hierboven) |
| `d2b2b450` | de fix: `_NEAR_EMPTY_COMPLETION_CHARS = 25` + nieuwe tak in `classify_failure()` |
| `495c8efb` | verplaatst een short-fixture in `tests/test_failclass_registry.py` onder de nieuwe drempel |

Test-schrijver en fix-schrijver zijn gescheiden gebleven in de commit-historie.

### T0-verificatie van de drempel

De onderbouwing van `25` is nagemeten tegen `t0_receipts.ndjson` (27.912 regels),
langs twee onafhankelijke datavormen:

1. **`failure_reason` in `provider=… returncode=…: <completion>`-vorm** — één
   receipt, lengte 17 (`Request timed out`, dispatch `20260817-d1592r3-pro`).
   Dat is exact de OI-1333-casus.
2. **`failure_reason` met expliciete `completion_len=`** — 21 receipts, kleinste
   waarde **34** (deepseek-harness), daarna 35, daarna 7392+.

Beide vormen bevestigen het geclaimde lege gat: **nul waarnemingen in [18, 33]**,
nul onder de 25. De drempel raakt precies één historisch receipt en laat de
34-tekens-groep met 9 tekens marge ongemoeid.

De 57 overige `unknown`-receipts lopen via het `if error:`-pad en worden door de
nieuwe tak niet bereikt; hun kortste `failure_reason` is 34 tekens. De verwijzing
naar die 34-tekensvloer in het codecommentaar beschrijft dus een pad dat de
nieuwe check niet kan raken. Dat maakt het commentaar ruim geformuleerd, niet de
fix onjuist.

**VNX CI:** workflow-conclusie `success` op head `495c8efb`, de daadwerkelijke
merge-head.
