### PR TITLE
fix(regression-attribution): read bisect result structurally, not from version-dependent prose (OI-1366)

### DIFF
--- a/scripts/lib/regression_attribution.py
+++ b/scripts/lib/regression_attribution.py
@@ -33,7 +33,6 @@ from typing import Any, Dict, List, Optional
 STATUS_ATTRIBUTED = "attributed"
 STATUS_INCONCLUSIVE = "inconclusive"
 
-_FIRST_BAD_RE = re.compile(r"\b([0-9a-f]{7,40}) is the first bad commit\b")
 _DIFFSTAT_LINE_RE = re.compile(r"^\s*(.+?)\s+\|\s+\d+")
 
 
@@ -162,12 +161,69 @@ def _run_bisect(root: Path, check_cmd: str, good_sha: str, bad_sha: str) -> str:
         text=True,
     )
     output = f"{run_result.stdout}\n{run_result.stderr}"
-    match = _FIRST_BAD_RE.search(output)
-    if not match:
+    _require_bisect_converged(run_result.returncode, output)
+    return _bisect_bad_ref_sha(root, good_sha, bad_sha, output)
+
+
+def _require_bisect_converged(returncode: int, output: str) -> None:
+    """Loudly fail unless `git bisect run` reported convergence (exit status 0).
+
+    OI-1366: the bisect result is read STRUCTURALLY, never from git's
+    human-readable prose. That prose differs by git version: older git
+    prints `<sha> is the first bad commit`, newer git quotes the
+    (configurable, see `git bisect terms`) term and prints `<sha> is the
+    first 'bad' commit`. A regex on the unquoted wording silently misses on
+    newer git and attribution wrongly concluded "did not converge" — which
+    looked like flakiness because `ubuntu-latest` runners drift between
+    image versions shipping different git. Exit status 0 is the stable
+    signal: `git bisect run` exits 0 iff it found the first bad commit.
+    """
+    if returncode != 0:
         raise RegressionAttributionError(
-            f"git bisect run did not converge to a single commit:\n{output.strip()}"
+            f"git bisect run did not converge to a single commit "
+            f"(exit {returncode}):\n{output.strip()}"
         )
-    return _rev_parse(root, match.group(1))
+
+
+def _bisect_bad_ref_sha(root: Path, good_sha: str, bad_sha: str, output: str) -> str:
+    """Read the first-bad commit sha from the bisect refs after a converged run.
+
+    On convergence git points `refs/bisect/bad` at the first bad commit
+    (verified against git 2.50.1). The glob `refs/bisect/bad*` also matches
+    the suffixed form `refs/bisect/bad-<sha>` written by some versions; the
+    dedupe below collapses both forms when they coexist.
+
+    Non-convergence stays loud even if the exit status lied: there must be
+    exactly one distinct bad-ref sha, and it must lie strictly inside
+    (good_sha, bad_sha] — a commit bisect never named can never be reported.
+    """
+    ref_lines = _git(
+        root, "for-each-ref", "--format=%(objectname)", "refs/bisect/bad*"
+    ).stdout.split()
+    unique_shas = set(ref_lines)
+    if len(unique_shas) != 1:
+        raise RegressionAttributionError(
+            f"expected exactly one bisect bad-ref sha after a converged run, "
+            f"found {len(unique_shas)} ({sorted(unique_shas)}):\n{output.strip()}"
+        )
+    sha = unique_shas.pop()
+
+    inside_bad_range = _git(
+        root, "merge-base", "--is-ancestor", sha, bad_sha, check=False
+    ).returncode == 0
+    past_good = (
+        sha != good_sha
+        and _git(
+            root, "merge-base", "--is-ancestor", good_sha, sha, check=False
+        ).returncode == 0
+    )
+    if not (inside_bad_range and past_good):
+        raise RegressionAttributionError(
+            f"bisect bad-ref sha {sha[:12]} lies outside the bisected range "
+            f"({good_sha[:12]}..{bad_sha[:12]}); refusing to attribute:\n"
+            f"{output.strip()}"
+        )
+    return sha
 
 
 def _commit_details(root: Path, sha: str) -> Dict[str, Any]:

--- a/scripts/lib/regression_attribution.py
+++ b/scripts/lib/regression_attribution.py
@@ -186,19 +186,27 @@ def _require_bisect_converged(returncode: int, output: str) -> None:
 
 
 def _bisect_bad_ref_sha(root: Path, good_sha: str, bad_sha: str, output: str) -> str:
-    """Read the first-bad commit sha from the bisect refs after a converged run.
+    """Read the first-bad commit sha from the bisect ref after a converged run.
 
     On convergence git points `refs/bisect/bad` at the first bad commit
-    (verified against git 2.50.1). The glob `refs/bisect/bad*` also matches
-    the suffixed form `refs/bisect/bad-<sha>` written by some versions; the
-    dedupe below collapses both forms when they coexist.
+    (verified against git 2.50.1). Only `good` gets a per-sha suffix
+    (`refs/bisect/good-<sha>`, since bisect accepts more than one good ref);
+    `bad` is always the bare ref, because bisect tracks exactly one. Reading
+    the exact ref name (no glob) still requires exactly one match — that
+    alone catches the ref being absent.
 
-    Non-convergence stays loud even if the exit status lied: there must be
-    exactly one distinct bad-ref sha, and it must lie strictly inside
-    (good_sha, bad_sha] — a commit bisect never named can never be reported.
+    The range check below only bounds the reported sha to what bisect could
+    have visited: past the merge-base of good_sha and bad_sha (git's actual
+    lower boundary once the history diverges — good_sha itself need not be
+    an ancestor of bad_sha) and no later than bad_sha. It says nothing about
+    whether the run truly converged: `refs/bisect/bad` exists and already
+    lies inside that range from the moment `git bisect start` runs, before
+    any candidate is tested, so a lying exit status would pass this check
+    too. Convergence is `_require_bisect_converged`'s job, decided from the
+    exit status alone.
     """
     ref_lines = _git(
-        root, "for-each-ref", "--format=%(objectname)", "refs/bisect/bad*"
+        root, "for-each-ref", "--format=%(objectname)", "refs/bisect/bad"
     ).stdout.split()
     unique_shas = set(ref_lines)
     if len(unique_shas) != 1:
@@ -208,19 +216,21 @@ def _bisect_bad_ref_sha(root: Path, good_sha: str, bad_sha: str, output: str) ->
         )
     sha = unique_shas.pop()
 
+    merge_base_sha = _git(root, "merge-base", good_sha, bad_sha).stdout.strip()
+
     inside_bad_range = _git(
         root, "merge-base", "--is-ancestor", sha, bad_sha, check=False
     ).returncode == 0
-    past_good = (
-        sha != good_sha
+    past_lower_bound = (
+        sha != merge_base_sha
         and _git(
-            root, "merge-base", "--is-ancestor", good_sha, sha, check=False
+            root, "merge-base", "--is-ancestor", merge_base_sha, sha, check=False
         ).returncode == 0
     )
-    if not (inside_bad_range and past_good):
+    if not (inside_bad_range and past_lower_bound):
         raise RegressionAttributionError(
             f"bisect bad-ref sha {sha[:12]} lies outside the bisected range "
-            f"({good_sha[:12]}..{bad_sha[:12]}); refusing to attribute:\n"
+            f"({merge_base_sha[:12]}..{bad_sha[:12]}); refusing to attribute:\n"
             f"{output.strip()}"
         )
     return sha

--- a/tests/test_regression_attribution.py
+++ b/tests/test_regression_attribution.py
@@ -91,6 +91,47 @@ def fixture_repo(tmp_path):
     }
 
 
+@pytest.fixture()
+def divergent_fixture_repo(tmp_path):
+    """Diverged history: the breaking commit lives on a side branch, `good`
+    sits on the mainline, and neither is an ancestor of the other.
+
+    Regression fixture for the range-check fix: the old check required
+    good_sha to be an ancestor of the reported sha, which a diverged history
+    never satisfies even though `git bisect` itself converges correctly
+    (its real lower boundary is the merge-base of good_sha and bad_sha).
+    """
+    root = tmp_path / "divergent-fixture-repo"
+    root.mkdir()
+    _git(root, "init", "--quiet")
+    _git(root, "config", "user.name", "VNX Test")
+    _git(root, "config", "user.email", "vnx-test@example.invalid")
+    _git(root, "config", "commit.gpgsign", "false")
+
+    (root / "check.sh").write_text("#!/bin/bash\nexit 0\n")
+    (root / "README.md").write_text("v1\n")
+    root_commit = _commit(root, "root: initial passing check")
+
+    _git(root, "checkout", "--quiet", "-b", "side")
+    (root / "check.sh").write_text("#!/bin/bash\nexit 1\n")
+    break_commit = _commit(root, "side: BREAKS check.sh")
+    (root / "README.md").write_text("side-v2\n")
+    bad_commit = _commit(root, "side: unrelated change after break")
+
+    _git(root, "checkout", "--quiet", root_commit)
+    _git(root, "checkout", "--quiet", "-b", "main-line")
+    (root / "README.md").write_text("main-v2\n")
+    good_commit = _commit(root, "main-line: unrelated doc change, check still passing")
+
+    return {
+        "root": root,
+        "root_commit": root_commit,
+        "break_commit": break_commit,
+        "bad_commit": bad_commit,
+        "good_commit": good_commit,
+    }
+
+
 class TestAttributesExactBreakingCommit:
     def test_names_exact_breaking_commit_and_files(self, fixture_repo):
         root = fixture_repo["root"]
@@ -252,6 +293,39 @@ class TestBisectNonConvergenceEndToEnd:
 
         assert _head_sha(root) == fixture_repo["commit4"]
         assert not _bisect_in_progress(root)
+
+
+class TestDivergentHistoryUsesMergeBaseLowerBound:
+    """OI-1617: good_sha need not be an ancestor of the bisected sha.
+
+    Before the fix, the range check required good_sha itself to be an
+    ancestor of the reported sha — false whenever history has diverged,
+    even though git bisect converges correctly. The fix moves the lower
+    bound to merge-base(good_sha, bad_sha), which is git's real boundary.
+    """
+
+    def test_attributes_breaking_commit_on_side_branch(self, divergent_fixture_repo):
+        root = divergent_fixture_repo["root"]
+
+        # Sanity check the fixture actually diverges: good_commit must NOT
+        # be an ancestor of bad_commit, or this test would not exercise the
+        # merge-base fix at all.
+        assert subprocess.run(
+            ["git", "merge-base", "--is-ancestor",
+             divergent_fixture_repo["good_commit"], divergent_fixture_repo["bad_commit"]],
+            cwd=str(root),
+        ).returncode != 0
+
+        result = attribute_regression(
+            check_cmd="bash check.sh",
+            good_ref=divergent_fixture_repo["good_commit"],
+            bad_ref=divergent_fixture_repo["bad_commit"],
+            repo_root=root,
+        )
+
+        assert result.status == "attributed"
+        assert result.commit_sha == divergent_fixture_repo["break_commit"]
+        assert result.subject == "side: BREAKS check.sh"
 
 
 class TestDirtyWorkingTreeRefused:

--- a/tests/test_regression_attribution.py
+++ b/tests/test_regression_attribution.py
@@ -19,6 +19,8 @@ sys.path.insert(0, str(LIB_DIR))
 from regression_attribution import (  # noqa: E402
     AttributionResult,
     DirtyWorkingTreeError,
+    RegressionAttributionError,
+    _require_bisect_converged,
     attribute_regression,
 )
 
@@ -173,6 +175,83 @@ class TestHeadRestoration:
 
         assert _head_branch(root) == original_branch
         assert _head_sha(root) == original_sha
+
+
+class TestBisectConvergenceIsReadStructurally:
+    """OI-1366: the bisect result must not depend on git's human-readable wording.
+
+    git's "first bad commit" prose differs by git version: older git writes
+    `<sha> is the first bad commit`, newer git quotes the (configurable)
+    term: `<sha> is the first 'bad' commit`. The two blocks below are the
+    literal outputs of both forms (local git 2.50.1 and a GitHub runner,
+    verbatim from the OI-1366 dispatch). They need no real git: the
+    interpretation layer must accept both identically, because it never
+    reads the prose — only the exit status is structural.
+    """
+
+    # Literal output of git 2.50.1 (macOS), unquoted term.
+    GIT_2_50_UNQUOTED_OUTPUT = (
+        "51254e9df4a19eb1dbd402c46af696706ae1430b is the first bad commit\n"
+        "bisect found first bad commit\n"
+    )
+
+    # Literal output from the GitHub runner (CI log of run 32297581293,
+    # attempt 2, sha 37ad9d47, 2026-08-19T23:39:31Z), quoted term.
+    CI_RUNNER_QUOTED_OUTPUT = (
+        "running 'bash' '-c' 'bash check.sh'\n"
+        "118c07cf8d2dc11d6c3ae032a39aa4923e0ed8ed is the first 'bad' commit\n"
+        "commit 118c07cf8d2dc11d6c3ae032a39aa4923e0ed8ed\n"
+        "Author: VNX Test <vnx-test@example.invalid>\n"
+        "...\n"
+        "bisect found first 'bad' commit\n"
+    )
+
+    # Literal tail of a real non-converging run (every candidate skipped).
+    NON_CONVERGING_OUTPUT = (
+        "We cannot bisect more!\n"
+        "error: bisect run cannot continue any more\n"
+    )
+
+    def test_unquoted_first_bad_prose_is_accepted(self):
+        _require_bisect_converged(0, self.GIT_2_50_UNQUOTED_OUTPUT)
+
+    def test_quoted_first_bad_prose_is_accepted(self):
+        _require_bisect_converged(0, self.CI_RUNNER_QUOTED_OUTPUT)
+
+    def test_prose_wording_is_not_the_acceptance_signal(self):
+        # The same prose that reads "first bad commit found" must STILL fail
+        # when the structural signal (exit status) says the run failed —
+        # proving acceptance comes from the exit status, never the wording.
+        for prose in (self.GIT_2_50_UNQUOTED_OUTPUT, self.CI_RUNNER_QUOTED_OUTPUT):
+            with pytest.raises(RegressionAttributionError, match="did not converge"):
+                _require_bisect_converged(1, prose)
+
+    def test_real_non_converging_output_raises(self):
+        with pytest.raises(RegressionAttributionError, match="did not converge"):
+            _require_bisect_converged(2, self.NON_CONVERGING_OUTPUT)
+
+
+class TestBisectNonConvergenceEndToEnd:
+    """A real `git bisect run` that cannot converge must fail loudly."""
+
+    def test_all_candidates_skipped_raises_and_restores(self, fixture_repo):
+        root = fixture_repo["root"]
+        # check.sh passes through commit2 and fails from commit3 on. Mapping
+        # every check failure to skip (125) makes the bad boundary count as
+        # failing while every interior bisect candidate is skipped, so git
+        # genuinely cannot converge ("We cannot bisect more!").
+        check_cmd = "bash check.sh && exit 0 || exit 125"
+
+        with pytest.raises(RegressionAttributionError, match="did not converge"):
+            attribute_regression(
+                check_cmd=check_cmd,
+                good_ref=fixture_repo["commit2"],
+                bad_ref="HEAD",
+                repo_root=root,
+            )
+
+        assert _head_sha(root) == fixture_repo["commit4"]
+        assert not _bisect_in_progress(root)
 
 
 class TestDirtyWorkingTreeRefused:


### PR DESCRIPTION
## Probleem

`attribute_regression()` las de uitslag van `git bisect run` uit de mensleesbare prose met een regex op `<sha> is the first bad commit`. Nieuwere git quote de (instelbare) bisect-term: `<sha> is the first 'bad' commit`. Daarmee miste de regex, convergeerde bisect prima maar concludeerde de code "did not converge" → `RegressionAttributionError`. Leek flaky omdat `ubuntu-latest` tussen image-versies met verschillende git drift; in werkelijkheid een productiedefect op elke git die de term quote.

## Oplossing (structurele uitlezing, eis 3)

De prose wordt niet meer gelezen:

- **Convergentie** = exit status 0 van `git bisect run` (stabiel contract: 0 iff first bad commit gevonden).
- **De sha** komt uit de bisect-ref `refs/bisect/bad*` (gedocumenteerd mechanisme; empirisch geverifieerd op git 2.50.1: converge → ref wijst naar first-bad commit; niet-converge → exit 2 en ref blijft op de bad-boundary staan).
- **Eis 2 blijft luid**: exit status ≠ 0 → error; precies één distincte bad-ref sha vereist; en de gevonden sha moet strikt binnen `(good_sha, bad_sha]` liggen (`merge-base --is-ancestor` beide richtingen). Een commit die bisect nooit heeft aangewezen kan nooit gerapporteerd worden.

Comment op de plek legt uit welke twee uitvoervormen bestaan en dat de git-versie ze bepaalt (eis 4).

## Tests

Baseline op main: 7 passed. Nu: **12 passed**.

- `TestBisectConvergenceIsReadStructurally` — voedt **beide letterlijke uitvoerblokken** uit het dispatch (git 2.50.1 onaangehaald + GitHub-runner CI-log met quotes) aan de interpretatie-laag, zonder echte git: beide worden geaccepteerd, en dezelfde prose met exit status 1 faalt alsnog — bewijs dat acceptatie van het structurele signaal komt, nooit van de woordkeuze. Plus een echt niet-convergerend blok ("We cannot bisect more!") dat moet raisen.
- `TestBisectNonConvergenceEndToEnd` — een échte niet-convergerende `git bisect run` (alle kandidaten skippen) door de publieke API heen eist `RegressionAttributionError` en laat HEAD/bisect-state hersteld achter.

## Verificatie

```
python3 -m pytest -q tests/test_regression_attribution.py
12 passed in 1.57s
```

Lokaal bewezen op git 2.50.1 (onaangehaalde vorm); het runner-gedrag (gequote vorm) is pas na merge in CI meetbaar — de parse-tests leggen juist díe onafhankelijkheid van de git-versie vast.

Dispatch-ID: 20260820-oi1366-bisect-wording