### PR TITLE
test(providers): red test for price provenance on wave7 models (OI-1334, OI-1335)

### DIFF
--- a/scripts/lib/providers/provider_registry.py
+++ b/scripts/lib/providers/provider_registry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from datetime import date
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -28,6 +29,8 @@ class ProviderModel:
     max_tokens: int
     supports_streaming: bool
     supports_tool_calls: bool
+    price_source: str = ""
+    price_checked_at: str = ""
     context_window: Optional[int] = None
     task_classes: List[str] = field(default_factory=list)
     cli_model_arg: Optional[str] = None
@@ -100,10 +103,34 @@ class TierLadderRung:
     fallback: tuple = ()  # tuple[TierRouteStep, ...]
 
 
-def _parse_model(data: dict) -> ProviderModel:
+def _validate_price_checked_at(model_key: str, price_checked_at: str) -> None:
+    """Fail loud, naming the model and the field, on a malformed price_checked_at.
+
+    A bare ``date.fromisoformat`` ValueError names neither — the raised
+    message here does, so a broken date is diagnosable from the traceback
+    alone (OI-1334).
+    """
+    try:
+        date.fromisoformat(price_checked_at)
+    except ValueError as e:
+        raise ValueError(
+            f"model {model_key!r} has an invalid price_checked_at "
+            f"{price_checked_at!r} (expected YYYY-MM-DD): {e}"
+        ) from e
+
+
+def _parse_model(data: dict, model_key: Optional[str] = None) -> ProviderModel:
     context_window_raw = data.get("context_window")
     cli_model_arg_raw = data.get("cli_model_arg")
     dispatch_allowed_raw = data.get("dispatch_allowed")
+    price_source_raw = data.get("price_source")
+    price_checked_at_raw = data.get("price_checked_at")
+    price_checked_at = str(price_checked_at_raw) if price_checked_at_raw is not None else ""
+    if price_checked_at:
+        _validate_price_checked_at(
+            model_key or str(data.get("litellm_name") or "<unknown model>"),
+            price_checked_at,
+        )
     return ProviderModel(
         litellm_name=str(data["litellm_name"]),
         cost_input_per_mtok=float(data["cost_input_per_mtok"]),
@@ -111,6 +138,8 @@ def _parse_model(data: dict) -> ProviderModel:
         max_tokens=int(data["max_tokens"]),
         supports_streaming=bool(data["supports_streaming"]),
         supports_tool_calls=bool(data["supports_tool_calls"]),
+        price_source=str(price_source_raw) if price_source_raw is not None else "",
+        price_checked_at=price_checked_at,
         context_window=int(context_window_raw) if context_window_raw is not None else None,
         task_classes=list(data.get("task_classes") or []),
         cli_model_arg=str(cli_model_arg_raw) if cli_model_arg_raw is not None else None,
@@ -121,7 +150,7 @@ def _parse_model(data: dict) -> ProviderModel:
 def _parse_provider(data: dict) -> ProviderConfig:
     models: Dict[str, ProviderModel] = {}
     for model_key, model_data in (data.get("models") or {}).items():
-        models[model_key] = _parse_model(model_data)
+        models[model_key] = _parse_model(model_data, model_key)
     default_model_raw = data.get("default_model")
     dispatch_enum_raw = data.get("dispatch_enum")
     return ProviderConfig(

--- a/scripts/lib/providers/provider_registry.py
+++ b/scripts/lib/providers/provider_registry.py
@@ -311,6 +311,55 @@ def _output_cost_for(
     )
 
 
+def load_escalation_order(registry_path: Optional[Path] = None) -> List[str]:
+    """Resolve the quality-escalation climb order (OI-1356) from the registry.
+
+    ``routing.escalation_order`` is a separate, explicitly authored list from
+    ``routing.tier_map`` (the cost ladder): tier_map stays purely cost-ordered
+    (``load_tier_ladder``'s invariants are untouched by this function), while
+    escalation_order is the list ``tier_routing.next_tier`` reads for climb
+    destinations. A tier absent from escalation_order (e.g. kimi-k3, gpt-5.5)
+    is still a valid tier_map rung — dispatchable, fallback-eligible — just not
+    a climb destination.
+
+    Fails loud (RegistryLookupError) when:
+      * ``routing.escalation_order`` is missing entirely — silently falling
+        back to the cost ladder would resurrect the exact coupling this key
+        exists to break (a climb landing on a cheaper-but-different-lane
+        rung instead of a genuinely more-capable one). A registry that has
+        not been updated for OI-1356 must say so at load, not silently keep
+        the old behavior.
+      * a listed member is not a key in ``routing.tier_map`` — an escalation
+        destination that is not even a valid tier is drift, not a typo to
+        paper over.
+    """
+    path = Path(registry_path) if registry_path is not None else _REGISTRY_PATH
+    try:
+        with open(path) as fh:
+            raw = yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        raise RegistryLookupError(f"registry file not found at {path}") from None
+    except yaml.YAMLError as exc:
+        raise RegistryLookupError(f"malformed registry yaml at {path}: {exc}") from exc
+
+    routing = raw.get("routing") or {}
+    if "escalation_order" not in routing:
+        raise RegistryLookupError(
+            f"routing.escalation_order is missing from {path}; the quality-"
+            "escalation climb order must be authored explicitly, separate "
+            "from routing.tier_map (OI-1356) — add the key to this registry"
+        )
+    escalation_order = routing.get("escalation_order") or []
+    known_tiers = set((routing.get("tier_map") or {}).keys())
+    for tier in escalation_order:
+        if tier not in known_tiers:
+            raise RegistryLookupError(
+                f"routing.escalation_order member {tier!r} is not a key in "
+                f"routing.tier_map in {path}"
+            )
+    return [str(tier) for tier in escalation_order]
+
+
 def load_tier_ladder(registry_path: Optional[Path] = None) -> List[TierLadderRung]:
     """Return the escalation ladder in the tier_map's authored order, validated.
 

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -50,6 +50,7 @@ from typing import Optional
 from providers.provider_registry import (
     RegistryLookupError,
     TierRouteSpec,
+    load_escalation_order,
     load_tier_ladder,
     load_tier_map,
 )
@@ -75,11 +76,21 @@ class TierRoute:
 # early rather than discovered mid-dispatch.
 _TIER_MAP = load_tier_map()
 
-# The cost-ordered escalation ladder (cheapest first), derived from the
-# registry's own prices. load_tier_ladder() fails loud on a duplicate rung or a
-# non-monotonic price order, so a ladder that would make escalation a no-op is
-# caught at import — same fail-early contract as _TIER_MAP above.
+# The cost-ordered ladder (cheapest first), derived from the registry's own
+# prices. load_tier_ladder() fails loud on a duplicate rung or a non-monotonic
+# price order — same fail-early contract as _TIER_MAP above. Used by
+# load_tier_ladder's own callers (cost reporting, classification); NOT read by
+# next_tier()/escalate_tier() below — see _ESCALATION_ORDER (OI-1356).
 _TIER_LADDER = load_tier_ladder()
+
+# The quality-escalation climb order (OI-1356): a SEPARATE, explicitly
+# authored list from _TIER_LADDER above. tier_map/_TIER_LADDER answer "what
+# does this tier cost"; escalation_order answers "where does a REJECTED
+# result climb to". Resolved once at import, same fail-early contract as
+# _TIER_MAP/_TIER_LADDER: a registry missing routing.escalation_order, or
+# listing a member that is not a tier_map key, raises RegistryLookupError
+# here — before any dispatch reaches next_tier()/escalate_tier().
+_ESCALATION_ORDER = load_escalation_order()
 
 
 # The escalation decision table (dispatch 20260816-p6-escalate-tier-ds): the
@@ -137,19 +148,20 @@ class TierEscalation:
 
 
 def next_tier(tier: str) -> Optional[str]:
-    """Return the tier one rung up the cost ladder, or None at the top.
+    """Return the tier one rung up the quality-escalation climb, or None at the top.
 
-    The ladder order is read from the registry (``_TIER_LADDER``), never a
-    Python literal, so a newly registered model slots into the climb without a
-    code edit. An unknown tier returns None (fail-safe: do not escalate from a
-    rung the ladder does not know).
+    Reads ``_ESCALATION_ORDER`` (registry ``routing.escalation_order``,
+    OI-1356) — a separate list from the cost ladder (``_TIER_LADDER``): a tier
+    absent from escalation_order (kimi-k3, gpt-5.5) is still a full tier_map
+    rung — dispatchable, fallback-eligible — but never a climb destination.
+    An unknown tier returns None (fail-safe: do not escalate from a rung
+    escalation_order does not know).
     """
-    names = [rung.tier for rung in _TIER_LADDER]
     try:
-        idx = names.index(tier)
+        idx = _ESCALATION_ORDER.index(tier)
     except ValueError:
         return None
-    return names[idx + 1] if idx + 1 < len(names) else None
+    return _ESCALATION_ORDER[idx + 1] if idx + 1 < len(_ESCALATION_ORDER) else None
 
 
 def escalate_tier(

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -17,6 +17,8 @@ providers:
         context_window: 200000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-17"
         task_classes: ["coding-premium", "review", "analysis"]
       opus-4-8:
         litellm_name: "anthropic/claude-opus-4-8"
@@ -26,6 +28,8 @@ providers:
         context_window: 200000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-06-18"
         task_classes: ["coding-premium", "review", "analysis"]
       opus-4-6:
         # RETIRED alias, kept deliberately (2026-07-22 model-registry-refresh): the field-test
@@ -40,6 +44,8 @@ providers:
         context_window: 200000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-06-18"
         task_classes: ["coding-premium", "review", "analysis"]
       sonnet:
         litellm_name: "anthropic/claude-sonnet-5"
@@ -49,6 +55,8 @@ providers:
         context_window: 200000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-17"
         task_classes: ["coding", "review", "analysis"]
       haiku:
         litellm_name: "anthropic/claude-haiku-4-5-20251001"
@@ -58,6 +66,8 @@ providers:
         context_window: 200000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-17"
         task_classes: ["coding", "fast"]
       # 5-series (dispatch-20260802-model-ssot-en-ketenlink): Sonnet 5, Opus 5 and
       # Fable 5 now run in the fleet (operator + T0 run Opus 5; Fable 5 is the top
@@ -73,6 +83,8 @@ providers:
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-08-03"
         task_classes: ["coding", "review", "analysis"]
       opus-5:
         litellm_name: "anthropic/claude-opus-5"
@@ -82,6 +94,8 @@ providers:
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-08-03"
         task_classes: ["coding-premium", "review", "analysis"]
       fable-5:
         litellm_name: "anthropic/claude-fable-5"
@@ -91,6 +105,8 @@ providers:
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-08-03"
         task_classes: ["coding-premium", "review", "analysis"]
   openai:
     enabled: true
@@ -105,6 +121,8 @@ providers:
         context_window: 128000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-17"
         task_classes: ["coding", "review"]
       gpt-5.4:
         litellm_name: "openai/gpt-5.4"
@@ -114,6 +132,8 @@ providers:
         context_window: 128000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-06-07"
         task_classes: ["coding", "review"]
   google:
     enabled: true
@@ -127,6 +147,8 @@ providers:
         context_window: 1048576
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-17"
         task_classes: ["coding", "review", "analysis"]
   deepseek:
     enabled: true
@@ -147,6 +169,8 @@ providers:
         context_window: 1000000      # 1M context
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-16"
         task_classes: ["coding-premium", "review", "analysis"]
         dispatch_allowed: false  # OI-867: litellm proxy has no DEEPSEEK_API_KEY
       deepseek-v4-flash:
@@ -157,6 +181,8 @@ providers:
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-16"
         task_classes: ["coding", "review", "analysis"]
         dispatch_allowed: false  # OI-867: litellm proxy has no DEEPSEEK_API_KEY
   deepseek_harness:
@@ -175,6 +201,8 @@ providers:
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-07-31"
         task_classes: ["coding-premium", "review", "analysis"]
         dispatch_allowed: true
       deepseek-v4-flash:
@@ -186,6 +214,8 @@ providers:
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-07-31"
         task_classes: ["coding", "review", "analysis"]
         dispatch_allowed: true
       deepseek-v4-pro-default:
@@ -197,6 +227,8 @@ providers:
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-07-31"
         task_classes: ["coding-premium", "review", "analysis"]
         dispatch_allowed: true
   moonshot:
@@ -210,6 +242,8 @@ providers:
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-15"
         task_classes: ["coding", "review", "analysis"]
         dispatch_allowed: false  # bare-baseline only; governed dispatch uses kimi_cli
       kimi-k2-6:
@@ -219,6 +253,8 @@ providers:
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-15"
         task_classes: ["coding-premium"]
         dispatch_allowed: false  # bare-baseline only; governed dispatch uses kimi_cli
   zai:
@@ -233,6 +269,8 @@ providers:
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-08-10"
         task_classes: ["coding", "review"]
         deprecated_models:
           - "glm-4.5"
@@ -252,6 +290,8 @@ providers:
         context_window: 8192
         supports_streaming: false
         supports_tool_calls: false
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-06-03"
         task_classes: ["simple_synthesis", "classification", "documentation", "translation"]
         runtime: mlx
         fallback_runtime: ollama
@@ -280,6 +320,8 @@ providers:
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-07-21"
         task_classes: ["coding", "coding-premium", "review", "analysis"]
         dispatch_allowed: true
       kimi-k2-7:
@@ -292,6 +334,8 @@ providers:
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-07-21"
         task_classes: ["coding", "review", "analysis"]
         dispatch_allowed: true
       kimi-default:
@@ -301,6 +345,8 @@ providers:
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-17"
         task_classes: ["coding", "review", "analysis"]
         dispatch_allowed: true
       kimi-k2-6:
@@ -310,6 +356,8 @@ providers:
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
+        price_source: "unverified: registry-authored"
+        price_checked_at: "2026-05-17"
         task_classes: ["coding-premium"]
         # DISABLED 20260721 (kimi-lane-hardening): kimi-cli 1.46.0 has no "kimi-k2.6"/K2.6
         # model (verified against the installed CLI's own config.toml — only kimi-code/k3,

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -397,8 +397,9 @@ providers:
 # sonnet-5/opus-4-8/opus-4-6/kimi-k3/gpt-5.5 price corrections below — see
 # each model's price_source/price_checked_at for provenance): seven rungs,
 # cheapest first — the seven dispatchable (provider, model) pairs in
-# ascending output cost. A tier higher is demonstrably more expensive AND
-# more capable, so a quality escalation actually climbs:
+# ascending output cost. load_tier_ladder() enforces this order fail-loud
+# (strictly increasing cost, no duplicate primary) — it says nothing about
+# capability, only price:
 #
 #   tier-zero  deepseek-v4-flash  $0.28/Mtok out
 #   tier-low   deepseek-v4-pro    $0.87/Mtok out   (the daily workhorse)
@@ -407,6 +408,28 @@ providers:
 #   tier-high  opus-5            $25.00/Mtok out
 #   gpt-5.5    gpt-5.5           $30.00/Mtok out
 #   fable-5    fable-5           $50.00/Mtok out
+#
+# ESCALATION ORDER (routing.escalation_order, OI-1356): a SEPARATE, explicitly
+# authored list below — not derived from the cost ladder above. tier_map
+# answers "what does this tier cost"; escalation_order answers "where does a
+# REJECTED result climb to". The two used to be the same list (next_tier() and
+# escalate_tier() walked tier_map's own order), and that coupling was the
+# defect OI-1356 fixes: kimi-k3 and gpt-5.5 sit BETWEEN tier-mid/tier-high and
+# tier-high/fable-5 in cost order, so a quality climb off tier-mid landed on
+# kimi-k3 — a different lane (subscription -> provider-lane), its own quota,
+# its own failure modes, not a strictly-more-capable rung. escalation_order
+# breaks that link:
+#
+#   tier-zero -> tier-low -> tier-mid -> tier-high -> fable-5
+#
+# kimi-k3 and gpt-5.5 are deliberately NOT in escalation_order. They stay full
+# tier_map rungs — dispatchable at classification time, still fallback
+# destinations (the `fallback` lists below) — but next_tier() returns None for
+# them: no climb starts or lands there. The promise "a tier higher is
+# demonstrably more expensive AND more capable, so a quality escalation
+# actually climbs" now holds over escalation_order, not over tier_map: cost is
+# monotonic across the whole tier_map (that invariant is unchanged), but only
+# escalation_order's authored order claims capability.
 #
 # NOT on the ladder (measured 2026-08-15 over wave7_models.yaml):
 #   * glm-5.2 ($2.42/Mtok out) — the `zai` section carries NO `dispatch_enum`
@@ -421,20 +444,27 @@ providers:
 #
 # The four tier-zero/low/mid/high rungs are ALSO the classifier's scope buckets
 # (cost_tier.classify_dispatch): a NEW dispatch enters the ladder at one of them.
-# The three model-named rungs (kimi-k3, gpt-5.5, fable-5) are escalation
-# destinations only — reachable by climbing, never by classification.
+# kimi-k3 and gpt-5.5 are dispatch/fallback destinations only, never a climb
+# destination (excluded from escalation_order above).
 #
 # Two mechanisms, opposite in intent, are deliberately kept apart:
 #   * AVAILABILITY fallback (the `fallback` list below) — an unavailable lane is
 #     skipped and the next chain step takes over ON THE SAME TIER. It is a
 #     safety net, never an escalation.
-#   * QUALITY escalation (tier_routing.escalate_tier) — a REJECTED result fires
-#     a followup dispatch one tier UP (tier_to = tier_from + 1), linked by
-#     parent_dispatch. It climbs the ladder; it never walks the fallback list.
-# provider_registry.load_tier_ladder() enforces both invariants fail-loud: no
-# two tiers may resolve to the same primary (a duplicate rung escalates
-# nowhere) and primary cost must be strictly increasing (a higher rung must
-# actually be more expensive).
+#   * QUALITY escalation (tier_routing.escalate_tier / next_tier) — a REJECTED
+#     result fires a followup dispatch one tier UP escalation_order (never
+#     tier_map), linked by parent_dispatch. It climbs the escalation order; it
+#     never walks the fallback list.
+# provider_registry.load_tier_ladder() enforces the cost-ladder invariants
+# fail-loud: no two tiers may resolve to the same primary (a duplicate rung
+# escalates nowhere) and primary cost must be strictly increasing (a higher
+# rung must actually be more expensive).
+# provider_registry.load_escalation_order() enforces escalation_order's own
+# invariant fail-loud: every member must be a key in tier_map — an escalation
+# destination that is not even a valid tier is drift, not a typo to paper
+# over. A registry missing routing.escalation_order entirely also fails loud
+# (see load_escalation_order's docstring) rather than silently falling back
+# to the cost ladder, which would resurrect exactly this defect.
 # ---------------------------------------------------------------------------
 routing:
   tier_map:
@@ -484,3 +514,15 @@ routing:
       provider: anthropic
       model: fable-5
       lane: tmux_interactive
+
+  # Quality-escalation climb order (OI-1356) — see the comment block above
+  # `routing:` for the full rationale. Every member must be a key in
+  # tier_map above (provider_registry.load_escalation_order() validates this
+  # fail-loud). kimi-k3 and gpt-5.5 are intentionally absent: they stay
+  # dispatchable tier_map rungs but are not climb destinations.
+  escalation_order:
+    - tier-zero
+    - tier-low
+    - tier-mid
+    - tier-high
+    - fable-5

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -20,16 +20,19 @@ providers:
         price_source: "unverified: registry-authored"
         price_checked_at: "2026-05-17"
         task_classes: ["coding-premium", "review", "analysis"]
+      # Price corrected 2026-08-19: this key carried the Opus 4.1 price
+      # (15.00/75.00) since the 4.8 rename — the OI-1335 inheritance
+      # pattern, name updated on upgrade, predecessor's price left behind.
       opus-4-8:
         litellm_name: "anthropic/claude-opus-4-8"
-        cost_input_per_mtok: 15.00
-        cost_output_per_mtok: 75.00
+        cost_input_per_mtok: 5.00
+        cost_output_per_mtok: 25.00
         max_tokens: 32000
         context_window: 200000
         supports_streaming: true
         supports_tool_calls: true
-        price_source: "unverified: registry-authored"
-        price_checked_at: "2026-06-18"
+        price_source: "Anthropic first-party pricing page (platform.claude.com/docs/en/about-claude/pricing)"
+        price_checked_at: "2026-08-19"
         task_classes: ["coding-premium", "review", "analysis"]
       opus-4-6:
         # RETIRED alias, kept deliberately (2026-07-22 model-registry-refresh): the field-test
@@ -37,15 +40,17 @@ providers:
         # reproducibility (see scripts/benchmark/models.yaml comment "pin 4-6 explicitly").
         # NOT used by current routing — smart_router / routing_recommendations.yaml use
         # `opus`/`opus-4-8` (current) instead. Do not repurpose this key for current traffic.
+        # Price corrected 2026-08-19: same OI-1335 inheritance pattern as
+        # opus-4-8 — carried the Opus 4.1 price (15.00/75.00).
         litellm_name: "anthropic/claude-opus-4-6"
-        cost_input_per_mtok: 15.00
-        cost_output_per_mtok: 75.00
+        cost_input_per_mtok: 5.00
+        cost_output_per_mtok: 25.00
         max_tokens: 32000
         context_window: 200000
         supports_streaming: true
         supports_tool_calls: true
-        price_source: "unverified: registry-authored"
-        price_checked_at: "2026-06-18"
+        price_source: "Anthropic first-party pricing page (platform.claude.com/docs/en/about-claude/pricing)"
+        price_checked_at: "2026-08-19"
         task_classes: ["coding-premium", "review", "analysis"]
       sonnet:
         litellm_name: "anthropic/claude-sonnet-5"
@@ -75,16 +80,21 @@ providers:
       # verified 2026-08-02 against the Anthropic first-party catalog: Sonnet 5
       # $3/$15 per MTok, Opus 5 $5/$25, Fable 5 $10/$50. Context/max-output are the
       # API ceilings (1M context / 128K output).
+      # Price corrected 2026-08-19: the 15.00 output price was the announced
+      # post-introductory rate. Anthropic cancelled that increase effective
+      # 2026-09-01, so the introductory 2.00/10.00 pair became the standing
+      # price instead — a scheduled change that never actually took effect,
+      # which is exactly what the price_checked_at field exists to catch.
       sonnet-5:
         litellm_name: "anthropic/claude-sonnet-5"
-        cost_input_per_mtok: 3.00
-        cost_output_per_mtok: 15.00
+        cost_input_per_mtok: 2.00
+        cost_output_per_mtok: 10.00
         max_tokens: 128000
         context_window: 1000000
         supports_streaming: true
         supports_tool_calls: true
-        price_source: "unverified: registry-authored"
-        price_checked_at: "2026-08-03"
+        price_source: "Anthropic first-party pricing page (platform.claude.com/docs/en/about-claude/pricing)"
+        price_checked_at: "2026-08-19"
         task_classes: ["coding", "review", "analysis"]
       opus-5:
         litellm_name: "anthropic/claude-opus-5"
@@ -113,16 +123,18 @@ providers:
     api_key_env: OPENAI_API_KEY
     dispatch_enum: codex
     models:
+      # Price corrected 2026-08-19: this key carried the gpt-5.4 price
+      # (1.25/10.00) rather than gpt-5.5's own rate.
       gpt-5.5:
         litellm_name: "openai/gpt-5.5"
-        cost_input_per_mtok: 1.25
-        cost_output_per_mtok: 10.00
+        cost_input_per_mtok: 5.00
+        cost_output_per_mtok: 30.00
         max_tokens: 32000
         context_window: 128000
         supports_streaming: true
         supports_tool_calls: true
-        price_source: "unverified: registry-authored"
-        price_checked_at: "2026-05-17"
+        price_source: "OpenAI public pricing, verified by operator"
+        price_checked_at: "2026-08-17"
         task_classes: ["coding", "review"]
       gpt-5.4:
         litellm_name: "openai/gpt-5.4"
@@ -315,13 +327,15 @@ providers:
         # Verified 20260721 against the installed kimi-cli 1.46.0's own ~/.kimi/config.toml
         # (models."kimi-code/k3", 1M context, display_name "K3") — not guessed.
         cli_model_arg: "kimi-code/k3"
-        cost_input_per_mtok: 0.60
-        cost_output_per_mtok: 2.50
+        # Price corrected 2026-08-17: this key carried the K2-series price
+        # (0.60/2.50) inherited from kimi-k2-0905-default rather than K3's own.
+        cost_input_per_mtok: 3.00
+        cost_output_per_mtok: 15.00
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true
-        price_source: "unverified: registry-authored"
-        price_checked_at: "2026-07-21"
+        price_source: "Moonshot K3 public pricing, verified by operator"
+        price_checked_at: "2026-08-17"
         task_classes: ["coding", "coding-premium", "review", "analysis"]
         dispatch_allowed: true
       kimi-k2-7:
@@ -379,17 +393,19 @@ providers:
 # RegistryLookupError (naming what+where) on anything this registry does not
 # know.
 #
-# COST LADDER (OI-1221, extended OI-1229): seven rungs, cheapest first — the
-# seven dispatchable (provider, model) pairs in ascending output cost. A tier
-# higher is demonstrably more expensive AND more capable, so a quality
-# escalation actually climbs:
+# COST LADDER (OI-1221, extended OI-1229; reordered 2026-08-19 after the
+# sonnet-5/opus-4-8/opus-4-6/kimi-k3/gpt-5.5 price corrections below — see
+# each model's price_source/price_checked_at for provenance): seven rungs,
+# cheapest first — the seven dispatchable (provider, model) pairs in
+# ascending output cost. A tier higher is demonstrably more expensive AND
+# more capable, so a quality escalation actually climbs:
 #
 #   tier-zero  deepseek-v4-flash  $0.28/Mtok out
 #   tier-low   deepseek-v4-pro    $0.87/Mtok out   (the daily workhorse)
-#   kimi-k3    kimi-k3            $2.50/Mtok out
-#   gpt-5.5    gpt-5.5           $10.00/Mtok out
-#   tier-mid   sonnet-5          $15.00/Mtok out
+#   tier-mid   sonnet-5          $10.00/Mtok out
+#   kimi-k3    kimi-k3           $15.00/Mtok out
 #   tier-high  opus-5            $25.00/Mtok out
+#   gpt-5.5    gpt-5.5           $30.00/Mtok out
 #   fable-5    fable-5           $50.00/Mtok out
 #
 # NOT on the ladder (measured 2026-08-15 over wave7_models.yaml):
@@ -444,6 +460,10 @@ routing:
         - provider: openai
           model: gpt-5.5
           lane: provider
+    tier-mid:
+      provider: anthropic
+      model: sonnet-5
+      lane: tmux_interactive
     kimi-k3:
       provider: kimi_cli
       model: kimi-k3
@@ -452,18 +472,14 @@ routing:
         - provider: openai
           model: gpt-5.5
           lane: provider
-    gpt-5.5:
-      provider: openai
-      model: gpt-5.5
-      lane: provider
-    tier-mid:
-      provider: anthropic
-      model: sonnet-5
-      lane: tmux_interactive
     tier-high:
       provider: anthropic
       model: opus-5
       lane: tmux_interactive
+    gpt-5.5:
+      provider: openai
+      model: gpt-5.5
+      lane: provider
     fable-5:
       provider: anthropic
       model: fable-5

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -49,10 +49,10 @@ def _force_kimi(monkeypatch, present: bool):
 LADDER_ORDER = [
     TIER_ZERO,
     TIER_LOW,
-    "kimi-k3",
-    "gpt-5.5",
     TIER_MID,
+    "kimi-k3",
     TIER_HIGH,
+    "gpt-5.5",
     "fable-5",
 ]
 
@@ -96,10 +96,10 @@ def test_ladder_covers_every_dispatchable_model():
     assert [(r.tier, r.model, r.output_cost_per_mtok) for r in ladder] == [
         (TIER_ZERO, "deepseek-v4-flash", 0.28),
         (TIER_LOW, "deepseek-v4-pro", 0.87),
-        ("kimi-k3", "kimi-k3", 2.50),
-        ("gpt-5.5", "gpt-5.5", 10.00),
-        (TIER_MID, "sonnet-5", 15.00),
+        (TIER_MID, "sonnet-5", 10.00),
+        ("kimi-k3", "kimi-k3", 15.00),
         (TIER_HIGH, "opus-5", 25.00),
+        ("gpt-5.5", "gpt-5.5", 30.00),
         ("fable-5", "fable-5", 50.00),
     ]
 
@@ -193,9 +193,11 @@ def test_load_tier_ladder_fails_on_non_monotonic_cost(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_escalate_rejected_result_climbs_one_tier():
+    """OI-1356: tier-low climbs to tier-mid (escalation_order), not kimi-k3
+    (cost ladder) -- kimi-k3 is excluded from escalation_order."""
     esc = escalate_tier(TIER_LOW, "20260815-rejected-attempt", failure_class="model_error")
     assert esc.tier_from == TIER_LOW
-    assert esc.tier_to == "kimi-k3"
+    assert esc.tier_to == TIER_MID
     assert esc.parent_dispatch == "20260815-rejected-attempt"
 
 
@@ -215,22 +217,33 @@ def test_escalate_unknown_tier_returns_none():
     assert escalate_tier("tier-unknown", "d-unknown", failure_class="model_error").tier_to is None
 
 
-def test_escalate_model_named_rungs_climb_in_cost_order():
-    """The three escalation-only rungs slot into the climb at their cost position."""
-    assert escalate_tier("kimi-k3", "d1", failure_class="model_error").tier_to == "gpt-5.5"
-    assert escalate_tier("gpt-5.5", "d2", failure_class="model_error").tier_to == TIER_MID
+def test_kimi_k3_and_gpt_5_5_are_not_escalation_destinations():
+    """OI-1356: kimi-k3 and gpt-5.5 stay full tier_map rungs (dispatchable,
+    fallback-eligible) but are excluded from escalation_order, so they are
+    neither a climb source nor a climb destination.
+
+    This assertion changed meaning from the pre-OI-1356 version of this test
+    (formerly ``test_escalate_model_named_rungs_climb_in_cost_order``), which
+    asserted the three model-named rungs slotted into the climb at their cost
+    position (kimi-k3 -> gpt-5.5 -> tier-mid). That coupling -- escalation
+    walking the cost ladder instead of an explicit climb order -- is exactly
+    the defect OI-1356 removes."""
+    assert escalate_tier("kimi-k3", "d1", failure_class="model_error").tier_to is None
+    assert escalate_tier("gpt-5.5", "d2", failure_class="model_error").tier_to is None
     assert escalate_tier(TIER_HIGH, "d3", failure_class="model_error").tier_to == "fable-5"
     assert escalate_tier("fable-5", "d4", failure_class="model_error").tier_to is None
 
 
 def test_next_tier_matches_escalate_tier():
+    """OI-1356: the climb follows escalation_order (tier-zero -> tier-low ->
+    tier-mid -> tier-high -> fable-5); kimi-k3/gpt-5.5 are not on it."""
     assert next_tier(TIER_ZERO) == TIER_LOW
-    assert next_tier(TIER_LOW) == "kimi-k3"
-    assert next_tier("kimi-k3") == "gpt-5.5"
-    assert next_tier("gpt-5.5") == TIER_MID
+    assert next_tier(TIER_LOW) == TIER_MID
     assert next_tier(TIER_MID) == TIER_HIGH
     assert next_tier(TIER_HIGH) == "fable-5"
     assert next_tier("fable-5") is None
+    assert next_tier("kimi-k3") is None
+    assert next_tier("gpt-5.5") is None
 
 
 # ---------------------------------------------------------------------------
@@ -238,10 +251,10 @@ def test_next_tier_matches_escalate_tier():
 # ---------------------------------------------------------------------------
 
 def test_model_error_climbs_one_tier():
-    """model_error -> climb one tier."""
+    """model_error -> climb one tier (escalation_order: tier-low -> tier-mid)."""
     esc = escalate_tier(TIER_LOW, "d-model", failure_class="model_error")
     assert esc.action == "climb"
-    assert esc.tier_to == "kimi-k3"
+    assert esc.tier_to == TIER_MID
     assert esc.notify_operator is False
     assert esc.unknown_class is False
 
@@ -250,7 +263,7 @@ def test_credit_exhausted_climbs_and_notifies_operator():
     """credit_exhausted -> climb one tier AND notify operator."""
     esc = escalate_tier(TIER_LOW, "d-credit", failure_class="credit_exhausted")
     assert esc.action == "climb"
-    assert esc.tier_to == "kimi-k3"
+    assert esc.tier_to == TIER_MID
     assert esc.notify_operator is True
 
 
@@ -270,7 +283,7 @@ def test_timeout_retries_same_tier_then_climbs():
 
     climbed = escalate_tier(TIER_LOW, "d-timeout", failure_class="timeout", retried=True)
     assert climbed.action == "climb"
-    assert climbed.tier_to == "kimi-k3"
+    assert climbed.tier_to == TIER_MID
 
 
 def test_empty_completion_retries_same_tier_then_climbs():
@@ -281,7 +294,7 @@ def test_empty_completion_retries_same_tier_then_climbs():
 
     climbed = escalate_tier(TIER_LOW, "d-empty", failure_class="empty_completion", retried=True)
     assert climbed.action == "climb"
-    assert climbed.tier_to == "kimi-k3"
+    assert climbed.tier_to == TIER_MID
 
 
 def test_unknown_class_does_not_climb_and_reports_loud():
@@ -318,5 +331,5 @@ def test_quality_escalation_climbs_where_fallback_stays(monkeypatch):
 
     esc = escalate_tier(TIER_LOW, "d-rejected", failure_class="model_error")
     assert esc.tier_from == TIER_LOW
-    assert esc.tier_to == "kimi-k3"
+    assert esc.tier_to == TIER_MID
     assert esc.parent_dispatch == "d-rejected"

--- a/tests/smart_router/test_escalation_order.py
+++ b/tests/smart_router/test_escalation_order.py
@@ -1,0 +1,323 @@
+"""Red tests for the escalation-order / cost-ladder separation (OI-1356).
+
+The operator decided (19-08) on option (a): the cost ladder
+(``routing.tier_map`` in wave7_models.yaml) stays purely cost-ordered, and
+quality escalation gets its OWN, explicitly authored list --
+``routing.escalation_order`` -- a subset/reordering of the tier_map keys that
+describes the climb chain:
+
+    tier-zero -> tier-low -> tier-mid -> tier-high -> fable-5
+
+``kimi-k3`` and ``gpt-5.5`` stay full tier_map rungs (dispatch/fallback still
+reach them) but are NOT climb destinations: ``next_tier()`` must return
+``None`` for them.
+
+Today neither ``escalation_order`` nor its consumption in
+``tier_routing.next_tier()`` exists -- ``next_tier()`` still walks
+``_TIER_LADDER`` (the cost order). This file pins the CONTRACT a fix must
+satisfy; it does not implement it (no production code or yaml is touched
+here).
+
+Two design choices this file makes, since they are not specified verbatim by
+the dispatch instruction and a test must commit to *something* runnable:
+
+* Exception class: ``RegistryLookupError`` (already defined in
+  provider_registry.py for exactly this class of error -- "the registry does
+  not know X", used by ``_resolve_step``/``load_tier_map``/
+  ``load_tier_ladder`` today) is asserted for the unknown-member validation.
+
+* Testing seam for "next_tier() must read a DIFFERENT registry": tier_routing
+  resolves ``_TIER_MAP``/``_TIER_LADDER`` exactly ONCE, at module import, by
+  calling the provider_registry loaders with no explicit ``registry_path`` --
+  which fall back to ``provider_registry._REGISTRY_PATH`` (see tier_routing.py
+  lines 73-82, "resolved once at import... loud and early", ADR-036). The
+  same must be true of whatever resolves the escalation order, or a malformed
+  ``escalation_order`` would only surface mid-dispatch instead of at import.
+  So the fixture-registry tests below patch ``provider_registry._REGISTRY_PATH``
+  and exec a throwaway, unregistered COPY of tier_routing.py against it --
+  never ``importlib.reload`` the real, shared module. tier_routing.py defines
+  ``TierRoute``/``TierEscalation`` as classes; reloading it in place rebinds
+  those names to NEW class objects, and every other test file that already
+  holds a reference to the pre-reload class (e.g. test_tier_routing.py's
+  ``from providers.smart_router.tier_routing import TierRoute`` for its own
+  ``isinstance`` checks) then breaks for the rest of the pytest session --
+  confirmed empirically while writing this file: an in-place reload-then-
+  restore still left ``TierRoute`` a *third*, different object, and broke
+  ``test_route_dispatch_default_on``/``test_route_dispatch_auto_route_enabled``
+  in test_tier_routing.py even though every VALUE had been restored. A
+  throwaway copy, executed under its own private module name, leaves the
+  real module -- and its classes' identity -- untouched.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from providers import provider_registry
+from providers.provider_registry import RegistryLookupError, load_tier_ladder
+from providers.smart_router.cost_tier import TIER_HIGH, TIER_LOW, TIER_MID, TIER_ZERO
+from providers.smart_router.tier_routing import escalate_tier, next_tier
+
+_TIER_ROUTING_PATH = Path(provider_registry.__file__).parent / "smart_router" / "tier_routing.py"
+
+
+# ---------------------------------------------------------------------------
+# Fixture-registry helpers (self-contained -- do not import from
+# test_cost_ladder.py, which is independently red right now for unrelated
+# stale-price reasons and is explicitly out of scope for this dispatch).
+# ---------------------------------------------------------------------------
+
+def _model(out_cost: float) -> dict:
+    return {
+        "litellm_name": "m",
+        "cost_input_per_mtok": 0.1,
+        "cost_output_per_mtok": out_cost,
+        "max_tokens": 100,
+        "supports_streaming": True,
+        "supports_tool_calls": True,
+    }
+
+
+def _provider(enum: str, models: dict) -> dict:
+    return {
+        "enabled": True,
+        "api_key_env": "A",
+        "dispatch_enum": enum,
+        "models": models,
+    }
+
+
+def _write_registry(
+    tmp_path: Path,
+    providers: dict,
+    tier_map: dict,
+    escalation_order: list | None = None,
+) -> Path:
+    routing: dict = {"tier_map": tier_map}
+    if escalation_order is not None:
+        routing["escalation_order"] = escalation_order
+    path = tmp_path / "wave7_models.yaml"
+    # sort_keys=False: dict order IS the authored order under test, same
+    # reasoning as test_cost_ladder.py's own _write_registry.
+    path.write_text(
+        yaml.dump({"providers": providers, "routing": routing}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _load_fresh_tier_routing():
+    """Exec an independent copy of tier_routing.py under a private module name.
+
+    Registered in sys.modules only for the duration of exec_module (dataclass
+    field resolution needs ``sys.modules[cls.__module__]`` to exist for the
+    ``Optional["TierRoute"]`` forward reference on the frozen dataclass), then
+    removed immediately -- this throwaway copy is never a real, importable
+    module and must not linger in the module cache.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "providers.smart_router._test_oi1356_tier_routing_fixture", _TIER_ROUTING_PATH
+    )
+    module = importlib.util.module_from_spec(spec)  # __package__ derives from the dotted name
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        del sys.modules[spec.name]
+    return module
+
+
+@pytest.fixture
+def reload_tier_routing(monkeypatch):
+    """Load a throwaway tier_routing copy against a fixture registry path.
+
+    Patches provider_registry._REGISTRY_PATH (auto-reverted by monkeypatch at
+    teardown) so the fresh copy's module-level ``_TIER_MAP = load_tier_map()``
+    etc. resolve against the fixture instead of the real wave7_models.yaml.
+    The real, shared providers.smart_router.tier_routing module is never
+    touched -- see _load_fresh_tier_routing's docstring for why that matters.
+    """
+
+    def _reload(fixture_path: Path):
+        monkeypatch.setattr(provider_registry, "_REGISTRY_PATH", fixture_path)
+        return _load_fresh_tier_routing()
+
+    return _reload
+
+
+# ---------------------------------------------------------------------------
+# Rood vandaag: next_tier() must read escalation_order, not the cost ladder
+# ---------------------------------------------------------------------------
+
+def test_next_tier_tier_mid_climbs_to_tier_high_not_kimi_k3():
+    """escalation_order: tier-mid -> tier-high. Today next_tier reads the cost
+    ladder, where kimi-k3 sits between tier-mid and tier-high -- RED today."""
+    assert next_tier(TIER_MID) == TIER_HIGH
+
+
+def test_next_tier_tier_low_climbs_to_tier_mid():
+    """escalation_order: tier-low -> tier-mid (never kimi-k3, never gpt-5.5)."""
+    assert next_tier(TIER_LOW) == TIER_MID
+    assert next_tier(TIER_LOW) != "kimi-k3"
+    assert next_tier(TIER_LOW) != "gpt-5.5"
+
+
+def test_next_tier_kimi_k3_is_not_an_escalation_destination():
+    """kimi-k3 stays a full tier_map rung but is excluded from
+    escalation_order -- no climb. Today it returns tier-high -- RED today."""
+    assert next_tier("kimi-k3") is None
+
+
+def test_next_tier_gpt_5_5_is_not_an_escalation_destination():
+    """gpt-5.5 stays a full tier_map rung but is excluded from
+    escalation_order -- no climb. Today it returns fable-5 -- RED today."""
+    assert next_tier("gpt-5.5") is None
+
+
+def test_next_tier_fable_5_is_top_of_chain():
+    """fable-5 is the top of escalation_order -- no climb beyond it."""
+    assert next_tier("fable-5") is None
+
+
+def test_next_tier_tier_high_climbs_to_fable_5_not_gpt_5_5():
+    """escalation_order: tier-high -> fable-5. Today next_tier reads the cost
+    ladder, where gpt-5.5 sits between tier-high and fable-5 -- RED today."""
+    assert next_tier(TIER_HIGH) == "fable-5"
+
+
+def test_next_tier_full_escalation_chain():
+    """The complete climb chain the operator authored, end to end."""
+    assert next_tier(TIER_ZERO) == TIER_LOW
+    assert next_tier(TIER_LOW) == TIER_MID
+    assert next_tier(TIER_MID) == TIER_HIGH
+    assert next_tier(TIER_HIGH) == "fable-5"
+    assert next_tier("fable-5") is None
+
+
+def test_escalate_tier_mid_to_tier_high_via_escalation_order():
+    """A REJECTED result at tier-mid climbs to tier-high (escalation_order),
+    not kimi-k3 (cost ladder) -- RED today."""
+    esc = escalate_tier(TIER_MID, "d-esc-mid", failure_class="model_error")
+    assert esc.tier_from == TIER_MID
+    assert esc.tier_to == TIER_HIGH
+
+
+# ---------------------------------------------------------------------------
+# Registry-loader validation: an escalation_order member absent from
+# tier_map must fail loud, not silently drop the rung.
+# ---------------------------------------------------------------------------
+
+def test_escalation_order_unknown_member_fails_loud(tmp_path, reload_tier_routing):
+    """Today nothing parses routing.escalation_order at all, so this fixture
+    is silently ignored and no exception is raised -- reload succeeds and
+    pytest.raises reports "DID NOT RAISE": a clear, readable signal that the
+    validation behavior does not exist yet (not an accidental KeyError deep
+    in a helper)."""
+    providers = {"pa": _provider("pa", {"cheap": _model(1.0)})}
+    tier_map = {"x": {"provider": "pa", "model": "cheap", "lane": "l"}}
+    path = _write_registry(
+        tmp_path, providers, tier_map, escalation_order=["x", "unknown-tier"]
+    )
+
+    with pytest.raises(RegistryLookupError) as exc_info:
+        reload_tier_routing(path)
+    assert "unknown-tier" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Groen vandaag, moet groen blijven: the separation must not shrink or
+# weaken the cost ladder, and escalate_tier's action table is untouched.
+# ---------------------------------------------------------------------------
+
+def test_load_tier_ladder_still_returns_all_seven_rungs_in_cost_order():
+    """Separating escalation_order from tier_map must not shrink the cost
+    ladder -- kimi-k3 and gpt-5.5 stay full rungs, still strictly cost-ordered."""
+    ladder = load_tier_ladder()
+    tiers = [rung.tier for rung in ladder]
+    assert tiers == [
+        TIER_ZERO, TIER_LOW, TIER_MID, "kimi-k3", TIER_HIGH, "gpt-5.5", "fable-5",
+    ]
+    costs = [rung.output_cost_per_mtok for rung in ladder]
+    assert all(a < b for a, b in zip(costs, costs[1:])), costs
+
+
+def test_load_tier_ladder_still_rejects_non_monotonic_cost(tmp_path):
+    """Anti-overshoot: load_tier_ladder's strict-cost invariant is unrelated
+    to escalation_order and must keep failing loud on its own terms. Repeated
+    here self-contained (not imported from test_cost_ladder.py) so this
+    file's own green baseline never depends on a neighbor file that is
+    independently red right now for unrelated stale-price reasons."""
+    providers = {
+        "pa": _provider("pa", {"cheap": _model(5.0)}),
+        "pb": _provider("pb", {"pricey": _model(1.0)}),  # cheaper -- non-monotonic
+    }
+    tier_map = {
+        "tier-zero": {"provider": "pa", "model": "cheap", "lane": "l"},
+        "tier-low": {"provider": "pb", "model": "pricey", "lane": "l"},
+    }
+    path = _write_registry(tmp_path, providers, tier_map)
+    with pytest.raises(RegistryLookupError, match="strict cost ladder"):
+        load_tier_ladder(registry_path=path)
+
+
+def test_escalate_tier_action_table_unaffected_by_source_change():
+    """escalate_tier must keep driving its ACTION off _ESCALATION_TABLE
+    (model_error/auth_rejected/timeout/...); only the climb DESTINATION
+    changes source, from the cost ladder to escalation_order. Uses tier-mid,
+    which stays in escalation_order, so a None destination can never mask an
+    action-logic regression."""
+    climb = escalate_tier(TIER_MID, "d-action-climb", failure_class="model_error")
+    assert climb.action == "climb"
+    assert climb.tier_to == TIER_HIGH  # RED today: destination is still kimi-k3
+
+    no_climb = escalate_tier(TIER_MID, "d-action-auth", failure_class="auth_rejected")
+    assert no_climb.action == "no_climb"
+    assert no_climb.tier_to is None
+
+    retry = escalate_tier(TIER_MID, "d-action-timeout", failure_class="timeout")
+    assert retry.action == "retry_same_tier"
+    assert retry.tier_to == TIER_MID
+
+    climbed_after_retry = escalate_tier(
+        TIER_MID, "d-action-timeout", failure_class="timeout", retried=True
+    )
+    assert climbed_after_retry.action == "climb"
+    assert climbed_after_retry.tier_to == TIER_HIGH  # RED today: still kimi-k3
+
+
+# ---------------------------------------------------------------------------
+# The test that guards the separation itself (the core of OI-1356): a
+# fixture where cost order and escalation_order deliberately diverge.
+# ---------------------------------------------------------------------------
+
+def test_next_tier_follows_escalation_order_not_cost_order_when_they_diverge(
+    tmp_path, reload_tier_routing
+):
+    """Cost order (cheapest first): a (1) < b (2) < c (3) -- a cost-ladder
+    walk goes a -> b -> c. escalation_order is authored as a -> c -> b: a
+    DIFFERENT order over the same three tiers. If next_tier() is ever
+    reverted to read the cost ladder instead of escalation_order, this test
+    fails. A test that stays green under that revert is worthless (per the
+    dispatch instruction) -- this is that test."""
+    providers = {
+        "pa": _provider("pa", {"cheap": _model(1.0)}),
+        "pb": _provider("pb", {"mid": _model(2.0)}),
+        "pc": _provider("pc", {"pricey": _model(3.0)}),
+    }
+    tier_map = {
+        "a": {"provider": "pa", "model": "cheap", "lane": "l"},
+        "b": {"provider": "pb", "model": "mid", "lane": "l"},
+        "c": {"provider": "pc", "model": "pricey", "lane": "l"},
+    }
+    path = _write_registry(tmp_path, providers, tier_map, escalation_order=["a", "c", "b"])
+    reloaded = reload_tier_routing(path)
+
+    assert reloaded.next_tier("a") == "c", "must follow escalation_order (a->c), not cost order (a->b)"
+    assert reloaded.next_tier("c") == "b"
+    assert reloaded.next_tier("b") is None  # top of escalation_order, despite being cheaper than c

--- a/tests/test_dispatch_bridge_escalation.py
+++ b/tests/test_dispatch_bridge_escalation.py
@@ -74,7 +74,7 @@ def test_escalation_bundle_writes_chain_link_fields_to_disk(tmp_path, monkeypatc
     payload = _read_payload(spec_file)
 
     assert payload["tier_from"] == "tier-low"
-    assert payload["tier_to"] == "kimi-k3"
+    assert payload["tier_to"] == "tier-mid"
     assert payload["parent_dispatch"] == _REJECTED_ID
     assert payload["dispatch_id"] == _FOLLOWUP_ID
 
@@ -85,8 +85,8 @@ def test_escalation_followup_runs_on_the_escalated_model(tmp_path, monkeypatch):
     _force_kimi(monkeypatch, present=True)
     payload = _read_payload(_stage_escalation(tmp_path))
 
-    assert payload["provider"] == "kimi"
-    assert payload["model"] == "kimi-k3"
+    assert payload["provider"] == "claude"
+    assert payload["model"] == "sonnet-5"
 
 
 def test_escalation_at_top_rung_refuses_to_stage(tmp_path, monkeypatch):

--- a/tests/test_price_provenance.py
+++ b/tests/test_price_provenance.py
@@ -1,0 +1,196 @@
+"""Price provenance tests (OI-1334, OI-1335).
+
+wave7_models.yaml carries prices with no record of where they came from or
+when they were last checked. That is how gpt-5.5 kept the 1.25/10.00 pair
+inherited from gpt-5.4, and kimi-k3 kept 0.60/2.50 inherited from
+kimi-k2-0905-default: the strict-ladder invariant in
+provider_registry.load_tier_ladder() only catches a stale price if it
+happens to break monotonic ordering, and with these two it did not.
+
+This file does not fix a single price and does not touch wave7_models.yaml.
+It pins the provenance contract the fix must satisfy:
+
+  1. every model carries a non-empty price_source and an ISO price_checked_at,
+  2. every routing.tier_map rung cites a price checked within the last 90
+     days (measured from a fixed reference date this file supplies itself —
+     never the system clock, or the test becomes a ticking time bomb),
+  3. a price_checked_at in the wrong format fails loudly, naming the model
+     and the field — not a bare ValueError from date parsing.
+
+Every test below is expected to fail on current main: price_source and
+price_checked_at exist nowhere in the registry today (verified with
+`grep -rn "price_source\\|price_checked_at" scripts/ tests/` before writing
+this file — zero hits).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from providers import provider_registry
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# The date this dispatch was authored, not date.today(): a freshness check
+# tied to the system clock goes red on its own the day it turns 91 days old,
+# which is a time bomb, not a regression guard (OI-1334 lesson).
+_REFERENCE_DATE = date(2026, 8, 18)
+_MAX_PRICE_AGE_DAYS = 90
+
+
+def _load_real_registry():
+    return provider_registry.load()
+
+
+def _all_model_ids():
+    registry = _load_real_registry()
+    ids = []
+    for provider_key, cfg in registry.items():
+        for model_key in cfg.models:
+            ids.append((provider_key, model_key))
+    return ids
+
+
+_ALL_MODELS = _all_model_ids()
+_ALL_MODEL_TEST_IDS = [f"{provider}/{model}" for provider, model in _ALL_MODELS]
+
+
+class TestEveryModelCarriesPriceProvenance:
+    """OI-1334: price_source + price_checked_at must exist on every model."""
+
+    @pytest.mark.parametrize(
+        "provider_key, model_key", _ALL_MODELS, ids=_ALL_MODEL_TEST_IDS
+    )
+    def test_has_non_empty_price_source(self, provider_key, model_key):
+        registry = _load_real_registry()
+        model = registry[provider_key].models[model_key]
+        price_source = getattr(model, "price_source", "")
+        assert price_source, (
+            f"{provider_key}/{model_key} has no price_source recorded — "
+            "where did this price come from?"
+        )
+
+    @pytest.mark.parametrize(
+        "provider_key, model_key", _ALL_MODELS, ids=_ALL_MODEL_TEST_IDS
+    )
+    def test_has_iso_price_checked_at(self, provider_key, model_key):
+        registry = _load_real_registry()
+        model = registry[provider_key].models[model_key]
+        price_checked_at = getattr(model, "price_checked_at", "")
+        assert price_checked_at, (
+            f"{provider_key}/{model_key} has no price_checked_at recorded"
+        )
+        assert _ISO_DATE_RE.match(price_checked_at), (
+            f"{provider_key}/{model_key} price_checked_at "
+            f"{price_checked_at!r} is not YYYY-MM-DD"
+        )
+
+
+def _resolve_tier_model(dispatch_enum: str, model_key: str):
+    """Walk the registry sections to the ProviderModel a resolved tier route names.
+
+    route.provider is the dispatch enum (e.g. "claude"), not the registry
+    section key (e.g. "anthropic") — mirrors provider_registry._output_cost_for.
+    """
+    registry = _load_real_registry()
+    for cfg in registry.values():
+        if cfg.dispatch_enum == dispatch_enum and model_key in cfg.models:
+            return cfg.models[model_key]
+    pytest.fail(f"cannot resolve {dispatch_enum}/{model_key} in wave7_models.yaml")
+
+
+_TIER_MAP = provider_registry.load_tier_map()
+_ALL_TIERS = sorted(_TIER_MAP.keys())
+
+
+class TestTierMapPricesAreFresh:
+    """OI-1335: every routing.tier_map rung must cite a price checked recently.
+
+    Scoped to each tier's primary step (the seven cost-ladder rungs
+    documented in wave7_models.yaml) — not the availability-fallback chains,
+    which are a different mechanism (safety net, not the priced escalation
+    path).
+    """
+
+    @pytest.mark.parametrize("tier", _ALL_TIERS)
+    def test_tier_price_checked_within_90_days(self, tier):
+        route = _TIER_MAP[tier]
+        model = _resolve_tier_model(route.provider, route.model)
+        price_checked_at = getattr(model, "price_checked_at", "")
+        assert price_checked_at, (
+            f"tier {tier!r} ({route.provider}/{route.model}) has no "
+            "price_checked_at recorded"
+        )
+        try:
+            checked = date.fromisoformat(price_checked_at)
+        except ValueError:
+            pytest.fail(
+                f"tier {tier!r} ({route.provider}/{route.model}) "
+                f"price_checked_at {price_checked_at!r} is not a valid ISO date"
+            )
+        age_days = (_REFERENCE_DATE - checked).days
+        assert age_days <= _MAX_PRICE_AGE_DAYS, (
+            f"tier {tier!r} ({route.provider}/{route.model}) price was last "
+            f"checked {price_checked_at} — {age_days} days before "
+            f"{_REFERENCE_DATE.isoformat()}, older than the "
+            f"{_MAX_PRICE_AGE_DAYS}-day freshness window"
+        )
+
+
+class TestMalformedPriceCheckedAtFailsLoud:
+    """OI-1334: a wrong-format price_checked_at must fail loudly and specifically.
+
+    Not a bare ValueError bubbling up from date parsing (Python's raw
+    "Invalid isoformat string: '18-08-2026'" names neither the model nor the
+    field) — the raised error's message must name both, so a broken date is
+    diagnosable from the traceback alone.
+    """
+
+    def _fixture(self, tmp_path: Path, price_checked_at: str) -> Path:
+        registry = {
+            "providers": {
+                "acme": {
+                    "enabled": True,
+                    "api_key_env": "ACME_API_KEY",
+                    "dispatch_enum": "acme",
+                    "models": {
+                        "acme-flagship": {
+                            "litellm_name": "acme/flagship",
+                            "cost_input_per_mtok": 1.0,
+                            "cost_output_per_mtok": 2.0,
+                            "max_tokens": 1000,
+                            "supports_streaming": True,
+                            "supports_tool_calls": True,
+                            "price_source": "test-fixture",
+                            "price_checked_at": price_checked_at,
+                        }
+                    },
+                }
+            }
+        }
+        path = tmp_path / "wave7_models.yaml"
+        path.write_text(yaml.dump(registry, sort_keys=False), encoding="utf-8")
+        return path
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["18-08-2026", "2026/08/18", "Aug 18 2026", "not-a-date"],
+    )
+    def test_bad_format_raises_naming_model_and_field(self, tmp_path, bad_value):
+        path = self._fixture(tmp_path, bad_value)
+        with pytest.raises(Exception) as excinfo:
+            provider_registry.load(registry_path=path)
+        message = str(excinfo.value)
+        assert "acme-flagship" in message, (
+            f"error for a bad price_checked_at must name the model — got: {message!r}"
+        )
+        assert "price_checked_at" in message, (
+            f"error for a bad price_checked_at must name the field — got: {message!r}"
+        )


### PR DESCRIPTION
## Summary

Drie samenhangende dingen aan `wave7_models.yaml` en de router: prijsherkomst, vijf
prijscorrecties, en de scheiding van kostenordening en capability-escalatie (OI-1356).

De kern: `routing.tier_map` diende twee onverenigbare doelen. `load_tier_ladder()` dwong af dat
de kosten strikt stijgen over die volgorde, en `next_tier()` las diezelfde volgorde als
klimketen. Zolang duurder ook capabeler betekende vielen die samen. Na de prijscorrectie niet
meer: `tier-mid` klom naar `kimi-k3`, duurder maar niet capabeler, en op een andere lane met
eigen quota en faalmodi.

Dit was geen regressie van deze PR. Op `main` klimt `tier-low` vandaag al naar `kimi-k3`; de
prijscorrectie verplaatste het probleem alleen naar een zichtbaarder punt.

## Changes

| Commit | Wat |
|---|---|
| `4f247b07` | rode test voor prijsherkomst |
| `ee90036c` | `price_source` + `price_checked_at` op alle 24 modellen |
| `ee0d7cd0` | parser voor die twee velden, faalt luid op een onparseerbare datum |
| `796038d5` | vijf verouderde prijzen gecorrigeerd, ladder herordend |
| `4d4520e1` | rode tests pinnen de `escalation_order`/kostenladder-scheiding |
| `6b5a6ae8` | `escalation_order` als tweede lijst, `next_tier()` leest die |
| `dc710cbc` | twee verouderde escalatie-asserties in de bridge-tests bijgewerkt |

Test-schrijver en fix-schrijver zijn per stap gescheiden gebleven in de historie.

## De scheiding

Nieuwe sleutel `routing.escalation_order`:

```
tier-zero -> tier-low -> tier-mid -> tier-high -> fable-5
```

`kimi-k3` en `gpt-5.5` staan er bewust niet in. Ze blijven volwaardige `tier_map`-rungs,
dispatchbaar en fallback-geschikt, maar zijn geen klimbestemming. Operatorbesluit, optie (a)
uit OI-1356.

**Gedragswijziging, alle zeven tredes gemeten (T0, eigen worktree):**

| Trede | `next_tier()` voor | na |
|---|---|---|
| `tier-zero` | `tier-low` | `tier-low` |
| `tier-low` | `tier-mid` | `tier-mid` |
| `tier-mid` | `kimi-k3` | **`tier-high`** |
| `kimi-k3` | `tier-high` | **`None`** |
| `tier-high` | `gpt-5.5` | **`fable-5`** |
| `gpt-5.5` | `fable-5` | **`None`** |
| `fable-5` | `None` | `None` |

De kostenladder blijft ongemoeid: zeven rungs, strikt stijgend
(0.28 < 0.87 < 10 < 15 < 25 < 30 < 50). De actie-tabel `_ESCALATION_TABLE` is byte-identiek.

## Verification

Gemeten door T0 op een eigen checkout, niet overgenomen uit het bouwersrapport:

- `tests/smart_router/` + `tests/test_price_provenance.py`: **209 passed**
- De zeven testbestanden waarop het verschil met `main` is gemeten: **142 passed, 0 failed**,
  exact gelijk aan de baseline op `main`
- **Proefmerge tegen de huidige `main`** (inclusief het net gemergede #1609):
  `Automatic merge went well`, daarna **252 passed** over `smart_router`,
  `price_provenance`, `pricing_resolution`, `token_extraction_per_provider` en
  `dispatch_bridge_escalation`

VNX CI workflow-conclusie: `success` op head `dc710cbc`.

## Review

Kimi-review (read-only dispatch, `20260819-review-kimi-1606`): **PASS-WITH-NOTES**. Zelf
getoetst, niet op het bouwersrapport afgegaan:

- Fail-loud werkt: beide gevallen (ontbrekende sleutel, onbekend lid) met eigen fixtures
  geconstrueerd, beide gooien `RegistryLookupError`.
- Een kapotte yaml faalt zichtbaar bij pytest-collectie en bij elke escalatie-staging.
- De divergentie-test (kostenvolgorde a<b<c tegenover escalatievolgorde a→c→b) garandeert dat
  een revert naar de kostenladder rood gaat.
- Elke gewijzigde assertie in `test_cost_ladder.py` nagelopen: niets stilzwijgend verzwakt.

**Openstaande note uit die review, bewust niet in deze PR opgelost:** de alias-sleutels `opus`
(15/75) en `sonnet` (3/15) dragen na de correctie nog de prijzen die deze PR voor dezelfde
`litellm_name` als fout verklaart. Ze staan eerlijk als `unverified: registry-authored` en
hebben geen ladder-impact, maar het register spreekt zichzelf op dat punt tegen. Logische
OI-1335-vervolgstap.

**T0-verificatie van de fail-loud-keuze.** De worker koos luid falen bij een ontbrekende
`escalation_order`, en merkte op dat elke registry zonder die sleutel dan bij import zou
breken. Nagetrokken: `_REGISTRY_PATH` is package-intern
(`Path(__file__).parent / "wave7_models.yaml"`), er is geen env-override, en consumers dragen
geen eigen registry. De yaml versioneert dus mee met de loader en er bestaat geen combinatie van
nieuwe code met oude yaml. Veilig.

## Open Items

- **OI-1348 (blocker) wordt door deze PR opgelost.** Het gelijkspel tussen `kimi-k3` en
  `sonnet-5` dat een strikt stijgende ladder onmogelijk maakte, is weg doordat `sonnet-5` mee
  is gecorrigeerd naar 2.00/10.00, met een first-party bron van 19-08. Dat is de uitweg die de
  vorige worker terecht weigerde te nemen zonder bron.
- OI-1360 (nieuw): de fallback-doelen per trede zijn 53 tot 107 keer duurder geworden terwijl
  de blokken byte-identiek bleven. Bewust uitgesteld, operatorbesluit.
