### PR TITLE
fix(report-to-receipt-converter): scope dedup guard to completion-kind rows

### DIFF
--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1098,16 +1098,35 @@ def _convert_one_detailed(
     # parsing/hashing the mapper file and keeps the ScanStats.duplicate_count
     # honest (the converter didn't build this receipt — the hot-path did).
     #
-    # The guard fires for ANY existing receipt (not only contract_invalid):
-    # the hot-path's emit_dispatch_receipt writes richer data (token_usage,
-    # cost_usd, session_id) than the converter can reconstruct from the
-    # report, so the hot-path's receipt should always win.  Checking only
-    # for contract_invalid would miss cases where the converter's
-    # fail-closed checks produce a different status (e.g. failure when the
-    # hot-path wrote contract_invalid).
+    # The guard must fire ONLY on an existing COMPLETION record for this
+    # dispatch, never on any line that merely carries the dispatch_id.
+    # review_gate/state_mutation/sub_dispatch/... rows (dispatch_identity.
+    # RECEIPT_KINDS — the closed set every emitter's receipt_kind is
+    # validated against) reference the dispatch_id without ever recording
+    # that the dispatch itself finished; matching on dispatch_id alone made
+    # the guard refuse to book a real completion the moment ANY such row
+    # existed, even when no completion row had ever been written. Every
+    # emitter that DOES record the dispatch's own completion — the worker's
+    # Completion Protocol, dispatch_govern.ensure_receipt's synthesized
+    # fallback, phantom_guard, pr_enforcement, envelope_govern,
+    # provider_dispatch, and this converter's own build_receipt_from_report
+    # (receipt["receipt_kind"] set above) — stamps the same receipt_kind
+    # this converter just built, so comparing against that field scopes the
+    # guard to the record kind it actually needs to detect.
+    #
+    # Once scoped to a real completion row, the guard fires for ANY status
+    # on that row (not only contract_invalid): the hot-path's
+    # emit_dispatch_receipt writes richer data (token_usage, cost_usd,
+    # session_id) than the converter can reconstruct from the report, so the
+    # hot-path's receipt should always win. Checking only for
+    # contract_invalid would miss cases where the converter's fail-closed
+    # checks produce a different status (e.g. failure when the hot-path
+    # wrote contract_invalid).
     _guard_did = receipt.get("dispatch_id")
+    _guard_kind = receipt.get("receipt_kind")
     if (
         _guard_did
+        and _guard_kind
         and receipts_file
         and Path(receipts_file).exists()
     ):
@@ -1125,10 +1144,13 @@ def _convert_one_detailed(
                     _rec = json.loads(_line)
                 except json.JSONDecodeError:
                     continue
-                if _rec.get("dispatch_id") == _guard_did:
+                if (
+                    _rec.get("dispatch_id") == _guard_did
+                    and _rec.get("receipt_kind") == _guard_kind
+                ):
                     logger.info(
                         "report_to_receipt_converter: skipping dispatch=%s — "
-                        "receipt already exists (hot-path wrote first)",
+                        "completion receipt already exists (hot-path wrote first)",
                         _guard_did,
                     )
                     return AppendResult(

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -1513,6 +1513,143 @@ class TestConverterDoubleCountGuard:
         assert len(lines) >= 1, "expected at least one receipt line"
 
 
+class TestConverterDedupGuardMatchesCompletionKindOnly:
+    """The hot-path duplicate guard in _convert_one_detailed() must match
+    only an existing COMPLETION record for this dispatch_id — a ledger row
+    whose receipt_kind equals the "dispatch" member of dispatch_identity.
+    RECEIPT_KINDS, the same closed set every receipt_kind is validated
+    against (dispatch_identity.validate_receipt_kind). review_gate /
+    state_mutation / sub_dispatch rows reference the dispatch_id without
+    ever recording that the dispatch itself finished, and must never block
+    booking the real completion."""
+
+    def test_non_completion_rows_do_not_block_booking(self, tmp_path, state_dir):
+        """A ledger holding only a review_gate row and a state_mutation row
+        for this dispatch_id (no receipt_kind=dispatch row at all) must NOT
+        be mistaken for an existing completion — the converter must book
+        the missing completion instead of skipping."""
+        dispatch_id = "20260821-guard-noncompletion-only"
+        receipts_file = state_dir / "t0_receipts.ndjson"
+        seed_lines = [
+            {
+                "dispatch_id": dispatch_id,
+                "event_type": "review_gate_requested",
+                "receipt_kind": "review_gate",
+                "status": "requested",
+                "source": "vnx_governance",
+                "timestamp": "2026-08-21T09:00:00Z",
+            },
+            {
+                "dispatch_id": dispatch_id,
+                "event_type": "roadmap_transition",
+                "receipt_kind": "state_mutation",
+                "status": "success",
+                "source": "pr_merge",
+                "timestamp": "2026-08-21T09:05:00Z",
+            },
+        ]
+        receipts_file.write_text(
+            "\n".join(json.dumps(l, separators=(",", ":")) for l in seed_lines) + "\n",
+            encoding="utf-8",
+        )
+
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id)
+
+        result = convert_report_to_receipt(report, receipts_file=str(receipts_file))
+
+        assert result is not None
+        assert result.status == "appended", (
+            f"expected the converter to book the missing completion, got {result.status!r}"
+        )
+        all_lines = receipts_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(all_lines) == 3, "the completion row must be booked alongside the seeded rows"
+        booked_kinds = [json.loads(l).get("receipt_kind") for l in all_lines]
+        assert booked_kinds.count("dispatch") == 1, (
+            "exactly one completion (receipt_kind=dispatch) row must exist"
+        )
+
+    def test_existing_completion_row_still_blocks_booking(self, tmp_path, state_dir):
+        """A ledger that already carries a receipt_kind=dispatch/status=done
+        completion row must still be treated as already booked — the guard
+        must not lose this case while narrowing its match."""
+        dispatch_id = "20260821-guard-completion-exists"
+        receipts_file = state_dir / "t0_receipts.ndjson"
+        existing = {
+            "dispatch_id": dispatch_id,
+            "event_type": "subprocess_completion",
+            "receipt_kind": "dispatch",
+            "status": "done",
+            "source": "tmux_interactive",
+            "terminal": "T1",
+            "timestamp": "2026-08-21T09:10:00Z",
+        }
+        receipts_file.write_text(
+            json.dumps(existing, separators=(",", ":")) + "\n", encoding="utf-8",
+        )
+
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id)
+
+        result = convert_report_to_receipt(report, receipts_file=str(receipts_file))
+
+        assert result is not None
+        assert result.status == "duplicate"
+        lines = receipts_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1, "no second completion row must be appended"
+
+    def test_completion_row_alongside_other_rows_still_blocks_booking(
+        self, tmp_path, state_dir,
+    ):
+        """A completion row (receipt_kind=dispatch) sitting NEXT TO
+        review_gate/state_mutation rows for the same dispatch_id must still
+        be detected — the guard must not require the completion row to be
+        the only line in the ledger."""
+        dispatch_id = "20260821-guard-completion-plus-others"
+        receipts_file = state_dir / "t0_receipts.ndjson"
+        seed_lines = [
+            {
+                "dispatch_id": dispatch_id,
+                "event_type": "review_gate_requested",
+                "receipt_kind": "review_gate",
+                "status": "requested",
+                "source": "vnx_governance",
+                "timestamp": "2026-08-21T09:00:00Z",
+            },
+            {
+                "dispatch_id": dispatch_id,
+                "event_type": "subprocess_completion",
+                "receipt_kind": "dispatch",
+                "status": "done",
+                "source": "tmux_interactive",
+                "terminal": "T1",
+                "timestamp": "2026-08-21T09:02:00Z",
+            },
+            {
+                "dispatch_id": dispatch_id,
+                "event_type": "roadmap_transition",
+                "receipt_kind": "state_mutation",
+                "status": "success",
+                "source": "pr_merge",
+                "timestamp": "2026-08-21T09:05:00Z",
+            },
+        ]
+        receipts_file.write_text(
+            "\n".join(json.dumps(l, separators=(",", ":")) for l in seed_lines) + "\n",
+            encoding="utf-8",
+        )
+
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id)
+
+        result = convert_report_to_receipt(report, receipts_file=str(receipts_file))
+
+        assert result is not None
+        assert result.status == "duplicate"
+        all_lines = receipts_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(all_lines) == 3, "no new row must be appended when a completion row already exists"
+
+
 # ---------------------------------------------------------------------------
 # Part 12: _is_known_dispatch — dispatch register cross-check (OI-1110)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_convert_one_detailed()`'s hot-path duplicate guard in `report_to_receipt_converter.py` matched ANY ledger line carrying the dispatch_id — a `review_gate` request row or a `state_mutation` row was enough to make it conclude the dispatch's completion was already booked, permanently.
- Measured live 21-08 on `20260821-q2-feature-plan-untrack` and `20260821-q4-ci-gate-tests-dequarantine`: both did real work, wrote a contract-valid report, and shipped a PR, but their completion row is missing. The converter refused to book either with `receipt already exists (hot-path wrote first)`, even though no completion row ever existed.
- Fix: the guard now also compares `receipt_kind`, scoping the match to the same `"dispatch"` value (`dispatch_identity.RECEIPT_KINDS` closed set) every completion emitter across the fleet already stamps for a dispatch's own lifecycle receipt — the worker's Completion Protocol, `dispatch_govern.ensure_receipt`'s synthesized fallback, `phantom_guard`, `pr_enforcement`, `envelope_govern`, `provider_dispatch`, and this converter's own `build_receipt_from_report`.

## Changes
- `scripts/lib/report_to_receipt_converter.py`: the hot-path dedup guard in `_convert_one_detailed()` now requires both `dispatch_id` AND `receipt_kind` to match before treating an existing ledger line as "already booked."
- `tests/test_report_to_receipt_converter.py`: adds `TestConverterDedupGuardMatchesCompletionKindOnly` with three regression tests:
  1. `test_non_completion_rows_do_not_block_booking` — a ledger with only a `review_gate` row and a `state_mutation` row for a dispatch_id → the converter books the completion.
  2. `test_existing_completion_row_still_blocks_booking` — a ledger with an existing `receipt_kind=dispatch`/`status=done` completion row → the converter books nothing.
  3. `test_completion_row_alongside_other_rows_still_blocks_booking` — a completion row sitting next to `review_gate`/`state_mutation` rows → still detected, still no duplicate booking.

## Verification
- `python3 -m pytest tests/test_report_to_receipt_converter.py -q` → **155 passed**
- Direct neighbours: `python3 -m pytest tests/test_report_parser_model_provider.py -q` → **38 passed**; `python3 -m pytest tests/test_tmux_interactive_dispatch.py -q` → **232 passed**
- Real dry-run against the two named dispatches with the fixed code (no writes — verified `t0_receipts.ndjson` and the watermark files kept their pre-run mtimes/sizes):
  ```
  INFO __main__: report_to_receipt_converter: [dry-run] would book dispatch=20260821-q2-feature-plan-untrack event_type=task_complete status= file=20260821-q2-feature-plan-untrack.md
  INFO __main__: report_to_receipt_converter: [dry-run] would book dispatch=20260821-q4-ci-gate-tests-dequarantine event_type=task_complete status= file=20260821-q4-ci-gate-tests-dequarantine.md
  INFO __main__: report_to_receipt_converter: [dry-run] 2 would be booked; nothing written
  ```
  (2 would be booked, vs. 0 before the fix.) Per dispatch instruction, this run was dry-only — the real booking is left for the operator to run after merge.

## Open Items
None.