### PR TITLE
fix(panel): dispatch panel seats under a role that exists in both registers (OI-1359)

### DIFF
--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -92,13 +92,22 @@ def main(argv: "list[str] | None" = None) -> int:
     # → no cited synthesis (sales-copilot T0, 2026-07-10). unified_reports_dir().parent IS
     # that data_dir, so the write-path and read-path agree.
     data_dir = str(_resolve_reports_dir().parent)
-    # role="deliberation-panelist" (OI-811): _make_default_dispatcher defaults to
-    # "plan-reviewer" for its original run_panel caller. A diverge/contrarian/verify/
-    # synthesis prompt is NOT a plan review — tagging it plan-reviewer wrapped it in
-    # "you are an independent plan reviewer... review the IMPLEMENTATION PLAN" framing,
-    # which a plan-reviewer-role worker correctly rejected as not a plan, corrupting the
-    # panel stage.
-    dispatcher = _make_default_dispatcher(data_dir, args.timeout, role="deliberation-panelist")
+    # role="research-analyst" (OI-811, corrected OI-1359): _make_default_dispatcher
+    # defaults to "plan-reviewer" for its original run_panel caller. A diverge/
+    # contrarian/verify/synthesis prompt is NOT a plan review — tagging it
+    # plan-reviewer wrapped it in "you are an independent plan reviewer... review the
+    # IMPLEMENTATION PLAN" framing, which a plan-reviewer-role worker correctly
+    # rejected as not a plan, corrupting the panel stage. OI-811 fixed that call site
+    # but invented role="deliberation-panelist", which exists in NEITHER register
+    # (no agents/deliberation-panelist/, no profile in worker_permissions.yaml) — every
+    # seat then failed fail-closed in resolve_worker_profile before producing any
+    # content (OI-1359). "research-analyst" is a real role in both registers: it
+    # analyzes and writes only its own report (file_write_scope limited to
+    # unified_reports/**, Edit/MultiEdit denied) — the posture a panel seat needs.
+    # It is also not "plan-reviewer", so the branch in _make_default_dispatcher below
+    # still gives it the generic (non-plan-framed) file-ref instruction, preserving
+    # the OI-811 fix.
+    dispatcher = _make_default_dispatcher(data_dir, args.timeout, role="research-analyst")
     # OI-1154: the synthesis coverage floor comes from the config, never a Python literal.
     min_seats = load_synthesis_min_seats()
 

--- a/tests/test_panel_cli.py
+++ b/tests/test_panel_cli.py
@@ -54,7 +54,7 @@ def test_seats_filters_to_requested_roster(tmp_path, monkeypatch):
         ("codex", "gpt-5.5"),
         ("claude", "sonnet"),
     ]
-    assert calls["dispatcher_factory"]["role"] == "deliberation-panelist"
+    assert calls["dispatcher_factory"]["role"] == "research-analyst"
 
 
 def test_unknown_seat_errors_without_dispatch(tmp_path, monkeypatch, capsys):
@@ -107,7 +107,11 @@ def test_default_omits_roster_kwarg_to_preserve_full_fleet_path(tmp_path, monkey
 
 def test_dispatcher_factory_receives_non_plan_reviewer_role(tmp_path, monkeypatch):
     """OI-811: panel.py must not dispatch its stage prompts under the plan-reviewer role —
-    that framing caused a plan-reviewer-role worker to reject a non-plan panel artifact."""
+    that framing caused a plan-reviewer-role worker to reject a non-plan panel artifact.
+    OI-1359: the OI-811 fix used role="deliberation-panelist", a role that exists in
+    neither register — every seat failed fail-closed before producing content. The role
+    is now "research-analyst" (see test_dispatcher_role_exists_in_both_registers below
+    for the register-backed check that this string stays real)."""
     panel = _load_panel_cli()
     calls = {}
 
@@ -124,7 +128,7 @@ def test_dispatcher_factory_receives_non_plan_reviewer_role(tmp_path, monkeypatc
     rc = panel.main(["sweep", "audit src/", "--out", str(tmp_path / "report.md")])
 
     assert rc == 0
-    assert calls["role"] == "deliberation-panelist"
+    assert calls["role"] == "research-analyst"
     assert calls["role"] != "plan-reviewer"
 
 
@@ -182,3 +186,51 @@ def test_panel_refusal_returns_nonzero_and_loud(tmp_path, monkeypatch, capsys):
     assert rc == 1
     assert "SYNTHESIS REFUSED" in captured.err
     assert "1/5" in captured.err
+
+
+def test_dispatcher_role_exists_in_both_registers(tmp_path, monkeypatch):
+    """OI-1359: panel.py dispatched under role="deliberation-panelist", which is a key
+    in NEITHER register (no agents/deliberation-panelist/ dir, no profile in
+    worker_permissions.yaml). resolve_worker_profile fails closed on that: every seat
+    refused before producing any content, providerneutrally (codex and kimi failed the
+    same way).
+
+    This test does not repeat a literal role string on both sides of an equality (that
+    only proves the string matches itself). It captures the role panel.py actually
+    passes to the dispatcher factory, then checks it against the two REAL registers:
+    a non-empty profile in worker_permissions.yaml (via the same load_permissions()
+    resolve_worker_profile uses), and an agents/<role>/ directory on disk.
+    """
+    import worker_permissions
+
+    panel = _load_panel_cli()
+    calls = {}
+
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
+        calls["role"] = role
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    def fake_run_deliberation(*args, **kwargs):
+        return _FakeResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main(["sweep", "audit src/", "--out", str(tmp_path / "report.md")])
+
+    assert rc == 0
+    role = calls["role"]
+    assert role, "panel.py must pass a non-empty role to the dispatcher factory"
+
+    profile = worker_permissions.load_permissions(role)
+    assert profile.allowed_tools, (
+        f"role {role!r} has no usable profile in worker_permissions.yaml — "
+        "resolve_worker_profile() would fall back to the restrictive code-worker "
+        "default (or raise UnknownRoleError if agents/<role>/ is also missing)"
+    )
+
+    agents_dir = REPO_ROOT / "agents" / role
+    assert agents_dir.is_dir(), (
+        f"agents/{role}/ does not exist — resolve_worker_profile() raises "
+        "UnknownRoleError for a role absent from both registers"
+    )


### PR DESCRIPTION
## Summary

`scripts/panel.py` dispatched every panel seat under `role="deliberation-panelist"`, a role that exists in **neither** register: no `agents/deliberation-panelist/` directory, no profile in `.vnx/worker_permissions.yaml`. `resolve_worker_profile()` fails closed on that (`scripts/lib/worker_permissions.py:518`), so every seat refused before any inference happened — providerneutral, codex and kimi failed identically. A full panel run produced 23,276 words of zero-content dispatches, all exit_code 1, output tokens 0.

## Changes

- `scripts/panel.py`: `_make_default_dispatcher(..., role="deliberation-panelist")` → `role="research-analyst"`. `research-analyst` exists in both registers (`.vnx/worker_permissions.yaml` profile + `agents/research-analyst/`) and its posture (analyze, write only its own report, no code mutation, `Edit`/`MultiEdit` denied) fits a panel seat. It is not `"plan-reviewer"`, so `_make_default_dispatcher`'s framing branch still gives it the generic (non-plan-framed) file-ref instruction — the OI-811 fix stays intact.
- Updated the comment block explaining the role choice and why it must not be `plan-reviewer`.
- `tests/test_panel_cli.py`: updated the two existing tests that asserted the (broken) literal `"deliberation-panelist"` role string, and added `test_dispatcher_role_exists_in_both_registers` — a register-backed test that captures the role panel.py actually passes to the dispatcher factory and checks it against the real `worker_permissions.yaml` profile loader (`load_permissions`) and `agents/<role>/` on disk, instead of repeating a literal string on both sides.

## Test plan

- [x] `pytest tests/test_panel_cli.py -v` — 7 passed
- [x] Sanity-checked the new register-backed test actually catches the regression: temporarily reverted the role to `"deliberation-panelist"` and confirmed 3 tests fail (including the new one) with a clear `AssertionError` naming the missing profile
- [x] Real panel run against the dev store (see dispatch report / Open Items for outcome — a second, out-of-scope governance-layer gap was discovered during this run and is documented there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)