### PR TITLE
fix(open-items): sync report Open Items into the ledger (OI-1289)

### DIFF
--- a/scripts/lib/open_items_from_report.py
+++ b/scripts/lib/open_items_from_report.py
@@ -1,0 +1,133 @@
+"""open_items_from_report.py — push a worker report's ## Open Items entries
+into the open-items ledger (OI-1289).
+
+Part of the same pipeline the CLAUDE.md report contract describes:
+  report on disk -> receipt processor -> t0_receipts.ndjson (+ open_items.json)
+
+This module does NOT scan unified_reports/ on its own — it is handed the
+report text report_to_receipt_converter.py already read, at the point that
+report's receipt lands (or is confirmed to already exist). No second report
+scanner is introduced.
+
+"Correctly formatted item" reuses validate_report.extract_open_items() — the
+same shape the pre-submit format check already enforces
+(``- [ ] [blocker|warn|info] Title``) — so this path and that check can never
+define "an item" differently. An explicit "None" body and an introductory
+prose line both fail that shape and are therefore never picked up; no
+special-casing is needed here for either.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sys
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_LIB_DIR = Path(__file__).resolve().parent
+_SCRIPTS_DIR = _LIB_DIR.parent
+
+_OPEN_ITEMS_HEADING = "## Open Items"
+
+# Conservative-default contract (OI-1289): an automatically-ingested item
+# never becomes a blocker on its own — severity only rises above this
+# default when the report itself is explicit (a real [blocker]/[warn] tag).
+_VALID_SEVERITIES = ("blocker", "warn", "info")
+_DEFAULT_SEVERITY = "info"
+
+
+def _normalize_severity(raw_severity: str) -> str:
+    """Map a raw severity token to the ledger's vocabulary.
+
+    Falls back to the conservative default (_DEFAULT_SEVERITY) for anything
+    outside the recognised set — this is the safety net that keeps a future
+    upstream change from silently inflating the blocker count.
+    """
+    severity = (raw_severity or "").strip().lower()
+    return severity if severity in _VALID_SEVERITIES else _DEFAULT_SEVERITY
+
+
+def _dedup_key(dispatch_id: str, title: str) -> str:
+    """Stable dedup key: reprocessing the same report must not duplicate items."""
+    digest = hashlib.sha256(title.encode("utf-8")).hexdigest()[:16]
+    return f"report_oi:{dispatch_id}:{digest}"
+
+
+def sync_open_items_from_report(
+    text: str,
+    *,
+    dispatch_id: str,
+    report_path: str,
+    oim: Optional[Any] = None,
+) -> List[Tuple[str, bool]]:
+    """Register every formatted ``## Open Items`` entry in *text* to the ledger.
+
+    Returns a list of (item_id, created) pairs, one per formatted item found.
+    ``created=False`` means the item already existed (dedup_key match), not a
+    fresh entry — reprocessing the same report is therefore idempotent.
+
+    Returns ``[]`` when the section is absent, explicitly reports "None", or
+    contains only prose (no line matches the formatted-item shape) — no
+    ``open_items_manager`` import happens in that case, so a report with zero
+    items never pays the STATE_DIR resolution cost.
+
+    *oim* injects an already-loaded ``open_items_manager`` module — used by
+    tests to point at an isolated STATE_DIR. Production callers omit it and
+    get the real module via a lazy import.
+
+    Never raises: a per-item registration failure (including the acceptance-
+    criterion guard's ``ValueError``) is logged and skipped, never fatal to
+    the caller's receipt-append flow.
+    """
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    from report_body_contract import _extract_section  # noqa: PLC0415
+    from validate_report import extract_open_items  # noqa: PLC0415
+
+    section = _extract_section(text, _OPEN_ITEMS_HEADING)
+    if not section:
+        return []
+
+    items = extract_open_items(section)
+    if not items:
+        return []
+
+    if oim is None:
+        import open_items_manager as oim  # noqa: PLC0415
+
+    results: List[Tuple[str, bool]] = []
+    for raw_severity, raw_title in items:
+        title = raw_title.strip()
+        if not title:
+            continue
+        severity = _normalize_severity(raw_severity)
+
+        try:
+            item_id, created = oim.add_item_programmatic(
+                title=title,
+                severity=severity,
+                dispatch_id=dispatch_id,
+                report_path=report_path,
+                dedup_key=_dedup_key(dispatch_id, title),
+                source="report_open_items",
+            )
+        except ValueError as exc:
+            # Acceptance-criterion guard: title reads as a passed check-off,
+            # not a problem. Skip it — one bad title must not crash the sync.
+            logger.warning(
+                "open_items_from_report: skipped item dispatch=%s title=%r: %s",
+                dispatch_id, title, exc,
+            )
+            continue
+        except Exception as exc:
+            logger.warning(
+                "open_items_from_report: registration failed dispatch=%s title=%r: %s",
+                dispatch_id, title, exc,
+            )
+            continue
+
+        results.append((item_id, created))
+
+    return results

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1154,6 +1154,7 @@ def _convert_one_detailed(
     # wrote contract_invalid).
     _guard_did = receipt.get("dispatch_id")
     _guard_kind = receipt.get("receipt_kind")
+    _guard_matched = False
     if (
         _guard_did
         and _guard_kind
@@ -1183,15 +1184,26 @@ def _convert_one_detailed(
                         "completion receipt already exists (hot-path wrote first)",
                         _guard_did,
                     )
-                    if not dry_run:
-                        _sync_report_open_items(receipt, text)
-                    return AppendResult(
-                        status="duplicate",
-                        receipts_file=Path(receipts_file),
-                        idempotency_key=_guard_did,
-                    ), "duplicate"
+                    _guard_matched = True
+                    break
         except OSError:
             pass  # can't read NDJSON — fall through to normal append (idempotency will catch it)
+
+    # The sync call sits outside the OSError-scoped try above and outside
+    # any handler that reads a specific exception attribute (see the
+    # append_receipt_payload try/except below): a sync-branch failure of
+    # ANY shape must never be mistaken for — or swallowed alongside — an
+    # NDJSON-read or booking failure. _sync_report_open_items() never raises
+    # on its own (it self-guards and logs), so this call is a plain
+    # statement, not a try body.
+    if _guard_matched:
+        if not dry_run:
+            _sync_report_open_items(receipt, text)
+        return AppendResult(
+            status="duplicate",
+            receipts_file=Path(receipts_file),
+            idempotency_key=_guard_did,
+        ), "duplicate"
 
     if dry_run:
         logger.info(
@@ -1202,6 +1214,11 @@ def _convert_one_detailed(
         )
         return receipt, "would_append"
 
+    # The booking call and its AppendReceiptError/.code handling are scoped
+    # to this try alone. The open-items sync runs strictly AFTER this block
+    # returns a result, never inside it — a sync-branch failure (of any
+    # shape, with or without a .code attribute) must never be caught by a
+    # handler that assumes every exception here is an AppendReceiptError.
     try:
         result = append_receipt_payload(
             receipt,
@@ -1209,9 +1226,6 @@ def _convert_one_detailed(
             cache_window_seconds=cache_window_seconds,
             skip_enrichment=True,  # converter receipts skip quality advisory
         )
-        if result.status in ("appended", "duplicate"):
-            _sync_report_open_items(receipt, text)
-        return result, result.status
     except AppendReceiptError as exc:
         if exc.code == "missing_model":
             logger.warning(
@@ -1230,6 +1244,10 @@ def _convert_one_detailed(
             report_path.name, exc,
         )
         return None, "error"
+
+    if result.status in ("appended", "duplicate"):
+        _sync_report_open_items(receipt, text)
+    return result, result.status
 
 
 def convert_report_to_receipt(

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1023,6 +1023,36 @@ def build_receipt_from_report(
 #                 actual append_receipt_payload() call — nothing was written,
 #                 no watermark entry, no fail-closed check even attempted.
 
+def _sync_report_open_items(receipt: Dict[str, Any], text: str) -> None:
+    """Best-effort: push *text*'s ``## Open Items`` entries into the ledger.
+
+    OI-1289: runs at the point a report already has (or is confirmed to
+    already have) a governed receipt — the hook point the dispatch calls
+    for, not a second report scanner. Never raises: a sync failure must
+    never turn a successful receipt append into a failed one.
+    """
+    dispatch_id = receipt.get("dispatch_id")
+    if not dispatch_id:
+        return
+    try:
+        from open_items_from_report import sync_open_items_from_report
+        registered = sync_open_items_from_report(
+            text,
+            dispatch_id=str(dispatch_id),
+            report_path=str(receipt.get("report_path") or ""),
+        )
+        if registered:
+            logger.info(
+                "report_to_receipt_converter: synced %d open item(s) from dispatch=%s",
+                len(registered), dispatch_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "report_to_receipt_converter: open-items sync failed dispatch=%s: %s",
+            dispatch_id, exc,
+        )
+
+
 def _convert_one_detailed(
     report_path: Path,
     *,
@@ -1153,6 +1183,8 @@ def _convert_one_detailed(
                         "completion receipt already exists (hot-path wrote first)",
                         _guard_did,
                     )
+                    if not dry_run:
+                        _sync_report_open_items(receipt, text)
                     return AppendResult(
                         status="duplicate",
                         receipts_file=Path(receipts_file),
@@ -1177,6 +1209,8 @@ def _convert_one_detailed(
             cache_window_seconds=cache_window_seconds,
             skip_enrichment=True,  # converter receipts skip quality advisory
         )
+        if result.status in ("appended", "duplicate"):
+            _sync_report_open_items(receipt, text)
         return result, result.status
     except AppendReceiptError as exc:
         if exc.code == "missing_model":

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1245,6 +1245,27 @@ def _convert_one_detailed(
         )
         return None, "error"
 
+    # append_receipt_payload's documented contract (payload.py's own OI-948
+    # guard, and its mirror in scripts/append_receipt.py main()) is: return an
+    # AppendResult or raise AppendReceiptError — never return None. Every real
+    # branch of _write_receipt_under_lock honors that (confirmed by reading
+    # idempotency.py:191-281: each path returns AppendResult or raises).
+    # A None here is therefore not a legitimate "nothing was booked" outcome —
+    # it means whatever object is bound to append_receipt_payload at call time
+    # violated that contract (reproduced: pytest test-order pollution from
+    # test_heartbeat_subprocess_cleanup.py's `sys.modules["append_receipt"]`
+    # mutation can silently replace this symbol for the rest of the suite).
+    # Fail loud instead of letting it crash one line down as an opaque
+    # AttributeError, and never sync open items against a row that was never
+    # booked.
+    if result is None:
+        logger.error(
+            "report_to_receipt_converter: append_receipt_payload returned no "
+            "result (contract violation — expected AppendResult) dispatch=%s file=%s",
+            receipt.get("dispatch_id"), report_path.name,
+        )
+        return None, "error"
+
     if result.status in ("appended", "duplicate"):
         _sync_report_open_items(receipt, text)
     return result, result.status

--- a/scripts/validate_report.py
+++ b/scripts/validate_report.py
@@ -23,6 +23,27 @@ if str(SCRIPT_DIR) not in sys.path:
 
 from validate_template_tokens import validate_all_templates
 
+# Shape of a correctly-formatted Open Items entry: "- [ ] [severity] Title".
+# Single definition, reused by scripts/lib/open_items_from_report.py (OI-1289)
+# so the pre-submit format check and the ledger-sync path can never drift
+# apart on what counts as "a formatted item" vs. prose.
+OPEN_ITEM_PATTERN = re.compile(
+    r'-\s*\[\s*\]\s*\[(blocker|warn|info)\]\s*(.*)',
+    re.IGNORECASE,
+)
+
+
+def extract_open_items(open_items_content: str) -> List[Tuple[str, str]]:
+    """Extract (severity, title) pairs from a raw Open Items section body.
+
+    A bullet without the exact ``[blocker|warn|info]`` severity tag is prose,
+    not an item, and is not returned.
+    """
+    return [
+        (severity, title.strip())
+        for severity, title in OPEN_ITEM_PATTERN.findall(open_items_content)
+    ]
+
 
 class ReportValidator:
     """Validates unified reports for completeness and correctness"""
@@ -166,7 +187,8 @@ class ReportValidator:
             return  # Valid
 
         # Otherwise, validate item format
-        items = re.findall(r'-\s*\[\s*\]\s*\[(blocker|warn|info)\]', open_items_content, re.IGNORECASE)
+        parsed_items = extract_open_items(open_items_content)
+        items = [severity for severity, _ in parsed_items]
 
         if not items:
             # Has content but no properly formatted items

--- a/tests/test_open_items_from_report.py
+++ b/tests/test_open_items_from_report.py
@@ -397,3 +397,69 @@ def test_convert_one_detailed_survives_sync_error_without_code_attr(
     # The receipt line itself landed in the ledger despite the sync crash.
     ledger_text = Path(receipts_file).read_text(encoding="utf-8")
     assert "20260821-oi-sync-crash" in ledger_text
+
+
+def test_convert_one_detailed_survives_empty_append_result(
+    tmp_path: Path, monkeypatch, caplog,
+):
+    """append_receipt_payload's contract is to return an AppendResult or raise
+    AppendReceiptError — never return None (payload.py's own OI-948 guard
+    enforces exactly this on every real _write_receipt_under_lock path). A
+    caller that violates this contract (reproduced against this suite:
+    tests/test_heartbeat_subprocess_cleanup.py's ``_build_monitor()`` helper
+    permanently replaces ``sys.modules["append_receipt"].append_receipt_payload``
+    with a ``MagicMock(return_value=None)`` when ``append_receipt`` is already
+    the real, previously-imported module — a test-order pollution bug, not a
+    real booking outcome) must never crash the converter with an opaque
+    'NoneType' object has no attribute 'status'. It must fail loud (an ERROR
+    naming the dispatch-id) and skip the open-items sync — there is no booked
+    ledger row to hang open items off.
+    """
+    import report_to_receipt_converter as rtc
+
+    calls = []
+
+    def _fake_sync(text, *, dispatch_id, report_path, oim=None):
+        calls.append(dispatch_id)
+        return [("OI-999", True)]
+
+    monkeypatch.setattr(
+        "open_items_from_report.sync_open_items_from_report", _fake_sync
+    )
+    monkeypatch.setattr("append_receipt.append_receipt_payload", lambda *a, **k: None)
+
+    report = tmp_path / "20260821-oi-empty-append.md"
+    report.write_text(
+        "**Dispatch-ID**: 20260821-oi-empty-append\n"
+        "**Model**: sonnet\n"
+        "**Provider**: claude\n\n"
+        "## Summary\n\n"
+        "Implemented the sync path end to end and wired it into the converter.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 3 passed\n\n"
+        "## Open Items\n\n- [ ] [warn] Revisit the timeout value later\n",
+        encoding="utf-8",
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    with caplog.at_level(logging.ERROR, logger="report_to_receipt_converter"):
+        result, outcome = rtc._convert_one_detailed(report, receipts_file=receipts_file)
+
+    # No crash: the empty return is turned into an explicit "error" outcome,
+    # never a raised AttributeError.
+    assert result is None
+    assert outcome == "error"
+
+    # Nothing was booked, so the sync must never fire.
+    assert calls == []
+
+    # The failure is loud: an ERROR naming the dispatch-id.
+    errors = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+    assert any(
+        "20260821-oi-empty-append" in msg for msg in errors
+    ), f"expected a loud empty-result error, got: {errors}"
+
+    # Nothing landed in the ledger — the file was never created.
+    assert not Path(receipts_file).exists()

--- a/tests/test_open_items_from_report.py
+++ b/tests/test_open_items_from_report.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Tests for open_items_from_report — OI-1289: a worker report's ## Open
+Items section must land in the open-items ledger, not just markdown.
+
+Covers the five pieces of evidence the dispatch calls for:
+  1. Three correctly-formatted items -> all three land in the ledger, with
+     dispatch-id and report path attached.
+  2. A report that explicitly reports emptiness ("None...") -> zero items.
+  3. Reprocessing the same report twice -> item count stays the same
+     (dedup_key idempotency).
+  4. An introductory prose line in the section -> never becomes an item.
+  5. The conservative default severity is pinned to a direct assertion.
+
+Plus: no section at all -> zero items; a title that collides with the
+acceptance-criterion guard is skipped, not fatal; and a wiring test proving
+report_to_receipt_converter._convert_one_detailed() actually calls into the
+sync at the point a report's receipt lands (the "hook onto the existing
+processing point" requirement, not a second scanner).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+ROOT_DIR = TESTS_DIR.parent
+SCRIPTS_DIR = ROOT_DIR / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(SCRIPTS_LIB)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import open_items_from_report  # noqa: E402
+from open_items_from_report import sync_open_items_from_report  # noqa: E402
+
+
+def _load_oim(tmp_path: Path):
+    """Load a fresh open_items_manager instance pinned to an isolated STATE_DIR.
+
+    Same pattern as tests/test_open_items_dedup_status.py and
+    tests/test_open_items_acceptance_criterion_guard.py — a module-level
+    constant (STATE_DIR) resolved at import time means the ambient
+    open_items_manager singleton cannot be trusted to point at tmp_path.
+    """
+    env_patch = {
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_STATE_DIR": str(tmp_path / "data" / "state"),
+        "VNX_HOME": str(ROOT_DIR),
+    }
+    (tmp_path / "data" / "state").mkdir(parents=True, exist_ok=True)
+
+    mod_name = f"open_items_manager_oireport_{tmp_path.name}"
+    with patch.dict(os.environ, env_patch):
+        spec = importlib.util.spec_from_file_location(
+            mod_name, SCRIPTS_DIR / "open_items_manager.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            del sys.modules[mod_name]
+            raise
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# 1. Three formatted items land in the ledger
+# ---------------------------------------------------------------------------
+
+def test_three_formatted_items_land_in_ledger(tmp_path: Path):
+    oim = _load_oim(tmp_path)
+    text = (
+        "## Open Items\n\n"
+        "- [ ] [blocker] Parser crashes on empty input\n"
+        "- [ ] [warn] Timeout value is a guess, revisit\n"
+        "- [ ] [info] Consider caching the lookup table\n"
+    )
+
+    results = sync_open_items_from_report(
+        text,
+        dispatch_id="20260821-oi-three",
+        report_path="/tmp/reports/20260821-oi-three.md",
+        oim=oim,
+    )
+
+    assert len(results) == 3
+    assert all(created for _id, created in results)
+
+    data = oim.load_items()
+    items = data["items"]
+    assert len(items) == 3
+
+    titles = {i["title"] for i in items}
+    assert titles == {
+        "Parser crashes on empty input",
+        "Timeout value is a guess, revisit",
+        "Consider caching the lookup table",
+    }
+    severities = {i["title"]: i["severity"] for i in items}
+    assert severities["Parser crashes on empty input"] == "blocker"
+    assert severities["Timeout value is a guess, revisit"] == "warn"
+    assert severities["Consider caching the lookup table"] == "info"
+
+    for item in items:
+        assert item["origin_dispatch_id"] == "20260821-oi-three"
+        assert item["origin_report_path"] == "/tmp/reports/20260821-oi-three.md"
+
+
+# ---------------------------------------------------------------------------
+# 2. Explicit "None" yields zero items
+# ---------------------------------------------------------------------------
+
+def test_explicit_none_yields_zero_items(tmp_path: Path):
+    oim = _load_oim(tmp_path)
+    text = "## Open Items\n\nNone - all work completed and tested.\n"
+
+    results = sync_open_items_from_report(
+        text, dispatch_id="20260821-oi-none", report_path="x.md", oim=oim,
+    )
+
+    assert results == []
+    assert oim.load_items()["items"] == []
+
+
+def test_no_open_items_section_yields_zero_items(tmp_path: Path):
+    """A report with no ## Open Items heading at all also yields zero items."""
+    oim = _load_oim(tmp_path)
+    text = "## Summary\n\nDid the work.\n"
+
+    results = sync_open_items_from_report(
+        text, dispatch_id="20260821-oi-nosection", report_path="x.md", oim=oim,
+    )
+
+    assert results == []
+    assert oim.load_items()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Reprocessing the same report twice is idempotent
+# ---------------------------------------------------------------------------
+
+def test_reprocessing_same_report_is_idempotent(tmp_path: Path):
+    oim = _load_oim(tmp_path)
+    text = "## Open Items\n\n- [ ] [blocker] Something broke in the parser\n"
+
+    first = sync_open_items_from_report(
+        text, dispatch_id="20260821-oi-dup", report_path="x.md", oim=oim,
+    )
+    second = sync_open_items_from_report(
+        text, dispatch_id="20260821-oi-dup", report_path="x.md", oim=oim,
+    )
+
+    assert len(first) == 1
+    assert first[0][1] is True  # created on first pass
+    assert len(second) == 1
+    assert second[0][1] is False  # deduped on second pass
+    assert second[0][0] == first[0][0]  # same item id, not a new one
+
+    assert len(oim.load_items()["items"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. An introductory prose line never becomes an item
+# ---------------------------------------------------------------------------
+
+def test_prose_intro_line_is_not_an_item(tmp_path: Path):
+    oim = _load_oim(tmp_path)
+    text = (
+        "## Open Items\n\n"
+        "The following still needs follow-up before this can close:\n\n"
+        "- [ ] [warn] Double-check the retry budget\n"
+    )
+
+    results = sync_open_items_from_report(
+        text, dispatch_id="20260821-oi-prose", report_path="x.md", oim=oim,
+    )
+
+    assert len(results) == 1
+    items = oim.load_items()["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "Double-check the retry budget"
+
+
+# ---------------------------------------------------------------------------
+# 5. Conservative default severity is pinned
+# ---------------------------------------------------------------------------
+
+def test_default_severity_falls_back_to_info():
+    """Locks the chosen default (info) so a later change is visible, not silent.
+
+    An item's own [blocker]/[warn]/[info] tag is honored directly (the report
+    being explicit about it, per OI-1289) — the fallback only fires for a
+    token outside that vocabulary, which is the safety net against an
+    uncontrolled blocker count.
+    """
+    assert open_items_from_report._DEFAULT_SEVERITY == "info"
+    assert open_items_from_report._normalize_severity("blocker") == "blocker"
+    assert open_items_from_report._normalize_severity("WARN") == "warn"
+    assert open_items_from_report._normalize_severity("Info") == "info"
+    assert open_items_from_report._normalize_severity("critical") == "info"
+    assert open_items_from_report._normalize_severity("") == "info"
+
+
+def test_unrecognized_severity_token_defaults_to_info_end_to_end(tmp_path: Path):
+    """End-to-end: even if extraction ever hands back an out-of-vocabulary
+    severity, the ledger entry is conservative (info), never a blocker."""
+    oim = _load_oim(tmp_path)
+
+    # sync_open_items_from_report() does `from validate_report import
+    # extract_open_items` locally on every call, so patching
+    # validate_report's own definition is what actually takes effect.
+    import validate_report
+
+    original = validate_report.extract_open_items
+    try:
+        validate_report.extract_open_items = lambda _content: [
+            ("critical", "Unrecognized severity token")
+        ]
+        results = sync_open_items_from_report(
+            "## Open Items\n\n- [ ] [critical] irrelevant, patched above\n",
+            dispatch_id="20260821-oi-defaultsev",
+            report_path="x.md",
+            oim=oim,
+        )
+    finally:
+        validate_report.extract_open_items = original
+
+    assert len(results) == 1
+    items = oim.load_items()["items"]
+    assert items[0]["severity"] == "info"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance-criterion guard: a bad title is skipped, not fatal
+# ---------------------------------------------------------------------------
+
+def test_acceptance_criterion_title_is_skipped_not_fatal(tmp_path: Path):
+    oim = _load_oim(tmp_path)
+    text = (
+        "## Open Items\n\n"
+        "- [ ] [info] CI green\n"
+        "- [ ] [warn] Real problem needing follow-up\n"
+    )
+
+    results = sync_open_items_from_report(
+        text, dispatch_id="20260821-oi-guard", report_path="x.md", oim=oim,
+    )
+
+    assert len(results) == 1
+    items = oim.load_items()["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "Real problem needing follow-up"
+
+
+# ---------------------------------------------------------------------------
+# Wiring: report_to_receipt_converter hooks into this sync at the point a
+# report's receipt lands — no second report scanner.
+# ---------------------------------------------------------------------------
+
+def test_convert_one_detailed_triggers_open_items_sync(tmp_path: Path, monkeypatch):
+    import report_to_receipt_converter as rtc
+
+    calls = []
+
+    def _fake_sync(text, *, dispatch_id, report_path, oim=None):
+        calls.append(dispatch_id)
+        return [("OI-999", True)]
+
+    monkeypatch.setattr(
+        "open_items_from_report.sync_open_items_from_report", _fake_sync
+    )
+
+    report = tmp_path / "20260821-oi-wire.md"
+    report.write_text(
+        "**Dispatch-ID**: 20260821-oi-wire\n"
+        "**Model**: sonnet\n"
+        "**Provider**: claude\n\n"
+        "## Summary\n\n"
+        "Implemented the sync path end to end and wired it into the converter.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 3 passed\n\n"
+        "## Open Items\n\n- [ ] [warn] Revisit the timeout value later\n",
+        encoding="utf-8",
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    result, outcome = rtc._convert_one_detailed(report, receipts_file=receipts_file)
+
+    assert outcome == "appended"
+    assert calls == ["20260821-oi-wire"]
+
+
+def test_convert_one_detailed_skips_sync_when_dry_run(tmp_path: Path, monkeypatch):
+    """A dry-run must leave zero observable state — the sync must not fire."""
+    import report_to_receipt_converter as rtc
+
+    calls = []
+
+    def _fake_sync(text, *, dispatch_id, report_path, oim=None):
+        calls.append(dispatch_id)
+        return [("OI-999", True)]
+
+    monkeypatch.setattr(
+        "open_items_from_report.sync_open_items_from_report", _fake_sync
+    )
+
+    report = tmp_path / "20260821-oi-wire-dry.md"
+    report.write_text(
+        "**Dispatch-ID**: 20260821-oi-wire-dry\n"
+        "**Model**: sonnet\n"
+        "**Provider**: claude\n\n"
+        "## Summary\n\n"
+        "Implemented the sync path end to end and wired it into the converter.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 3 passed\n\n"
+        "## Open Items\n\n- [ ] [warn] Revisit the timeout value later\n",
+        encoding="utf-8",
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    result, outcome = rtc._convert_one_detailed(
+        report, receipts_file=receipts_file, dry_run=True,
+    )
+
+    assert outcome == "would_append"
+    assert calls == []

--- a/tests/test_open_items_from_report.py
+++ b/tests/test_open_items_from_report.py
@@ -21,6 +21,7 @@ processing point" requirement, not a second scanner).
 from __future__ import annotations
 
 import importlib.util
+import logging
 import os
 import sys
 from pathlib import Path
@@ -337,3 +338,62 @@ def test_convert_one_detailed_skips_sync_when_dry_run(tmp_path: Path, monkeypatc
 
     assert outcome == "would_append"
     assert calls == []
+
+
+def test_convert_one_detailed_survives_sync_error_without_code_attr(
+    tmp_path: Path, monkeypatch, caplog,
+):
+    """A sync-branch failure carrying no ``.code`` attribute (e.g. a bare
+    AttributeError) must never abort the ledger booking. The sync sits on a
+    side branch off the main road — the receipt append is the main road and
+    must be booked and returned regardless of what the sync does, with the
+    sync failure logged loud (WARNING, dispatch-id + error) rather than
+    silently swallowed or allowed to shadow the booking outcome.
+    """
+    import report_to_receipt_converter as rtc
+
+    def _raise_no_code_attr(text, *, dispatch_id, report_path, oim=None):
+        raise AttributeError("simulated sync crash carrying no .code attribute")
+
+    monkeypatch.setattr(
+        "open_items_from_report.sync_open_items_from_report", _raise_no_code_attr
+    )
+
+    report = tmp_path / "20260821-oi-sync-crash.md"
+    report.write_text(
+        "**Dispatch-ID**: 20260821-oi-sync-crash\n"
+        "**Model**: sonnet\n"
+        "**Provider**: claude\n\n"
+        "## Summary\n\n"
+        "Implemented the sync path end to end and wired it into the converter.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 3 passed\n\n"
+        "## Open Items\n\n- [ ] [warn] Revisit the timeout value later\n",
+        encoding="utf-8",
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+    with caplog.at_level(logging.WARNING, logger="report_to_receipt_converter"):
+        result, outcome = rtc._convert_one_detailed(report, receipts_file=receipts_file)
+
+    # The ledger row is booked and returned — the sync crash never reaches
+    # the AppendReceiptError/.code handler and never turns a successful
+    # append into a rejected/errored one.
+    assert outcome == "appended"
+    assert result is not None
+    assert result.status == "appended"
+
+    # The failure is loud: a WARNING naming the dispatch-id and the error.
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "open-items sync failed" in msg
+        and "20260821-oi-sync-crash" in msg
+        and "simulated sync crash carrying no .code attribute" in msg
+        for msg in warnings
+    ), f"expected a loud sync-failure warning, got: {warnings}"
+
+    # The receipt line itself landed in the ledger despite the sync crash.
+    ledger_text = Path(receipts_file).read_text(encoding="utf-8")
+    assert "20260821-oi-sync-crash" in ledger_text


### PR DESCRIPTION
## Summary

A worker's `## Open Items` section only ever fed `validate_report.py`'s pre-submit format check. Nothing read the *content* into `open_items.json` — every finding a worker reported (including blockers) stayed invisible to governance unless someone manually transcribed it, as happened by hand for OI-1263..OI-1288 on 16-08.

## Changes

- `scripts/lib/open_items_from_report.py` (new): `sync_open_items_from_report()` extracts formatted `## Open Items` entries from a report's text and registers each via `open_items_manager.add_item_programmatic()`, with a stable `dedup_key` (dispatch_id + title hash), conservative default severity (`info`), and dispatch-id/report-path provenance on every item.
- `scripts/validate_report.py`: extracted the existing item-format regex into `extract_open_items()` (pure refactor, same behavior) so the pre-submit check and the ledger sync share one definition of "a correctly formatted item" — they can't drift apart.
- `scripts/lib/report_to_receipt_converter.py`: hooked `_sync_report_open_items()` into `_convert_one_detailed()` at the point a report's receipt already lands (appended / duplicate / the hot-path already-exists guard) — no second report scanner. Skipped entirely under `--dry-run`.

## Verification

```
python3 -m pytest tests/test_open_items_from_report.py tests/test_report_to_receipt_converter.py tests/test_open_items_dedup_status.py tests/test_open_items_acceptance_criterion_guard.py tests/test_open_items_state_dir_resolution.py -q
```
Result: `197 passed`

New test file `tests/test_open_items_from_report.py` (10 tests) covers the dispatch's required evidence:
1. Three formatted items land in the ledger with dispatch-id + report path.
2. An explicit "None" body yields zero items.
3. Reprocessing the same report twice is idempotent (dedup_key).
4. An introductory prose line never becomes an item.
5. The conservative default severity (`info`) is pinned directly (`test_default_severity_falls_back_to_info`), plus an end-to-end test forcing an out-of-vocabulary severity token through to prove the fallback.

Plus: no-section case, acceptance-criterion-guard interaction (bad title skipped, not fatal), and two wiring tests proving the converter actually calls the sync at the receipt-landing point, and that `--dry-run` never triggers it.

Pre-existing, unrelated failures confirmed via `git stash` bisection: `tests/test_open_items_gate_certification.py::TestContractAlignment` (2 tests, missing `serve_dashboard._read_gate_config`/`_write_gate_config` — a dashboard gap, present before this change too).

## Open Items

None — backfilling the existing report backlog into the ledger is explicitly out of scope per the dispatch (a separate decision); `scripts/lib/pr_enforcement.py` and `scripts/lib/tmux_interactive_dispatch.py` were not touched.