### PR TITLE
fix(tests): restore sys.modules after stubbing shared modules (OI-1403)

### DIFF
--- a/tests/test_governance_digest_certification.py
+++ b/tests/test_governance_digest_certification.py
@@ -42,6 +42,12 @@ for p in (str(SCRIPTS_DIR), str(LIB_DIR), str(DASHBOARD_DIR)):
 # ---------------------------------------------------------------------------
 
 def _install_stub_modules():
+    """Install lightweight stub modules so intelligence_daemon imports succeed.
+
+    Returns the pre-existing sys.modules entries for the four names touched
+    (or None for a name that wasn't imported yet), so the caller can restore
+    them once intelligence_daemon's module-level `from X import Y` has run.
+    """
     gather_mod = types.ModuleType("gather_intelligence")
     learning_mod = types.ModuleType("learning_loop")
     cached_mod = types.ModuleType("cached_intelligence")
@@ -70,20 +76,37 @@ def _install_stub_modules():
     cached_mod.CachedIntelligence = DummyCachedIntelligence
     tag_mod.TagIntelligenceEngine = DummyTagEngine
 
+    saved = {}
     for name, mod in [
         ("gather_intelligence", gather_mod),
         ("learning_loop", learning_mod),
         ("cached_intelligence", cached_mod),
         ("tag_intelligence", tag_mod),
     ]:
+        saved[name] = sys.modules.get(name)
         sys.modules[name] = mod
+    return saved
 
 
 def _load_daemon_module():
-    _install_stub_modules()
-    if "intelligence_daemon" in sys.modules:
-        del sys.modules["intelligence_daemon"]
-    return importlib.import_module("intelligence_daemon")
+    """Import (or reload) ``intelligence_daemon`` with stubs in place, then
+    restore ``sys.modules`` to its pre-stub state so the stubs do not
+    contaminate later tests (OI-1403: gather_intelligence/learning_loop/
+    cached_intelligence/tag_intelligence are real, shared modules that other
+    test files import by these exact names — leaving the stubs in place
+    silently swapped their real classes for Dummy* stand-ins process-wide).
+    """
+    saved = _install_stub_modules()
+    try:
+        if "intelligence_daemon" in sys.modules:
+            del sys.modules["intelligence_daemon"]
+        return importlib.import_module("intelligence_daemon")
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
 
 
 def _make_runner(tmp_path, interval=300):

--- a/tests/test_governance_digest_runner.py
+++ b/tests/test_governance_digest_runner.py
@@ -35,7 +35,12 @@ if str(LIB_DIR) not in sys.path:
 
 
 def _install_stub_modules():
-    """Install lightweight stub modules so intelligence_daemon imports succeed."""
+    """Install lightweight stub modules so intelligence_daemon imports succeed.
+
+    Returns the pre-existing sys.modules entries for the four names touched
+    (or None for a name that wasn't imported yet), so the caller can restore
+    them once intelligence_daemon's module-level `from X import Y` has run.
+    """
     gather_mod = types.ModuleType("gather_intelligence")
     learning_mod = types.ModuleType("learning_loop")
     cached_mod = types.ModuleType("cached_intelligence")
@@ -64,20 +69,37 @@ def _install_stub_modules():
     cached_mod.CachedIntelligence = DummyCachedIntelligence
     tag_mod.TagIntelligenceEngine = DummyTagEngine
 
+    saved = {}
     for name, mod in [
         ("gather_intelligence", gather_mod),
         ("learning_loop", learning_mod),
         ("cached_intelligence", cached_mod),
         ("tag_intelligence", tag_mod),
     ]:
+        saved[name] = sys.modules.get(name)
         sys.modules[name] = mod
+    return saved
 
 
 def _load_daemon_module():
-    _install_stub_modules()
-    if "intelligence_daemon" in sys.modules:
-        del sys.modules["intelligence_daemon"]
-    return importlib.import_module("intelligence_daemon")
+    """Import (or reload) ``intelligence_daemon`` with stubs in place, then
+    restore ``sys.modules`` to its pre-stub state so the stubs do not
+    contaminate later tests (OI-1403: gather_intelligence/learning_loop/
+    cached_intelligence/tag_intelligence are real, shared modules that other
+    test files import by these exact names — leaving the stubs in place
+    silently swapped their real classes for Dummy* stand-ins process-wide).
+    """
+    saved = _install_stub_modules()
+    try:
+        if "intelligence_daemon" in sys.modules:
+            del sys.modules["intelligence_daemon"]
+        return importlib.import_module("intelligence_daemon")
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
 
 
 def _make_daemon(tmp_path, monkeypatch) -> tuple:

--- a/tests/test_heartbeat_subprocess_cleanup.py
+++ b/tests/test_heartbeat_subprocess_cleanup.py
@@ -8,6 +8,7 @@ Fix: pop both structures before the early return.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import threading
@@ -20,6 +21,60 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+_UNSET = object()
+
+
+@contextlib.contextmanager
+def _stubbed_heartbeat_ack_monitor_deps():
+    """Make append_receipt/python_singleton importable with the attributes
+    heartbeat_ack_monitor's module-level `from X import Y` needs, then
+    restore sys.modules to exactly its prior state on exit.
+
+    OI-1403: the previous version used `sys.modules.setdefault(...)` and
+    then unconditionally overwrote `AppendReceiptError`/`append_receipt_payload`
+    on whatever ended up in sys.modules. In a full suite, append_receipt is
+    almost always already the REAL, shared module by the time this test file
+    runs — setdefault() is a no-op, and the two lines after it stomped the
+    real module's attributes with mocks, process-wide, with no teardown.
+    Every later test that goes through append_receipt.append_receipt_payload
+    (e.g. report_to_receipt_converter.py, which re-imports it via
+    sys.modules) then silently got a mock returning None instead of the
+    real function. Restoring here — unconditionally, on every exit path —
+    is only needed for the FIRST import of heartbeat_ack_monitor in a
+    session: once `from append_receipt import ...` has executed once, the
+    names are bound into heartbeat_ack_monitor's own namespace and further
+    mutation of sys.modules["append_receipt"] has no effect on it.
+    """
+    injected = []
+    saved_attrs = []
+
+    for name in ("append_receipt", "python_singleton"):
+        if name not in sys.modules:
+            sys.modules[name] = MagicMock()
+            injected.append(name)
+
+    mod_ar = sys.modules["append_receipt"]
+    mod_ps = sys.modules["python_singleton"]
+
+    for mod, attr, value in (
+        (mod_ar, "AppendReceiptError", Exception),
+        (mod_ar, "append_receipt_payload", MagicMock(return_value=None)),
+        (mod_ps, "enforce_python_singleton", MagicMock(return_value=None)),
+    ):
+        saved_attrs.append((mod, attr, getattr(mod, attr, _UNSET)))
+        setattr(mod, attr, value)
+
+    try:
+        yield
+    finally:
+        for mod, attr, original in saved_attrs:
+            if original is _UNSET:
+                delattr(mod, attr)
+            else:
+                setattr(mod, attr, original)
+        for name in injected:
+            sys.modules.pop(name, None)
+
 
 def _build_monitor():
     """Return a HeartbeatACKMonitor with all I/O stubbed out.
@@ -29,15 +84,8 @@ def _build_monitor():
     """
     # Import the class — its module-level `from append_receipt import ...`
     # runs at import time, so we stub it in sys.modules before importing.
-    mock_ar = MagicMock()
-    mock_ps = MagicMock()
-    sys.modules.setdefault("append_receipt", mock_ar)
-    sys.modules.setdefault("python_singleton", mock_ps)
-    sys.modules["append_receipt"].AppendReceiptError = Exception
-    sys.modules["append_receipt"].append_receipt_payload = MagicMock(return_value=None)
-    sys.modules["python_singleton"].enforce_python_singleton = MagicMock(return_value=None)
-
-    from heartbeat_ack_monitor import HeartbeatACKMonitor
+    with _stubbed_heartbeat_ack_monitor_deps():
+        from heartbeat_ack_monitor import HeartbeatACKMonitor
 
     monitor = HeartbeatACKMonitor.__new__(HeartbeatACKMonitor)
     monitor.active_dispatches = {}


### PR DESCRIPTION
## Summary
- `_build_monitor()` in `tests/test_heartbeat_subprocess_cleanup.py` used `sys.modules.setdefault(...)` and then unconditionally overwrote `AppendReceiptError`/`append_receipt_payload` on whatever ended up in `sys.modules["append_receipt"]`. In a full suite, `append_receipt` is almost always already the real, shared module by the time this file runs — `setdefault()` is a no-op, and the two lines after it stomp the real module's attributes with mocks, process-wide, with no teardown.
- Every later test that goes through `append_receipt.append_receipt_payload` dynamically (e.g. `report_to_receipt_converter.py`, which re-imports `append_receipt` via `sys.modules`) then silently got a mock returning `None` instead of the real function — a correct implementation could fail (false red), and a test asserting something is *not* booked would pass vacuously (false green, invisible).
- A sweep of `tests/` for the same shape found two more real instances in `test_governance_digest_runner.py` and `test_governance_digest_certification.py`: `_install_stub_modules()` permanently swaps `gather_intelligence`/`learning_loop`/`cached_intelligence`/`tag_intelligence` — real, shared modules other test files import by these exact names — for `Dummy*` stand-ins, with zero restore.

## Changes
- `tests/test_heartbeat_subprocess_cleanup.py`: replaced the bare `sys.modules.setdefault(...)` + attribute-stomp with `_stubbed_heartbeat_ack_monitor_deps()`, a context manager that snapshots whatever was on `append_receipt`/`python_singleton` before stubbing and restores it (or removes the module entirely if it didn't exist) once `from heartbeat_ack_monitor import HeartbeatACKMonitor` has captured what it needs.
- `tests/test_governance_digest_runner.py` and `tests/test_governance_digest_certification.py`: `_install_stub_modules()` now returns the pre-existing `sys.modules` entries; `_load_daemon_module()` wraps the reimport in try/finally and restores them afterward — mirroring the pattern already used correctly in `tests/test_intelligence_daemon_paths.py`.
- No production code touched. `scripts/lib/report_to_receipt_converter.py` was left untouched per the dispatch (PR #1643 is active there).

Sites reviewed and deliberately left alone (sweep command below): every other `sys.modules[...] = ` site in `tests/` registers real script code under a private, never-colliding alias (`append_receipt_testmodule`, `open_items_manager_oi941_*`, `_ar_testmod_*`, `terminal_state_shadow_lib`, `_smart_router_impl`, etc.) — nothing else ever imports that alias, so no shared module is at risk. Two borderline cases (`test_governance_audit_stamping.py`'s `feature_state_machine` swap and `test_shadow_verifier.py`'s `migrate_to_central_vnx` pop) already have try/finally cleanup but don't preserve a pre-existing real cache entry on the delete path — worst case is a redundant reimport next time, never a stale wrong mock, so left as-is.

## Verification
Targeted tests + immediate neighbors only, per dispatch instructions (not the full 18-minute suite).

Reproduction from the dispatch, now green:
```
$ python3 -m pytest tests/test_append_receipt.py tests/test_heartbeat_subprocess_cleanup.py tests/test_report_to_receipt_converter.py -q
172 passed in ~22s
```
(Before the fix: 2 failures in `test_report_to_receipt_converter.py` with `AttributeError: 'AttributeError' object has no attribute 'code'` — the polluted `AppendReceiptError` being `Exception` catching an `AttributeError` from calling the mocked `append_receipt_payload`.)

`test_heartbeat_subprocess_cleanup.py` alone, still fully green:
```
$ python3 -m pytest tests/test_heartbeat_subprocess_cleanup.py -v
5 passed in 0.23s
```

Module-attribute restoration proven (simulates full-suite ordering: `append_receipt` really imported first, then the heartbeat suite runs in the same process):
```
BEFORE suite run:
  append_receipt_payload is real function: True
  AppendReceiptError is real class: True
..... [100%]
5 passed
AFTER suite run:
  same module object in sys.modules: True
  append_receipt_payload is REAL function (not a mock): True
  AppendReceiptError is REAL class (not builtin Exception): True
PASS: module attribute restored to the real function after the file finishes.
```

Sweep command used:
```
grep -rn 'sys\.modules\[[^]]*\]\.\w\+\s*=' tests/                                          # attribute-stomp sub-pattern — only this file had it
grep -rn 'sys\.modules\[[^]]*\]\s*=\s*\|sys\.modules\.setdefault(' tests/ | grep -v 'patch.dict'  # whole-module replacements
```

`governance_digest` sweep fix, before/after (own files' pre-existing, unrelated failures — a `governance_digest.json` never gets created in this environment — are unchanged by this PR either way, confirming the fix is behavior-neutral for the files' own tests):
```
# BEFORE (git-reverted to confirm): certification+runner+tag_intelligence+gather_intelligence_exception_handling+learning_loop_gate
27 failed, 124 passed   # 25 pre-existing + 2 NEW false-reds in test_gather_intelligence_exception_handling.py

# AFTER (this PR's fix applied): same 5 files
25 failed, 126 passed   # only the 25 pre-existing, unrelated failures — zero downstream contamination
```
`test_governance_digest_runner.py` alone: 11 failed, 20 passed (unchanged before/after — pre-existing, out of scope, not a sys.modules issue: `governance_digest.json` is never created in this environment).
`test_governance_digest_certification.py` alone: 14 failed, 34 passed (same — unchanged before/after).

Also confirmed the exact same *unrelated* pre-existing false-red in `test_gather_intelligence_exception_handling.py` (a caplog/logging-propagation issue, not sys.modules pollution) reproduces from a clean `git stash` baseline with zero changes applied — it's pre-existing in `test_intelligence_daemon_paths.py`'s own reload path and out of this PR's scope.

## Open Items
- `test_governance_digest_runner.py` (11 tests) and `test_governance_digest_certification.py` (14 tests) each have pre-existing, unrelated failures: `governance_digest.json` is never produced by `runner.run_once()` in this environment. Confirmed present before this PR's changes too (isolated single-file runs are unaffected by the sys.modules fix). Not touched here per the dispatch's boundary ("raak geen productiecode aan tenzij de sweep een echt defect blootlegt; meld dat eerst") — flagging for a separate dispatch.
- A second, unrelated pre-existing bug: running `tests/test_intelligence_daemon_paths.py` before `tests/test_gather_intelligence_exception_handling.py` causes 2 false-red failures there (`AssertionError: no logs of level DEBUG or higher triggered on gather_intelligence`) — a caplog/logging-propagation issue tied to `importlib.reload()`, not a sys.modules-stub-without-restore issue. Reproduces identically on a clean baseline with none of this PR's changes applied. Out of scope for OI-1403; flagging for a separate investigation.
- Two borderline `sys.modules` sites reviewed but not fixed (see Changes section): `test_governance_audit_stamping.py:276` and `test_shadow_verifier.py:95`/96 — both fail toward forcing a redundant reimport, never toward a silently-wrong stale mock, so lower severity than OI-1403's pattern.