### PR TITLE
fix(ci-gate): repair five stale closure_verifier branch-matching tests (OI-1375)

### DIFF
--- a/scripts/ci/test_exclusions.txt
+++ b/scripts/ci/test_exclusions.txt
@@ -113,7 +113,6 @@ tests/test_billing_safety.py  # OI-951: doc/content drift the test already asser
 tests/test_build_t0_state_exception_handling.py  # OI-1227: red solo — build_t0_state.py exited 1 on main (1 failed, 1 passed)
 tests/test_burnin_certification.py  # hangs without VNX_HEADLESS_CLI=echo; covered by burn-in-headless.yml
 tests/test_busy_terminal_certification.py  # OI-1227: red solo — rc_check_terminal call not found in busy-term dispatch (6 failed, 5 errors, 35 passed)
-tests/test_ci_gate.py  # OI-1227: red solo — closure-verifier gate rejects/misses report_path + contract hash (5 failed, 17 passed)
 tests/test_claude_github_review_linkage.py  # OI-1227: red solo — MagicMock not JSON serializable in request handler (3 failed, 33 passed)
 tests/test_cleanup_stale_vnx_sessions.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
 tests/test_cli_flag_forwarding.py  # OI-1227: red solo — RGM lambda got unexpected kwarg 'strict' (1 failed, 17 passed)

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -342,6 +342,9 @@ def test_closure_verifier_ci_gate_pass(gate_env):
         "advisory_findings": [],
         "contract_hash": "abcd1234abcd1234",
         "report_path": str(report_file),
+        # ADR-005: a result without a matching branch is stale evidence and
+        # gets rejected by _find_gate_result, regardless of its other fields.
+        "branch": "feat/test",
     }
     (results_dir / "pr-99-ci_gate.json").write_text(
         json.dumps(result_data), encoding="utf-8",
@@ -382,6 +385,9 @@ def test_closure_verifier_ci_gate_fail_one_blocking(gate_env):
         "advisory_findings": [],
         "contract_hash": "abcd1234abcd1234",
         "report_path": str(report_file),
+        # ADR-005: a result without a matching branch is stale evidence and
+        # gets rejected by _find_gate_result, regardless of its other fields.
+        "branch": "feat/test",
     }
     (results_dir / "pr-100-ci_gate.json").write_text(
         json.dumps(result_data), encoding="utf-8",
@@ -399,7 +405,14 @@ def test_closure_verifier_ci_gate_fail_one_blocking(gate_env):
     ci_check = next((c for c in checks if c.name == "gate_ci_gate"), None)
     assert ci_check is not None
     assert ci_check.status == "FAIL"
-    assert "blocking" in ci_check.detail.lower() or "1" in ci_check.detail
+    # gate_status.is_pass() checks `status in FAIL_STATES` before it ever
+    # inspects blocking_findings/blocking_count, so an explicit status="fail"
+    # always reports as "status: fail" — the blocking_count in this fixture
+    # never reaches the detail string. This was true before ADR-005 too; the
+    # old "blocking"/"1" assertion never actually observed real behavior
+    # because the branch bug always short-circuited to "no ci_gate result
+    # found" first.
+    assert "status: fail" in ci_check.detail
 
 
 def test_closure_verifier_ci_gate_running_is_fail(gate_env):
@@ -421,6 +434,9 @@ def test_closure_verifier_ci_gate_running_is_fail(gate_env):
         "advisory_findings": [],
         "contract_hash": "",
         "report_path": "",
+        # ADR-005: a result without a matching branch is stale evidence and
+        # gets rejected by _find_gate_result, regardless of its other fields.
+        "branch": "feat/test",
     }
     (results_dir / "pr-101-ci_gate.json").write_text(
         json.dumps(result_data), encoding="utf-8",
@@ -460,6 +476,9 @@ def test_closure_verifier_ci_gate_rejects_empty_report_path(gate_env):
         "advisory_findings": [],
         "contract_hash": "abcd1234abcd1234",
         "report_path": "",  # empty — should be rejected
+        # ADR-005: a result without a matching branch is stale evidence and
+        # gets rejected by _find_gate_result, regardless of its other fields.
+        "branch": "feat/test",
     }
     (results_dir / "pr-102-ci_gate.json").write_text(
         json.dumps(result_data), encoding="utf-8",
@@ -501,6 +520,9 @@ def test_closure_verifier_ci_gate_rejects_empty_contract_hash(gate_env):
         "advisory_findings": [],
         "contract_hash": "",  # empty — should be rejected
         "report_path": str(report_file),
+        # ADR-005: a result without a matching branch is stale evidence and
+        # gets rejected by _find_gate_result, regardless of its other fields.
+        "branch": "feat/test",
     }
     (results_dir / "pr-103-ci_gate.json").write_text(
         json.dumps(result_data), encoding="utf-8",
@@ -519,6 +541,54 @@ def test_closure_verifier_ci_gate_rejects_empty_contract_hash(gate_env):
     assert ci_check is not None
     assert ci_check.status == "FAIL"
     assert "contract_hash" in ci_check.detail
+
+
+def test_closure_verifier_ci_gate_rejects_result_missing_branch_field(gate_env):
+    """ADR-005 pin: a result with no ``branch`` field at all is stale evidence
+    and must be rejected the same as a result for a different branch — even
+    though every other field (status/contract_hash/report_path) is valid.
+    Without this test the five tests above could regress back to writing
+    branch-less fixtures and still pass, because they'd merely be asserting
+    on whatever detail _find_gate_result happens to produce for "no match"."""
+    import closure_verifier as cv
+    from review_contract import ReviewContract
+
+    results_dir = gate_env["results_dir"]
+    pr_id = "PR-104"
+    report_file = gate_env["headless_reports_dir"] / "test-ci_gate-pr-104.md"
+    report_file.write_text("# ci_gate report\nStatus: PASS\n", encoding="utf-8")
+
+    result_data = {
+        "gate": "ci_gate",
+        "pr_id": pr_id,
+        "pr_number": 104,
+        "status": "pass",
+        "blocking_count": 0,
+        "advisory_count": 0,
+        "blocking_findings": [],
+        "advisory_findings": [],
+        "contract_hash": "abcd1234abcd1234",
+        "report_path": str(report_file),
+        # Deliberately no "branch" field — this is the stale-evidence shape
+        # ADR-005 exists to reject.
+    }
+    (results_dir / "pr-104-ci_gate.json").write_text(
+        json.dumps(result_data), encoding="utf-8",
+    )
+
+    contract = ReviewContract(
+        pr_id=pr_id,
+        branch="feat/test",
+        review_stack=["ci_gate"],
+        risk_class="medium",
+        changed_files=[],
+        content_hash="",
+    )
+    checks = cv._validate_review_evidence(contract, results_dir)
+    ci_check = next((c for c in checks if c.name == "gate_ci_gate"), None)
+    assert ci_check is not None
+    assert ci_check.status == "FAIL"
+    assert ci_check.detail == "no ci_gate result found"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes OI-1375: `tests/test_ci_gate.py` was quarantined (line 116 of `scripts/ci/test_exclusions.txt`), not a CI-vs-local divergence — CI never ran the file.
- Root cause: ADR-005 rejects a `ci_gate` result whose `branch` field doesn't match the contract's branch. Five tests built a `ReviewContract(branch="feat/test")` but wrote result JSON with no `branch` field, so `_find_gate_result` rejected the fixture as stale and every assertion failed on `"no ci_gate result found"` instead of the specific reason it claimed to check. Production code (`closure_verifier.py`, `gate_status.py`) is untouched — only the stale fixtures were wrong.
- A sixth, related bug surfaced once the branch match succeeded: `test_closure_verifier_ci_gate_fail_one_blocking` asserted the detail would mention "blocking"/"1", but `gate_status.is_pass()` checks `status in FAIL_STATES` before it ever inspects `blocking_findings`, so an explicit `status="fail"` always reports `"status: fail"`. That assertion never matched real behavior — it just never got far enough to observe it before this fix.

## Changes
- `tests/test_ci_gate.py`: added `"branch": "feat/test"` to the five stale result fixtures, with a comment on each explaining why (ADR-005 stale-evidence rejection). Corrected the `fail_one_blocking` assertion to match verified `gate_status.is_pass()` precedence. Added `test_closure_verifier_ci_gate_rejects_result_missing_branch_field` pinning the ADR-005 rejection itself, so the stale-fixture assumption can't silently regress.
- `scripts/ci/test_exclusions.txt`: removed the `tests/test_ci_gate.py` quarantine line — the file is green and rejoins the Profile A sweep.

## Verification
- `python3 -m pytest tests/test_ci_gate.py -q` → `26 passed`
- `python3 -m pytest tests/test_closure_verifier.py -q` → `38 passed, 7 warnings` (pre-existing legacy-`verdict` deprecation warnings, unrelated to this change)
- `python3 scripts/ci/check_test_exclusions.py` → `PASS — every exclusion carries a reason, paths resolve, no duplicates.`
- `grep -n test_ci_gate scripts/ci/test_exclusions.txt` → empty

Per dispatch instructions, this PR's own CI run drives the full Profile A sweep over the whole tree — that sweep was not run locally.

## Open Items
None

Dispatch-ID: 20260821-q4-ci-gate-tests-dequarantine