### PR TITLE
fix(gate-obligation-runner): unknown/unavailable gate status never lands fulfilled (OI-1400)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -65,6 +65,10 @@ from gate_obligations import (  # noqa: E402
     pr_number_from_pr_id,
     update_obligation,
 )
+from gate_status import (  # noqa: E402
+    PASS_STATES as _GATE_RESULT_PASS_STATES,
+    UNAVAILABLE_STATES as _GATE_RESULT_UNAVAILABLE_STATES,
+)
 
 _LOG = logging.getLogger("gate_obligation_runner")
 
@@ -81,18 +85,30 @@ _UNRESOLVABLE_ESCALATION_ATTEMPTS = 96
 # A gate RESULT can itself report a TEMPORARY refusal rather than a real
 # verdict on the code: ``status=running`` means a CI check is still in flight
 # (gate_executor's ci_gate path — not all checks reached a terminal bucket
-# yet), and ``status=not_executable`` with ``reason=provider_disabled`` means
+# yet), ``status=not_executable`` with ``reason=provider_disabled`` means
 # the gate is parked by config (e.g. VNX_CI_GATE_REQUIRED=0 —
 # gate_result_parser._classify_unavailable / gate_request_handler
-# ._mark_gate_unavailable). Neither says anything about the code; both are
-# "not yet", not "no". Treating either as terminal burns the obligation
-# forever — measured live against PR #1627 (OI-1384): CI had actually passed,
-# but the recorded obligation was a dead not_executable/provider_disabled with
-# no report_path, no contract_hash, no branch, no commit_sha. Same shape as
-# the ``unresolvable`` PR-resolution path below: stays pending under a
-# bounded retry term, then escalates to the loud terminal not_executable — a
-# temporary refusal that recurs forever must still eventually alarm someone,
-# just not on the first attempt.
+# ._mark_gate_unavailable), and ``status=unavailable`` (gate_status.py's
+# UNAVAILABLE_STATES — gate_recorder.record_failure books this for an
+# execution failure: crash, timeout, stall, a failed worktree checkout) means
+# the provider never produced a verdict at all. None of the three says
+# anything about the code; all are "not yet", not "no". Treating any of them
+# as terminal burns the obligation forever — measured live against PR #1627
+# (OI-1384): CI had actually passed, but the recorded obligation was a dead
+# not_executable/provider_disabled with no report_path, no contract_hash, no
+# branch, no commit_sha. A consumer project separately measured the
+# ``unavailable`` case (OI-1400): PR #966/#967 booked ``fulfilled`` off a
+# not_executable/provider-not-installed and an unavailable/worktree-checkout-
+# failed result respectively, both with empty contract_hash and report_path —
+# because the fallback below defaulted every non-terminal, non-temporary
+# status to fulfilled. All three temporary cases stay pending under a bounded
+# retry term, then escalate to the loud terminal not_executable — a temporary
+# refusal that recurs forever must still eventually alarm someone, just not
+# on the first attempt. Anything left over — a status this runner has never
+# seen — takes the SAME pending/escalate path (OI-1400): the fallback used to
+# read "anything I don't recognise as terminal is a pass," which is how the
+# two obligations above landed silently fulfilled with zero evidence. The
+# fallback now reads "anything I don't recognise as a pass is NOT a pass."
 _TEMPORARY_RESULT_STATUSES = frozenset({"running"})
 _TEMPORARY_NOT_EXECUTABLE_REASONS = frozenset({"provider_disabled"})
 _TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
@@ -643,9 +659,39 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
                 "not broken — the obligation waits for it to be re-enabled or for a "
                 "future run, not permanently refused"
             )
-        else:
+        elif result_status in _GATE_RESULT_UNAVAILABLE_STATES:
+            temp_reason = "gate_run_unavailable"
+            temp_detail = (
+                f"{gate} for PR #{pr_number} reported unavailable"
+                + (f" ({result_reason})" if result_reason else "")
+                + " — the provider produced no verdict at all (outage, quota, "
+                "timeout, or a failed setup step such as a worktree checkout), "
+                "not a judgment on the code; will be re-attempted on the next run"
+            )
+        elif result_status in TERMINAL_STATUSES or result_status in _GATE_RESULT_PASS_STATES:
             temp_reason = None
             temp_detail = None
+        else:
+            # OI-1400: a status that is neither a known terminal obligation
+            # state nor a known gate-result pass must NEVER fall through to
+            # "fulfilled" — that silent default is exactly how PR #966/#967
+            # in a consumer project landed as vervuld with zero evidence
+            # (empty contract_hash, empty report_path). Treat an unrecognised
+            # status the same as the other temporary refusals above: pending,
+            # loud, and bounded — never a quiet pass.
+            temp_reason = "gate_status_unknown"
+            temp_detail = (
+                f"{gate} for PR #{pr_number} returned an unrecognised result "
+                f"status ({result_status!r}) — refusing to record that as "
+                "fulfilled; staying pending until a recognised status is seen "
+                "or this escalates"
+            )
+            _LOG.warning(
+                "gate_obligation_runner: unrecognised result status %r for "
+                "pr=%s gate=%s (reason=%r) — NOT marking the obligation "
+                "fulfilled (OI-1400)",
+                result_status, pr_number, gate, result_reason,
+            )
 
         if temp_reason is not None:
             # Same shape as the `unresolvable` PR-resolution path: stays

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -40,6 +40,7 @@ import producer_freshness
 from dispatch_cli import run_dispatch
 from gate_obligations import (
     NO_GATE_KEY,
+    STATUS_FAILED,
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
@@ -512,6 +513,145 @@ def test_runner_escalates_temporary_refusal_to_not_executable_after_threshold(tm
     assert record["status"] == STATUS_NOT_EXECUTABLE
     assert record["reason"] == "gate_parked_timeout"
     assert record["attempts"] == runner._TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# 2c. OI-1400: an unknown/unavailable gate status must never fall through
+# to "fulfilled" — that silent default is exactly how a consumer project's
+# PR #966/#967 booked vervuld off a not_executable/provider-not-installed and
+# an unavailable/worktree-checkout-failed result, both with empty
+# contract_hash and empty report_path.
+# ---------------------------------------------------------------------------
+
+
+def test_runner_leaves_pending_on_unavailable_result(tmp_path, monkeypatch):
+    """status=unavailable (gate_status.UNAVAILABLE_STATES) means the provider
+    produced no verdict at all — outage, quota, timeout, or a failed setup
+    step such as a worktree checkout (measured live: a consumer project's
+    PR #967 booked vervuld off exactly this shape). Must stay pending with a
+    reason that names the outage, not "gate_parked" (that name is reserved
+    for a config-disabled gate) and never "fulfilled"."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260821-oi1400-unavailable", gate="codex_gate",
+        project_id="vnx-dev", pr_number=967,
+    )
+    manager = _FakeManager(
+        state_dir, result_status="unavailable", result_reason="worktree_checkout_failed",
+    )
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 1
+    record = _read_obligation(state_dir, "20260821-oi1400-unavailable")
+    assert record["status"] == STATUS_PENDING
+    assert record["attempts"] == 1
+    assert record["reason"] == "gate_run_unavailable"
+    assert "unavailable" in record["reason_detail"]
+    assert "worktree_checkout_failed" in record["reason_detail"]
+
+
+def test_runner_escalates_unavailable_to_not_executable_after_threshold(tmp_path, monkeypatch):
+    """Same bounded-retry-then-escalate shape as the other temporary
+    refusals: an unavailable result that recurs forever must still
+    eventually alarm someone, just not on the first attempt."""
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="20260821-oi1400-unavailable-escalate", gate="codex_gate",
+        project_id="vnx-dev", pr_number=968,
+    )
+    update_obligation(path, attempts=runner._TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS - 1)
+    manager = _FakeManager(state_dir, result_status="unavailable", result_reason="timeout")
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260821-oi1400-unavailable-escalate")
+    assert record["status"] == STATUS_NOT_EXECUTABLE
+    assert record["reason"] == "gate_run_unavailable_timeout"
+    assert record["attempts"] == runner._TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS
+
+
+def test_runner_does_not_fulfill_on_unknown_result_status(tmp_path, monkeypatch):
+    """A gate result status this runner has never seen before must NOT fall
+    through to `fulfilled` — that silent default is the exact bug behind
+    OI-1400. It must land somewhere safe and visible (pending, loud reason)
+    instead."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260821-oi1400-unknown-status", gate="codex_gate",
+        project_id="vnx-dev", pr_number=969,
+    )
+    manager = _FakeManager(state_dir, result_status="quantum_flux_undecided")
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    record = _read_obligation(state_dir, "20260821-oi1400-unknown-status")
+    assert record["status"] != STATUS_FULFILLED, (
+        "an unrecognised result status must never silently land as fulfilled"
+    )
+    assert summary["pending_after"] == 1
+    assert record["status"] == STATUS_PENDING
+    assert record["attempts"] == 1
+    assert record["reason"] == "gate_status_unknown"
+    assert "quantum_flux_undecided" in record["reason_detail"]
+
+
+def test_runner_fulfills_a_normal_passing_gate_result(tmp_path, monkeypatch):
+    """The doorval inversion must not touch the ordinary success path: a gate
+    that actually ran and decided PASS still lands fulfilled.
+
+    ``status="pass"`` is the real verdict value a genuine passing gate run
+    writes — confirmed via
+    ``grep -n '"status": verdict' scripts/lib/gate_executor.py``
+    (ci_gate's ``_ci_gate_summary``/``verdict`` produce exactly ``"pass"``,
+    ``"fail"``, or ``"running"``) and cross-checked against the canonical
+    vocabulary in ``scripts/lib/gate_status.py`` (``PASS_STATES = {"approve",
+    "completed", "pass", "passed"}``), which is what this fix imports as
+    ``_GATE_RESULT_PASS_STATES`` to decide the fulfilled path."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260821-oi1400-normal-pass", gate="ci_gate",
+        project_id="vnx-dev", pr_number=970,
+    )
+    manager = _FakeManager(state_dir, result_status="pass")
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260821-oi1400-normal-pass")
+    assert record["status"] == STATUS_FULFILLED
+    assert record["attempts"] == 1
+
+
+def test_runner_known_terminal_statuses_stay_unchanged(tmp_path, monkeypatch):
+    """The three obligation-level terminal statuses (failed, fulfilled,
+    not_executable) must keep resolving to themselves — the doorval
+    inversion narrows the fallback, it must not touch the already-correct
+    literal mappings."""
+    for status, pr_number in (
+        (STATUS_FAILED, 971),
+        (STATUS_FULFILLED, 972),
+        (STATUS_NOT_EXECUTABLE, 973),
+    ):
+        state_dir = _make_state_dir(tmp_path / f"terminal-{status}")
+        dispatch_id = f"20260821-oi1400-terminal-{status}"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate",
+            project_id="vnx-dev", pr_number=pr_number,
+        )
+        manager = _FakeManager(state_dir, result_status=status)
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 0
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == status, f"result status {status!r} must stay terminal as itself"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`fulfill_obligation()` booked ANY gate-result status it didn't recognise as `STATUS_FULFILLED` — the fallthrough was "anything not known-terminal is a pass." A consumer project measured the live fallout: PR #966 booked `vervuld` off a `not_executable`/`provider_not_installed` result, and PR #967 booked `vervuld` off an `unavailable`/worktree-checkout-failed result — both with an empty `contract_hash` and empty `report_path`, i.e. zero evidence that any review ever ran.

## Changes

1. `status=unavailable` (`gate_status.UNAVAILABLE_STATES`) now joins the temporary-refusal set alongside `status=running` and `not_executable`/`provider_disabled` (PR #1633, OI-1384) — same bounded pending-then-escalate shape, with its own reason (`gate_run_unavailable`) so the record shows this was an outage, not a parked gate.
2. The fallthrough is inverted (the real fix): only a known terminal obligation status or a known gate-result pass status (`gate_status.PASS_STATES`) now reaches `fulfilled`. Anything else — a status this runner has never seen — takes the same pending/escalate path instead of a silent pass.

`scripts/gate_obligation_runner.py` now imports `PASS_STATES`/`UNAVAILABLE_STATES` from `scripts/lib/gate_status.py`, the existing single source of truth for the gate-result status vocabulary, instead of hand-rolling a second one.

No existing obligations were touched — this only changes how *future* runs classify a result.

## Verification

Confirmed the real "pass" verdict value via:
```
grep -n '"status": verdict' scripts/lib/gate_executor.py
```
→ `ci_gate`'s `verdict` is literally `"pass"`/`"fail"`/`"running"` (`scripts/lib/gate_executor.py:225-231`), matching `gate_status.PASS_STATES`.

Ran the touched test file plus its direct neighbours:
```
python3 -m pytest tests/test_gate_obligations.py tests/test_gate_obligation_runner.py tests/test_gate_obligation_runner_scope.py -v
```
→ 54 passed, 0 failed.

Also ran `tests/test_gate_status_schema.py` and `tests/test_gate_runner.py` to check for regressions in the shared `gate_status` vocabulary: 2 pre-existing failures (`test_closure_verifier_reads_status_completed_as_pass`, `TestGateTimeoutConfig::test_default_stall_threshold`) reproduce identically on `origin/main` with this change stashed out — unrelated to this PR, not introduced by it.

New tests added (`tests/test_gate_obligations.py`):
- `test_runner_leaves_pending_on_unavailable_result` — unavailable stays pending with a reason naming the outage.
- `test_runner_escalates_unavailable_to_not_executable_after_threshold` — same bounded escalation as the other temporary refusals.
- `test_runner_does_not_fulfill_on_unknown_result_status` — a made-up status never lands fulfilled.
- `test_runner_fulfills_a_normal_passing_gate_result` — the ordinary success path (`status="pass"`) is unbroken.
- `test_runner_known_terminal_statuses_stay_unchanged` — `failed`/`fulfilled`/`not_executable` still resolve to themselves.

## Open Items

None. Existing burned/false-fulfilled obligations (113 burned, 2 false-fulfilled per the dispatch) are out of scope — this PR only stops the count from growing.