### PR TITLE
fix(pr-enforcement): resolve the real pushed branch instead of dispatch/<id> (OI-1372)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -184,14 +184,28 @@ def _enforce_push_pr(
                 dispatch_id, _claim_reason, base_ref,
                 base_sha[:12] if base_sha else None,
             )
-        from tmux_worktree import classify_path  # noqa: PLC0415
+        from tmux_worktree import classify_path, resolve_effective_branch  # noqa: PLC0415
+        # OI-1372: a dispatch instruction can prescribe its own branch name — the
+        # worker then pushes THAT branch, never touching dispatch/<id> at all. Read
+        # the ACTUAL checked-out branch (mirrors _resolve_phantom_diff's OI-870
+        # fix) instead of enforcing push+PR against a name that was never used, or
+        # the guard rejects a real, delivered success as dispatch_branch_no_pr.
+        effective_branch = resolve_effective_branch(
+            wt=wt_path, expected_branch=branch, dispatch_id=dispatch_id,
+        )
+        if effective_branch != branch:
+            logger.info(
+                "envelope: PR-enforcement branch resolved dispatch=%s expected=%r "
+                "actual=%r (OI-1372)",
+                dispatch_id, branch, effective_branch,
+            )
         state = classify_path(
-            wt=wt_path, branch=branch, dispatch_id=dispatch_id, base_sha=base_sha,
+            wt=wt_path, branch=effective_branch, dispatch_id=dispatch_id, base_sha=base_sha,
         )
         from pr_enforcement import enforce_pr_exists  # noqa: PLC0415
         pr_result = enforce_pr_exists(
             dispatch_id=dispatch_id,
-            branch=branch,
+            branch=effective_branch,
             worktree_state=state,
             repo_root=repo_root,
             receipts_file=receipts_file,

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1288,6 +1288,7 @@ class TmuxInteractiveDispatch:
         """
         try:
             from pr_enforcement import enforce_pr_exists  # noqa: PLC0415
+            from tmux_worktree import resolve_effective_branch  # noqa: PLC0415
 
             # OI-1127: hand the worktree path through so a "dirty" verdict is
             # split into substantive vs scratch and substantive work is
@@ -1298,9 +1299,30 @@ class TmuxInteractiveDispatch:
             # directory (external cleanup, crash-restart) must degrade to the
             # back-compat path, not feed a dead path into git.
             _wt_path = worktree_handle.path if worktree_handle.path.is_dir() else None
+            # OI-1372: a dispatch instruction can prescribe its own branch name —
+            # the worker then pushes THAT branch, never touching
+            # worktree_handle.branch (dispatch/<id>) at all. Read the ACTUAL
+            # checked-out branch (mirrors _resolve_phantom_diff's OI-870 fix)
+            # instead of enforcing push+PR against a name that was never used,
+            # or the guard rejects a real, delivered success as
+            # dispatch_branch_no_pr.
+            _branch = (
+                resolve_effective_branch(
+                    wt=_wt_path, expected_branch=worktree_handle.branch,
+                    dispatch_id=dispatch_id,
+                )
+                if _wt_path is not None
+                else worktree_handle.branch
+            )
+            if _branch != worktree_handle.branch:
+                logger.info(
+                    "interactive: PR-enforcement branch resolved dispatch=%s "
+                    "expected=%r actual=%r (OI-1372)",
+                    dispatch_id, worktree_handle.branch, _branch,
+                )
             result = enforce_pr_exists(
                 dispatch_id=dispatch_id,
-                branch=worktree_handle.branch,
+                branch=_branch,
                 worktree_state=worktree_state,
                 repo_root=self._project_root,
                 receipts_file=self._receipts_file,

--- a/scripts/lib/tmux_worktree.py
+++ b/scripts/lib/tmux_worktree.py
@@ -239,6 +239,65 @@ def classify(handle: WorktreeHandle) -> Literal["clean", "committed", "pushed", 
     )
 
 
+def _drift_safe_effective_branch(
+    *, current: str, branch: str, dispatch_id: str,
+) -> "tuple[str, bool]":
+    """Decide whether the ACTUAL checked-out branch (*current*) is a safe
+    substitute for the EXPECTED dispatch-id-derived branch (*branch*), or
+    OI-1124 cross-dispatch identity drift.
+
+    Returns ``(effective_branch, is_drift)``:
+    - ``(branch, False)``  — *current* is empty or already equals *branch*: no
+      substitution needed.
+    - ``(branch, True)``   — *current* names a DIFFERENT dispatch's branch
+      (cross-dispatch drift) — the caller must treat this as a safety concern
+      and never redirect enforcement onto it.
+    - ``(current, False)`` — *current* is a legitimate substitute: a
+      worker-chosen custom name (``fix/...``), or the SAME dispatch under a
+      different branch form/prefix. OI-1372: a dispatch instruction can
+      prescribe its own branch name, and the worker then pushes THAT branch,
+      not ``dispatch/<id>`` — *current* is where any push actually landed.
+    """
+    if not current or current == branch:
+        return branch, False
+    drift = _DISPATCH_BRANCH_RE.match(current)
+    expected_ids = {dispatch_id}
+    expected = _DISPATCH_BRANCH_RE.match(branch)
+    if expected:
+        expected_ids.add(expected.group("id"))
+    if drift and drift.group("id") not in expected_ids:
+        return branch, True
+    return current, False
+
+
+def resolve_effective_branch(
+    *, wt: "Path | str", expected_branch: str, dispatch_id: str,
+) -> str:
+    """OI-1372: resolve the branch push/PR enforcement should actually target.
+
+    Reads the worktree's checked-out branch directly (mirrors
+    ``envelope_govern_support._resolve_phantom_diff``'s OI-870 fix) instead of
+    trusting the dispatch-id-derived name unconditionally. A dispatch
+    instruction can prescribe its own branch name (fix-forward, or a
+    worker-chosen name) — the worker then pushes THAT branch, not
+    ``dispatch/<id>``, and PR-enforcement code that only ever looks at
+    ``dispatch/<id>`` rejects a real, delivered success as
+    ``dispatch_branch_no_pr`` (a false failure booked over completed work).
+
+    Returns the checked-out branch when it is a legitimate custom name (or the
+    same dispatch under a different form); returns *expected_branch* unchanged
+    when the checked-out branch names a DIFFERENT dispatch's identity (OI-1124
+    cross-dispatch drift) — that case is a safety concern ``classify_path``'s
+    own guard classifies ``dirty``, not a legitimate rename, so this function
+    never redirects enforcement onto it.
+    """
+    current = _current_branch(wt)
+    effective_branch, _is_drift = _drift_safe_effective_branch(
+        current=current, branch=expected_branch, dispatch_id=dispatch_id,
+    )
+    return effective_branch
+
+
 def classify_path(
     *,
     wt: "Path | str",
@@ -284,24 +343,26 @@ def classify_path(
     # reap preserves and locks it for identity review instead of reaping or
     # branch-deleting under the wrong identity. Worker-chosen non-dispatch
     # branches (``fix/...``) and a re-formed branch carrying the OWN id keep
-    # their normal verdicts: identity is intact there, only the form differs.
+    # their normal verdicts: identity is intact there, only the form differs
+    # — and (OI-1372) THAT checked-out branch, not the dispatch-id-derived
+    # name, is what the remote-push check below targets: a dispatch
+    # instruction can prescribe its own branch name, and the worker then
+    # pushes THAT branch, never touching ``dispatch/<id>`` at all.
     current = _current_branch(wt)
-    if current and current != branch:
-        drift = _DISPATCH_BRANCH_RE.match(current)
-        expected_ids = {dispatch_id}
-        expected = _DISPATCH_BRANCH_RE.match(branch)
-        if expected:
-            expected_ids.add(expected.group("id"))
-        if drift and drift.group("id") not in expected_ids:
-            logger.warning(
-                "OI-1124 BRANCH-IDENTITY DRIFT: worktree %s (dispatch %s) is "
-                "checked out on %r, which names a DIFFERENT dispatch (%r); "
-                "expected %r. Classifying 'dirty' so the worktree is preserved "
-                "for identity review instead of reaped or merged under the "
-                "wrong name.",
-                wt, dispatch_id, current, drift.group("id"), branch,
-            )
-            return "dirty"
+    effective_branch, _is_drift = _drift_safe_effective_branch(
+        current=current, branch=branch, dispatch_id=dispatch_id,
+    )
+    if _is_drift:
+        drift_id = _DISPATCH_BRANCH_RE.match(current).group("id")
+        logger.warning(
+            "OI-1124 BRANCH-IDENTITY DRIFT: worktree %s (dispatch %s) is "
+            "checked out on %r, which names a DIFFERENT dispatch (%r); "
+            "expected %r. Classifying 'dirty' so the worktree is preserved "
+            "for identity review instead of reaped or merged under the "
+            "wrong name.",
+            wt, dispatch_id, current, drift_id, branch,
+        )
+        return "dirty"
 
     status_result = _run(
         [
@@ -342,8 +403,14 @@ def classify_path(
         return "clean"
 
     # New commits exist (HEAD diverged from a known base) — determine whether
-    # they've been pushed to origin.
-    remote_ref = branch if branch.startswith("refs/") else f"refs/heads/{branch}"
+    # they've been pushed to origin. Uses effective_branch (OI-1372): the
+    # actually-checked-out branch when it is a legitimate custom name, so a
+    # dispatch that pushed onto a prescribed branch is measured against WHERE
+    # it actually pushed, not the dispatch-id-derived name it never touched.
+    remote_ref = (
+        effective_branch if effective_branch.startswith("refs/")
+        else f"refs/heads/{effective_branch}"
+    )
     try:
         ls_result = _run(
             ["git", "-C", str(wt), "ls-remote", "origin", remote_ref],
@@ -351,10 +418,12 @@ def classify_path(
         )
         remote_output = ls_result.stdout.strip() if ls_result.returncode == 0 else ""
     except subprocess.TimeoutExpired:
-        logger.warning("ls-remote timed out for %s; treating as committed", branch)
+        logger.warning("ls-remote timed out for %s; treating as committed", effective_branch)
         return "committed"
     except Exception as exc:
-        logger.warning("ls-remote failed for %s (%s); treating as committed", branch, exc)
+        logger.warning(
+            "ls-remote failed for %s (%s); treating as committed", effective_branch, exc,
+        )
         return "committed"
 
     if not remote_output:

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -2,14 +2,14 @@
   "couplings": [
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 760,
+      "line": 843,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 763,
+      "line": 846,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
@@ -632,14 +632,14 @@
     },
     {
       "file": "tests/test_failclass_registry.py",
-      "line": 736,
+      "line": 1087,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_failclass_registry.py",
-      "line": 768,
+      "line": 1119,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_resolve_phantom_diff"
@@ -869,6 +869,20 @@
       "symbol": "ProviderAdapter.run"
     },
     {
+      "file": "tests/test_oi1372_pr_enforcement_branch_resolution.py",
+      "line": 224,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_oi1372_pr_enforcement_branch_resolution.py",
+      "line": 241,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_enforce_push_pr"
+    },
+    {
       "file": "tests/test_phantom_guard_branch_fallback.py",
       "line": 122,
       "mechanism": "direct-call",
@@ -1010,35 +1024,35 @@
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1036,
+      "line": 1037,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1036,
+      "line": 1037,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_enforce_push_pr"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1127,
+      "line": 1128,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1127,
+      "line": 1128,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_enforce_push_pr"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1143,
+      "line": 1144,
       "mechanism": "logger-name",
       "module_target": "dispatch_envelope",
       "symbol": ""

--- a/tests/test_oi1372_pr_enforcement_branch_resolution.py
+++ b/tests/test_oi1372_pr_enforcement_branch_resolution.py
@@ -1,0 +1,256 @@
+"""test_oi1372_pr_enforcement_branch_resolution.py — OI-1372 regression.
+
+On 20-08 two dispatches delivered real, complete work (green tests, a commit,
+a pushed branch, a real PR) and were BOTH booked as ``status=failure`` with
+``error=dispatch_branch_no_pr``, because PR enforcement only ever looked at
+``dispatch/<dispatch-id>`` — the branch a fresh worktree starts on — while the
+dispatch instruction had prescribed its own branch name and the worker pushed
+THAT branch instead. ``gh pr create --head dispatch/<id>`` then failed with
+"No commits between main and dispatch/<id>", and the guard rejected a real
+success.
+
+The fix (mirrors ``envelope_govern_support._resolve_phantom_diff``'s OI-870
+model): read the worktree's ACTUAL checked-out branch instead of trusting the
+dispatch-id-derived name unconditionally — ``tmux_worktree.resolve_effective_branch``
+and the ``classify_path`` refactor it shares logic with.
+
+Real git repos throughout (mirrors test_tmux_worktree.py); only
+``gh_pr_ensure.ensure_pr`` is mocked — nothing here touches GitHub.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import tmux_worktree
+from tmux_worktree import allocate, classify, resolve_effective_branch
+
+
+# ---------------------------------------------------------------------------
+# Shared real-git fixture (mirrors test_tmux_worktree.py::_init_git_repo_with_origin)
+# ---------------------------------------------------------------------------
+
+def _init_git_repo_with_origin(tmp_path: Path) -> Path:
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", str(bare), str(local)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "checkout", "-b", "main"], capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "push", "-u", "origin", "main"], check=True, capture_output=True)
+    return local
+
+
+def _commit_on_new_branch(wt_path: Path, branch: str, filename: str) -> None:
+    """Simulate a dispatch instruction that prescribed its own branch name:
+    the worker checks out *branch* (never touching dispatch/<id> again) and
+    commits real work there."""
+    subprocess.run(
+        ["git", "-C", str(wt_path), "checkout", "-b", branch], check=True, capture_output=True,
+    )
+    (wt_path / filename).write_text("real work\n")
+    subprocess.run(["git", "-C", str(wt_path), "add", filename], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wt_path), "commit", "-m", "worker commit"], check=True, capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mechanism level: resolve_effective_branch / classify_path
+# ---------------------------------------------------------------------------
+
+def test_resolve_effective_branch_returns_custom_name_when_pushed(tmp_path):
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1372-a", repo_root=local)
+    _commit_on_new_branch(handle.path, "fix/report-wrapper-red-tests", "work.txt")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", "fix/report-wrapper-red-tests"],
+        check=True, capture_output=True,
+    )
+
+    effective = resolve_effective_branch(
+        wt=handle.path, expected_branch=handle.branch, dispatch_id="oi1372-a",
+    )
+    assert effective == "fix/report-wrapper-red-tests"
+
+
+def test_resolve_effective_branch_preserves_cross_dispatch_drift_safety(tmp_path):
+    """OI-1124 safety net stays intact: a worktree checked out on a DIFFERENT
+    dispatch's branch must NOT be redirected — resolve_effective_branch keeps
+    returning the expected (dispatch/<id>) name so classify_path's own guard
+    still classifies it 'dirty', never silently substituting the foreign
+    identity."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1372-victim", repo_root=local)
+    subprocess.run(
+        ["git", "-C", str(handle.path), "checkout", "-b", "dispatch/oi1372-donor"],
+        check=True, capture_output=True,
+    )
+
+    effective = resolve_effective_branch(
+        wt=handle.path, expected_branch=handle.branch, dispatch_id="oi1372-victim",
+    )
+    assert effective == handle.branch  # NOT redirected to dispatch/oi1372-donor
+    assert classify(handle) == "dirty"  # classify_path's own guard still fires
+
+
+def test_classify_reports_pushed_not_committed_on_custom_branch(tmp_path):
+    """THE bug, at the classification layer: before OI-1372, classify_path
+    checked ls-remote against dispatch/<id> (never pushed) and misclassified a
+    pushed custom branch as 'committed' — pr_enforcement then tried to push+PR
+    dispatch/<id> itself, which carries no commits (the literal "No commits
+    between main and dispatch/<id>" gh error from the field report)."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1372-b", repo_root=local)
+    _commit_on_new_branch(handle.path, "fix/report-wrapper-red-tests", "work.txt")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", "fix/report-wrapper-red-tests"],
+        check=True, capture_output=True,
+    )
+    assert classify(handle) == "pushed"
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint level, tmux lane (the DEFAULT lane) — _enforce_pr_exists
+# ---------------------------------------------------------------------------
+
+def _tmux_dispatch_instance(tmp_path: Path, project_root: Path):
+    from tmux_interactive_dispatch import TmuxInteractiveDispatch
+    return TmuxInteractiveDispatch(
+        project_root=project_root,
+        state_dir=tmp_path / "state",
+        receipts_file=tmp_path / "state" / "t0_receipts.ndjson",
+    )
+
+
+def test_tmux_lane_accepts_pushed_custom_branch_no_dispatch_branch_no_pr(tmp_path):
+    """Requirement 1: a dispatch that pushed to a DIFFERENT branch with a real
+    PR must NOT be status=failure, and dispatch_branch_no_pr must not occur."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1372-c", repo_root=local)
+    _commit_on_new_branch(handle.path, "fix/report-wrapper-red-tests", "work.txt")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", "fix/report-wrapper-red-tests"],
+        check=True, capture_output=True,
+    )
+
+    inst = _tmux_dispatch_instance(tmp_path, local)
+    state = classify(handle)
+    assert state == "pushed"
+
+    with patch(
+        "gh_pr_ensure.ensure_pr",
+        return_value={"pr_number": 4242, "created": True, "reason": None},
+    ) as mock_ensure:
+        result = inst._enforce_pr_exists(
+            dispatch_id="oi1372-c", label="T1", worktree_handle=handle, worktree_state=state,
+        )
+
+    assert result.applicable is True
+    assert result.ok is True, f"must not reject as dispatch_branch_no_pr: {result.reason}"
+    assert result.pr_number == 4242
+    mock_ensure.assert_called_once()
+    called_branch = mock_ensure.call_args.args[0] if mock_ensure.call_args.args \
+        else mock_ensure.call_args.kwargs.get("branch")
+    assert called_branch == "fix/report-wrapper-red-tests", (
+        f"PR must be opened against the branch actually pushed, got {called_branch!r}"
+    )
+
+
+def test_tmux_lane_pr_creation_failure_on_custom_branch_is_still_loud(tmp_path):
+    """Requirement 2 (guard preservation): the fix only relocates WHERE the
+    guard looks — a real PR-creation failure on the (correctly resolved)
+    custom branch must still be a loud, receipt-visible failure, not silently
+    swallowed."""
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1372-e", repo_root=local)
+    _commit_on_new_branch(handle.path, "fix/report-wrapper-red-tests", "work.txt")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", "fix/report-wrapper-red-tests"],
+        check=True, capture_output=True,
+    )
+
+    inst = _tmux_dispatch_instance(tmp_path, local)
+    (tmp_path / "state").mkdir(parents=True, exist_ok=True)
+    state = classify(handle)
+    assert state == "pushed"
+
+    with patch(
+        "gh_pr_ensure.ensure_pr",
+        return_value={"pr_number": None, "created": False, "reason": "gh auth expired"},
+    ):
+        result = inst._enforce_pr_exists(
+            dispatch_id="oi1372-e", label="T1", worktree_handle=handle, worktree_state=state,
+        )
+
+    assert result.applicable is True
+    assert result.ok is False
+    assert result.reason and "gh auth expired" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint level, envelope lane (codex/claude-subprocess) — _enforce_push_pr
+# ---------------------------------------------------------------------------
+
+def test_envelope_lane_accepts_pushed_custom_branch_no_dispatch_branch_no_pr(tmp_path):
+    """Same requirement 1, exercised through dispatch_envelope._enforce_push_pr
+    (the envelope-lane chokepoint pointed at by the dispatch instruction)."""
+    import dispatch_envelope
+    from envelope_types import _AdapterResult
+
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1372-f", repo_root=local)
+    _commit_on_new_branch(handle.path, "fix/report-wrapper-red-tests", "work.txt")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", "fix/report-wrapper-red-tests"],
+        check=True, capture_output=True,
+    )
+
+    success_result = _AdapterResult(returncode=0, completion_text="done", status="success")
+
+    with patch(
+        "gh_pr_ensure.ensure_pr",
+        return_value={"pr_number": 7777, "created": True, "reason": None},
+    ) as mock_ensure:
+        outcome = dispatch_envelope._enforce_push_pr(
+            dispatch_id="oi1372-f",
+            branch=handle.branch,
+            wt_path=handle.path,
+            repo_root=local,
+            receipts_file=tmp_path / "t0_receipts.ndjson",
+            result=success_result,
+        )
+
+    assert outcome.status == "success", (
+        f"must not reject as dispatch_branch_no_pr: {outcome.error!r}"
+    )
+    mock_ensure.assert_called_once()
+    called_branch = mock_ensure.call_args.args[0] if mock_ensure.call_args.args \
+        else mock_ensure.call_args.kwargs.get("branch")
+    assert called_branch == "fix/report-wrapper-red-tests"


### PR DESCRIPTION
## Summary

PR enforcement (`pr_enforcement.enforce_pr_exists`, called from both the tmux and envelope lanes) only ever checked `dispatch/<dispatch-id>` for a push and a PR. When a dispatch instruction prescribes its own branch name, the worker pushes a *different* branch, so the guard found nothing on `dispatch/<id>` and booked a completed, PR'd dispatch as `status=failure` with `error=dispatch_branch_no_pr` ("No commits between main and dispatch/<id>").

Two dispatches on 2026-08-20 hit exactly this: green tests, a real commit, a pushed branch, a real PR — all booked as failure.

## Changes

- `scripts/lib/tmux_worktree.py`: `classify_path` now resolves the worktree's *actual* checked-out branch (mirrors `envelope_govern_support._resolve_phantom_diff`'s OI-870 model — `git rev-parse --abbrev-ref HEAD`) and uses it for the remote-push lookup when it is a legitimate custom name. New `resolve_effective_branch()` helper, built on a shared `_drift_safe_effective_branch()` so the OI-1124 cross-dispatch-identity-drift check isn't duplicated.
- `scripts/lib/dispatch_envelope.py` (`_enforce_push_pr`): resolves the effective branch before calling `classify_path`/`enforce_pr_exists`, targeting the branch that was actually pushed.
- `scripts/lib/tmux_interactive_dispatch.py` (`_enforce_pr_exists`): same fix for the tmux lane (the default lane).
- `orphan_sweep.py` needed **no change** — it calls `classify_path` directly and inherits the fix transparently.
- `tests/test_oi1372_pr_enforcement_branch_resolution.py` (new): real-git regression tests, both directions — a pushed custom branch with a real PR must not be `dispatch_branch_no_pr`; a genuine PR-creation failure on that branch must still be loud. Plus an OI-1124 drift-safety-preserved test and a `classify_path` mechanism-level test.
- `tests/data/dispatch_envelope_census.json`: regenerated (`python3 tests/dispatch_envelope_census_scanner.py`) to include the new test file's couplings.

**Out of scope, verified by fresh census grep** (`grep -rn 'branch = f"dispatch/\|branch=f"dispatch/' --include='*.py' scripts/lib/`):
- `envelope_govern_support.py:158/165` — this IS the OI-870 model function (`_resolve_phantom_diff`) itself; per the dispatch instruction, left untouched.
- `phantom_guard.py:266` (`_resolve_fix_forward_diff`'s parent-dispatch fallback) and `:397` (`guard_at_govern`'s diff fallback) — separate diff-computation checks with their own `work_ref`/`pr_id`/`parent_dispatch` precedence chains, not the push+PR chokepoint that produced this failure.
- `report_to_receipt_converter.py:613` (`_check_branch_on_origin`, OI-1203) — a *different*, narrower check: it only falls back to the dispatch-id-derived branch when the report's `pr_ref` field is absent/unparseable; a correctly-declared `pr_ref` bypasses it entirely. Shares the same structural assumption but wasn't what produced this dispatch's reported symptom (confirmed: "No commits between main and dispatch/<id>" is `gh pr create`'s stderr via `pr_enforcement.py`/`gh_pr_ensure.py`, not this converter). Flagged as a narrower follow-up, not fixed here to keep this PR scoped to the actual chokepoint.
- `tmux_worktree.py:153` (`allocate()`'s initial branch creation) — correct and intentional; not part of the bug.

## Verification

Census re-run (literal output):
```
scripts/lib/envelope_govern_support.py:158:            branch = f"dispatch/{_sanitize_dispatch_id(dispatch_id)}"
scripts/lib/envelope_govern_support.py:165:        branch = f"dispatch/{_sanitize_dispatch_id(dispatch_id)}"
scripts/lib/tmux_worktree.py:153:    branch = f"dispatch/{dispatch_id}"
scripts/lib/orphan_sweep.py:375:            branch = f"dispatch/{wid}"
scripts/lib/phantom_guard.py:266:                branch = f"dispatch/{_sanitize_dispatch_id(_parent)}"
scripts/lib/phantom_guard.py:397:                branch = f"dispatch/{_sanitize_dispatch_id(dispatch_id)}"
scripts/lib/report_to_receipt_converter.py:613:    branch = f"dispatch/{dispatch_id}"
```

Confirmed the bug reproduces pre-fix (manual repro, custom branch pushed to real origin): `classify()` returned `"committed"` instead of `"pushed"`, because `ls-remote` was checked against `dispatch/<id>` (never pushed), which then made `pr_enforcement` try to push+PR an empty `dispatch/<id>` branch — the literal `gh pr create` failure mode from the field report.

Targeted tests, both directions (both green with the fix, both fail/error pre-fix — verified via `git stash` of the three source files):
```
python3 -m pytest tests/test_oi1372_pr_enforcement_branch_resolution.py tests/test_tmux_worktree.py \
  tests/test_lane_matrix_row7_push_pr.py tests/test_pr_enforcement.py tests/test_tmux_interactive_dispatch.py \
  tests/test_dispatch_envelope.py tests/test_dispatch_envelope_plan.py tests/test_provider_dispatch_worktree_isolation.py \
  tests/test_headless_worktree_isolation.py tests/test_dispatch_envelope_characterization.py \
  tests/test_dispatch_envelope_fail_loud.py tests/test_dispatch_envelope_field_propagation.py \
  tests/test_orphan_sweep.py tests/test_phantom_guard_oi869_oi870.py tests/test_phantom_guard_branch_fallback.py \
  tests/test_phantom_guard_fix_forward.py tests/test_dispatch_envelope_annotations_resolve.py \
  tests/test_role_applied_provider_lane.py tests/test_envelope_ringbuffer_teardown_oi902.py \
  tests/test_envelope_role_propagation.py tests/test_receipt_v2_pr4_wiring.py \
  --deselect tests/test_receipt_v2_pr4_wiring.py::test_t24_envelope_subpath_verification_from_report -q
```
→ `577 passed, 1 deselected`. The one deselected test (`test_t24_envelope_subpath_verification_from_report`) fails identically on unmodified `HEAD` (verified via `git stash`) — pre-existing, unrelated to this change.

## Open Items

- `report_to_receipt_converter.py`'s `_check_branch_on_origin`/`_check_pr_delivery` (OI-1203) shares the same dispatch-id-derived branch assumption as a narrower fallback path (only reached when a report's `pr_ref` is missing/unparseable). Not fixed here — flagged as a follow-up if it starts producing its own false failures.