### PR TITLE
test(pricing-resolution): red tests for OI-1355 model-name resolution defect

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -480,9 +480,7 @@ def _resolve_registry_model_entry(cfg: Any, registry_key: str, model: str) -> Op
          boundary match). This keeps a dated/suffixed real model id (the
          registry's own "haiku" litellm_name is "claude-haiku-4-5-20251001")
          resolving after the fix, not just the two exact tiers above.
-         Longest-key-wins makes the pick independent of iteration order; a
-         tie between two equally-long candidates is refused (None) rather
-         than guessed — same principle as tier 3's total-miss case below.
+         Longest-key-wins makes the pick independent of iteration order.
 
     Returns None on a total miss. A miss is a valid, non-terminal signal here:
     `_compute_cost` falls back to the provider_costs rate table on a None, so
@@ -502,7 +500,11 @@ def _resolve_registry_model_entry(cfg: Any, registry_key: str, model: str) -> Op
         key=len,
         reverse=True,
     )
-    if candidates and (len(candidates) == 1 or len(candidates[0]) != len(candidates[1])):
+    # A same-length tie for candidates[0] is impossible by construction: two
+    # equal-length dict keys that both hyphen-prefix `stripped` would force
+    # stripped[:L] to equal both keys, i.e. the keys themselves would be
+    # equal — but cfg.models is a dict, so its keys are already unique.
+    if candidates:
         return cfg.models[candidates[0]]
     return None
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -447,6 +447,65 @@ _PROVIDER_TO_REGISTRY_KEY: Dict[str, str] = {
     "local-gemma": "local_gemma",
 }
 
+# OI-1355: registry-section-specific model-name prefix a real provider model
+# slug carries but the registry's own keys do not — e.g. Anthropic hands back
+# "claude-opus-5" while wave7_models.yaml's anthropic section keys it "opus-5".
+# Only anthropic needs this today; other sections' model strings already hit
+# an exact key (litellm sub-providers) via the "/" split above the call site.
+_REGISTRY_KEY_MODEL_PREFIX: Dict[str, str] = {
+    "anthropic": "claude-",
+}
+
+
+def _resolve_registry_model_entry(cfg: Any, registry_key: str, model: str) -> Optional[Any]:
+    """Deterministically resolve `model` to one ProviderModel entry in `cfg.models`.
+
+    Three tiers, each strictly more specific than the last and NONE dependent
+    on dict iteration order (OI-1355: the prior substring scan picked
+    whichever key happened to iterate first, so "claude-opus-5" silently
+    priced as the shorter "opus" key purely because "opus" comes first in
+    wave7_models.yaml):
+
+      1. Exact key match on the raw (slash-stripped) model name — covers the
+         bare aliases ("opus", "sonnet", "haiku") and litellm sub-provider
+         model names (the "/" split already happened above).
+      2. Exact key match after stripping the registry section's known model
+         name-prefix (e.g. "claude-" for the anthropic section), so a real
+         Anthropic model slug like "claude-opus-5" or "claude-sonnet-5"
+         resolves to its OWN key ("opus-5", "sonnet-5") instead of a
+         same-family key that merely happens to be a substring of it.
+      3. The single LONGEST registry key that hyphen-bounds-prefixes the
+         (prefix-stripped) name — e.g. "haiku-4-5-20251001" against
+         {"opus", "sonnet", "haiku"} picks "haiku" (the only, hence longest,
+         boundary match). This keeps a dated/suffixed real model id (the
+         registry's own "haiku" litellm_name is "claude-haiku-4-5-20251001")
+         resolving after the fix, not just the two exact tiers above.
+         Longest-key-wins makes the pick independent of iteration order; a
+         tie between two equally-long candidates is refused (None) rather
+         than guessed — same principle as tier 3's total-miss case below.
+
+    Returns None on a total miss. A miss is a valid, non-terminal signal here:
+    `_compute_cost` falls back to the provider_costs rate table on a None, so
+    refusing to guess is always safer than fabricating a price.
+    """
+    model_key = model.split("/")[-1] if "/" in model else model
+    if model_key in cfg.models:
+        return cfg.models[model_key]
+
+    prefix = _REGISTRY_KEY_MODEL_PREFIX.get(registry_key)
+    stripped = model_key[len(prefix):] if prefix and model_key.startswith(prefix) else model_key
+    if stripped != model_key and stripped in cfg.models:
+        return cfg.models[stripped]
+
+    candidates = sorted(
+        (k for k in cfg.models if stripped.startswith(k + "-")),
+        key=len,
+        reverse=True,
+    )
+    if candidates and (len(candidates) == 1 or len(candidates[0]) != len(candidates[1])):
+        return cfg.models[candidates[0]]
+    return None
+
 
 def _load_pricing_from_registry(provider: str, model: str) -> Optional[Dict[str, float]]:
     """Load {input, output} pricing per MTok from wave7_models.yaml. Returns None on miss.
@@ -474,13 +533,13 @@ def _load_pricing_from_registry(provider: str, model: str) -> Optional[Dict[str,
                 provider, registry_key,
             )
             return None
-        model_key = model.split("/")[-1] if "/" in model else model
-        entry = (
-            cfg.models.get(model_key)
-            or next((v for k, v in cfg.models.items() if k in model_key or model_key in k), None)
-            or next(iter(cfg.models.values()), None)
-        )
+        entry = _resolve_registry_model_entry(cfg, registry_key, model)
         if entry is None:
+            logger.warning(
+                "_load_pricing_from_registry: no match for provider=%s model=%s "
+                "(registry_key=%s, %d models in section) — miss, not a fabricated price",
+                provider, model, registry_key, len(cfg.models),
+            )
             return None
         return {
             "input": float(entry.cost_input_per_mtok),

--- a/tests/test_pricing_resolution.py
+++ b/tests/test_pricing_resolution.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""OI-1355 — model-name resolution defect in the cost path.
+
+``_load_pricing_from_registry()`` in ``scripts/lib/provider_dispatch.py``
+resolves a model name to its registry-configured price via three steps:
+exact key, then a substring match tried in DICT-ITERATION order, then a
+blind first-entry fallback. Two defects stack:
+
+  1. The substring step accepts the first dict-order match instead of the
+     most specific one, so a provider-prefixed model name like
+     "claude-opus-5" can resolve to a shorter/wrong key ("opus") when that
+     key happens to iterate earlier than the exact-suffix key ("opus-5").
+  2. On total mismatch, the third step blindly returns the FIRST model in
+     the section and reports it as a confirmed price, instead of a miss.
+
+These tests build their OWN registry fixtures — never the live
+wave7_models.yaml — because its anthropic prices are being corrected in
+flight by PR #1606; hardcoding live values here would break the moment
+that PR lands. Where dict ORDER matters to reproduce the defect, a
+fixture's order deliberately mirrors wave7_models.yaml's anthropic section
+(opus, opus-4-8, opus-4-6, sonnet, haiku, sonnet-5, opus-5, fable-5), noted
+per-test — the PRICES themselves are synthetic and stable.
+
+Production code (``scripts/lib/provider_dispatch.py``) is READ-ONLY here.
+The fix lands in a separate dispatch; these tests pin only the two
+observable ends (an exact-after-prefix match must win over a broader
+substring; a total miss must never fabricate a price) without prescribing
+the matching strategy or the miss signal (None vs. exception).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import provider_dispatch as pd  # noqa: E402
+
+
+def _fake_provider_cfg(model_items):
+    """Build a fake ProviderConfig-like object with an ORDERED `models` dict.
+
+    `model_items` is an ordered list of (key, cost_input, cost_output)
+    tuples — insertion order is preserved and drives the dict-iteration-
+    order defect under test. Mirrors the real ProviderConfig/ProviderModel
+    shape (a `.models` dict of objects carrying `.cost_input_per_mtok` /
+    `.cost_output_per_mtok`) without touching the live registry file.
+    """
+    cfg = MagicMock()
+    cfg.models = {
+        key: MagicMock(cost_input_per_mtok=cost_in, cost_output_per_mtok=cost_out)
+        for key, cost_in, cost_out in model_items
+    }
+    return cfg
+
+
+def _patched_registry(**sections):
+    """Patch providers.provider_registry.load() to return a fixture registry.
+
+    `_load_pricing_from_registry` does
+    `from providers import provider_registry as _reg; registry = _reg.load()`
+    — patching the `load` attribute on the already-imported module
+    intercepts that call regardless of how many times the local import
+    runs, since `_reg` is always the same module object from sys.modules.
+    """
+    return patch("providers.provider_registry.load", return_value=sections)
+
+
+# ---------------------------------------------------------------------------
+# RED today: dict-order substring match beats the exact-after-prefix key.
+# ---------------------------------------------------------------------------
+
+class TestSubstringMatchPicksWrongKey:
+
+    def test_claude_opus_5_must_not_resolve_to_bare_opus_price(self):
+        """claude-opus-5 should price as opus-5, not as the broader "opus" key.
+
+        Fixture order mirrors wave7_models.yaml's anthropic section: "opus"
+        iterates before "opus-5", so today's
+        `next((v for k, v in cfg.models.items() if k in model_key or model_key in k))`
+        matches "opus" first purely because it comes first in the dict, and
+        returns its price (10.0/50.0) instead of opus-5's (5.0/25.0).
+        """
+        cfg = _fake_provider_cfg([
+            ("opus", 10.0, 50.0),
+            ("sonnet", 3.0, 15.0),
+            ("haiku", 1.0, 5.0),
+            ("opus-5", 5.0, 25.0),
+        ])
+        with _patched_registry(anthropic=cfg):
+            pricing = pd._load_pricing_from_registry("claude", "claude-opus-5")
+        assert pricing == {"input": 5.0, "output": 25.0}, (
+            f"claude-opus-5 must resolve the opus-5 entry (5.0/25.0), got {pricing!r} "
+            "— the bare 'opus' entry is winning on dict order, not model identity"
+        )
+
+    def test_claude_opus_4_8_must_not_resolve_to_bare_opus_price(self):
+        """claude-opus-4-8 should price as opus-4-8, not as the broader "opus" key.
+
+        Same defect, second instance: "opus" precedes "opus-4-8" in dict
+        order, so the substring step matches "opus" first even though
+        "opus-4-8" is the exact-suffix match.
+        """
+        cfg = _fake_provider_cfg([
+            ("opus", 10.0, 50.0),
+            ("opus-4-8", 7.0, 35.0),
+            ("sonnet", 3.0, 15.0),
+        ])
+        with _patched_registry(anthropic=cfg):
+            pricing = pd._load_pricing_from_registry("claude", "claude-opus-4-8")
+        assert pricing == {"input": 7.0, "output": 35.0}, (
+            f"claude-opus-4-8 must resolve the opus-4-8 entry (7.0/35.0), got {pricing!r} "
+            "— the bare 'opus' entry is winning on dict order, not model identity"
+        )
+
+    def test_claude_sonnet_5_resolution_must_come_from_the_sonnet_5_key(self):
+        """Pins PROVENANCE, not just the outcome value.
+
+        On the live registry, "sonnet" and "sonnet-5" happen to share a
+        price today, so a naive `pricing == {'input': 3.0, 'output': 15.0}`
+        check would stay green even if the fix still resolves the wrong
+        key — it would only break once those live prices diverge. This
+        fixture gives the two keys deliberately DIFFERENT prices, in the
+        same dict order as the live registry (sonnet before sonnet-5), so
+        only a resolution that actually picks "sonnet-5" can pass.
+        """
+        cfg = _fake_provider_cfg([
+            ("opus", 10.0, 50.0),
+            ("sonnet", 3.0, 15.0),
+            ("haiku", 1.0, 5.0),
+            ("sonnet-5", 4.0, 20.0),
+        ])
+        with _patched_registry(anthropic=cfg):
+            pricing = pd._load_pricing_from_registry("claude", "claude-sonnet-5")
+        assert pricing == {"input": 4.0, "output": 20.0}, (
+            f"claude-sonnet-5 must resolve the sonnet-5 entry (4.0/20.0), got {pricing!r} "
+            "— the bare 'sonnet' entry is winning on dict order; this is masked on the "
+            "live registry today only because sonnet and sonnet-5 happen to share a price"
+        )
+
+
+# ---------------------------------------------------------------------------
+# RED today: total mismatch fabricates a price instead of missing.
+# ---------------------------------------------------------------------------
+
+class TestBlindFallbackFabricatesAPrice:
+
+    def test_totally_unknown_model_yields_no_fabricated_price(self):
+        """A model with no registry relationship at all must not price as
+        whatever happens to be the section's first entry.
+
+        The fix may signal the miss as `None` or as a raised exception —
+        both are acceptable per dispatch instruction (the miss-signal
+        design is left to the fix). Only the ABSENCE of a fabricated price
+        is pinned here.
+        """
+        cfg = _fake_provider_cfg([
+            ("opus", 10.0, 50.0),
+            ("sonnet", 3.0, 15.0),
+            ("haiku", 1.0, 5.0),
+        ])
+        with _patched_registry(anthropic=cfg):
+            try:
+                pricing = pd._load_pricing_from_registry("claude", "zzz-totally-unrelated-model")
+            except Exception:
+                return  # an explicit failure signal is an acceptable miss
+        assert pricing is None, (
+            f"a model with no registry match must miss (None), got fabricated pricing {pricing!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GREEN today, must stay green: exact-match paths the fix must not break.
+# ---------------------------------------------------------------------------
+
+class TestExactAndSubProviderMatchesAreUnaffected:
+
+    def test_bare_exact_key_sonnet_keeps_own_price(self):
+        """A bare exact registry key hits `cfg.models.get(model_key)`
+        directly — the first branch, untouched by the substring/fallback
+        defect — and must keep resolving to its own price.
+        """
+        cfg = _fake_provider_cfg([
+            ("opus", 10.0, 50.0),
+            ("sonnet", 3.0, 15.0),
+            ("haiku", 1.0, 5.0),
+        ])
+        with _patched_registry(anthropic=cfg):
+            pricing = pd._load_pricing_from_registry("claude", "sonnet")
+        assert pricing == {"input": 3.0, "output": 15.0}
+
+    def test_bare_exact_key_haiku_keeps_own_price(self):
+        cfg = _fake_provider_cfg([
+            ("opus", 10.0, 50.0),
+            ("sonnet", 3.0, 15.0),
+            ("haiku", 1.0, 5.0),
+        ])
+        with _patched_registry(anthropic=cfg):
+            pricing = pd._load_pricing_from_registry("claude", "haiku")
+        assert pricing == {"input": 1.0, "output": 5.0}
+
+    def test_litellm_subprovider_deepseek_resolves_exact_model(self):
+        """litellm:deepseek + a slash-qualified model name.
+
+        `registry_key` is extracted from the colon-delimited provider
+        string ("litellm:deepseek" -> "deepseek"), and `model_key` is the
+        part after the slash in "deepseek/deepseek-v4-pro" — both hit the
+        exact-match branch, unaffected by the substring/fallback defect.
+        """
+        cfg = _fake_provider_cfg([
+            ("deepseek-v4-pro", 0.435, 0.87),
+            ("deepseek-v4-flash", 0.14, 0.28),
+        ])
+        with _patched_registry(deepseek=cfg):
+            pricing = pd._load_pricing_from_registry("litellm:deepseek", "deepseek/deepseek-v4-pro")
+        assert pricing == {"input": 0.435, "output": 0.87}

--- a/tests/test_token_extraction_per_provider.py
+++ b/tests/test_token_extraction_per_provider.py
@@ -406,9 +406,17 @@ class TestComputeCost:
 
     def test_load_pricing_registry_openai_codex(self):
         import provider_dispatch as pd
-        pricing = pd._load_pricing_from_registry("codex", "")
+        pricing = pd._load_pricing_from_registry("codex", "gpt-5.5")
         assert pricing is not None
-        assert pricing["input"] > 0
+        assert abs(pricing["input"] - 1.25) < 1e-6
+        assert abs(pricing["output"] - 10.0) < 1e-6
+
+    def test_load_pricing_registry_openai_codex_empty_model_returns_none(self):
+        """OI-1355: an empty/unknown model name must miss, not fall back to the
+        first entry in the section (the blind first-match fallback removed in #1609)."""
+        import provider_dispatch as pd
+        pricing = pd._load_pricing_from_registry("codex", "")
+        assert pricing is None
 
     def test_load_pricing_registry_unknown_provider_returns_none(self):
         import provider_dispatch as pd

--- a/tests/test_token_extraction_per_provider.py
+++ b/tests/test_token_extraction_per_provider.py
@@ -405,11 +405,23 @@ class TestComputeCost:
         assert pricing["output"] > 0
 
     def test_load_pricing_registry_openai_codex(self):
+        """codex -> openai section resolution: this proves the KEY mapping
+        (codex resolves into the openai section and picks the gpt-5.5 entry
+        intact), not a specific price. The price itself is owned by the
+        registry — and by PR #1606, which corrects it — so pin against what
+        the registry itself declares for gpt-5.5, not a literal that goes
+        stale the moment that PR lands.
+        """
         import provider_dispatch as pd
+        from providers import provider_registry
+
+        expected = provider_registry.load()["openai"].models["gpt-5.5"]
         pricing = pd._load_pricing_from_registry("codex", "gpt-5.5")
         assert pricing is not None
-        assert abs(pricing["input"] - 1.25) < 1e-6
-        assert abs(pricing["output"] - 10.0) < 1e-6
+        assert pricing["input"] > 0
+        assert pricing["output"] > 0
+        assert abs(pricing["input"] - expected.cost_input_per_mtok) < 1e-6
+        assert abs(pricing["output"] - expected.cost_output_per_mtok) < 1e-6
 
     def test_load_pricing_registry_openai_codex_empty_model_returns_none(self):
         """OI-1355: an empty/unknown model name must miss, not fall back to the


### PR DESCRIPTION
## Summary

OI-1355: `_load_pricing_from_registry()` in `scripts/lib/provider_dispatch.py` resolved a model
name with a dict-order-dependent substring scan, stacked on a blind first-entry fallback. Both
are replaced by a deterministic resolver. A miss now returns `None` plus a `warning` instead of
a fabricated price.

**Measured on `main` before the fix:**

| aanroep | voor | registry zegt |
|---|---|---|
| `claude-opus-5` | 15.0 / 75.0 (via `opus`) | `opus-5` = 5.0 / 25.0 |
| `claude-opus-4-8` | 15.0 / 75.0 (via `opus`) | `opus-4-8` = 5.0 / 25.0 |
| `claude-sonnet-5` | 3.0 / 15.0 (via `sonnet`) | `sonnet-5`, toevallig gelijk |
| `volstrekt-onbekend-model` | 15.0 / 75.0 **verzonnen** | geen match |

For `claude-opus-5`, the T0 model, cost reporting was a factor 3 too high. An unknown model got
the Opus rate reported as a confirmed cost.

## Changes

| Commit | Wat |
|---|---|
| `f19a3e35` | rode tests (`tests/test_pricing_resolution.py`, 7 tests, 4 rood) |
| `561e7246` | de fix: `_resolve_registry_model_entry()`, drie deterministische trappen |
| `afc344c5` | herstel van een verouderde test die op de verwijderde fallback leunde |
| `37ad9d47` | merge-volgorde-bom eruit + dode gelijkspel-tak verwijderd |

Test-schrijver en fix-schrijver zijn gescheiden gebleven in de commit-historie.

## Verification

**Na de fix, gemeten op de branch:**

| aanroep | na |
|---|---|
| `claude-opus-5` | 5.0 / 25.0 (via `opus-5`) |
| `claude-sonnet-5` | 3.0 / 15.0 (via `sonnet-5`, herkomst gecorrigeerd) |
| `haiku-4-5` | 1.0 / 5.0 (via de langste prefix-match) |
| `volstrekt-onbekend-model` | `None` + WARNING |
| `codex` met lege modelnaam | `None` + WARNING |

`tests/test_pricing_resolution.py` + `tests/test_token_extraction_per_provider.py`: **34 passed**.

**Proefmerge tegen PR #1606** (T0, eigen worktree): `Automatic merge went well`,
daarna `tests/test_pricing_resolution.py` + `tests/test_token_extraction_per_provider.py` +
`tests/smart_router/` + `tests/test_price_provenance.py` = **244 passed**.

VNX CI workflow-conclusie: `success` op head `37ad9d47`.

## Review

Kimi-review (read-only dispatch, `20260819-review-kimi-1609`): **PASS-WITH-NOTES**. Zelfstandig
getoetst, niet op het bouwersrapport afgegaan:

- **Volgorde-onafhankelijkheid bewezen** met 500 willekeurige permutaties van de live
  anthropic-sectie; `claude-opus-5` resolvet elke keer naar `opus-5`.
- **Miss-keten getraceerd** tot in `emit_provider_cost`: miss → `resolve_cost_usd` → `None` →
  `billing_mode="unmetered"`. Nergens een stil `0.0`.
- **Twee live gevallen gevonden die de bouwer niet meldde**: `gemini-2.5-flash` kreeg
  pro-prijzen (circa 16x te hoog) en `gpt-5.2-codex` kreeg gpt-5.5-prijzen. Beide nu correct
  via de rate-tabel.
- **Een merge-volgorde-bom gevonden**: deze PR asserteerde `gpt-5.5` op 1.25/10.0 terwijl
  #1606 die prijs op 5.0/30.0 zet. Wie als tweede mergde, maakte `main` rood, en geen van beide
  CI's zou dat zien omdat elke PR groen is tegen zijn eigen basis. Opgelost in `37ad9d47`: de
  assertie leest de verwachte waarde nu uit de registry in plaats van een literal te bezitten
  die een andere PR beheert.
- **De gelijkspel-tak was dode code.** Twee verschillende sleutels van gelijke lengte kunnen
  nooit allebei prefix van dezelfde string zijn. Argument door de fix-schrijver nagerekend en
  bevestigd; tak verwijderd.

## Bekende gedragswijziging

Legacy modelnamen als `claude-3-5-haiku-20241022` misten voorheen niet (ze raakten via de
substring-match de `haiku`-sleutel) en missen nu wel. Ze vallen door naar
`provider_costs.resolve_cost_usd`, die voor de claude-lane `None` teruggeeft. Dat is het
correcte gedocumenteerde-$0-resultaat voor een subscription-lane, dus geen verlies. Gemeten,
niet aangenomen.

## Open Items

- OI-1361 (nieuw): `_compute_kimi_cost()` draagt dezelfde blinde eerste-treffer-fallback. Buiten
  scope gehouden, apart item.
