### PR TITLE
feat(gate-obligation-runner): scoped --since / --dispatch-prefix (OI-1378)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -50,7 +50,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
@@ -101,6 +101,93 @@ def utc_now_iso() -> str:
     from datetime import datetime, timezone  # noqa: PLC0415
 
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Scope filtering (OI-1378: --since / --dispatch-prefix)
+# ---------------------------------------------------------------------------
+
+_DISPATCH_ID_DATE_RE = re.compile(r"^(\d{4})(\d{2})(\d{2})-")
+
+
+def _parse_declared_at_date(value: Any) -> Optional[str]:
+    """Return the ``YYYY-MM-DD`` prefix of a parseable ISO8601 ``declared_at``.
+
+    Returns None when the value is missing, blank, or not a parseable
+    timestamp — the caller falls back to the dispatch_id date prefix rather
+    than guess.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    from datetime import datetime  # noqa: PLC0415
+
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return text[:10]
+
+
+def _dispatch_id_date(dispatch_id: str) -> Optional[str]:
+    """Return the ``YYYY-MM-DD`` date prefix of a ``YYYYMMDD-...`` dispatch_id."""
+    match = _DISPATCH_ID_DATE_RE.match(dispatch_id or "")
+    if not match:
+        return None
+    year, month, day = match.groups()
+    from datetime import date  # noqa: PLC0415
+
+    try:
+        date(int(year), int(month), int(day))
+    except ValueError:
+        return None
+    return f"{year}-{month}-{day}"
+
+
+def _obligation_scope_date(record: Dict[str, Any], dispatch_id: str) -> Optional[str]:
+    """Resolve the date used to test an obligation against ``--since``.
+
+    Prefers ``declared_at``; falls back to the dispatch_id's date prefix when
+    ``declared_at`` is absent or unparseable. Returns None when neither source
+    yields a real date — an obligation with no known date counts as OUT of
+    scope under an active ``--since`` (scope means scope, no silent inclusion).
+    """
+    return _parse_declared_at_date(record.get("declared_at")) or _dispatch_id_date(dispatch_id)
+
+
+def _valid_since_date(value: str) -> str:
+    """argparse type= validator for ``--since``: must be a real YYYY-MM-DD date."""
+    from datetime import date  # noqa: PLC0415
+
+    parts = value.split("-")
+    try:
+        if len(parts) != 3:
+            raise ValueError(value)
+        date(int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"invalid --since date {value!r}: expected YYYY-MM-DD"
+        ) from None
+    return value
+
+
+def _in_scope(
+    path: Path,
+    record: Dict[str, Any],
+    *,
+    since: Optional[str],
+    dispatch_prefix: Optional[str],
+) -> bool:
+    """Whether an obligation is inside the ``--since`` / ``--dispatch-prefix`` scope."""
+    dispatch_id = str(record.get("dispatch_id") or path.stem)
+    if dispatch_prefix and not dispatch_id.startswith(dispatch_prefix):
+        return False
+    if since:
+        scope_date = _obligation_scope_date(record, dispatch_id)
+        if scope_date is None or scope_date < since:
+            return False
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -572,8 +659,21 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
 # ---------------------------------------------------------------------------
 
 
-def run(state_dir: Path, *, write: bool = True) -> Dict[str, Any]:
-    """Fulfil every pending obligation under ``state_dir``. Returns a summary."""
+def run(
+    state_dir: Path,
+    *,
+    write: bool = True,
+    since: Optional[str] = None,
+    dispatch_prefix: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fulfil every in-scope pending obligation under ``state_dir``. Returns a summary.
+
+    ``since`` (``YYYY-MM-DD``) and ``dispatch_prefix`` narrow which obligations
+    are processed — combinable as an AND. ``obligations_seen`` always reports
+    the full store (unaffected by scope); ``obligations_in_scope`` and
+    ``pending_after`` are scope-filtered. With neither argument, scope is the
+    full store and behavior is unchanged from before scoping existed.
+    """
     state_dir = Path(state_dir)
     outcomes: List[Dict[str, Any]] = []
     pending_after = 0
@@ -588,7 +688,12 @@ def run(state_dir: Path, *, write: bool = True) -> Dict[str, Any]:
             "outcomes": [],
             "pending_after": -1,
         }
-    for path, record in obligations:
+    scoped: List[Tuple[Path, Dict[str, Any]]] = [
+        (path, record)
+        for path, record in obligations
+        if _in_scope(path, record, since=since, dispatch_prefix=dispatch_prefix)
+    ]
+    for path, record in scoped:
         if record.get("status", STATUS_PENDING) in TERMINAL_STATUSES:
             continue
         if not write:
@@ -609,6 +714,9 @@ def run(state_dir: Path, *, write: bool = True) -> Dict[str, Any]:
         "state_dir": str(state_dir),
         "timestamp": utc_now_iso(),
         "obligations_seen": len(obligations),
+        "obligations_in_scope": len(scoped),
+        "since": since,
+        "dispatch_prefix": dispatch_prefix,
         "outcomes": outcomes,
         "pending_after": pending_after,
         "unresolvable_after": sum(
@@ -652,6 +760,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--no-write", action="store_true",
         help="Dry run: report pending obligations without fulfilling them",
     )
+    parser.add_argument(
+        "--since", type=_valid_since_date, default=None,
+        help=(
+            "Only process obligations declared on/after this date (YYYY-MM-DD). "
+            "Falls back to the dispatch_id date prefix when declared_at is "
+            "missing/unparseable; an obligation with neither is out of scope."
+        ),
+    )
+    parser.add_argument(
+        "--dispatch-prefix", default=None,
+        help="Only process obligations whose dispatch_id starts with this string",
+    )
     parser.add_argument("--json", action="store_true", help="Machine-readable output")
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args(argv)
@@ -670,7 +790,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"ERROR: state dir not found: {state_dir}", file=sys.stderr)
         return 20
 
-    summary = run(state_dir, write=not args.no_write)
+    summary = run(
+        state_dir,
+        write=not args.no_write,
+        since=args.since,
+        dispatch_prefix=args.dispatch_prefix,
+    )
     if args.json:
         print(json.dumps(summary, indent=2))
     else:

--- a/tests/test_gate_obligation_runner_scope.py
+++ b/tests/test_gate_obligation_runner_scope.py
@@ -1,0 +1,283 @@
+"""tests/test_gate_obligation_runner_scope.py — OI-1378: --since / --dispatch-prefix.
+
+The obligation runner works but has never run write=True against the live
+store: 328 pending obligations at once is weeks of backlog in one shot. This
+pins the scope filter that lets the runner be pointed at a slice (the last
+week, or one dispatch-id prefix) instead of the whole backlog.
+
+Filter contract:
+  - ``--since YYYY-MM-DD`` filters on ``declared_at``; falls back to the
+    dispatch_id's ``YYYYMMDD-`` date prefix when ``declared_at`` is missing or
+    unparseable; an obligation with neither is OUT of scope under an active
+    ``--since`` (scope means scope, no silent inclusion).
+  - ``--dispatch-prefix`` filters on a literal dispatch_id prefix.
+  - Combinable as AND.
+  - With neither flag, behavior is byte-for-byte unchanged: same
+    ``obligations_seen`` and same ``pending_after`` as before scoping existed.
+  - The scope itself (``since``, ``dispatch_prefix``, ``obligations_in_scope``)
+    is reported in the JSON summary alongside the existing ``obligations_seen``.
+
+Tests run against throwaway dirs under tmp_path — never ~/.vnx-data/.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import gate_obligation_runner as runner  # noqa: E402
+from gate_obligations import (  # noqa: E402
+    STATUS_PENDING,
+    obligation_path,
+    register_obligation,
+    update_obligation,
+)
+
+
+def _state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "vnx-data" / "state"
+    (state_dir / "review_gates" / "obligations").mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _make_obligation(
+    state_dir: Path,
+    *,
+    dispatch_id: str,
+    gate: str = "codex_gate",
+    declared_at: str | None = "__default__",
+) -> Path:
+    """Register a pending obligation, optionally overriding declared_at.
+
+    ``declared_at="__default__"`` leaves register_obligation's own timestamp;
+    any other value (including None) is stamped over it via update_obligation
+    so tests can simulate a missing/legacy declared_at field.
+    """
+    path = register_obligation(state_dir, dispatch_id=dispatch_id, gate=gate)
+    assert path is not None
+    if declared_at != "__default__":
+        update_obligation(path, declared_at=declared_at)
+    return path
+
+
+def _read(state_dir: Path, dispatch_id: str) -> dict:
+    import json
+
+    return json.loads(obligation_path(state_dir, dispatch_id).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# --since
+# ---------------------------------------------------------------------------
+
+
+def test_since_excludes_older_and_keeps_newer(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(
+        state_dir, dispatch_id="20260810-old-oblig", declared_at="2026-08-10T09:00:00Z",
+    )
+    _make_obligation(
+        state_dir, dispatch_id="20260820-new-oblig", declared_at="2026-08-20T09:00:00Z",
+    )
+
+    summary = runner.run(state_dir, write=False, since="2026-08-14")
+
+    assert summary["obligations_in_scope"] == 1
+    assert summary["pending_after"] == 1
+    dispatch_ids = {o["dispatch_id"] for o in summary["outcomes"]}
+    assert dispatch_ids == {"20260820-new-oblig"}
+
+
+# ---------------------------------------------------------------------------
+# --dispatch-prefix
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_prefix_filters_by_prefix(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(state_dir, dispatch_id="20260820-q1-alpha")
+    _make_obligation(state_dir, dispatch_id="20260820-q2-beta")
+
+    summary = runner.run(state_dir, write=False, dispatch_prefix="20260820-q1")
+
+    assert summary["obligations_in_scope"] == 1
+    assert summary["pending_after"] == 1
+    dispatch_ids = {o["dispatch_id"] for o in summary["outcomes"]}
+    assert dispatch_ids == {"20260820-q1-alpha"}
+
+
+# ---------------------------------------------------------------------------
+# Combined: AND
+# ---------------------------------------------------------------------------
+
+
+def test_since_and_dispatch_prefix_combine_as_and(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    # Matches both filters.
+    _make_obligation(
+        state_dir, dispatch_id="20260820-q1-match", declared_at="2026-08-20T09:00:00Z",
+    )
+    # Right prefix, wrong date (too old) — excluded by --since.
+    _make_obligation(
+        state_dir, dispatch_id="20260810-q1-tooold", declared_at="2026-08-10T09:00:00Z",
+    )
+    # Right date, wrong prefix — excluded by --dispatch-prefix.
+    _make_obligation(
+        state_dir, dispatch_id="20260820-other-branch", declared_at="2026-08-20T09:00:00Z",
+    )
+
+    summary = runner.run(
+        state_dir, write=False, since="2026-08-14", dispatch_prefix="20260820-q1",
+    )
+
+    assert summary["obligations_in_scope"] == 1
+    assert summary["pending_after"] == 1
+    dispatch_ids = {o["dispatch_id"] for o in summary["outcomes"]}
+    assert dispatch_ids == {"20260820-q1-match"}
+
+
+# ---------------------------------------------------------------------------
+# No flags: unchanged behavior
+# ---------------------------------------------------------------------------
+
+
+def test_no_flags_behaves_identically_to_unscoped(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(
+        state_dir, dispatch_id="20260810-old-oblig", declared_at="2026-08-10T09:00:00Z",
+    )
+    _make_obligation(
+        state_dir, dispatch_id="20260820-new-oblig", declared_at="2026-08-20T09:00:00Z",
+    )
+    _make_obligation(state_dir, dispatch_id="no-date-here-oblig", declared_at=None)
+
+    baseline = runner.run(state_dir, write=False)
+    scoped_but_open = runner.run(state_dir, write=False, since=None, dispatch_prefix=None)
+
+    assert baseline["obligations_seen"] == 3
+    assert baseline["pending_after"] == 3
+    assert baseline["obligations_in_scope"] == baseline["obligations_seen"]
+    assert scoped_but_open["obligations_seen"] == baseline["obligations_seen"]
+    assert scoped_but_open["pending_after"] == baseline["pending_after"]
+
+
+# ---------------------------------------------------------------------------
+# declared_at fallback / missing-both exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_missing_declared_at_falls_back_to_dispatch_id_date_prefix(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(state_dir, dispatch_id="20260810-nodate-oblig", declared_at=None)
+
+    included = runner.run(state_dir, write=False, since="2026-08-05")
+    excluded = runner.run(state_dir, write=False, since="2026-08-15")
+
+    assert included["obligations_in_scope"] == 1
+    assert included["pending_after"] == 1
+    assert excluded["obligations_in_scope"] == 0
+    assert excluded["pending_after"] == 0
+
+
+def test_missing_both_is_out_of_scope_only_when_since_active(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(state_dir, dispatch_id="no-date-here-oblig", declared_at=None)
+
+    without_since = runner.run(state_dir, write=False)
+    with_since = runner.run(state_dir, write=False, since="2026-01-01")
+
+    assert without_since["obligations_in_scope"] == 1
+    assert without_since["pending_after"] == 1
+    assert with_since["obligations_in_scope"] == 0
+    assert with_since["pending_after"] == 0
+
+
+def test_unparseable_declared_at_falls_back_to_dispatch_id_date_prefix(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(
+        state_dir, dispatch_id="20260812-garbage-timestamp", declared_at="not-a-date",
+    )
+
+    included = runner.run(state_dir, write=False, since="2026-08-01")
+    excluded = runner.run(state_dir, write=False, since="2026-08-13")
+
+    assert included["obligations_in_scope"] == 1
+    assert excluded["obligations_in_scope"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Scope fields land in the JSON summary
+# ---------------------------------------------------------------------------
+
+
+def test_scope_fields_present_in_summary(tmp_path):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(
+        state_dir, dispatch_id="20260820-q1-scoped", declared_at="2026-08-20T09:00:00Z",
+    )
+    _make_obligation(
+        state_dir, dispatch_id="20260801-out-of-scope", declared_at="2026-08-01T09:00:00Z",
+    )
+
+    summary = runner.run(
+        state_dir, write=False, since="2026-08-14", dispatch_prefix="20260820",
+    )
+
+    assert summary["since"] == "2026-08-14"
+    assert summary["dispatch_prefix"] == "20260820"
+    assert summary["obligations_in_scope"] == 1
+    assert summary["obligations_seen"] == 2
+
+
+def test_scope_fields_present_via_cli_json(tmp_path, capsys):
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(
+        state_dir, dispatch_id="20260820-cli-scoped", declared_at="2026-08-20T09:00:00Z",
+    )
+
+    rc = runner.main(
+        [
+            "--state-dir", str(state_dir),
+            "--no-write", "--json",
+            "--since", "2026-08-14",
+            "--dispatch-prefix", "20260820",
+        ]
+    )
+    out = capsys.readouterr().out
+    import json
+
+    payload = json.loads(out)
+    assert payload["since"] == "2026-08-14"
+    assert payload["dispatch_prefix"] == "20260820"
+    assert payload["obligations_in_scope"] == 1
+    assert rc == 11  # one obligation still pending within scope
+
+
+# ---------------------------------------------------------------------------
+# --since validation
+# ---------------------------------------------------------------------------
+
+
+def test_since_rejects_malformed_date(tmp_path, capsys):
+    state_dir = _state_dir(tmp_path)
+    import pytest
+
+    with pytest.raises(SystemExit):
+        runner.main(["--state-dir", str(state_dir), "--no-write", "--since", "not-a-date"])
+    err = capsys.readouterr().err
+    assert "--since" in err
+
+
+def test_registered_obligation_status_untouched_by_scope_check(tmp_path):
+    """Sanity: scope filtering happens before the terminal-status skip, and a
+    freshly registered obligation is still pending — the filter itself never
+    mutates records."""
+    state_dir = _state_dir(tmp_path)
+    _make_obligation(state_dir, dispatch_id="20260820-untouched")
+    runner.run(state_dir, write=False, since="2026-08-01")
+    assert _read(state_dir, "20260820-untouched")["status"] == STATUS_PENDING


### PR DESCRIPTION
## Summary
- Add `--since YYYY-MM-DD` and `--dispatch-prefix <str>` to `scripts/gate_obligation_runner.py`, combinable as AND, so the obligation backlog can be worked in slices instead of all at once.
- `--since` filters on `declared_at`; falls back to the `dispatch_id`'s `YYYYMMDD-` date prefix when `declared_at` is missing/unparseable; an obligation with neither is out of scope while `--since` is active (no silent inclusion).
- JSON summary gains `since`, `dispatch_prefix`, `obligations_in_scope` alongside the existing `obligations_seen`; `pending_after` now counts within scope only.
- Exit codes untouched: 11 when `pending_after > 0`, 0 when zero, 20 on error.
- Filter lives in `run()`, not `main()` — same function the tests call.

## Test plan
- [x] `python3 -m pytest tests/test_gate_obligation_runner_scope.py -q` — 11 passed
- [x] `python3 -m pytest tests/test_gate_obligation_runner.py -q` — 16 passed
- [x] `python3 -m pytest tests/test_gate_obligations.py -q` — 18 passed
- [x] Live-store dry run without flags: `obligations_seen=456 obligations_in_scope=456 pending_after=333` (drifted up from the 451/328 cited in the dispatch brief — the store is live and kept accumulating obligations between the original measurement and this run; the no-flag code path is provably unchanged since scope defaults to the full set)
- [x] Live-store dry run `--since 2026-08-14`: `obligations_in_scope=261 pending_after=261`
- [x] rc=11 in both runs above (pending_after > 0)

Dispatch-ID: 20260821-q1-obligation-runner-since

🤖 Generated with [Claude Code](https://claude.com/claude-code)