### PR TITLE
fix(ci-gate): speak gh 2.76.2's pr-checks JSON schema (OI-1321)

### DIFF
--- a/scripts/lib/gate_executor.py
+++ b/scripts/lib/gate_executor.py
@@ -16,6 +16,16 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+# `gh pr checks --json` (gh 2.76.2, measured 2026-08-20) has no `status`/
+# `conclusion` fields — it exposes `bucket`, which gh itself documents
+# (`gh pr checks --help`) as categorizing the raw `state` into exactly one
+# of: pass, fail, pending, skipping, cancel. "pending" is the only
+# non-terminal bucket; a bucket outside this known set is treated as
+# non-terminal too, so an unrecognized future value holds the verdict at
+# "running" instead of silently completing.
+_CI_CHECK_BUCKET_TERMINAL = {"pass", "fail", "skipping", "cancel"}
+_CI_CHECK_BUCKET_SKIP = {"skipping", "cancel"}
+
 
 def _format_ci_gate_report(
     *,
@@ -50,18 +60,18 @@ def _format_ci_gate_report(
         if passed:
             lines.append("### Passed")
             for c in passed:
-                lines.append(f"- [OK] {c.get('name', '?')} — {c.get('conclusion', 'SUCCESS')}")
+                lines.append(f"- [OK] {c.get('name', '?')} — {c.get('state', 'SUCCESS')}")
             lines.append("")
         if failed:
             lines.append("### Failed [BLOCKING]")
             for c in failed:
-                lines.append(f"- [BLOCKING] {c.get('name', '?')} — {c.get('conclusion', 'FAILURE')}")
+                lines.append(f"- [BLOCKING] {c.get('name', '?')} — {c.get('state', 'FAILURE')}")
                 lines.append(f"  - **Severity**: blocking")
             lines.append("")
         if skipped:
             lines.append("### Skipped / Cancelled")
             for c in skipped:
-                lines.append(f"- [ADVISORY] {c.get('name', '?')} — {c.get('conclusion', 'SKIPPED')}")
+                lines.append(f"- [ADVISORY] {c.get('name', '?')} — {c.get('state', 'SKIPPED')}")
             lines.append("")
     lines.append(f"**Status**: {'FAIL' if failed else 'PASS' if status == 'pass' else status.upper()}")
     lines.append(f"Passed: {len(passed)} | Failed: {len(failed)} | Skipped: {len(skipped)}")
@@ -161,7 +171,7 @@ class GateExecutorMixin:
         start = time.monotonic()
         try:
             proc = subprocess.run(
-                ["gh", "pr", "checks", str(pr_number), "--json", "name,status,conclusion"],
+                ["gh", "pr", "checks", str(pr_number), "--json", "name,bucket,state"],
                 capture_output=True, text=True, timeout=60, check=False,
             )
         except subprocess.TimeoutExpired:
@@ -205,11 +215,11 @@ class GateExecutorMixin:
                 )
             # no checks → vacuous pass; checks_list stays empty
 
-        passed = [c for c in checks_list if (c.get("conclusion") or "").upper() == "SUCCESS"]
-        failed = [c for c in checks_list if (c.get("conclusion") or "").upper() == "FAILURE"]
-        skipped = [c for c in checks_list if (c.get("conclusion") or "").upper() in ("SKIPPED", "CANCELLED")]
+        passed = [c for c in checks_list if (c.get("bucket") or "").lower() == "pass"]
+        failed = [c for c in checks_list if (c.get("bucket") or "").lower() == "fail"]
+        skipped = [c for c in checks_list if (c.get("bucket") or "").lower() in _CI_CHECK_BUCKET_SKIP]
         all_complete = all(
-            (c.get("status") or "").upper() == "COMPLETED" for c in checks_list
+            (c.get("bucket") or "").lower() in _CI_CHECK_BUCKET_TERMINAL for c in checks_list
         ) if checks_list else True  # vacuously complete when no checks
 
         # Determine terminal verdict
@@ -240,7 +250,7 @@ class GateExecutorMixin:
             {
                 "severity": "blocking",
                 "title": c.get("name", "unknown"),
-                "description": f"CI check '{c.get('name', '?')}' concluded with {c.get('conclusion', 'FAILURE')}",
+                "description": f"CI check '{c.get('name', '?')}' concluded with {c.get('state', 'FAILURE')}",
             }
             for c in failed
         ]
@@ -248,7 +258,7 @@ class GateExecutorMixin:
             {
                 "severity": "advisory",
                 "title": c.get("name", "unknown"),
-                "description": f"CI check '{c.get('name', '?')}' was {c.get('conclusion', 'SKIPPED')}",
+                "description": f"CI check '{c.get('name', '?')}' was {c.get('state', 'SKIPPED')}",
             }
             for c in skipped
         ]

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -140,12 +140,12 @@ def _make_subprocess_run(checks_json_str, head_sha="abc1234def5678", checks_retu
 
 
 def test_case_a_all_checks_pass(gate_env):
-    """Case A: all checks COMPLETED/SUCCESS → status=pass, blocking=[], verdict PASS."""
+    """Case A: all checks bucket=pass → status=pass, blocking=[], verdict PASS."""
     executor = _make_mock_executor(gate_env)
     pr_number = 42
     checks = [
-        {"name": "ci/test", "status": "COMPLETED", "conclusion": "SUCCESS"},
-        {"name": "ci/lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "ci/test", "bucket": "pass", "state": "SUCCESS"},
+        {"name": "ci/lint", "bucket": "pass", "state": "SUCCESS"},
     ]
     request_payload = _make_request_payload(
         pr_number=pr_number,
@@ -183,12 +183,12 @@ def test_case_a_all_checks_pass(gate_env):
 
 
 def test_case_b_one_failed_check(gate_env):
-    """Case B: 1 FAILURE check → blocking_findings has 1 entry, status=fail."""
+    """Case B: 1 bucket=fail check → blocking_findings has 1 entry, status=fail."""
     executor = _make_mock_executor(gate_env)
     pr_number = 43
     checks = [
-        {"name": "ci/test", "status": "COMPLETED", "conclusion": "SUCCESS"},
-        {"name": "ci/security", "status": "COMPLETED", "conclusion": "FAILURE"},
+        {"name": "ci/test", "bucket": "pass", "state": "SUCCESS"},
+        {"name": "ci/security", "bucket": "fail", "state": "FAILURE"},
     ]
     request_payload = _make_request_payload(
         pr_number=pr_number,
@@ -225,12 +225,12 @@ def test_case_b_one_failed_check(gate_env):
 
 
 def test_case_c_checks_running(gate_env):
-    """Case C: checks IN_PROGRESS → status=running, no terminal verdict yet."""
+    """Case C: one check bucket=pending → status=running, no terminal verdict yet."""
     executor = _make_mock_executor(gate_env)
     pr_number = 44
     checks = [
-        {"name": "ci/test", "status": "IN_PROGRESS", "conclusion": None},
-        {"name": "ci/lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "ci/test", "bucket": "pending", "state": "IN_PROGRESS"},
+        {"name": "ci/lint", "bucket": "pass", "state": "SUCCESS"},
     ]
     request_payload = _make_request_payload(
         pr_number=pr_number,
@@ -531,7 +531,7 @@ def test_contract_hash_determinism(gate_env):
     executor = _make_mock_executor(gate_env)
     pr_number = 50
     head_sha = "deadbeef1234"
-    checks = [{"name": "ci/test", "status": "COMPLETED", "conclusion": "SUCCESS"}]
+    checks = [{"name": "ci/test", "bucket": "pass", "state": "SUCCESS"}]
 
     def _run(cmd, **kwargs):
         cmd_str = " ".join(str(c) for c in cmd)
@@ -627,7 +627,7 @@ def test_contract_mode_uses_request_contract_hash(gate_env):
     executor = _make_mock_executor(gate_env)
     pr_number = 70
     contract_content_hash = "aabbccdd11223344"  # simulates ReviewContract.content_hash
-    checks = [{"name": "ci/test", "status": "COMPLETED", "conclusion": "SUCCESS"}]
+    checks = [{"name": "ci/test", "bucket": "pass", "state": "SUCCESS"}]
     request_payload = _make_request_payload(
         pr_number=pr_number,
         headless_reports_dir=gate_env["headless_reports_dir"],
@@ -655,7 +655,7 @@ def test_legacy_mode_contract_hash_is_sha256_of_execution_params(gate_env):
     executor = _make_mock_executor(gate_env)
     pr_number = 71
     head_sha = "cafebabe1234"
-    checks = [{"name": "ci/test", "status": "COMPLETED", "conclusion": "SUCCESS"}]
+    checks = [{"name": "ci/test", "bucket": "pass", "state": "SUCCESS"}]
     request_payload = _make_request_payload(
         pr_number=pr_number,
         headless_reports_dir=gate_env["headless_reports_dir"],
@@ -785,7 +785,7 @@ def test_running_verdict_resets_request_to_requested(gate_env):
     executor = _make_mock_executor(gate_env)
     pr_number = 80
     checks = [
-        {"name": "ci/test", "status": "IN_PROGRESS", "conclusion": None},
+        {"name": "ci/test", "bucket": "pending", "state": "IN_PROGRESS"},
     ]
     request_payload = _make_request_payload(
         pr_number=pr_number,
@@ -820,7 +820,7 @@ def test_completed_verdict_marks_request_completed(gate_env):
     """Finding 3 complement: terminal verdicts (pass/fail) still mark request as completed."""
     executor = _make_mock_executor(gate_env)
     pr_number = 81
-    checks = [{"name": "ci/test", "status": "COMPLETED", "conclusion": "SUCCESS"}]
+    checks = [{"name": "ci/test", "bucket": "pass", "state": "SUCCESS"}]
     request_payload = _make_request_payload(
         pr_number=pr_number,
         headless_reports_dir=gate_env["headless_reports_dir"],
@@ -904,3 +904,176 @@ def test_cli_per_pr_forwards_branch_and_require_github_pr(gate_env, tmp_path, mo
     assert captured.get("require_github_pr") is True, (
         "--require-github-pr must be forwarded to verify_pr_closure"
     )
+
+
+# ---------------------------------------------------------------------------
+# OI-1321: golden gh 2.76.2 JSON-schema fixtures.
+#
+# gh 2.76.2 (measured 2026-08-20) rejects `--json name,status,conclusion`
+# outright: "Unknown JSON field: status" / "conclusion". The only fields it
+# accepts are: bucket, completedAt, description, event, link, name,
+# startedAt, state, workflow. `gh pr checks --help` documents `bucket` as
+# categorizing the raw `state` into exactly one of: pass, fail, pending,
+# skipping, cancel.
+#
+# These three fixtures are the LITERAL `gh pr checks <pr> --json
+# name,state,bucket` output captured against real PRs in this repo on
+# 2026-08-20, not hand-written approximations — a hand-written fixture
+# could accidentally match whatever field names the parser happens to read,
+# which is exactly the failure mode this dispatch exists to close.
+# ---------------------------------------------------------------------------
+
+# Captured from `gh pr checks 1617 --json name,state,bucket` — a merged PR,
+# every check terminal and bucket=pass.
+_GH_2_76_2_GOLDEN_ALL_PASS = [
+    {"bucket": "pass", "name": "Profile B (snapshot integration)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Profile C (adoption smoke tests)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Trace Token Validation", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Dashboard TS Lint (fixture-gate + typecheck)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "ADR-003: No Anthropic SDK Imports", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "secret scan (gitleaks)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Gov-D3: Attestation signature gate (advisory)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Dispatch-ID Slug-Match Gate", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "docs/core/SUBSYSTEMS.md matches the live registry", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Repo-local state-pin gate (#1043 footgun)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Profile D (pip install smoke)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Profile A (doctor + core tests)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "vnx doctor smoke", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Lint Patterns (silent-except + atomic-write)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Anchor Immutability Check", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "ADR-003: No Anthropic SDK Imports", "state": "SUCCESS"},
+]
+
+# Captured from `gh pr checks 1613 --json name,state,bucket` — one required
+# check failed (bucket=fail), two skipped (bucket=skipping).
+_GH_2_76_2_GOLDEN_ONE_FAIL = [
+    {"bucket": "skipping", "name": "Profile B (snapshot integration)", "state": "SKIPPED"},
+    {"bucket": "skipping", "name": "Profile C (adoption smoke tests)", "state": "SKIPPED"},
+    {"bucket": "pass", "name": "secret scan (gitleaks)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Gov-D3: Attestation signature gate (advisory)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Trace Token Validation", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Lint Patterns (silent-except + atomic-write)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Anchor Immutability Check", "state": "SUCCESS"},
+    {"bucket": "fail", "name": "Profile A (doctor + core tests)", "state": "FAILURE"},
+    {"bucket": "pass", "name": "Dashboard TS Lint (fixture-gate + typecheck)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "vnx doctor smoke", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "docs/core/SUBSYSTEMS.md matches the live registry", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Repo-local state-pin gate (#1043 footgun)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Profile D (pip install smoke)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "ADR-003: No Anthropic SDK Imports", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Dispatch-ID Slug-Match Gate", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "ADR-003: No Anthropic SDK Imports", "state": "SUCCESS"},
+]
+
+# Captured from `gh pr checks 1619 --json name,state,bucket` while two
+# workflows were still mid-run — bucket=pending, state=IN_PROGRESS.
+_GH_2_76_2_GOLDEN_STILL_RUNNING = [
+    {"bucket": "pass", "name": "ADR-003: No Anthropic SDK Imports", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Lint Patterns (silent-except + atomic-write)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Repo-local state-pin gate (#1043 footgun)", "state": "SUCCESS"},
+    {"bucket": "pending", "name": "Profile A (doctor + core tests)", "state": "IN_PROGRESS"},
+    {"bucket": "pass", "name": "Profile D (pip install smoke)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Trace Token Validation", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Anchor Immutability Check", "state": "SUCCESS"},
+    {"bucket": "pending", "name": "Dashboard TS Lint (fixture-gate + typecheck)", "state": "IN_PROGRESS"},
+    {"bucket": "pass", "name": "Gov-D3: Attestation signature gate (advisory)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "Dispatch-ID Slug-Match Gate", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "docs/core/SUBSYSTEMS.md matches the live registry", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "secret scan (gitleaks)", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "vnx doctor smoke", "state": "SUCCESS"},
+    {"bucket": "pass", "name": "ADR-003: No Anthropic SDK Imports", "state": "SUCCESS"},
+]
+
+
+def test_golden_gh_2_76_2_fully_green_pr_gives_pass_with_evidence(gate_env):
+    """A fully-green PR against the real gh 2.76.2 schema reaches verdict=pass
+    with a non-empty contract_hash AND report_path, and the report file is
+    actually on disk — the layer-2 regression this dispatch exists to close
+    (a parser reading a vanished `status`/`conclusion` field silently stalls
+    at verdict=running forever and never writes a report at all)."""
+    executor = _make_mock_executor(gate_env)
+    pr_number = 1617
+    request_payload = _make_request_payload(
+        pr_number=pr_number,
+        headless_reports_dir=gate_env["headless_reports_dir"],
+    )
+
+    with patch("gate_executor.subprocess") as mock_sub, \
+         patch("gate_executor.shutil.which", return_value="/usr/bin/gh"):
+        mock_sub.run.side_effect = _make_subprocess_run(
+            json.dumps(_GH_2_76_2_GOLDEN_ALL_PASS)
+        )
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        result = executor._execute_ci_gate(
+            gate="ci_gate", pr_number=pr_number, pr_id="",
+            request_payload=request_payload,
+        )
+
+    assert result["status"] == "pass"
+    assert result["contract_hash"] != "", "pass verdict must carry a non-empty contract_hash"
+    assert result["report_path"] != "", "pass verdict must carry a non-empty report_path"
+    assert Path(result["report_path"]).is_file(), "report must actually exist on disk"
+    assert result["blocking_findings"] == []
+    assert len(result["passed_checks"]) == len(_GH_2_76_2_GOLDEN_ALL_PASS)
+
+
+def test_golden_gh_2_76_2_one_failed_check_gives_fail(gate_env):
+    """A PR with one bucket=fail check against the real gh 2.76.2 schema
+    reaches verdict=fail, with the failing check named in blocking_findings."""
+    executor = _make_mock_executor(gate_env)
+    pr_number = 1613
+    request_payload = _make_request_payload(
+        pr_number=pr_number,
+        headless_reports_dir=gate_env["headless_reports_dir"],
+    )
+
+    with patch("gate_executor.subprocess") as mock_sub, \
+         patch("gate_executor.shutil.which", return_value="/usr/bin/gh"):
+        mock_sub.run.side_effect = _make_subprocess_run(
+            json.dumps(_GH_2_76_2_GOLDEN_ONE_FAIL)
+        )
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        result = executor._execute_ci_gate(
+            gate="ci_gate", pr_number=pr_number, pr_id="",
+            request_payload=request_payload,
+        )
+
+    assert result["status"] == "fail"
+    assert result["blocking_count"] == 1
+    assert result["failed_checks"] == ["Profile A (doctor + core tests)"]
+    assert result["contract_hash"] != ""
+    assert result["report_path"] != ""
+    assert Path(result["report_path"]).is_file()
+    # The two skipping-bucket checks land as advisory, not blocking.
+    assert result["advisory_count"] == 2
+
+
+def test_golden_gh_2_76_2_pending_check_gives_running_and_no_report(gate_env):
+    """A PR with a bucket=pending check against the real gh 2.76.2 schema
+    reaches verdict=running and writes NO report — this is exactly the
+    silent layer-2 failure mode: before the fix, `status`/`conclusion` are
+    always None under the new schema, so verdict is permanently stuck at
+    running regardless of what the checks actually say."""
+    executor = _make_mock_executor(gate_env)
+    pr_number = 1619
+    request_payload = _make_request_payload(
+        pr_number=pr_number,
+        headless_reports_dir=gate_env["headless_reports_dir"],
+    )
+
+    with patch("gate_executor.subprocess") as mock_sub, \
+         patch("gate_executor.shutil.which", return_value="/usr/bin/gh"):
+        mock_sub.run.side_effect = _make_subprocess_run(
+            json.dumps(_GH_2_76_2_GOLDEN_STILL_RUNNING)
+        )
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        result = executor._execute_ci_gate(
+            gate="ci_gate", pr_number=pr_number, pr_id="",
+            request_payload=request_payload,
+        )
+
+    assert result["status"] == "running"
+    assert result["contract_hash"] == ""
+    assert result["report_path"] == ""
+    # No report file was written anywhere under the reports dir.
+    assert list(gate_env["headless_reports_dir"].glob("*.md")) == []


### PR DESCRIPTION
## Summary

`ci_gate` was the last standing review-gate lane (gemini off-PATH, codex rate-limited, claude_github default-off) and it was completely broken against the installed `gh` CLI. `gh pr checks --json name,status,conclusion` fails outright on gh 2.76.2 (`Unknown JSON field: "status"`) — those fields were retired. This stayed invisible because `VNX_CI_GATE_REQUIRED` defaults off, so nobody exercised the gate.

The defect has two layers:
1. **The call** requested `status`/`conclusion`, fields `gh` no longer serves.
2. **The parser, silently.** A layer-1-only fix (correct fields, unchanged parser) would make `gh` exit 0 while `conclusion`/`status` read as `None` forever — `passed`/`failed` stay empty, `all_complete` is `False`, verdict is permanently `running`, and the report (only written on a terminal pass/fail) never gets written. A quiet failure mode, worse than the loud one it replaces.

## Changes

- `scripts/lib/gate_executor.py`: swap the `gh pr checks` field list to `name,bucket,state` (gh 2.76.2's actual schema — measured directly, not guessed). `gh pr checks --help` documents `bucket` as categorizing `state` into exactly `pass`/`fail`/`pending`/`skipping`/`cancel`. Rederive `passed`/`failed`/`skipped`/`all_complete` from `bucket` instead of the retired `status`/`conclusion`. An unrecognized bucket value is treated as non-terminal (not silently "complete"), so a future schema drift stalls the verdict at `running` instead of silently passing. Report formatter and `blocking_findings`/`advisory_findings` now read `state` for display text instead of the vanished `conclusion`.
- `tests/test_ci_gate.py`: updated all existing check fixtures from the old `{status, conclusion}` shape to the real `{bucket, state}` shape, and added three new golden-fixture tests that pin the **literal** `gh pr checks <pr> --json name,state,bucket` JSON captured against real PRs in this repo on 2026-08-20:
  - `test_golden_gh_2_76_2_fully_green_pr_gives_pass_with_evidence` (PR #1617, all-pass) — verdict `pass`, non-empty `contract_hash` and `report_path`, report file actually exists on disk.
  - `test_golden_gh_2_76_2_one_failed_check_gives_fail` (PR #1613, one `fail` + two `skipping`) — verdict `fail`, correct blocking/advisory split.
  - `test_golden_gh_2_76_2_pending_check_gives_running_and_no_report` (PR #1619, one `pending`) — verdict `running`, empty `contract_hash`/`report_path`, **no report file written** — this is exactly the case the silent layer-2 bug would have gotten wrong.

`VNX_CI_GATE_REQUIRED` is left off by default, unchanged — enabling it is a separate operator decision.

## Verification

**Before fix** — `gh pr checks 1619 --json name,status,conclusion`:
```
gh: Unknown JSON field: "status"
Available fields:
  bucket
  completedAt
  description
  event
  link
  name
  startedAt
  state
  workflow
```

**After fix** — `gh pr checks 1619 --json name,bucket,state` (rc=0):
```json
[{"bucket":"pass","name":"ADR-003: No Anthropic SDK Imports","state":"SUCCESS"}, ...,{"bucket":"pending","name":"Profile A (doctor + core tests)","state":"IN_PROGRESS"}, ...]
```

**Tests** — `pytest tests/test_ci_gate.py -q`: 20 passed, 5 pre-existing failures (confirmed identical on unmodified `main` via `git stash` — unrelated `closure_verifier`/`_find_gate_result` lookup issue, out of this dispatch's scope). New golden tests: `pytest tests/test_ci_gate.py -k golden -v` → 3 passed.

Neighbor test files that import `gate_executor` (`test_gate_unavailable_rollup.py`, `test_role_scope_outside_triage.py`, `test_w3j_followup_cleanups.py`, `test_wiring_gate_shadow_mode.py`, `test_worker_permissions_role_scope.py`): 75 passed.

## Test plan
- [x] `pytest tests/test_ci_gate.py -q` — 20 passed / 5 pre-existing unrelated failures
- [x] `pytest tests/test_ci_gate.py -k golden -v` — 3 new golden-schema tests passed
- [x] Neighbor test files — 75 passed
- [x] `gh pr checks <pr> --json name,bucket,state` confirmed rc=0 against 3 real PRs (#1617, #1613, #1619)

Dispatch-ID: 20260820-p6-ci-gate-gh-schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)