### PR TITLE
fix(envelope): degrade outcome on receipt-emit gap, never plain success (OI-1287)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -12,6 +12,14 @@ and never flipped into a `failed` work status. Report is emitted before the
 receipt so the receipt carries the linkage even when the report file is new
 (ADR-005).
 
+OI-1287: decoupling the work fate from the receipt fate must not also mean
+laundering a proof-chain gap into a plain "success". ``_envelope_outcome``
+(used by every envelope entry point below) degrades the caller-visible
+EnvelopeResult to status="receipt_missing"/returncode=1 whenever GOVERN's
+receipt_path comes back None for otherwise-successful work — never by
+rewriting the WORK status itself, only the dispatch-level outcome built on
+top of it.
+
 Per-lane dual-receipt safety: GOVERN emits both report AND receipt. When the
 receipt NDJSON already contains a line for this dispatch_id (e.g. written by
 deliver_with_recovery's internal close-out), the GOVERN receipt write is skipped
@@ -356,16 +364,58 @@ class LaneRouter:
 # Envelope entry point
 # ---------------------------------------------------------------------------
 
+# OI-1287: the WORK outcome (did the adapter finish its job) and the PROOF
+# outcome (did a ledger line land) are different facts. OI-1179 correctly
+# stopped a receipt-emit failure from flipping a successful dispatch to
+# `failed` — but the fix left the dispatch-level EnvelopeResult reading a
+# plain "success" with returncode 0 even when GOVERN reported no receipt_path
+# at all, so a proof-chain gap could land silently as a clean pass. This
+# status is stamped only in that gap — never in place of a real
+# "failure"/"timeout", and never by rewriting adapter_result.status itself
+# (envelope_govern._record_receipt_emit_failure's trail record still carries
+# the true work_status untouched).
+RECEIPT_MISSING_STATUS = "receipt_missing"
+
+
+def _envelope_outcome(
+    work_status: str, receipt_path: Optional[Path], error: Optional[str],
+) -> "tuple[str, int, Optional[str]]":
+    """Derive the caller-visible (status, returncode, error) for an
+    EnvelopeResult from the WORK status and whether GOVERN actually produced
+    a ledger receipt.
+
+    work_status == "success" with receipt_path is None is the OI-1287 proof-
+    chain gap: the outcome is degraded to RECEIPT_MISSING_STATUS/returncode 1
+    so it can never be mistaken for a clean pass, while work_status itself
+    (recorded separately in the receipt_emit_failures.ndjson trail written by
+    envelope_govern._record_receipt_emit_failure) is never rewritten. Every
+    other combination — including idempotent dedup, where receipt_path is a
+    real path pointing at the existing ledger — passes through unchanged.
+    """
+    if work_status == "success" and receipt_path is None:
+        return (
+            RECEIPT_MISSING_STATUS,
+            1,
+            error or (
+                "work succeeded but no ledger receipt was written "
+                "(proof-chain gap — see receipt_emit_failures.ndjson)"
+            ),
+        )
+    return work_status, (0 if work_status == "success" else 1), error
+
 
 def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
     """Run PREPARE -> ROUTE -> EXECUTE -> GOVERN for the given lane.
 
-    Returns EnvelopeResult on success / failure / timeout.
+    Returns EnvelopeResult on success / failure / timeout / receipt_missing.
 
     OI-1179: a receipt-emit failure no longer raises — ``_govern`` records a
     proof-chain gap (loud error log + ``receipt_emit_failures.ndjson`` trail)
-    and returns ``receipt_path=None``, so ``returncode`` still reflects whether
-    the WORK succeeded, never whether the proof landed.
+    and returns ``receipt_path=None``; the WORK status recorded in that trail
+    is never rewritten. OI-1287: ``_envelope_outcome`` still degrades the
+    returned status/returncode to "receipt_missing"/1 in that gap so the
+    caller-visible outcome is never a plain, unqualified "success" with no
+    ledger line behind it.
     """
     # ROUTE
     router = LaneRouter()
@@ -405,14 +455,16 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
         enriched_spec, adapter_result, start_time, end_time, integrity=integrity
     )
 
-    returncode = 0 if adapter_result.status == "success" else 1
+    _status, _returncode, _error = _envelope_outcome(
+        adapter_result.status, receipt_path, adapter_result.error,
+    )
     return EnvelopeResult(
-        status=adapter_result.status,
-        returncode=returncode,
+        status=_status,
+        returncode=_returncode,
         report_path=report_path,
         receipt_path=receipt_path,
         completion_text=adapter_result.completion_text,
-        error=adapter_result.error,
+        error=_error,
     )
 
 
@@ -647,13 +699,14 @@ def run_envelope_plan(
         base_ref=_base_ref,
     )
 
+    _status, _returncode, _error = _envelope_outcome(result.status, receipt_path, result.error)
     return EnvelopeResult(
-        status=result.status,
-        returncode=0 if result.status == "success" else 1,
+        status=_status,
+        returncode=_returncode,
         report_path=report_path,
         receipt_path=receipt_path,
         completion_text=result.completion_text,
-        error=result.error,
+        error=_error,
     )
 
 
@@ -862,11 +915,12 @@ def run_envelope_headless_plan(
         base_ref=_base_ref,
     )
 
+    _status, _returncode, _error = _envelope_outcome(result.status, receipt_path, result.error)
     return EnvelopeResult(
-        status=result.status,
-        returncode=0 if result.status == "success" else 1,
+        status=_status,
+        returncode=_returncode,
         report_path=report_path,
         receipt_path=receipt_path,
         completion_text=result.completion_text,
-        error=result.error,
+        error=_error,
     )

--- a/scripts/lib/envelope_types.py
+++ b/scripts/lib/envelope_types.py
@@ -48,9 +48,18 @@ class EnvelopeSpec:
 
 @dataclass
 class EnvelopeResult:
-    """Outcome from a complete envelope run."""
+    """Outcome from a complete envelope run.
 
-    status: str           # "success" | "failure" | "timeout"
+    OI-1287: ``status`` carries one more value than the adapter's own three —
+    ``"receipt_missing"`` — stamped by ``dispatch_envelope._envelope_outcome``
+    only when the WORK succeeded but GOVERN produced no ledger receipt (a
+    proof-chain gap). It is never used in place of a genuine "failure"/
+    "timeout", and the underlying WORK status is never rewritten to produce
+    it — see ``envelope_govern._record_receipt_emit_failure``'s trail record
+    for that untouched value.
+    """
+
+    status: str           # "success" | "failure" | "timeout" | "receipt_missing"
     returncode: int
     report_path: Optional[Path]
     receipt_path: Optional[Path]

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -16,112 +16,112 @@
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 34,
+      "line": 35,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "EnvelopeSpec"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 35,
+      "line": 36,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "LaneRouter"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 36,
+      "line": 37,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 236,
+      "line": 237,
       "mechanism": "patch-string",
       "module_target": "envelope_govern",
       "symbol": "_archive_dispatch_events"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 237,
+      "line": 238,
       "mechanism": "patch-string",
       "module_target": "envelope_govern",
       "symbol": "_clear_dispatch_events"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 390,
+      "line": 398,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 395,
+      "line": 403,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 611,
+      "line": 622,
       "mechanism": "logger-name",
       "module_target": "envelope_govern_support",
       "symbol": ""
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 645,
+      "line": 656,
       "mechanism": "logger-name",
       "module_target": "envelope_govern_support",
       "symbol": ""
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 647,
+      "line": 658,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_receipt_exists_for_dispatch"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 838,
+      "line": 849,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 920,
+      "line": 931,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 945,
+      "line": 956,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 980,
+      "line": 991,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 1001,
+      "line": 1012,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 1016,
+      "line": 1027,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -512,6 +512,20 @@
       "symbol": "_govern"
     },
     {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 860,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 861,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
       "file": "tests/test_envelope_govern_contract_enforce.py",
       "line": 39,
       "mechanism": "direct-call",
@@ -744,42 +758,63 @@
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 342,
+      "line": 308,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 342,
+      "line": 308,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 344,
+      "line": 310,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 406,
+      "line": 388,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 406,
+      "line": 388,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 408,
+      "line": 390,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 452,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 452,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 454,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -1193,6 +1228,7 @@
     "dispatch_envelope.LaneRouter::get",
     "dispatch_envelope::_dispatch_branch_name",
     "dispatch_envelope::_enforce_push_pr",
+    "dispatch_envelope::_envelope_outcome",
     "dispatch_envelope::_is_dispatch_branch_ref",
     "dispatch_envelope::_receipts_file_for",
     "dispatch_envelope::_resolve_base_sha",

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -5,8 +5,9 @@ Verifies:
 2. Failure path: spawn error -> BOTH report AND receipt emitted, status "failure".
 3. Timeout path: spawn timed_out -> BOTH report AND receipt emitted, status "timeout".
 4. Stopped_early path (claude-only): spawn stopped_early -> BOTH report AND receipt, status "success".
-5. Receipt-emit failure -> proof-chain gap recorded, work status preserved (OI-1179).
-6. receipt_path returns None -> proof-chain gap recorded, work status preserved (OI-1179).
+5. Receipt-emit failure -> proof-chain gap recorded, work status preserved (OI-1179),
+   dispatch-level outcome degraded to receipt_missing/returncode 1 (OI-1287).
+6. receipt_path returns None -> same as 5 (OI-1179 + OI-1287).
 7. Idempotent dedup: pre-existing receipt line -> GOVERN skips write, no double-emit.
 8. Flag-off: VNX_UNIFIED_ENVELOPE unset -> legacy dispatch called, envelope NOT invoked.
 9. Flag-on: VNX_UNIFIED_ENVELOPE=1 + lanes contains lane -> envelope invoked.
@@ -258,12 +259,14 @@ class TestEnvelopeEventArchiveClear:
 
 
 class TestEnvelopeReceiptEmitFailure:
-    """OI-1179: a failed receipt emit is a proof-chain gap, not a work failure.
+    """OI-1179 + OI-1287: a failed receipt emit is a proof-chain gap, not a work
+    failure — but it also must not land as a plain, unqualified success.
 
-    The dispatch's WORK status is preserved (success -> returncode 0, receipt_path
-    None) and the gap is recorded loudly to receipt_emit_failures.ndjson with the
-    VNX_RECEIPT_EMIT_FAILURE marker so governance can claim it instead of writing
-    it off as failed.
+    The WORK status is preserved untouched (recorded as "success" in the
+    receipt_emit_failures.ndjson trail's work_status field, VNX_RECEIPT_EMIT_FAILURE
+    marker, so governance can claim it instead of writing it off as failed) while the
+    dispatch-level EnvelopeResult is degraded to status="receipt_missing"/returncode 1
+    so the missing ledger line can never be mistaken for a clean pass (OI-1287).
     """
 
     def _run(self, spec, codex_result, *, receipt_side_effect=None, receipt_return=_UNSET):
@@ -284,14 +287,18 @@ class TestEnvelopeReceiptEmitFailure:
             if line.strip()
         ]
 
-    def test_receipt_emit_raises_preserves_work_status(self, spec):
+    def test_receipt_emit_raises_degrades_outcome_but_preserves_work_status(self, spec):
         codex_result = _FakeCodexResult(returncode=0)
         result = self._run(spec, codex_result, receipt_side_effect=RuntimeError("disk full"))
 
-        assert result.status == "success"
-        assert result.returncode == 0
+        # OI-1287: the outcome must no longer read as a plain success.
+        assert result.status == "receipt_missing"
+        assert result.status != "success"
+        assert result.returncode == 1
         assert result.receipt_path is None
+        assert result.error is not None and "receipt" in result.error.lower()
 
+        # OI-1179: the WORK status itself stays truthfully "success" in the trail.
         records = self._trail(spec)
         assert len(records) == 1  # single record — no double-record
         assert records[0]["marker"] == "VNX_RECEIPT_EMIT_FAILURE"
@@ -299,12 +306,13 @@ class TestEnvelopeReceiptEmitFailure:
         assert records[0]["dispatch_id"] == spec.dispatch_id
         assert "disk full" in records[0]["reason"]
 
-    def test_none_receipt_path_preserves_work_status(self, spec):
+    def test_none_receipt_path_degrades_outcome_but_preserves_work_status(self, spec):
         codex_result = _FakeCodexResult(returncode=0)
         result = self._run(spec, codex_result, receipt_return=None)
 
-        assert result.status == "success"
-        assert result.returncode == 0
+        assert result.status == "receipt_missing"
+        assert result.status != "success"
+        assert result.returncode == 1
         assert result.receipt_path is None
 
         records = self._trail(spec)
@@ -472,7 +480,8 @@ class TestClaudeEnvelopeEmitsBothReportAndReceipt:
 
 
 class TestClaudeEnvelopeReceiptEmitFailure:
-    """OI-1179: a failed receipt emit is a proof-chain gap, not a work failure (claude lane)."""
+    """OI-1179 + OI-1287: a failed receipt emit is a proof-chain gap, not a work
+    failure (claude lane) — but must not land as a plain, unqualified success either."""
 
     def _run(self, spec_claude, claude_result, *, receipt_side_effect=None, receipt_return=_UNSET):
         _, _, mock_report, mock_receipt = _stub_governance(
@@ -492,12 +501,13 @@ class TestClaudeEnvelopeReceiptEmitFailure:
             if line.strip()
         ]
 
-    def test_receipt_emit_raises_preserves_work_status(self, spec_claude):
+    def test_receipt_emit_raises_degrades_outcome_but_preserves_work_status(self, spec_claude):
         claude_result = _FakeClaudeResult(returncode=0)
         result = self._run(spec_claude, claude_result, receipt_side_effect=RuntimeError("disk full"))
 
-        assert result.status == "success"
-        assert result.returncode == 0
+        assert result.status == "receipt_missing"
+        assert result.status != "success"
+        assert result.returncode == 1
         assert result.receipt_path is None
 
         records = self._trail(spec_claude)
@@ -507,12 +517,13 @@ class TestClaudeEnvelopeReceiptEmitFailure:
         assert records[0]["dispatch_id"] == spec_claude.dispatch_id
         assert "disk full" in records[0]["reason"]
 
-    def test_none_receipt_path_preserves_work_status(self, spec_claude):
+    def test_none_receipt_path_degrades_outcome_but_preserves_work_status(self, spec_claude):
         claude_result = _FakeClaudeResult(returncode=0)
         result = self._run(spec_claude, claude_result, receipt_return=None)
 
-        assert result.status == "success"
-        assert result.returncode == 0
+        assert result.status == "receipt_missing"
+        assert result.status != "success"
+        assert result.returncode == 1
         assert result.receipt_path is None
 
         records = self._trail(spec_claude)

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -826,3 +826,48 @@ class TestEnvelopeWorktreeIsolation:
         assert adapter_calls == [], "ProviderAdapter.run must NOT be called when worktree creation fails"
         mock_govern.assert_called_once()
         mock_remove.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# OI-1287: work succeeded but GOVERN produced no ledger receipt -> the
+# dispatch-level outcome must not read as a plain success.
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeReceiptGapDegradesOutcome:
+    """OI-1287 (provider lane): _govern returning receipt_path=None for
+    otherwise-successful work must not land as EnvelopeResult(status="success").
+    """
+
+    def test_receipt_gap_degrades_outcome_but_preserves_work_completion(self, tmp_path):
+        plan = _make_provider_plan(tmp_path, dispatch_id="receipt-gap-provider-test")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_report = data_dir / "unified_reports" / "receipt-gap-provider-test.md"
+
+        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
+            return _fake_adapter_success()
+
+        _fake_consumer_root = tmp_path / "consumer-root"
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=_fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   return_value=_FAKE_WT_PATH), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(ProviderAdapter, "run", fake_adapter_run), \
+             patch("dispatch_envelope._govern", return_value=(fake_report, None)):
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        # OI-1287: no ledger line landed -> the outcome must not read as success.
+        assert result.status == "receipt_missing"
+        assert result.status != "success"
+        assert result.returncode == 1
+        assert result.receipt_path is None
+        # The report GOVERN did produce, and the worker's completion text, are
+        # still surfaced — the WORK itself is not erased, only the outcome
+        # is no longer an unqualified pass.
+        assert result.report_path == fake_report
+        assert result.completion_text == "done"

--- a/tests/test_headless_worktree_isolation.py
+++ b/tests/test_headless_worktree_isolation.py
@@ -277,6 +277,52 @@ class TestHeadlessWorktreeIsolation:
             "the worktree would leak on every headless dispatch"
         )
 
+    def test_receipt_gap_degrades_outcome_but_preserves_work_completion(self, tmp_path: Path) -> None:
+        """OI-1287 (headless lane): _govern returning receipt_path=None for
+        otherwise-successful work must not land as EnvelopeResult(status="success")."""
+        spec = _make_headless_spec(tmp_path=tmp_path)
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert plan.lane == "claude_headless"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_report = data_dir / "unified_reports" / f"{plan.dispatch_id}.md"
+
+        fake_consumer_root = tmp_path / "consumer-root"
+        fake_consumer_root.mkdir()
+        fake_wt_path = fake_consumer_root / ".vnx-data" / "worktrees" / f"dispatch-{plan.dispatch_id}"
+        fake_wt_path.mkdir(parents=True)
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            return (fake_report, None)
+
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   return_value=fake_wt_path), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          return_value=_fake_adapter_success()), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir,
+                role=plan.role,
+            )
+
+        # OI-1287: no ledger line landed -> the outcome must not read as success.
+        assert result.status == "receipt_missing"
+        assert result.status != "success"
+        assert result.returncode == 1
+        assert result.receipt_path is None
+        # The report GOVERN did produce, and the worker's completion text, are
+        # still surfaced — the WORK itself is not erased.
+        assert result.report_path == fake_report
+        assert result.completion_text == "done"
+
 
 # ---------------------------------------------------------------------------
 # Test 2 — OI-1158: the isolation boundary through the ACTUAL door entry point


### PR DESCRIPTION
## Summary
- `envelope_govern._govern()` returning `receipt_path=None` for otherwise-successful work (a refused ledger write — e.g. the fail-closed model check in `_validate_model_present`) previously left `run_envelope`/`run_envelope_plan`/`run_envelope_headless_plan` building an `EnvelopeResult(status="success", returncode=0)` with no receipt line anywhere in the ledger. Green on the outside, nothing on the inside.
- Added `dispatch_envelope._envelope_outcome()`, used by all three envelope entry points: when WORK status is `"success"` and `receipt_path is None`, the caller-visible outcome degrades to `status="receipt_missing"`, `returncode=1`. Every other combination (failure, timeout, idempotent dedup where `receipt_path` is a real existing-ledger path) passes through unchanged.
- OI-1179's deliberate decoupling is preserved: the underlying WORK status is never rewritten — `envelope_govern._record_receipt_emit_failure`'s trail record (`receipt_emit_failures.ndjson`) still carries `work_status="success"` untouched. Only the dispatch-level outcome built on top of it is degraded.
- `scripts/lib/tmux_interactive_dispatch.py`, `scripts/lib/report_to_receipt_converter.py`, and `scripts/gate_obligation_runner.py` were left untouched per dispatch scope. The fail-closed model check itself (`_validate_model_present`) was not weakened — this PR only changes what happens *after* it refuses.

## Changes
- `scripts/lib/dispatch_envelope.py`: new `_envelope_outcome()` helper (+ `RECEIPT_MISSING_STATUS` constant), wired into `run_envelope`, `run_envelope_plan`, `run_envelope_headless_plan`. Module + function docstrings updated to describe OI-1287 alongside OI-1179. The two isolation-failure short-circuit paths (worktree creation fails) were already hardcoded `status="failure"` and are unaffected.
- `scripts/lib/envelope_types.py`: `EnvelopeResult.status` docstring/comment now documents the fourth value, `"receipt_missing"`.
- `tests/test_dispatch_envelope.py`: updated the two existing OI-1179 receipt-emit-failure tests (codex + claude lane) that previously asserted the buggy `status=="success"`/`returncode==0` behavior — now assert the degraded outcome while re-asserting the trail's `work_status=="success"` is untouched.
- `tests/test_dispatch_envelope_plan.py`, `tests/test_headless_worktree_isolation.py`: new regression tests for the same gap in the provider-plan and headless-plan lanes.
- `tests/data/dispatch_envelope_census.json`: regenerated via `python3 tests/dispatch_envelope_census_scanner.py` to reflect the new coupling points from the added tests (a fixture the characterization test enforces byte-for-byte).

## Verification
Targeted files + direct neighbours only, per dispatch scope (full suite NOT run):

```
python3 -m pytest tests/test_dispatch_envelope.py tests/test_dispatch_envelope_plan.py \
  tests/test_headless_worktree_isolation.py tests/test_dispatch_envelope_characterization.py \
  tests/test_envelope_ringbuffer_teardown_oi902.py tests/test_role_applied_provider_lane.py \
  tests/test_envelope_role_propagation.py tests/test_envelope_govern_contract_enforce.py \
  tests/test_dispatch_envelope_field_propagation.py tests/test_lane_matrix_row7_push_pr.py \
  tests/test_data_dir_resolution.py tests/test_dispatch_metadata_lock_timeout.py \
  tests/test_tmux_interactive_dispatch_metadata.py tests/test_dispatch_envelope_fail_loud.py \
  tests/test_failure_classification.py -q
# 267 passed in 17.56s
```

The three dispatch-required scenarios, isolated:
```
tests/test_dispatch_envelope.py::TestEnvelopeReceiptEmitFailure::test_receipt_emit_raises_degrades_outcome_but_preserves_work_status PASSED
tests/test_dispatch_envelope.py::TestEnvelopeReceiptEmitFailure::test_none_receipt_path_degrades_outcome_but_preserves_work_status PASSED
tests/test_dispatch_envelope.py::TestClaudeEnvelopeReceiptEmitFailure::test_receipt_emit_raises_degrades_outcome_but_preserves_work_status PASSED
tests/test_dispatch_envelope.py::TestClaudeEnvelopeReceiptEmitFailure::test_none_receipt_path_degrades_outcome_but_preserves_work_status PASSED
tests/test_dispatch_envelope_plan.py::TestEnvelopeReceiptGapDegradesOutcome::test_receipt_gap_degrades_outcome_but_preserves_work_completion PASSED
tests/test_headless_worktree_isolation.py::TestHeadlessWorktreeIsolation::test_receipt_gap_degrades_outcome_but_preserves_work_completion PASSED
tests/test_dispatch_envelope.py::TestEnvelopeEmitsBothReportAndReceipt (3 tests, unchanged success/failure/timeout paths) PASSED
tests/test_dispatch_envelope.py::TestEnvelopeIdempotentDedup (4 tests, unchanged) PASSED
# 13 passed in 0.83s
```

Known pre-existing, unrelated failures observed in the same run of `test_observability_linkage.py` (`NotADirectoryError` on `.git/worktrees` when `create_dispatch_worktree` runs from inside this nested dispatch worktree) — not touched by this diff, matches the documented "nested worktree breaks dispatch tests" environment gap.

## Open Items
None