### PR TITLE
fix(tmux-lane): book the ledger row when the worker never emits one (OI-1383, OI-1382)

### DIFF
--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1018,12 +1018,17 @@ def build_receipt_from_report(
 #   "skipped_non_dispatch" — OI-1120: report classified as a known non-dispatch
 #                 producer (HEADLESS gate report, panel output, worktree-release
 #                 output) — never a receipt candidate, never dead-lettered.
+#   "would_append" — OI-1383/OI-1382 (--dry-run): the receipt built cleanly and
+#                 would have been appended, but dry_run=True suppressed the
+#                 actual append_receipt_payload() call — nothing was written,
+#                 no watermark entry, no fail-closed check even attempted.
 
 def _convert_one_detailed(
     report_path: Path,
     *,
     receipts_file: Optional[str] = None,
     cache_window_seconds: int = 300,
+    dry_run: bool = False,
 ) -> Tuple[Optional[Any], str]:  # (Optional[AppendResult], outcome_tag)
     """Convert one report file to a governed receipt; classify the outcome.
 
@@ -1031,6 +1036,13 @@ def _convert_one_detailed(
     fail-closed model rejection, append failure) is caught here and turned
     into a (None, outcome_tag) result so a single poisoned report can never
     propagate an exception into a caller's batch loop.
+
+    ``dry_run=True`` (OI-1383/OI-1382): builds the receipt exactly as normal
+    (including the pre-existing-receipt duplicate guard below, which only
+    reads the ledger) but never calls ``append_receipt_payload`` — nothing is
+    written. Returns ``(receipt_dict, "would_append")`` instead of
+    ``(AppendResult, "appended")`` so the caller can report intent without a
+    write having happened.
     """
     # OI-1120: classify BEFORE any receipt-building work. A known non-dispatch
     # report (HEADLESS gate output, panel output, worktree-release output) is
@@ -1127,6 +1139,15 @@ def _convert_one_detailed(
         except OSError:
             pass  # can't read NDJSON — fall through to normal append (idempotency will catch it)
 
+    if dry_run:
+        logger.info(
+            "report_to_receipt_converter: [dry-run] would book dispatch=%s "
+            "event_type=%s status=%s file=%s",
+            receipt.get("dispatch_id"), receipt.get("event_type"),
+            receipt.get("status"), report_path.name,
+        )
+        return receipt, "would_append"
+
     try:
         result = append_receipt_payload(
             receipt,
@@ -1210,6 +1231,13 @@ class ScanStats:
     # non-dispatch reports (the headless/ directory is scanned every cycle),
     # and that must read as healthy, not as "attempted with zero success".
     skipped_non_dispatch_count: int = 0
+    # OI-1383/OI-1382 (--dry-run): reports that WOULD have produced a new
+    # receipt, counted separately from new_count because nothing was actually
+    # written. Deliberately excluded from attempted_count for the same reason
+    # skipped_non_dispatch_count is — a dry-run scan is never "attempted with
+    # zero success", and _write_scan_heartbeat is skipped entirely for a
+    # dry-run so this count never influences health status either way.
+    would_append_count: int = 0
 
     @property
     def attempted_count(self) -> int:
@@ -1270,6 +1298,7 @@ def scan_and_convert(
     state_dir: Optional[Path] = None,
     *,
     cache_window_seconds: int = 300,
+    dry_run: bool = False,
 ) -> ScanStats:
     """Scan report directories and convert unprocessed reports.
 
@@ -1286,6 +1315,12 @@ def scan_and_convert(
     never becomes a dispatch report on a later scan); rejected, malformed,
     and errored reports are NOT marked processed, so they are retried on the
     next scan once their cause is fixed.
+
+    ``dry_run=True`` (OI-1383/OI-1382): reports what WOULD be booked without
+    writing a receipt or a watermark entry for ANY outcome — including a
+    would-be "appended"/"duplicate"/"skipped_non_dispatch" report, which under
+    a real run would be marked processed. See ``_convert_one_detailed``'s
+    ``"would_append"`` outcome tag.
 
     A single poisoned report can never abort the scan (OI-997): each
     report's conversion is wrapped in try/except here, in addition to
@@ -1316,6 +1351,7 @@ def scan_and_convert(
     malformed_count = 0
     error_count = 0
     skipped_non_dispatch_count = 0
+    would_append_count = 0
 
     for reports_dir in reports_dirs:
         if not isinstance(reports_dir, Path):
@@ -1339,6 +1375,7 @@ def scan_and_convert(
                     report_path,
                     receipts_file=receipts_file,
                     cache_window_seconds=cache_window_seconds,
+                    dry_run=dry_run,
                 )
             except Exception as exc:
                 # Belt-and-suspenders: _convert_one_detailed() already catches
@@ -1352,6 +1389,11 @@ def scan_and_convert(
                     report_path.name, type(exc).__name__, exc,
                 )
                 error_count += 1
+                continue
+
+            if outcome == "would_append":
+                # dry_run: never touch a watermark, never write anything.
+                would_append_count += 1
                 continue
 
             if outcome in ("appended", "duplicate", "skipped_non_dispatch"):
@@ -1390,8 +1432,156 @@ def scan_and_convert(
         malformed_count=malformed_count,
         error_count=error_count,
         skipped_non_dispatch_count=skipped_non_dispatch_count,
+        would_append_count=would_append_count,
     )
-    _write_scan_heartbeat(state_dir, stats)
+    # dry_run: no write happened, so no heartbeat about a scan cycle either —
+    # a dry-run must leave zero observable state behind.
+    if not dry_run:
+        _write_scan_heartbeat(state_dir, stats)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Targeted conversion — specific dispatch_ids, no directory scan
+# ---------------------------------------------------------------------------
+
+def convert_dispatch_ids(
+    dispatch_ids: "List[str]",
+    state_dir: Optional[Path] = None,
+    *,
+    dry_run: bool = False,
+    cache_window_seconds: int = 300,
+) -> ScanStats:
+    """Convert reports for a SPECIFIC set of dispatch_ids — no directory scan.
+
+    OI-1383/OI-1382 (--dispatch-id): resolves each id directly via
+    ``report_path.resolve_report_path()`` (the canonical
+    ``$VNX_DATA_DIR/unified_reports/<id>.md`` form plus its two legacy
+    filename variants) instead of globbing every ``*.md`` file in
+    ``unified_reports/``. Built for booking a dispatch the lane's own
+    fallback (or a worker) missed, without letting a full scan loose over the
+    entire report inventory.
+
+    ``data_dir`` for the resolver is ``state_dir.parent`` — the same
+    convention ``dispatch_govern.GovernSpec`` and the rest of this module use
+    (``VNX_STATE_DIR`` defaults to ``VNX_DATA_DIR/state``).
+
+    A dispatch_id with no resolvable report file counts as ``malformed_count``
+    (logged at WARNING) rather than being silently dropped.
+
+    ``dry_run=True``: identical semantics to ``scan_and_convert``'s — nothing
+    is written, no watermark entry is left, for ANY outcome. See
+    ``_convert_one_detailed``'s ``"would_append"`` tag.
+    """
+    ids = [str(d).strip() for d in dispatch_ids if str(d).strip()]
+
+    if state_dir is None:
+        try:
+            state_dir = _resolve_state_dir()
+        except Exception as exc:
+            logger.error("report_to_receipt_converter: cannot resolve state_dir: %s", exc)
+            return ScanStats()
+
+    state_dir.mkdir(parents=True, exist_ok=True)
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+    watermark_path = state_dir / _WATERMARK_FILENAME
+    bash_watermark_path = state_dir / _BASH_WATERMARK_FILENAME
+    watermark = _load_watermark(watermark_path)
+    bash_watermark = _load_watermark(bash_watermark_path)
+
+    from report_path import resolve_report_path  # noqa: PLC0415
+    data_dir = state_dir.parent
+
+    new_count = 0
+    duplicate_count = 0
+    rejected_count = 0
+    malformed_count = 0
+    error_count = 0
+    skipped_non_dispatch_count = 0
+    would_append_count = 0
+
+    for dispatch_id in ids:
+        resolved = resolve_report_path(dispatch_id, data_dir=data_dir)
+        if resolved is None:
+            logger.warning(
+                "report_to_receipt_converter: --dispatch-id %s — no report file "
+                "found under %s/unified_reports",
+                dispatch_id, data_dir,
+            )
+            malformed_count += 1
+            continue
+        report_path = resolved.path
+
+        try:
+            file_hash = _compute_sha256(report_path)
+        except OSError as exc:
+            logger.warning(
+                "report_to_receipt_converter: --dispatch-id %s — cannot hash %s: %s",
+                dispatch_id, report_path, exc,
+            )
+            malformed_count += 1
+            continue
+
+        # Same cross-processor dedup as scan_and_convert(): already-processed
+        # reports are silently skipped, not counted — in BOTH modes, so a
+        # dry-run accurately reflects what a real run would (not) do.
+        if file_hash in watermark or file_hash in bash_watermark:
+            continue
+
+        try:
+            result, outcome = _convert_one_detailed(
+                report_path,
+                receipts_file=receipts_file,
+                cache_window_seconds=cache_window_seconds,
+                dry_run=dry_run,
+            )
+        except Exception as exc:
+            logger.error(
+                "report_to_receipt_converter: --dispatch-id %s unhandled exception "
+                "converting %s: %s: %s",
+                dispatch_id, report_path.name, type(exc).__name__, exc,
+            )
+            error_count += 1
+            continue
+
+        if outcome == "would_append":
+            would_append_count += 1
+            continue
+
+        if outcome in ("appended", "duplicate", "skipped_non_dispatch"):
+            _mark_processed(file_hash, watermark_path)
+            watermark.add(file_hash)
+            _mark_processed(file_hash, bash_watermark_path)
+            bash_watermark.add(file_hash)
+            if outcome == "appended":
+                new_count += 1
+                logger.info(
+                    "report_to_receipt_converter: --dispatch-id receipt emitted "
+                    "dispatch=%s file=%s",
+                    result.idempotency_key[:20], report_path.name,
+                )
+            elif outcome == "duplicate":
+                duplicate_count += 1
+            else:  # "skipped_non_dispatch"
+                skipped_non_dispatch_count += 1
+        elif outcome == "rejected":
+            rejected_count += 1
+        elif outcome == "malformed":
+            malformed_count += 1
+        else:  # "error"
+            error_count += 1
+
+    stats = ScanStats(
+        new_count=new_count,
+        duplicate_count=duplicate_count,
+        rejected_count=rejected_count,
+        malformed_count=malformed_count,
+        error_count=error_count,
+        skipped_non_dispatch_count=skipped_non_dispatch_count,
+        would_append_count=would_append_count,
+    )
+    if not dry_run:
+        _write_scan_heartbeat(state_dir, stats)
     return stats
 
 
@@ -1414,7 +1604,8 @@ def _resolve_state_dir() -> Path:
 def main(argv: Optional[List[str]] = None) -> int:
     """Scan directories and convert frontmatter reports to receipts.
 
-    Usage: report_to_receipt_converter.py [--state-dir DIR] [DIR ...]
+    Usage: report_to_receipt_converter.py [--state-dir DIR] [--dispatch-id ID ...]
+                                           [--dry-run] [DIR ...]
     """
     import argparse
 
@@ -1424,28 +1615,59 @@ def main(argv: Optional[List[str]] = None) -> int:
         description="Generic unified_report -> receipt converter"
     )
     p.add_argument("--state-dir", default=None, help="Override $VNX_STATE_DIR path")
+    p.add_argument(
+        "--dispatch-id",
+        dest="dispatch_ids",
+        action="append",
+        default=None,
+        metavar="ID",
+        help=(
+            "Process only the report for this dispatch_id (repeatable). "
+            "Resolves via report_path.resolve_report_path() directly — no "
+            "directory scan. Ignores any positional DIR arguments."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Report what would be booked without writing a receipt or a "
+            "watermark entry (nothing on disk changes)."
+        ),
+    )
     p.add_argument("dirs", nargs="*", help="Reports directories to scan")
     args = p.parse_args(argv if argv is not None else sys.argv[1:])
 
     state_dir = Path(args.state_dir) if args.state_dir else None
 
-    if args.dirs:
-        dirs = [Path(d) for d in args.dirs]
+    if args.dispatch_ids:
+        stats = convert_dispatch_ids(
+            args.dispatch_ids, state_dir, dry_run=args.dry_run, cache_window_seconds=300,
+        )
     else:
-        try:
-            sd = state_dir or _resolve_state_dir()
-            from vnx_paths import ensure_env
-            paths = ensure_env()
-            data_dir = Path(paths.get("VNX_DATA_DIR", ""))
-            dirs = [
-                data_dir / "unified_reports",
-                data_dir / "unified_reports" / "headless",
-            ]
-        except Exception as exc:
-            logger.error("report_to_receipt_converter: cannot resolve dirs from env: %s", exc)
-            return 1
+        if args.dirs:
+            dirs = [Path(d) for d in args.dirs]
+        else:
+            try:
+                sd = state_dir or _resolve_state_dir()
+                from vnx_paths import ensure_env
+                paths = ensure_env()
+                data_dir = Path(paths.get("VNX_DATA_DIR", ""))
+                dirs = [
+                    data_dir / "unified_reports",
+                    data_dir / "unified_reports" / "headless",
+                ]
+            except Exception as exc:
+                logger.error("report_to_receipt_converter: cannot resolve dirs from env: %s", exc)
+                return 1
 
-    stats = scan_and_convert(dirs, state_dir, cache_window_seconds=300)
+        stats = scan_and_convert(dirs, state_dir, cache_window_seconds=300, dry_run=args.dry_run)
+
+    if args.dry_run:
+        logger.info(
+            "report_to_receipt_converter: [dry-run] %d would be booked; nothing written",
+            stats.would_append_count,
+        )
     if stats.new_count:
         logger.info("report_to_receipt_converter: %d new receipt(s) emitted", stats.new_count)
     if stats.skipped_non_dispatch_count:

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1391,9 +1391,30 @@ def scan_and_convert(
                 error_count += 1
                 continue
 
-            if outcome == "would_append":
-                # dry_run: never touch a watermark, never write anything.
-                would_append_count += 1
+            if dry_run:
+                # Codex finding (PR #1635): gate on dry_run itself, not on
+                # the outcome tag. _convert_one_detailed()'s own dry-run
+                # branch only ever returns "would_append", but the hot-path
+                # duplicate guard (checked before that branch) and the
+                # non-dispatch classifier (checked before even that) can
+                # both hand back "duplicate"/"skipped_non_dispatch" while
+                # dry_run=True. Counting here — before the write branch
+                # below is ever reached — means NO outcome tag, present or
+                # future, can fall through to _mark_processed(): the
+                # `continue` makes the write branch structurally
+                # unreachable whenever dry_run is True.
+                if outcome == "would_append":
+                    would_append_count += 1
+                elif outcome == "duplicate":
+                    duplicate_count += 1
+                elif outcome == "skipped_non_dispatch":
+                    skipped_non_dispatch_count += 1
+                elif outcome == "rejected":
+                    rejected_count += 1
+                elif outcome == "malformed":
+                    malformed_count += 1
+                else:  # "error" or any future/unrecognized tag
+                    error_count += 1
                 continue
 
             if outcome in ("appended", "duplicate", "skipped_non_dispatch"):
@@ -1490,6 +1511,7 @@ def convert_dispatch_ids(
     bash_watermark = _load_watermark(bash_watermark_path)
 
     from report_path import resolve_report_path  # noqa: PLC0415
+    from dispatch_spec import _ID_RE  # noqa: PLC0415 — canonical id-shape guard, same regex dispatch_bridge.py uses to kill path traversal before any path join
     data_dir = state_dir.parent
 
     new_count = 0
@@ -1501,6 +1523,23 @@ def convert_dispatch_ids(
     would_append_count = 0
 
     for dispatch_id in ids:
+        # Codex finding (PR #1635): dispatch_id is caller-supplied CLI input
+        # and resolve_report_path() formats it straight into filenames — a
+        # value containing "/" or ".." could resolve reads outside
+        # unified_reports/. Validate against the same id-shape regex
+        # dispatch_bridge.stage_spec_bundle() already validates against
+        # before any path join, so there is exactly one definition of "a
+        # valid dispatch id" in the codebase. Rejected loudly (WARNING +
+        # malformed_count), never silently dropped.
+        if not _ID_RE.match(dispatch_id):
+            logger.warning(
+                "report_to_receipt_converter: --dispatch-id %r rejected — does not "
+                "match the dispatch id pattern (dispatch_spec._ID_RE); refusing to "
+                "resolve a report path from it",
+                dispatch_id,
+            )
+            malformed_count += 1
+            continue
         resolved = resolve_report_path(dispatch_id, data_dir=data_dir)
         if resolved is None:
             logger.warning(
@@ -1544,8 +1583,26 @@ def convert_dispatch_ids(
             error_count += 1
             continue
 
-        if outcome == "would_append":
-            would_append_count += 1
+        if dry_run:
+            # Codex finding (PR #1635): same gate as scan_and_convert() —
+            # branch on dry_run itself, before the outcome tag is ever
+            # inspected, so the write branch below is structurally
+            # unreachable under dry_run regardless of which outcome
+            # _convert_one_detailed() hands back (including "duplicate"/
+            # "skipped_non_dispatch", both of which can occur even when
+            # dry_run=True — see scan_and_convert()'s equivalent comment).
+            if outcome == "would_append":
+                would_append_count += 1
+            elif outcome == "duplicate":
+                duplicate_count += 1
+            elif outcome == "skipped_non_dispatch":
+                skipped_non_dispatch_count += 1
+            elif outcome == "rejected":
+                rejected_count += 1
+            elif outcome == "malformed":
+                malformed_count += 1
+            else:  # "error" or any future/unrecognized tag
+                error_count += 1
             continue
 
         if outcome in ("appended", "duplicate", "skipped_non_dispatch"):

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1320,7 +1320,8 @@ def scan_and_convert(
     writing a receipt or a watermark entry for ANY outcome — including a
     would-be "appended"/"duplicate"/"skipped_non_dispatch" report, which under
     a real run would be marked processed. See ``_convert_one_detailed``'s
-    ``"would_append"`` outcome tag.
+    ``"would_append"`` outcome tag. A dry run also leaves ``state_dir`` itself
+    untouched: it is not created if it does not already exist.
 
     A single poisoned report can never abort the scan (OI-997): each
     report's conversion is wrapped in try/except here, in addition to
@@ -1335,7 +1336,8 @@ def scan_and_convert(
             logger.error("report_to_receipt_converter: cannot resolve state_dir: %s", exc)
             return ScanStats()
 
-    state_dir.mkdir(parents=True, exist_ok=True)
+    if not dry_run:
+        state_dir.mkdir(parents=True, exist_ok=True)
     receipts_file = str(state_dir / "t0_receipts.ndjson")
     watermark_path = state_dir / _WATERMARK_FILENAME
     # OI-1102: also load the Bash processor's watermark so a report processed
@@ -1503,7 +1505,8 @@ def convert_dispatch_ids(
             logger.error("report_to_receipt_converter: cannot resolve state_dir: %s", exc)
             return ScanStats()
 
-    state_dir.mkdir(parents=True, exist_ok=True)
+    if not dry_run:
+        state_dir.mkdir(parents=True, exist_ok=True)
     receipts_file = str(state_dir / "t0_receipts.ndjson")
     watermark_path = state_dir / _WATERMARK_FILENAME
     bash_watermark_path = state_dir / _BASH_WATERMARK_FILENAME

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1054,6 +1054,109 @@ class TmuxInteractiveDispatch:
                 exc,
             )
 
+    def _has_ledger_completion_row(self, dispatch_id: str) -> bool:
+        """Return True when a completion-family ledger row already exists for *dispatch_id*.
+
+        Scans ``self._receipts_file`` (t0_receipts.ndjson) the same way
+        ``_matching_receipts_split``'s canonical-signal branch does: a row whose
+        ``event_type`` ends in ``_completion`` is a real, already-landed ledger
+        entry — written either by the worker's own Completion Protocol shell
+        command or by ``dispatch_govern.ensure_receipt()``'s lane-synthesized
+        fallback. Both write ``event_type="subprocess_completion"``.
+
+        OI-1383/OI-1382: this check exists because a non-``None`` ``receipt``
+        variable does NOT mean a row landed on disk — the report-backstop
+        signal (``_wait_for_receipt`` signal 3) fabricates an in-memory receipt
+        dict from a complete+stable report file with no ledger write at all,
+        which satisfies ``ensure_receipt()``'s ``raw.receipt is not None`` gate
+        and makes it skip. The actual ledger file is the only source of truth
+        for whether a row was really written.
+
+        Best-effort: an unreadable ledger file counts as "no row" so the
+        caller's own fallback still gets a chance to book one — failing toward
+        an extra booking attempt, never toward silence.
+        """
+        if not self._receipts_file.exists():
+            return False
+        try:
+            with self._receipts_file.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line or dispatch_id not in line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(rec, dict):
+                        continue
+                    if rec.get("dispatch_id") != dispatch_id:
+                        continue
+                    if str(rec.get("event_type") or "").endswith("_completion"):
+                        return True
+        except OSError as exc:
+            logger.debug(
+                "interactive: ledger scan failed for dispatch=%s: %s", dispatch_id, exc,
+            )
+            return False
+        return False
+
+    def _fallback_book_ledger_row(
+        self, dispatch_id: str, report_path: "Path | None",
+    ) -> None:
+        """Book this dispatch's ledger row from the on-disk report when nothing else did.
+
+        OI-1383/OI-1382: audit-trail vangnet. Every ``govern()`` call in this
+        lane routes through here afterward. If neither the worker's own
+        Completion Protocol command nor ``dispatch_govern.ensure_receipt()``
+        landed a completion row (see ``_has_ledger_completion_row``), the
+        report ``govern()`` just wrote/validated on disk is the last remaining
+        source of truth — drive it through the SAME generic converter every
+        other report-to-receipt path uses
+        (``report_to_receipt_converter._convert_one_detailed``), never a
+        second parser.
+
+        Runs only when no row exists yet — a worker (or ``ensure_receipt()``)
+        that already wrote one leaves this a no-op, never a second row.
+
+        Never raises: a failure here is an audit-trail gap, and per contract
+        that must be LOUD (WARNING with dispatch_id + reason), never silent.
+        """
+        if self._has_ledger_completion_row(dispatch_id):
+            return
+        if report_path is None:
+            logger.warning(
+                "interactive: ledger fallback SKIPPED for dispatch=%s — govern() "
+                "produced no report_path to convert; no ledger row exists for "
+                "this dispatch",
+                dispatch_id,
+            )
+            return
+        try:
+            from report_to_receipt_converter import _convert_one_detailed  # noqa: PLC0415
+            _result, outcome = _convert_one_detailed(
+                Path(report_path), receipts_file=str(self._receipts_file),
+            )
+        except Exception as exc:  # noqa: BLE001 — audit-trail gap must never crash the dispatch
+            logger.warning(
+                "interactive: ledger fallback CRASHED for dispatch=%s report=%s "
+                "reason=%s: %s",
+                dispatch_id, report_path, type(exc).__name__, exc,
+            )
+            return
+        if outcome in ("appended", "duplicate"):
+            logger.info(
+                "interactive: ledger fallback booked dispatch=%s outcome=%s "
+                "via report=%s",
+                dispatch_id, outcome, report_path,
+            )
+        else:
+            logger.warning(
+                "interactive: ledger fallback did NOT book a row for dispatch=%s "
+                "reason=%s report=%s — audit-trail gap remains",
+                dispatch_id, outcome, report_path,
+            )
+
     def _govern_report(
         self,
         dispatch_id: str,
@@ -1121,6 +1224,7 @@ class TmuxInteractiveDispatch:
             token_usage=token_usage,
         )
         outcome = govern(spec, raw, lane="tmux_interactive")
+        self._fallback_book_ledger_row(dispatch_id, outcome.report_path)
         self._stamp_dispatch_metadata(
             dispatch_id=dispatch_id,
             terminal_id=terminal_id,

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1086,7 +1086,14 @@ class TmuxInteractiveDispatch:
                         continue
                     try:
                         rec = json.loads(line)
-                    except json.JSONDecodeError:
+                    except json.JSONDecodeError as exc:
+                        logger.warning(
+                            "interactive: ledger row unreadable for dispatch=%s "
+                            "(JSONDecodeError: %s) — skipping row, treating as "
+                            "no completion found for this line",
+                            dispatch_id,
+                            exc,
+                        )
                         continue
                     if not isinstance(rec, dict):
                         continue

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -2532,3 +2532,156 @@ class TestDryRun:
 
         beacon_path = state_dir / "health" / "report_to_receipt_converter.json"
         assert not beacon_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# PR #1635 codex-gate fix: dry_run must gate on dry_run itself, not on the
+# outcome tag. _convert_one_detailed()'s own dry-run branch only ever
+# returns "would_append", but two guards that run BEFORE that branch — the
+# hot-path duplicate check and the non-dispatch-filename classifier — can
+# both hand back "duplicate"/"skipped_non_dispatch" while dry_run=True.
+# Previously both outcomes fell through to _mark_processed(), so a dry run
+# could still leave a watermark entry behind.
+# ---------------------------------------------------------------------------
+
+def _seed_existing_receipt(state_dir: Path, dispatch_id: str) -> Path:
+    """Pre-populate t0_receipts.ndjson with a receipt for *dispatch_id* so
+    the hot-path duplicate guard in _convert_one_detailed() fires — same
+    setup as TestConverterDoubleCountGuard.test_existing_contract_invalid_skips_conversion."""
+    receipts_file = state_dir / "t0_receipts.ndjson"
+    existing_receipt = json.dumps({
+        "dispatch_id": dispatch_id,
+        "event_type": "report_contract_invalid",
+        "status": "contract_invalid",
+        "provider": "codex",
+        "model": "gpt-test",
+        "terminal": "T1",
+        "receipt_kind": "dispatch",
+        "role": "identity_unresolved",
+        "task_id": "unknown",
+        "timestamp": "2026-08-09T00:00:00Z",
+        "report_path": f"unified_reports/{dispatch_id}.md",
+    }, separators=(",", ":"))
+    receipts_file.write_text(existing_receipt + "\n", encoding="utf-8")
+    return receipts_file
+
+
+class TestDryRunGatesEveryOutcomeNotJustWouldAppend:
+    def test_scan_dry_run_duplicate_outcome_writes_nothing(self, reports_dir, state_dir):
+        dispatch_id = "20260821-dry-dup"
+        receipts_file = _seed_existing_receipt(state_dir, dispatch_id)
+        _write_frontmatter_report(reports_dir / f"{dispatch_id}.md", dispatch_id)
+
+        stats = scan_and_convert([reports_dir], state_dir, dry_run=True)
+
+        assert stats.duplicate_count == 1
+        assert stats.new_count == 0
+        # Receipts file must still hold only the ONE pre-existing line.
+        lines = receipts_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        # No watermark entry — a dry-run "duplicate" must be as invisible on
+        # disk as a dry-run "would_append".
+        assert not (state_dir / _WATERMARK_FILENAME).exists()
+        assert not (state_dir / "processed_receipts.txt").exists()
+
+    def test_scan_dry_run_skipped_non_dispatch_outcome_writes_nothing(self, reports_dir, state_dir):
+        report = reports_dir / "panel-strategy-dryrun01.md"
+        report.write_text(
+            "# Deliberation panel — strategy\n\n## Synthesis (cited)\n\nfoo\n",
+            encoding="utf-8",
+        )
+
+        stats = scan_and_convert([reports_dir], state_dir, dry_run=True)
+
+        assert stats.skipped_non_dispatch_count == 1
+        assert stats.new_count == 0
+        assert _count_receipts(state_dir) == 0
+        assert not (state_dir / _WATERMARK_FILENAME).exists()
+        assert not (state_dir / "processed_receipts.txt").exists()
+        assert report.exists(), "non-dispatch report must not be moved"
+
+    def test_dispatch_id_dry_run_duplicate_outcome_writes_nothing(self, reports_dir, state_dir):
+        dispatch_id = "20260821-dry-dup-targeted"
+        receipts_file = _seed_existing_receipt(state_dir, dispatch_id)
+        _write_frontmatter_report(reports_dir / f"{dispatch_id}.md", dispatch_id)
+
+        stats = convert_dispatch_ids([dispatch_id], state_dir, dry_run=True)
+
+        assert stats.duplicate_count == 1
+        assert stats.new_count == 0
+        lines = receipts_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        assert not (state_dir / _WATERMARK_FILENAME).exists()
+        assert not (state_dir / "processed_receipts.txt").exists()
+
+    def test_dispatch_id_dry_run_skipped_non_dispatch_outcome_writes_nothing(self, reports_dir, state_dir):
+        """A --dispatch-id value whose resolved filename matches a known
+        non-dispatch producer prefix ("panel-...") classifies as
+        "skipped_non_dispatch" — must still write nothing under dry_run."""
+        dispatch_id = "panel-dryrun-targeted01"
+        report = reports_dir / f"{dispatch_id}.md"
+        report.write_text(
+            "# Deliberation panel — strategy\n\n## Synthesis (cited)\n\nfoo\n",
+            encoding="utf-8",
+        )
+
+        stats = convert_dispatch_ids([dispatch_id], state_dir, dry_run=True)
+
+        assert stats.skipped_non_dispatch_count == 1
+        assert stats.new_count == 0
+        assert _count_receipts(state_dir) == 0
+        assert not (state_dir / _WATERMARK_FILENAME).exists()
+        assert not (state_dir / "processed_receipts.txt").exists()
+        assert report.exists()
+
+
+# ---------------------------------------------------------------------------
+# PR #1635 codex-gate fix: convert_dispatch_ids() must validate dispatch_id
+# against the canonical id-shape regex (dispatch_spec._ID_RE) BEFORE calling
+# resolve_report_path() — an id containing "/" or ".." would otherwise let
+# the resolver read a file outside unified_reports/. Same regex
+# dispatch_bridge.stage_spec_bundle() already validates against for exactly
+# this reason — no second definition of "a valid dispatch id".
+# ---------------------------------------------------------------------------
+
+class TestConvertDispatchIdsRejectsUnsafeIds:
+    def test_rejects_dispatch_id_containing_path_separator(self, reports_dir, state_dir, caplog):
+        with caplog.at_level(logging.WARNING, logger="report_to_receipt_converter"):
+            stats = convert_dispatch_ids(["sub/escape"], state_dir)
+
+        assert stats.malformed_count == 1
+        assert stats.new_count == 0
+        assert _count_receipts(state_dir) == 0
+        assert any(
+            "sub/escape" in r.message and "rejected" in r.message
+            for r in caplog.records
+        ), f"expected a loud rejection warning, got: {[r.message for r in caplog.records]}"
+
+    def test_rejects_dispatch_id_containing_dotdot_traversal(self, reports_dir, state_dir, caplog):
+        # A file OUTSIDE unified_reports/ that an unvalidated ".." id would
+        # reach if handed straight to resolve_report_path().
+        secret = reports_dir.parent / "secret.md"
+        secret.write_text("top secret\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="report_to_receipt_converter"):
+            stats = convert_dispatch_ids(["../secret"], state_dir)
+
+        assert stats.malformed_count == 1
+        assert stats.new_count == 0
+        assert _count_receipts(state_dir) == 0
+        assert any(
+            "../secret" in r.message and "rejected" in r.message
+            for r in caplog.records
+        ), f"expected a loud rejection warning, got: {[r.message for r in caplog.records]}"
+
+    def test_valid_id_still_resolves_normally(self, reports_dir, state_dir):
+        """Regression guard: the new validation must not reject a normal,
+        well-formed dispatch id."""
+        _write_frontmatter_report(
+            reports_dir / "20260821-still-valid.md", "20260821-still-valid",
+        )
+
+        stats = convert_dispatch_ids(["20260821-still-valid"], state_dir)
+
+        assert stats.new_count == 1
+        assert stats.malformed_count == 0

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -2533,6 +2533,40 @@ class TestDryRun:
         beacon_path = state_dir / "health" / "report_to_receipt_converter.json"
         assert not beacon_path.exists()
 
+    def test_scan_dry_run_does_not_create_state_dir(self, reports_dir, tmp_path):
+        """A dry run must leave zero trace — not even an empty state_dir.
+
+        Uses a state_dir path that does NOT exist yet (the `state_dir`
+        fixture pre-creates it, so this test builds its own path instead).
+        """
+        _write_frontmatter_report(
+            reports_dir / "20260821-dry-no-mkdir.md", "20260821-dry-no-mkdir",
+        )
+        missing_state_dir = tmp_path / "state-not-created"
+        assert not missing_state_dir.exists()
+
+        stats = scan_and_convert([reports_dir], missing_state_dir, dry_run=True)
+
+        assert stats.would_append_count == 1
+        assert not missing_state_dir.exists()
+
+    def test_dispatch_id_dry_run_does_not_create_state_dir(self, reports_dir, tmp_path):
+        """Same contract as scan_and_convert's, for the --dispatch-id entry
+        point: a dry run against a not-yet-existing state_dir must not
+        create it."""
+        _write_frontmatter_report(
+            reports_dir / "20260821-dry-id-no-mkdir.md", "20260821-dry-id-no-mkdir",
+        )
+        missing_state_dir = tmp_path / "state-not-created-by-id"
+        assert not missing_state_dir.exists()
+
+        stats = convert_dispatch_ids(
+            ["20260821-dry-id-no-mkdir"], missing_state_dir, dry_run=True,
+        )
+
+        assert stats.would_append_count == 1
+        assert not missing_state_dir.exists()
+
 
 # ---------------------------------------------------------------------------
 # PR #1635 codex-gate fix: dry_run must gate on dry_run itself, not on the

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -40,6 +40,7 @@ from report_to_receipt_converter import (
     _load_route_decision,
     _load_watermark,
     build_receipt_from_report,
+    convert_dispatch_ids,
     convert_report_to_receipt,
     parse_frontmatter,
     scan_and_convert,
@@ -2396,3 +2397,138 @@ class TestBoldBranchesLineAnchored:
         )
         fields = _extract_body_fields(text)
         assert "status" not in fields
+
+
+# ---------------------------------------------------------------------------
+# OI-1383/OI-1382: --dispatch-id (targeted conversion, no directory scan)
+# ---------------------------------------------------------------------------
+
+class TestConvertDispatchIds:
+    def test_converts_only_the_requested_dispatch(self, reports_dir, state_dir):
+        _write_frontmatter_report(reports_dir / "20260821-target-a.md", "20260821-target-a")
+        _write_frontmatter_report(reports_dir / "20260821-target-b.md", "20260821-target-b")
+
+        stats = convert_dispatch_ids(["20260821-target-a"], state_dir)
+
+        assert stats.new_count == 1
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        assert receipts[0]["dispatch_id"] == "20260821-target-a"
+
+    def test_repeatable_ids_each_booked_others_untouched(self, reports_dir, state_dir):
+        _write_frontmatter_report(reports_dir / "20260821-multi-a.md", "20260821-multi-a")
+        _write_frontmatter_report(reports_dir / "20260821-multi-b.md", "20260821-multi-b")
+        _write_frontmatter_report(reports_dir / "20260821-multi-c.md", "20260821-multi-c")
+
+        stats = convert_dispatch_ids(
+            ["20260821-multi-a", "20260821-multi-c"], state_dir,
+        )
+
+        assert stats.new_count == 2
+        ids_booked = {r["dispatch_id"] for r in _receipts(state_dir)}
+        assert ids_booked == {"20260821-multi-a", "20260821-multi-c"}
+
+    def test_unknown_dispatch_id_counts_malformed_no_crash(self, reports_dir, state_dir):
+        stats = convert_dispatch_ids(["20260821-does-not-exist"], state_dir)
+
+        assert stats.new_count == 0
+        assert stats.malformed_count == 1
+        assert _count_receipts(state_dir) == 0
+
+    def test_idempotent_rescan_by_id(self, reports_dir, state_dir):
+        _write_frontmatter_report(reports_dir / "20260821-target-idem.md", "20260821-target-idem")
+
+        stats1 = convert_dispatch_ids(["20260821-target-idem"], state_dir)
+        stats2 = convert_dispatch_ids(["20260821-target-idem"], state_dir)
+
+        assert stats1.new_count == 1
+        assert stats2.new_count == 0  # watermark prevents re-emission
+        assert _count_receipts(state_dir) == 1
+
+    def test_does_not_touch_sibling_reports_in_same_directory(self, reports_dir, state_dir):
+        """A --dispatch-id run books ONLY the requested id — a sibling report
+        sitting in the same unified_reports/ directory must be left
+        completely unprocessed (no receipt, no watermark entry)."""
+        _write_frontmatter_report(reports_dir / "20260821-scoped.md", "20260821-scoped")
+        sibling = reports_dir / "20260821-sibling.md"
+        _write_frontmatter_report(sibling, "20260821-sibling")
+
+        convert_dispatch_ids(["20260821-scoped"], state_dir)
+
+        ids_booked = {r["dispatch_id"] for r in _receipts(state_dir)}
+        assert ids_booked == {"20260821-scoped"}
+        wm = _load_watermark(state_dir / _WATERMARK_FILENAME)
+        assert _compute_sha256(sibling) not in wm
+
+
+# ---------------------------------------------------------------------------
+# OI-1383/OI-1382: --dry-run (report intent, write nothing, no watermark)
+# ---------------------------------------------------------------------------
+
+class TestDryRun:
+    def test_dry_run_writes_no_receipt(self, reports_dir, state_dir):
+        _write_frontmatter_report(reports_dir / "20260821-dry-a.md", "20260821-dry-a")
+
+        stats = scan_and_convert([reports_dir], state_dir, dry_run=True)
+
+        assert stats.would_append_count == 1
+        assert stats.new_count == 0
+        assert _count_receipts(state_dir) == 0
+
+    def test_dry_run_leaves_no_watermark_entry(self, reports_dir, state_dir):
+        report = reports_dir / "20260821-dry-wm.md"
+        _write_frontmatter_report(report, "20260821-dry-wm")
+
+        scan_and_convert([reports_dir], state_dir, dry_run=True)
+
+        wm_path = state_dir / _WATERMARK_FILENAME
+        assert not wm_path.exists()
+        bash_wm_path = state_dir / "processed_receipts.txt"
+        assert not bash_wm_path.exists()
+
+    def test_dry_run_count_unchanged_before_and_after(self, reports_dir, state_dir):
+        _write_frontmatter_report(reports_dir / "20260821-dry-count.md", "20260821-dry-count")
+
+        before = _count_receipts(state_dir)
+        scan_and_convert([reports_dir], state_dir, dry_run=True)
+        after = _count_receipts(state_dir)
+
+        assert before == after == 0
+
+    def test_dry_run_then_real_run_still_books_exactly_one(self, reports_dir, state_dir):
+        """A dry run must not poison the watermark or ledger — the real run
+        immediately after still books exactly one receipt."""
+        _write_frontmatter_report(
+            reports_dir / "20260821-dry-then-real.md", "20260821-dry-then-real",
+        )
+
+        dry_stats = scan_and_convert([reports_dir], state_dir, dry_run=True)
+        assert dry_stats.would_append_count == 1
+        assert _count_receipts(state_dir) == 0
+
+        real_stats = scan_and_convert([reports_dir], state_dir)
+        assert real_stats.new_count == 1
+        assert _count_receipts(state_dir) == 1
+
+    def test_dispatch_id_dry_run_targeted_writes_nothing(self, reports_dir, state_dir):
+        _write_frontmatter_report(
+            reports_dir / "20260821-dry-targeted.md", "20260821-dry-targeted",
+        )
+
+        stats = convert_dispatch_ids(
+            ["20260821-dry-targeted"], state_dir, dry_run=True,
+        )
+
+        assert stats.would_append_count == 1
+        assert _count_receipts(state_dir) == 0
+        assert not (state_dir / _WATERMARK_FILENAME).exists()
+
+    def test_dry_run_no_health_beacon_written(self, reports_dir, state_dir):
+        """dry_run must leave zero observable state — including the health
+        beacon _write_scan_heartbeat would otherwise write on a real scan."""
+        _write_frontmatter_report(reports_dir / "20260821-dry-beacon.md", "20260821-dry-beacon")
+
+        scan_and_convert([reports_dir], state_dir, dry_run=True)
+
+        beacon_path = state_dir / "health" / "report_to_receipt_converter.json"
+        assert not beacon_path.exists()

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -3537,6 +3537,46 @@ class TestLedgerRowFallback(_LaneTestCase):
         self.assertIn(self.DISPATCH_ID, joined)
         self.assertIn("ledger fallback", joined)
 
+    def test_unreadable_ledger_row_warns_instead_of_silently_skipping(self):
+        """An unparseable line in t0_receipts.ndjson must not make
+        _has_ledger_completion_row silently conclude "no row" — that is
+        exactly the spot deciding whether the vangnet fires a duplicate
+        booking. A broken row on disk must be LOUD (WARNING + dispatch_id),
+        never quietly swallowed by the JSONDecodeError guard."""
+        lane, _reports_dir = self._make_lane_and_reports_dir()
+        self.receipts_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.receipts_file.open("a", encoding="utf-8") as fh:
+            fh.write(f'{{"dispatch_id": "{self.DISPATCH_ID}", "event_type": BROKEN\n')
+
+        with self.assertLogs("tmux_interactive_dispatch", level="WARNING") as cm:
+            result = lane._has_ledger_completion_row(self.DISPATCH_ID)
+
+        self.assertFalse(result, "an unreadable row is not a completion row")
+        joined = "\n".join(cm.output)
+        self.assertIn(self.DISPATCH_ID, joined)
+        self.assertIn("JSONDecodeError", joined)
+
+    def test_unreadable_ledger_row_does_not_block_scan_of_later_valid_row(self):
+        """A broken line must be skipped (with a warning), not treated as a
+        reason to abort the scan — a genuine completion row further down the
+        same file must still be found."""
+        lane, _reports_dir = self._make_lane_and_reports_dir()
+        self.receipts_file.parent.mkdir(parents=True, exist_ok=True)
+        valid_row = {
+            "dispatch_id": self.DISPATCH_ID,
+            "event_type": "subprocess_completion",
+        }
+        with self.receipts_file.open("a", encoding="utf-8") as fh:
+            fh.write(f'{{"dispatch_id": "{self.DISPATCH_ID}", "event_type": BROKEN\n')
+            fh.write(json.dumps(valid_row) + "\n")
+
+        with self.assertLogs("tmux_interactive_dispatch", level="WARNING"):
+            result = lane._has_ledger_completion_row(self.DISPATCH_ID)
+
+        self.assertTrue(
+            result, "a valid completion row later in the file must still be found",
+        )
+
 
 # ---------------------------------------------------------------------------
 # RECEIPT step: dedup — authored > synthesized; late worker wins

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -3387,6 +3387,158 @@ class TestReceiptFallback(_LaneTestCase):
 
 
 # ---------------------------------------------------------------------------
+# RECEIPT step: OI-1383/OI-1382 — ledger-row fallback when neither the worker
+# nor ensure_receipt() ever wrote one (report_backstop fools ensure_receipt's
+# "raw.receipt is not None" gate: that receipt is a fabricated in-memory dict,
+# never a landed ledger row).
+# ---------------------------------------------------------------------------
+
+_FALLBACK_TEST_REPORT_BODY = (
+    "## Summary\n\nImplemented the fallback per dispatch specification. "
+    "All targeted tests pass and the change stays within scope.\n\n"
+    "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+    "## Verification\n\npytest tests/test_example.py -x: 3 passed\n\n"
+    "## Open Items\n\nNone\n"
+)
+
+
+class TestLedgerRowFallback(_LaneTestCase):
+    """_govern_report books its own ledger row when nothing else did."""
+
+    def _make_lane_and_reports_dir(self):
+        lane = TmuxInteractiveDispatch(
+            self.state_dir,
+            receipts_file=self.receipts_file,
+            project_root=self.state_dir,
+        )
+        reports_dir = self.state_dir.parent / "unified_reports"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        return lane, reports_dir
+
+    def _ledger_rows_for(self, dispatch_id):
+        if not self.receipts_file.exists():
+            return []
+        lines = [
+            json.loads(ln)
+            for ln in self.receipts_file.read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+        return [r for r in lines if r.get("dispatch_id") == dispatch_id]
+
+    def test_books_ledger_row_from_report_when_worker_skipped_protocol(self):
+        """Report on disk is the ONLY source: no worker-emitted row exists, and
+        the receipt _wait_for_receipt would hand to govern() is the fabricated
+        report_backstop dict (never itself written to the ledger). The
+        fallback must still book exactly one real ledger row from the report.
+        """
+        lane, reports_dir = self._make_lane_and_reports_dir()
+        report_path = reports_dir / f"{self.DISPATCH_ID}.md"
+        report_path.write_text(_FALLBACK_TEST_REPORT_BODY, encoding="utf-8")
+
+        # Exact shape _wait_for_receipt's signal-3 report_backstop produces
+        # (tmux_interactive_dispatch.py, _wait_for_receipt): non-None, but
+        # never appended to t0_receipts.ndjson anywhere.
+        backstop_receipt = {
+            "dispatch_id": self.DISPATCH_ID,
+            "status": "done",
+            "event_type": "subprocess_completion",
+            "source": "report_backstop",
+            "_signal": "report_backstop",
+            "report_path": str(report_path),
+        }
+
+        self.assertFalse(self.receipts_file.exists(), "no ledger row must exist before govern()")
+
+        result_path = lane._govern_report(
+            dispatch_id=self.DISPATCH_ID,
+            terminal_id="ephemeral",
+            instruction="do the thing",
+            receipt=backstop_receipt,
+            duration_seconds=42.0,
+            model="sonnet",
+            role="backend-developer",
+        )
+
+        self.assertIsNotNone(result_path, "govern() must still emit a report")
+        rows = self._ledger_rows_for(self.DISPATCH_ID)
+        self.assertEqual(
+            len(rows), 1,
+            f"expected exactly one fallback-booked ledger row, got: {rows}",
+        )
+        booked = rows[0]
+        self.assertIn(
+            booked.get("event_type"),
+            ("task_complete", "task_failed", "report_contract_invalid"),
+            f"unexpected event_type on fallback-booked row: {booked}",
+        )
+        # Identity comes from the report govern() itself wrote (frontmatter),
+        # not from an assumption made by the fallback.
+        self.assertEqual(booked.get("model"), "sonnet")
+        self.assertEqual(booked.get("provider"), "claude")
+
+    def test_no_second_row_when_worker_wrote_own(self):
+        """The worker's own Completion Protocol run already landed a row in
+        t0_receipts.ndjson before govern() is called (signal-1 canonical).
+        The fallback must be a complete no-op — no second row."""
+        lane, reports_dir = self._make_lane_and_reports_dir()
+        report_path = reports_dir / f"{self.DISPATCH_ID}.md"
+        report_path.write_text(_FALLBACK_TEST_REPORT_BODY, encoding="utf-8")
+
+        worker_receipt = {
+            "event_type": "subprocess_completion",
+            "receipt_kind": "dispatch",
+            "dispatch_id": self.DISPATCH_ID,
+            "terminal": "ephemeral",
+            "terminal_id": "ephemeral",
+            "status": "done",
+            "source": "tmux_interactive",
+            "timestamp": "2026-08-21T12:00:00Z",
+            "report_path": str(report_path),
+            "provider": "claude",
+            "sub_provider": "anthropic",
+            "model": "sonnet",
+            "lane": "tmux_interactive",
+        }
+        self.receipts_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.receipts_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(worker_receipt) + "\n")
+
+        lane._govern_report(
+            dispatch_id=self.DISPATCH_ID,
+            terminal_id="ephemeral",
+            instruction="do the thing",
+            receipt=worker_receipt,
+            duration_seconds=12.0,
+            model="sonnet",
+            role="backend-developer",
+        )
+
+        rows = self._ledger_rows_for(self.DISPATCH_ID)
+        self.assertEqual(
+            len(rows), 1,
+            f"worker already wrote its own row — fallback must not add a second: {rows}",
+        )
+        self.assertEqual(
+            rows[0].get("source"), "tmux_interactive",
+            "the surviving row must still be the worker's own, untouched",
+        )
+
+    def test_warns_loudly_when_no_report_to_fall_back_on(self):
+        """No worker row AND govern() produced no report_path (e.g. emit
+        failure) — the fallback cannot book anything and must say so loudly
+        (WARNING with the dispatch_id), never fail silently."""
+        lane, _reports_dir = self._make_lane_and_reports_dir()
+
+        with self.assertLogs("tmux_interactive_dispatch", level="WARNING") as cm:
+            lane._fallback_book_ledger_row(self.DISPATCH_ID, None)
+
+        self.assertFalse(self._ledger_rows_for(self.DISPATCH_ID))
+        joined = "\n".join(cm.output)
+        self.assertIn(self.DISPATCH_ID, joined)
+        self.assertIn("ledger fallback", joined)
+
+
+# ---------------------------------------------------------------------------
 # RECEIPT step: dedup — authored > synthesized; late worker wins
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `_wait_for_receipt`'s report-backstop signal (signal 3) fabricates an in-memory completion receipt from a complete+stable report file with **no write to `t0_receipts.ndjson`**. That non-`None` receipt satisfies `dispatch_govern.ensure_receipt()`'s `raw.receipt is not None` gate, which makes it skip — so a worker that did real work, wrote a valid contract report, and simply never ran the Completion Protocol shell command was left with **no ledger row at all**. Measured live 2026-08-21: 2 of 7 dispatches through this lane (`q2-feature-plan-untrack`, `q4-ci-gate-tests-dequarantine`).
- `_govern_report` now checks the real ledger file after `govern()` runs and, only when no completion row exists for the dispatch, drives the on-disk report through the existing `report_to_receipt_converter` path to book one. No second parser. A failed fallback logs loud at WARNING with the dispatch_id and reason — never silent.
- `report_to_receipt_converter`'s CLI gains `--dispatch-id ID` (repeatable, resolves via `report_path.resolve_report_path()` directly — no directory scan) and `--dry-run` (reports intent, writes nothing, leaves no watermark entry), so a missed dispatch can be booked after the fact without a full-inventory scan.

## Changes

- `scripts/lib/tmux_interactive_dispatch.py`: adds `_has_ledger_completion_row()` and `_fallback_book_ledger_row()`; wired into `_govern_report()` right after `govern(spec, raw, lane=...)`.
- `scripts/lib/report_to_receipt_converter.py`: `_convert_one_detailed()` gains `dry_run`; `scan_and_convert()` gains `dry_run`; new `convert_dispatch_ids()` for targeted, non-scanning conversion; `ScanStats` gains `would_append_count`; CLI (`main()`) gains `--dispatch-id` (repeatable) and `--dry-run`.
- `tests/test_tmux_interactive_dispatch.py`: new `TestLedgerRowFallback` — books a row from the report alone when the worker skipped the protocol; no second row when the worker's own row already landed; loud WARNING when there is no report to fall back on.
- `tests/test_report_to_receipt_converter.py`: new `TestConvertDispatchIds` and `TestDryRun` covering targeted booking, idempotency, unknown-id handling, and dry-run's zero-write/zero-watermark guarantee.

## Verification

```
python3 -m pytest tests/test_report_to_receipt_converter.py tests/test_tmux_interactive_dispatch.py tests/test_dispatch_govern.py tests/test_tmux_dispatch_pr_enforcement_annotation.py -q
```
```
........................................................................ [ 15%]
........................................................................ [ 31%]
........................................................................ [ 47%]
........................................................................ [ 63%]
........................................................................ [ 78%]
........................................................................ [ 94%]
.........................                                                [100%]
457 passed in 62.52s (0:01:02)
```

Also ran an end-to-end CLI smoke test (`--state-dir`/`--dispatch-id`/`--dry-run` against a scratch report) confirming: dry-run leaves zero files on disk (no `t0_receipts.ndjson`, no watermark); the follow-up real `--dispatch-id` run books exactly one correctly-identified row.

Did **not** run the full suite per dispatch instructions (targeted files + direct neighbors only) and did not touch `scripts/lib/pr_enforcement.py` (separate in-flight work).

## Open Items

None — backfilling the existing q2/q4 gap in the live ledger is explicitly out of scope for this PR (operator does that manually with the new `--dispatch-id` flag after merge).