### PR TITLE
fix(gate-obligation-runner): temporary gate refusal stays pending (OI-1384)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -78,6 +78,25 @@ _GH_TIMEOUT_SECONDS = 20
 # monitor uses before flagging a silently-pending gate key.
 _UNRESOLVABLE_ESCALATION_ATTEMPTS = 96
 
+# A gate RESULT can itself report a TEMPORARY refusal rather than a real
+# verdict on the code: ``status=running`` means a CI check is still in flight
+# (gate_executor's ci_gate path — not all checks reached a terminal bucket
+# yet), and ``status=not_executable`` with ``reason=provider_disabled`` means
+# the gate is parked by config (e.g. VNX_CI_GATE_REQUIRED=0 —
+# gate_result_parser._classify_unavailable / gate_request_handler
+# ._mark_gate_unavailable). Neither says anything about the code; both are
+# "not yet", not "no". Treating either as terminal burns the obligation
+# forever — measured live against PR #1627 (OI-1384): CI had actually passed,
+# but the recorded obligation was a dead not_executable/provider_disabled with
+# no report_path, no contract_hash, no branch, no commit_sha. Same shape as
+# the ``unresolvable`` PR-resolution path below: stays pending under a
+# bounded retry term, then escalates to the loud terminal not_executable — a
+# temporary refusal that recurs forever must still eventually alarm someone,
+# just not on the first attempt.
+_TEMPORARY_RESULT_STATUSES = frozenset({"running"})
+_TEMPORARY_NOT_EXECUTABLE_REASONS = frozenset({"provider_disabled"})
+_TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
+
 # PR-resolution outcomes. The runner must tell "no PR yet" (a wait) apart from
 # "cannot resolve because the environment is wrong" (a fault) IN THE RECORD,
 # not only in a log line — a pending obligation that is actually misconfigured
@@ -602,11 +621,74 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
         # leaves a loud not_executable/failed RESULT record — the obligation
         # must tell the same truth, not a cosmetic "fulfilled".
         result_status = ""
+        result_reason = ""
         try:
             if result_file.exists():
-                result_status = str(json.loads(result_file.read_text(encoding="utf-8")).get("status") or "")
+                result_data = json.loads(result_file.read_text(encoding="utf-8"))
+                result_status = str(result_data.get("status") or "")
+                result_reason = str(result_data.get("reason") or "")
         except (OSError, json.JSONDecodeError) as exc:
             _LOG.debug("result status unreadable for pr-%s-%s: %s", pr_number, gate, exc)
+
+        if result_status in _TEMPORARY_RESULT_STATUSES:
+            temp_reason = "gate_run_in_progress"
+            temp_detail = (
+                f"{gate} for PR #{pr_number} is still running — no verdict yet, "
+                "not a failure; will be re-attempted on the next run"
+            )
+        elif result_status == STATUS_NOT_EXECUTABLE and result_reason in _TEMPORARY_NOT_EXECUTABLE_REASONS:
+            temp_reason = "gate_parked"
+            temp_detail = (
+                f"{gate} is parked ({result_reason}: a config flag has it disabled), "
+                "not broken — the obligation waits for it to be re-enabled or for a "
+                "future run, not permanently refused"
+            )
+        else:
+            temp_reason = None
+            temp_detail = None
+
+        if temp_reason is not None:
+            # Same shape as the `unresolvable` PR-resolution path: stays
+            # pending under a bounded retry term, then escalates loudly
+            # (OI-1384) — never burns the obligation on the first temporary
+            # refusal.
+            update_obligation(
+                path,
+                status=STATUS_PENDING,
+                pr_number=pr_number,
+                branch=branch,
+                attempts=attempts,
+                last_attempt_at=now,
+                request_path=str(manager._request_path(gate, pr_number)),
+                result_path=str(result_file),
+                reason=temp_reason,
+                reason_detail=temp_detail,
+            )
+            outcome["action"] = "pending"
+            outcome["detail"] = temp_detail
+            if attempts >= _TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS:
+                escalation_detail = (
+                    f"{gate} stayed temporarily unavailable ({temp_reason}) for "
+                    f"{attempts} attempts (last status={result_status!r}, "
+                    f"reason={result_reason!r}) — escalating to a loud terminal failure"
+                )
+                update_obligation(
+                    path,
+                    status=STATUS_NOT_EXECUTABLE,
+                    pr_number=pr_number,
+                    branch=branch,
+                    attempts=attempts,
+                    last_attempt_at=now,
+                    resolved_at=utc_now_iso(),
+                    request_path=str(manager._request_path(gate, pr_number)),
+                    result_path=str(result_file),
+                    reason=f"{temp_reason}_timeout",
+                    reason_detail=escalation_detail,
+                )
+                outcome["action"] = "not_executable"
+                outcome["detail"] = escalation_detail
+            return outcome
+
         terminal = result_status if result_status in TERMINAL_STATUSES else STATUS_FULFILLED
         updated = update_obligation(
             path,

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -103,11 +103,23 @@ def _read_obligation(state_dir: Path, dispatch_id: str) -> dict:
 
 class _FakeManager:
     """Stands in for ReviewGateManager: writes the request+result records the
-    real manager's request_and_execute produces, without running any gate."""
+    real manager's request_and_execute produces, without running any gate.
 
-    def __init__(self, state_dir: Path, *, boom: bool = False) -> None:
+    ``result_status``/``result_reason`` let a test control what the gate
+    RESULT record reports (e.g. ``status="not_executable", reason=
+    "provider_disabled"`` for a parked gate, or ``status="running"`` for an
+    in-flight CI check) — OI-1384 fixtures for the runner's temporary-vs-
+    permanent-refusal distinction.
+    """
+
+    def __init__(
+        self, state_dir: Path, *, boom: bool = False,
+        result_status: str = "completed", result_reason: str | None = None,
+    ) -> None:
         self.state_dir = Path(state_dir)
         self.boom = boom
+        self.result_status = result_status
+        self.result_reason = result_reason
         self.calls = []
 
     def _request_path(self, gate: str, pr_number: int) -> Path:
@@ -128,8 +140,11 @@ class _FakeManager:
                 json.dumps({"gate": gate, "pr_number": pr_number, "status": "completed"}),
                 encoding="utf-8",
             )
+            result_payload = {"gate": gate, "pr_number": pr_number, "status": self.result_status}
+            if self.result_reason is not None:
+                result_payload["reason"] = self.result_reason
             self._result_path(gate, pr_number).write_text(
-                json.dumps({"gate": gate, "pr_number": pr_number, "status": "completed"}),
+                json.dumps(result_payload),
                 encoding="utf-8",
             )
         return {"pr_number": pr_number, "branch": branch, "gates": [], "has_required_failure": False}
@@ -404,6 +419,99 @@ def test_runner_never_refires_terminal_obligations(tmp_path, monkeypatch):
 
     assert summary["pending_after"] == 0
     assert manager.calls == [], "a fulfilled obligation must never re-fire the gate"
+
+
+# ---------------------------------------------------------------------------
+# 2b. OI-1384: a TEMPORARY refusal must not burn the obligation terminal.
+# ---------------------------------------------------------------------------
+
+
+def test_runner_leaves_pending_on_provider_disabled_result(tmp_path, monkeypatch):
+    """reason=provider_disabled means the gate is PARKED by config (e.g.
+    VNX_CI_GATE_REQUIRED=0), not that anything is broken — measured live
+    against PR #1627, where CI had actually passed but the obligation still
+    died as a permanent not_executable. Must stay pending so a later run can
+    retry once the gate is unparked."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260821-oi1384-parked", gate="ci_gate",
+        project_id="vnx-dev", pr_number=1627,
+    )
+    manager = _FakeManager(state_dir, result_status="not_executable", result_reason="provider_disabled")
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 1
+    record = _read_obligation(state_dir, "20260821-oi1384-parked")
+    assert record["status"] == STATUS_PENDING
+    assert record["attempts"] == 1
+    assert record["reason"] == "gate_parked"
+    assert "parked" in record["reason_detail"]
+    assert "not broken" in record["reason_detail"]
+
+
+def test_runner_leaves_pending_on_running_result(tmp_path, monkeypatch):
+    """status=running means the CI check is still in flight — a "not yet",
+    not a verdict. Must stay pending, not be marked fulfilled or terminal."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260821-oi1384-running", gate="ci_gate",
+        project_id="vnx-dev", pr_number=1628,
+    )
+    manager = _FakeManager(state_dir, result_status="running")
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 1
+    record = _read_obligation(state_dir, "20260821-oi1384-running")
+    assert record["status"] == STATUS_PENDING
+    assert record["attempts"] == 1
+    assert record["reason"] == "gate_run_in_progress"
+
+
+def test_runner_still_terminates_a_genuinely_permanent_refusal(tmp_path, monkeypatch):
+    """The fix narrows what burns the obligation — it must not widen what
+    stays pending. A gate that is not_executable for a structural reason
+    (the provider binary is not installed, not "disabled by a flag") is a
+    real, permanent refusal and must still terminate on the first attempt."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260821-oi1384-real-refusal", gate="codex_gate",
+        project_id="vnx-dev", pr_number=1629,
+    )
+    manager = _FakeManager(state_dir, result_status="not_executable", result_reason="provider_not_installed")
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260821-oi1384-real-refusal")
+    assert record["status"] == STATUS_NOT_EXECUTABLE
+    assert record["attempts"] == 1
+
+
+def test_runner_escalates_temporary_refusal_to_not_executable_after_threshold(tmp_path, monkeypatch):
+    """A temporary refusal that recurs forever must still eventually escalate
+    loudly — same shape as the `unresolvable` PR-resolution escalation path —
+    just not on the first attempt."""
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="20260821-oi1384-escalate", gate="ci_gate",
+        project_id="vnx-dev", pr_number=1630,
+    )
+    update_obligation(path, attempts=runner._TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS - 1)
+    manager = _FakeManager(state_dir, result_status="not_executable", result_reason="provider_disabled")
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260821-oi1384-escalate")
+    assert record["status"] == STATUS_NOT_EXECUTABLE
+    assert record["reason"] == "gate_parked_timeout"
+    assert record["attempts"] == runner._TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `reason=provider_disabled` (gate parked by a config flag, e.g. `VNX_CI_GATE_REQUIRED=0`) and `status=running` (CI check still in flight) were being folded into `TERMINAL_STATUSES`, burning the obligation to a permanent `not_executable`/`fulfilled` on the very first attempt.
- Measured live against PR #1627: CI had actually passed, but the recorded obligation was dead anyway — no `report_path`, no `contract_hash`, no `branch`, no `commit_sha`. Fleet-wide, 113 obligations (61 `ci_gate`, 52 `codex_gate`) had already been burned this way before this fix.
- Both temporary conditions now stay `pending` with an incremented attempt counter and a reason that names the real state (`gate_parked` / `gate_run_in_progress`), so a later run retries them — same shape as the existing `unresolvable` PR-resolution path, escalating to a loud terminal `not_executable` only after the bounded retry term (`_TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS`, same 96-attempt/~24h window).
- A genuinely structural refusal (e.g. the gate binary is not installed — `reason=provider_not_installed`) is untouched and still terminates on the first attempt.

## Out of scope (per dispatch)
- Does NOT repair the 113 already-burned obligations — that's a separate, later decision.
- Does NOT enable the parked `VNX_CI_GATE_REQUIRED` gate or touch any other config flag.
- Does NOT touch `envelope_govern.py`, `dispatch_envelope.py`, `tmux_interactive_dispatch.py`, or `report_to_receipt_converter.py`.

## Test plan
- [x] `test_runner_leaves_pending_on_provider_disabled_result` — `reason=provider_disabled` stays `pending`
- [x] `test_runner_leaves_pending_on_running_result` — `status=running` stays `pending`
- [x] `test_runner_still_terminates_a_genuinely_permanent_refusal` — a real structural refusal still terminates immediately (required negative-control test)
- [x] `test_runner_escalates_temporary_refusal_to_not_executable_after_threshold` — bounded retries still escalate loudly
- [x] `pytest tests/test_gate_obligations.py tests/test_gate_obligation_runner.py tests/test_gate_obligation_runner_scope.py` → 49 passed
- [x] Scoped, writing run of the real (non-mocked) runner against a parked `ci_gate` in a scratch state dir, using `--dispatch-prefix` to hit exactly one obligation: before `attempts=0`, after two consecutive runs `attempts=2`, `status=pending` throughout — never burns.

Dispatch-ID: 20260821-a7-obligation-temporary-stays-pending