### PR TITLE
fix(pr-enforcement): honor spec work_ref, never open a second PR (OI-1392)

### DIFF
--- a/scripts/lib/pr_enforcement.py
+++ b/scripts/lib/pr_enforcement.py
@@ -54,6 +54,19 @@ honors ``autopr_rejected`` the same way it honors ``phantom_rejected``) — so a
 dispatch that committed real work but never got it to a PR does NOT silently
 resolve as 'done'.
 
+work_ref (OI-1392): a dispatch spec can prescribe an explicit delivery branch —
+the phantom-guard has honored this since OI-1137. Push+PR enforcement did not:
+it always enforced against the worktree's own branch (OI-1372's resolved
+checked-out name, still ``dispatch/<id>`` when the worker never checks out
+anything else locally). A worker that commits on its own ``dispatch/<id>``
+AND separately pushes the same sha onto ``work_ref`` got a SECOND branch
+pushed and a SECOND PR opened against the stale ``dispatch/<id>`` base
+(#1631, #1632) — reverting already-merged work when that PR was merged. When
+*work_ref* is passed to ``enforce_pr_exists``, it is authoritative: the branch
+and worktree_state arguments are never consulted, nothing is ever pushed (the
+worker already delivered there), and at most one PR is ensured for
+*work_ref* itself. See ``_enforce_pr_exists_for_work_ref``.
+
 BILLING SAFETY: No Anthropic SDK. CLI-only (gh/git via subprocess, through
 gh_pr_ensure).
 """
@@ -94,6 +107,24 @@ class PrEnforcementResult:
     created: bool = False
     pushed: bool = False
     reason: Optional[str] = None
+
+
+def _normalize_work_ref(work_ref: "Optional[str]") -> "Optional[str]":
+    """Strip common ref prefixes from a work_ref so it names a bare branch.
+
+    Mirrors ``phantom_guard._normalize_branch_name`` (deliberately not
+    imported — that name is private to phantom_guard, which this module must
+    not be coupled to). ``work_ref`` may be declared as a bare branch name
+    (``dispatch/20260815-foo``) or with a remote/refs prefix
+    (``origin/dispatch/20260815-foo``); gh_pr_ensure targets a bare branch
+    name via ``--head``.
+    """
+    name = (work_ref or "").strip()
+    for prefix in ("refs/heads/", "refs/remotes/origin/", "origin/"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    return name or None
 
 
 def _get_remote_head(*, branch: str, repo_root: Path) -> "Optional[str]":
@@ -272,6 +303,7 @@ def enforce_pr_exists(
     target_remote_head: "Optional[str]" = None,
     skip_pr: bool = False,
     wt_path: "Optional[Path | str]" = None,
+    work_ref: "Optional[str]" = None,
 ) -> PrEnforcementResult:
     """Ensure *branch* is pushed to origin AND has an open PR.
 
@@ -306,11 +338,30 @@ def enforce_pr_exists(
     this through yet), a ``dirty`` verdict keeps the pre-OI-1119 behaviour:
     applicable=False, ok=True.
 
+    *work_ref* (OI-1392): when set, it is the authoritative delivery branch —
+    *branch*, *worktree_state* and *wt_path* are never consulted, and nothing
+    is ever pushed. This is intentionally a full bypass of the worktree_state
+    dispatch below, not an additional case inside it: any of those states
+    (including ``dirty``'s salvage path, which itself pushes a branch) could
+    still act on the worktree's OWN branch, which is exactly the second-branch
+    bug this closes. See ``_enforce_pr_exists_for_work_ref``.
+
     Never raises: a push or gh_pr_ensure exception is treated as a failure (still
     enforced — reported via PrEnforcementResult.ok=False + corrective receipt), not
     propagated, so a transient git/GitHub/network error never crashes the dispatch
     lane.
     """
+    work_ref_branch = _normalize_work_ref(work_ref)
+    if work_ref_branch:
+        return _enforce_pr_exists_for_work_ref(
+            dispatch_id=dispatch_id,
+            work_ref_branch=work_ref_branch,
+            repo_root=repo_root,
+            receipts_file=receipts_file,
+            pr_title=pr_title,
+            pr_body=pr_body,
+        )
+
     if worktree_state == "clean":
         return PrEnforcementResult(
             applicable=False, ok=True,
@@ -415,6 +466,70 @@ def enforce_pr_exists(
         kind="pr_failed",
     )
     return PrEnforcementResult(applicable=True, ok=False, pushed=pushed, reason=reason)
+
+
+def _enforce_pr_exists_for_work_ref(
+    *,
+    dispatch_id: str,
+    work_ref_branch: str,
+    repo_root: Path,
+    receipts_file: "str | Path",
+    pr_title: str,
+    pr_body: str,
+) -> PrEnforcementResult:
+    """OI-1392: enforcement scoped to a spec-declared work_ref — never the
+    worktree's own branch.
+
+    Never pushes anything: ``gh_pr_ensure.ensure_pr``/``create_pr`` only ever
+    run ``gh pr create --head <branch>``, which requires the branch to already
+    exist on origin — there is no push call in this path, by construction, so
+    the worktree's own ``dispatch/<id>`` branch (or any other branch) can never
+    be pushed as a side effect of this function.
+
+    - a PR already open for *work_ref_branch* → done, nothing created
+      (``ensure_pr``'s own ``find_open_pr`` short-circuit before any create
+      call — see gh_pr_ensure.py);
+    - none open yet → ensure exactly one, for *work_ref_branch*;
+    - *work_ref_branch* missing from origin (the worker declared a work_ref
+      but never actually delivered there) → a genuine, receipt-visible
+      failure, exactly like any other ``pr_failed``. This never falls back to
+      the worktree's own branch — that silent fallback is the bug OI-1392
+      closes (a stale-based second PR that reverts merged work when merged).
+    """
+    try:
+        from gh_pr_ensure import ensure_pr  # noqa: PLC0415
+        result = ensure_pr(work_ref_branch, repo_root, title=pr_title, body=pr_body, draft=False)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "pr_enforcement: ensure_pr raised for work_ref=%s: %s", work_ref_branch, exc,
+        )
+        result = {"pr_number": None, "created": False, "reason": f"ensure_pr exception: {exc}"}
+
+    pr_number = result.get("pr_number")
+    if pr_number is not None:
+        return PrEnforcementResult(
+            applicable=True, ok=True, pushed=False,
+            pr_number=pr_number, created=bool(result.get("created")),
+            reason=(
+                f"work_ref={work_ref_branch!r} (OI-1392) — "
+                + ("PR created" if result.get("created") else "PR already existed")
+            ),
+        )
+
+    reason = (
+        (result.get("reason") or f"gh pr create failed for work_ref branch {work_ref_branch!r}")
+        + " (OI-1392: work_ref was set — the worktree's own dispatch branch is "
+        "intentionally never used as a fallback destination)"
+    )
+    logger.warning(
+        "pr_enforcement: REJECTED (work_ref) dispatch=%s work_ref_branch=%s — %s",
+        dispatch_id, work_ref_branch, reason,
+    )
+    _record_corrective_receipt(
+        dispatch_id=dispatch_id, branch=work_ref_branch, reason=reason,
+        receipts_file=receipts_file, kind="pr_failed",
+    )
+    return PrEnforcementResult(applicable=True, ok=False, pushed=False, reason=reason)
 
 
 def _handle_dirty_substantive(

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1444,6 +1444,15 @@ class TmuxInteractiveDispatch:
                     f"(dispatch `{dispatch_id}`) — the worker pushed this branch "
                     "but did not open a PR itself. Please review before merging."
                 ),
+                # OI-1392: a spec-declared work_ref is where delivery actually
+                # landed — never the worktree's own dispatch/<id> branch, even
+                # when the worker also committed there. Sourced the same way
+                # _fail_loud_on_empty_extraction already reads it for the
+                # phantom-guard (the door exports it, see dispatch_cli.py).
+                # enforce_pr_exists treats a truthy work_ref as authoritative
+                # and ignores branch/worktree_state entirely — see its
+                # docstring and _enforce_pr_exists_for_work_ref.
+                work_ref=os.environ.get("VNX_WORK_REF") or None,
             )
         except Exception as exc:  # noqa: BLE001 — never block a real completion on this guard
             logger.error(

--- a/tests/test_oi1392_pr_enforcement_work_ref.py
+++ b/tests/test_oi1392_pr_enforcement_work_ref.py
@@ -1,0 +1,251 @@
+"""test_oi1392_pr_enforcement_work_ref.py — OI-1392 regression.
+
+A dispatch spec can carry a ``work_ref`` — the branch a fix-forward dispatch
+delivers onto. ``dispatch_bridge.py`` has supported that field since OI-1137,
+and phantom_guard already honors it. PR *enforcement*
+(``pr_enforcement.enforce_pr_exists``, the tmux lane's ``_enforce_pr_exists``)
+never did: it always enforced push+PR against the worktree's own branch — the
+checked-out name OI-1372 (#1623) resolves, which is STILL ``dispatch/<id>``
+when the worker never checks out anything else locally.
+
+On 21-08 that produced #1631 and #1632: a worker committed on its own
+``dispatch/<id>`` branch AND separately pushed the same sha onto its declared
+``work_ref``. Enforcement classified ``dispatch/<id>`` as ``committed`` (never
+pushed under that name), pushed it, and opened a SECOND PR against a base
+that was already behind main — merging it reverted already-merged work.
+
+This is the inversion PR #1623 (OI-1372) does NOT cover: before #1623 a
+worker delivering off ``dispatch/<id>`` produced a false FAILURE (safe: no
+merge risk). After #1623, given a work_ref target, it can produce a false
+SUCCESS with a real second PR (unsafe: reverts work on merge). Fixing this
+must not regress #1623 — test 3 below is the explicit proof it doesn't.
+
+Real git repos throughout (mirrors test_oi1372_pr_enforcement_branch_resolution.py);
+only ``gh_pr_ensure``'s gh-boundary functions are mocked — nothing here
+touches GitHub.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import tmux_worktree
+from tmux_worktree import allocate, classify
+
+
+# ---------------------------------------------------------------------------
+# Shared real-git fixture (mirrors test_oi1372_pr_enforcement_branch_resolution.py)
+# ---------------------------------------------------------------------------
+
+def _init_git_repo_with_origin(tmp_path: Path) -> Path:
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", str(bare), str(local)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "checkout", "-b", "main"], capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "push", "-u", "origin", "main"], check=True, capture_output=True)
+    return local
+
+
+def _commit_on_own_branch(wt_path: Path, filename: str) -> None:
+    """Worker commits WITHOUT checking out anything else — stays on the
+    worktree's own dispatch/<id> branch, exactly the case OI-1372's
+    checked-out-branch resolution cannot see."""
+    (wt_path / filename).write_text("real work\n")
+    subprocess.run(["git", "-C", str(wt_path), "add", filename], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wt_path), "commit", "-m", "worker commit"], check=True, capture_output=True,
+    )
+
+
+def _commit_on_new_branch(wt_path: Path, branch: str, filename: str) -> None:
+    """OI-1372 case: the worker checks out *branch* and commits real work there."""
+    subprocess.run(
+        ["git", "-C", str(wt_path), "checkout", "-b", branch], check=True, capture_output=True,
+    )
+    (wt_path / filename).write_text("real work\n")
+    subprocess.run(["git", "-C", str(wt_path), "add", filename], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wt_path), "commit", "-m", "worker commit"], check=True, capture_output=True,
+    )
+
+
+def _remote_branch_exists(repo_root: Path, branch: str) -> bool:
+    ls = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-remote", "origin", f"refs/heads/{branch}"],
+        capture_output=True, text=True, check=True,
+    )
+    return bool(ls.stdout.strip())
+
+
+def _tmux_dispatch_instance(tmp_path: Path, project_root: Path):
+    from tmux_interactive_dispatch import TmuxInteractiveDispatch
+    return TmuxInteractiveDispatch(
+        project_root=project_root,
+        state_dir=tmp_path / "state",
+        receipts_file=tmp_path / "state" / "t0_receipts.ndjson",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 (verplicht): work_ref set, worker commits on OWN dispatch branch AND
+# pushes the same sha to the doelbranch — exactly one branch, exactly one PR.
+# ---------------------------------------------------------------------------
+
+def test_work_ref_present_worker_delivers_to_target_exactly_one_branch_one_pr(
+    tmp_path, monkeypatch,
+):
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1392-a", repo_root=local)
+
+    # Worker commits on its own dispatch/<id> branch (never checks out
+    # anything else) ...
+    _commit_on_own_branch(handle.path, "work.txt")
+    # ... AND separately pushes that exact sha onto the doelbranch (work_ref) —
+    # dispatch/oi1392-a itself is never pushed.
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "origin", "HEAD:refs/heads/work/oi1392-target"],
+        check=True, capture_output=True,
+    )
+
+    inst = _tmux_dispatch_instance(tmp_path, local)
+    state = classify(handle)
+    assert state == "committed", "dispatch/oi1392-a was never pushed under its own name"
+
+    monkeypatch.setenv("VNX_WORK_REF", "work/oi1392-target")
+
+    with patch("gh_pr_ensure.find_open_pr", return_value=None), \
+         patch("gh_pr_ensure.create_pr", return_value=6001) as mock_create:
+        result = inst._enforce_pr_exists(
+            dispatch_id="oi1392-a", label="T1", worktree_handle=handle, worktree_state=state,
+        )
+
+    assert result.applicable is True
+    assert result.ok is True, result.reason
+    assert result.pr_number == 6001
+    assert result.created is True
+
+    mock_create.assert_called_once()
+    created_branch = mock_create.call_args.args[0] if mock_create.call_args.args \
+        else mock_create.call_args.kwargs.get("branch")
+    assert created_branch == "work/oi1392-target", (
+        f"PR must be opened against work_ref, got {created_branch!r}"
+    )
+
+    # Precisely ONE branch beyond main: dispatch/oi1392-a must NEVER have been
+    # pushed — that would be the second branch this fix forbids.
+    assert not _remote_branch_exists(local, "dispatch/oi1392-a"), (
+        "a second branch (the worktree's own dispatch/<id>) must never be pushed "
+        "when work_ref is set"
+    )
+    assert _remote_branch_exists(local, "work/oi1392-target")
+
+
+# ---------------------------------------------------------------------------
+# Test 2 (verplicht): work_ref set, a PR is ALREADY open for it — nothing
+# is created.
+# ---------------------------------------------------------------------------
+
+def test_work_ref_pr_already_open_creates_nothing(tmp_path, monkeypatch):
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1392-b", repo_root=local)
+
+    _commit_on_own_branch(handle.path, "work.txt")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "origin", "HEAD:refs/heads/work/oi1392-existing"],
+        check=True, capture_output=True,
+    )
+
+    inst = _tmux_dispatch_instance(tmp_path, local)
+    state = classify(handle)
+    assert state == "committed"
+
+    monkeypatch.setenv("VNX_WORK_REF", "work/oi1392-existing")
+
+    def _boom(*a, **kw):
+        raise AssertionError("gh pr create must never run when a PR already exists for work_ref")
+
+    with patch("gh_pr_ensure.find_open_pr", return_value=4321), \
+         patch("gh_pr_ensure.create_pr", side_effect=_boom) as mock_create:
+        result = inst._enforce_pr_exists(
+            dispatch_id="oi1392-b", label="T1", worktree_handle=handle, worktree_state=state,
+        )
+
+    assert result.applicable is True
+    assert result.ok is True, result.reason
+    assert result.pr_number == 4321
+    assert result.created is False
+    mock_create.assert_not_called()
+
+    assert not _remote_branch_exists(local, "dispatch/oi1392-b"), (
+        "no second branch may be pushed even when a PR already exists for work_ref"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 (verplicht): WITHOUT work_ref, behavior is byte-identical to today —
+# including the exact case #1623 (OI-1372) fixed: a worker that pushes to a
+# branch other than dispatch/<id> must NOT be rejected as dispatch_branch_no_pr.
+# ---------------------------------------------------------------------------
+
+def test_no_work_ref_unchanged_behavior_oi1623_custom_branch_still_fixed(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.delenv("VNX_WORK_REF", raising=False)
+
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("oi1392-c", repo_root=local)
+    _commit_on_new_branch(handle.path, "fix/oi1392-no-work-ref", "work.txt")
+    subprocess.run(
+        ["git", "-C", str(handle.path), "push", "-u", "origin", "fix/oi1392-no-work-ref"],
+        check=True, capture_output=True,
+    )
+
+    inst = _tmux_dispatch_instance(tmp_path, local)
+    state = classify(handle)
+    assert state == "pushed"
+
+    with patch(
+        "gh_pr_ensure.ensure_pr",
+        return_value={"pr_number": 8181, "created": True, "reason": None},
+    ) as mock_ensure:
+        result = inst._enforce_pr_exists(
+            dispatch_id="oi1392-c", label="T1", worktree_handle=handle, worktree_state=state,
+        )
+
+    assert result.applicable is True
+    assert result.ok is True, (
+        f"must not regress to dispatch_branch_no_pr (OI-1372/#1623): {result.reason}"
+    )
+    assert result.pr_number == 8181
+
+    mock_ensure.assert_called_once()
+    called_branch = mock_ensure.call_args.args[0] if mock_ensure.call_args.args \
+        else mock_ensure.call_args.kwargs.get("branch")
+    assert called_branch == "fix/oi1392-no-work-ref", (
+        f"PR must still be opened against the branch actually pushed, got {called_branch!r}"
+    )

--- a/tests/test_pr_enforcement.py
+++ b/tests/test_pr_enforcement.py
@@ -655,3 +655,142 @@ def test_pr_failed_still_works_with_new_params(monkeypatch, tmp_path):
     assert result.ok is False
     assert "gh rate limited" in result.reason
     assert captured["payload"]["autopr_kind"] == "pr_failed"
+
+
+# ---------------------------------------------------------------------------
+# OI-1392: work_ref is authoritative — branch/worktree_state never consulted.
+# Lane-level, real-git regression tests live in
+# test_oi1392_pr_enforcement_work_ref.py; these are the pure-function unit
+# tests for the same contract.
+# ---------------------------------------------------------------------------
+
+def test_work_ref_bypasses_branch_and_worktree_state(monkeypatch):
+    """work_ref set → ensure_pr is called for work_ref, never for `branch`, and
+    the worktree_state dispatch (committed → push) never runs."""
+    import gh_pr_ensure
+    push_calls = {"n": 0}
+
+    import pr_enforcement
+    monkeypatch.setattr(
+        pr_enforcement.subprocess, "run",
+        lambda *a, **kw: (push_calls.__setitem__("n", push_calls["n"] + 1), _CompletedRC(0))[1],
+    )
+
+    captured = {}
+
+    def _fake_ensure_pr(branch, repo_root, *, title, body, draft=False):
+        captured.update(branch=branch)
+        return {"pr_number": 6001, "created": True, "reason": None}
+
+    monkeypatch.setattr(gh_pr_ensure, "ensure_pr", _fake_ensure_pr)
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(worktree_state="committed", work_ref="work/oi1392-target")
+    )
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pushed is False
+    assert result.pr_number == 6001
+    assert result.created is True
+    assert captured["branch"] == "work/oi1392-target"
+    assert push_calls["n"] == 0, "work_ref must never trigger a git push"
+
+
+def test_work_ref_strips_ref_prefixes(monkeypatch):
+    """A work_ref declared with a remote/refs prefix is normalized to a bare
+    branch name before it reaches gh_pr_ensure (mirrors phantom_guard's own
+    normalization of the same field)."""
+    import gh_pr_ensure
+    captured = {}
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda branch, repo_root, **kw: (
+            captured.update(branch=branch), {"pr_number": 1, "created": True, "reason": None}
+        )[1],
+    )
+
+    pe.enforce_pr_exists(
+        **_kwargs(worktree_state="clean", work_ref="origin/work/oi1392-target")
+    )
+    assert captured["branch"] == "work/oi1392-target"
+
+
+def test_work_ref_already_open_pr_creates_nothing(monkeypatch):
+    """work_ref with an already-open PR → nothing created, no push."""
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": 4321, "created": False, "reason": None},
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(worktree_state="dirty", work_ref="work/oi1392-existing")
+    )
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pr_number == 4321
+    assert result.created is False
+    assert result.pushed is False
+
+
+def test_work_ref_missing_from_origin_is_loud_failure_not_a_second_branch(monkeypatch, tmp_path):
+    """work_ref set but never actually pushed to origin (gh pr create fails) →
+    a genuine, receipt-visible failure — NEVER a fallback to `branch`."""
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {
+            "pr_number": None, "created": False,
+            "reason": "gh pr create failed for branch 'work/oi1392-target' (no open PR found on retry)",
+        },
+    )
+
+    import pr_enforcement
+    push_calls = {"n": 0}
+    monkeypatch.setattr(
+        pr_enforcement.subprocess, "run",
+        lambda *a, **kw: (push_calls.__setitem__("n", push_calls["n"] + 1), _CompletedRC(0))[1],
+    )
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload),
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(
+            receipts_file=str(tmp_path / "r.ndjson"),
+            worktree_state="committed",
+            work_ref="work/oi1392-target",
+        )
+    )
+
+    assert result.applicable is True
+    assert result.ok is False
+    assert result.pushed is False
+    assert push_calls["n"] == 0, "a missing work_ref branch must never fall back to pushing `branch`"
+    payload = captured["payload"]
+    assert payload["branch"] == "work/oi1392-target"
+    assert payload["branch"] != "dispatch/d1"
+
+
+def test_empty_work_ref_falls_through_to_normal_behavior(monkeypatch):
+    """work_ref="" (or None) is indistinguishable from an absent work_ref — the
+    existing branch/worktree_state path runs unchanged."""
+    import gh_pr_ensure
+    captured = {}
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda branch, repo_root, **kw: (
+            captured.update(branch=branch), {"pr_number": 101, "created": True, "reason": None}
+        )[1],
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs(work_ref=""))
+
+    assert result.ok is True
+    assert captured["branch"] == "dispatch/d1"


### PR DESCRIPTION
## Summary

`pr_enforcement.enforce_pr_exists` always enforced push+PR against the worktree's own branch (OI-1372's resolved checked-out name — still `dispatch/<id>` when the worker never checks anything else out locally). A worker that commits on its own `dispatch/<id>` branch AND separately pushes the same sha onto its declared `work_ref` got a second branch pushed and a second PR opened against a stale `dispatch/<id>` base — that PR reverted already-merged work when merged (#1631, #1632).

## Changes

- `scripts/lib/pr_enforcement.py`: `enforce_pr_exists()` gains a `work_ref` parameter. When set (after `_normalize_work_ref` strips ref/remote prefixes), it is authoritative — `branch`/`worktree_state`/`wt_path` are never consulted and nothing is ever pushed. New `_enforce_pr_exists_for_work_ref()` ensures at most one PR for `work_ref` itself (idempotent via `gh_pr_ensure.ensure_pr`), with a receipt-visible `pr_failed` when `work_ref` was never actually pushed. Without `work_ref`, the existing worktree_state dispatch runs unchanged.
- `scripts/lib/tmux_interactive_dispatch.py`: `_enforce_pr_exists` now threads `work_ref=os.environ.get("VNX_WORK_REF") or None` into `enforce_pr_exists`, mirroring how `_fail_loud_on_empty_extraction` already reads the same env var for the phantom-guard.
- Phantom-guard, `scripts/gate_obligation_runner.py`, `envelope_govern.py`, `dispatch_envelope.py` — untouched (out of scope).

## Verification

Targeted tests + direct neighbors (not the full suite):

```
python3 -m pytest tests/test_oi1392_pr_enforcement_work_ref.py tests/test_pr_enforcement.py tests/test_oi1372_pr_enforcement_branch_resolution.py tests/test_pr_enforcement_dirty_substantive.py tests/test_lane_matrix_row7_push_pr.py tests/test_tmux_interactive_dispatch.py -q
295 passed in 52.42s
```

New file `tests/test_oi1392_pr_enforcement_work_ref.py` (real git, lane-level, mirrors `test_oi1372_pr_enforcement_branch_resolution.py`) carries the 3 required regression tests:
1. `test_work_ref_present_worker_delivers_to_target_exactly_one_branch_one_pr` — work_ref set, worker commits on own `dispatch/<id>` AND pushes the same sha to the target branch → exactly one branch (work_ref) and one PR; `dispatch/<id>` is proven never pushed via `git ls-remote`.
2. `test_work_ref_pr_already_open_creates_nothing` — work_ref with an already-open PR → nothing created (`gh pr create` asserted never called).
3. `test_no_work_ref_unchanged_behavior_oi1623_custom_branch_still_fixed` — no work_ref → behavior identical to today, including the exact OI-1372/#1623 case (worker pushes to a custom branch, must not regress to `dispatch_branch_no_pr`).

`tests/test_pr_enforcement.py` also gained 5 pure-function unit tests for the new bypass (prefix normalization, already-open-PR no-op, missing-work_ref-branch loud failure with no push fallback, empty-string work_ref falls through unchanged).

## Open Items

None