### PR TITLE
fix(kimi-gate): distinguish parse miss from provider outage (OI-1291)

### DIFF
--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -25,6 +25,15 @@ quota-403/429/auth error, times out, or returns output without a verdict block,
 the result status is ``unavailable`` — never ``fail``. Eleven quota-403 outages
 were once booked as eleven rejected PRs because the no-verdict path defaulted to
 "fail"; absence of evidence must surface as absence, not as a rejection.
+
+OI-1291: ``unavailable`` is not a single cause. ``reason`` distinguishes three
+disjoint states: ``dispatch_error`` (the dispatcher itself raised — no report
+was ever produced), ``parse_error`` (a report came back with content but no
+readable ```json``` verdict block — kimi DID respond, the block just didn't
+parse), and ``no_verdict`` (the report was empty/whitespace — a genuinely
+empty delivery). Only ``dispatch_error``/``no_verdict`` may claim a provider
+outage in their summary text; ``parse_error`` must not, since the provider
+plainly produced output.
 """
 from __future__ import annotations
 
@@ -116,14 +125,16 @@ def _get_diff(pr: str, diff_file: "str | None") -> "str | None":
         return None
 
 
-def _verdict_to_status(verdict: dict) -> "tuple[str, list, str]":
+def _verdict_to_status(verdict: dict, report_text: str = "") -> "tuple[str, list, str]":
     """Map the extracted verdict to (status, blocking_findings, residual_risk).
 
-    OI-1142: an empty ``verdict`` means the provider produced no readable verdict
-    at all — the kimi CLI hit a quota-403/429/auth error, was cut off, or emitted
-    output without the contract's JSON block. That is a tool outage, not a review
-    outcome, and it maps to ``unavailable``. Only a REAL parsed verdict may ever
-    produce ``fail``.
+    OI-1142: an empty ``verdict`` means no readable verdict could be extracted.
+    OI-1291 splits that further: if ``report_text`` itself is empty/whitespace,
+    the provider delivered nothing at all (a real outage/empty-completion
+    signal). If ``report_text`` has content but no readable ```json``` block,
+    the provider DID respond — the block just failed to parse, which is a
+    parse miss, not an outage. Either way this maps to ``unavailable`` and
+    only a REAL parsed verdict may ever produce ``fail``.
     """
     v = (verdict.get("verdict") or "").strip().lower() if verdict else ""
     findings = verdict.get("findings") or [] if verdict else []
@@ -136,17 +147,30 @@ def _verdict_to_status(verdict: dict) -> "tuple[str, list, str]":
         return "pass", [], residual
     if v in {"fail", "blocked"} or blocking:
         return "fail", blocking, residual or "kimi gate reported blocking findings"
+    if residual:
+        return "unavailable", [], residual
+    if (report_text or "").strip():
+        return (
+            "unavailable",
+            [],
+            f"kimi returned a {len(report_text)}-char report, but it contained no "
+            "readable ```json``` verdict block (parse miss — kimi did respond)",
+        )
     return (
         "unavailable",
         [],
-        residual
-        or "kimi produced no readable verdict (provider outage/quota/truncation) — not a review outcome",
+        "kimi produced no readable verdict (provider outage/quota/truncation) — not a review outcome",
     )
 
 
-def _status_summary(status: str, blocking: list) -> str:
-    """Summary line for the result record — outage vs verdict must be unmistakable."""
+def _status_summary(status: str, blocking: list, reason: str = "", report_len: int = 0) -> str:
+    """Summary line for the result record — outage vs parse-miss vs verdict must be unmistakable."""
     if status == "unavailable":
+        if reason == "parse_error":
+            return (
+                f"kimi gate: UNAVAILABLE (parse_error — kimi returned a {report_len}-char "
+                "report, but it contained no readable verdict block — NOT a review fail)"
+            )
         return "kimi gate: UNAVAILABLE (provider outage/no verdict — NOT a review fail)"
     return f"kimi gate: {status} ({len(blocking)} blocking finding(s))"
 
@@ -192,8 +216,16 @@ def main(argv: "list[str] | None" = None) -> int:
         reason = "dispatch_error"
     else:
         verdict = _extract_verdict(report_text or "")
-        status, blocking, residual = _verdict_to_status(verdict)
-        reason = "verdict" if verdict else "no_verdict"
+        status, blocking, residual = _verdict_to_status(verdict, report_text or "")
+        if verdict:
+            reason = "verdict"
+        elif (report_text or "").strip():
+            # OI-1291: a report came back with content, it just didn't parse —
+            # distinct from a genuinely empty delivery (see reason="no_verdict"
+            # below) and from a dispatch_error (no report at all, above).
+            reason = "parse_error"
+        else:
+            reason = "no_verdict"
 
     record = {
         "gate": "kimi_gate",
@@ -206,7 +238,7 @@ def main(argv: "list[str] | None" = None) -> int:
         "status": status,
         "reason": reason,
         "duration_seconds": round(duration, 3),
-        "summary": _status_summary(status, blocking),
+        "summary": _status_summary(status, blocking, reason, len(report_text or "")),
         "provider": "kimi",
         "model": args.model,
         "dispatch_id": dispatch_id,
@@ -244,7 +276,13 @@ def main(argv: "list[str] | None" = None) -> int:
     if args.json:
         print(json.dumps(record, indent=2))
     elif status == "unavailable":
-        print("VERDICT: UNAVAILABLE  (provider outage/no verdict — NOT a review fail)")
+        if reason == "parse_error":
+            print(
+                f"VERDICT: UNAVAILABLE  (parse_error — kimi returned a {len(report_text or '')}-char "
+                "report, but it contained no readable verdict block — NOT a review fail)"
+            )
+        else:
+            print("VERDICT: UNAVAILABLE  (provider outage/no verdict — NOT a review fail)")
     else:
         print(f"VERDICT: {status.upper()}  ({len(blocking)} blocking)")
         for f in blocking:

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -45,17 +45,29 @@ failure-path ``emit_unified_report`` call runs on the dispatcher's failure
 path too. A spooled 403 error body reads as "content", so that axis booked a
 real outage as "kimi did respond, parse miss" — the same failure class this
 whole fix exists to remove, just mirrored. The report's own YAML frontmatter
-carries a signal content can't fake: ``exit_code`` and ``token_usage.output``
-are stamped by the lane from the actual spawn result, not guessed from the
-response text. A non-zero ``exit_code`` (or zero output tokens) with
-readable frontmatter means the provider run itself failed — that is
-``dispatch_error``, even though a report exists. Only ``exit_code == 0``
-with readable frontmatter and no verdict block is a genuine ``parse_error``.
-When the frontmatter can't be read at all (older/foreign report shape), the
-outcome can't be read off the report — this falls back to the pre-fix-forward
-default of ``parse_error``, which is intentionally too broad: a masked
-provider failure with no readable ``exit_code`` would still land here, but
-there is no other signal left to tell the two apart.
+carries a signal content can't fake: ``exit_code`` is stamped by the lane
+from the actual spawn result, not guessed from the response text. A
+non-zero ``exit_code`` with readable frontmatter means the provider run
+itself failed — that is ``dispatch_error``, even though a report exists.
+Only ``exit_code == 0`` with readable frontmatter and no verdict block is a
+genuine ``parse_error``. When the frontmatter can't be read at all
+(older/foreign report shape), the outcome can't be read off the report —
+this falls back to the pre-fix-forward default of ``parse_error``, which is
+intentionally too broad: a masked provider failure with no readable
+``exit_code`` would still land here, but there is no other signal left to
+tell the two apart.
+
+OI-1291 (fix-forward, meetgat correction): the first cut of the frontmatter
+axis also treated zero output tokens as a failure signal on its own. On the
+kimi lane, post-run token capture is frequently unavailable — the lane
+stamps ``token_usage_measured: false`` and ``output: 0`` on those runs, so
+zero output tokens routinely means "not measured", not "the run produced
+nothing". A count of 766 kimi reports on disk found 502 with exit_code 0,
+real content, and ``token_usage_measured: false`` — successful runs the
+raw-zero check booked as provider outages, reintroducing OI-1291's original
+bug on a different axis. ``output_tokens`` now only counts as a failure
+signal when the frontmatter's own ``token_usage_measured`` flag is true;
+otherwise only ``exit_code`` decides.
 """
 from __future__ import annotations
 
@@ -151,22 +163,35 @@ def _get_diff(pr: str, diff_file: "str | None") -> "str | None":
 def _frontmatter_run_outcome(report_text: str) -> "tuple[bool | None, object, object]":
     """Read ``exit_code``/``token_usage.output`` off the report's own YAML
     frontmatter to tell a provider-side run failure apart from a genuine
-    parse miss (OI-1291 fix-forward).
+    parse miss (OI-1291 fix-forward, meetgat correction).
 
     Content existing is not proof kimi actually completed a review: the
     failure-path ``emit_unified_report`` call writes a report too, so a
     spooled 403 body is "content" by the same measure as a real review. The
-    frontmatter's ``exit_code``/``token_usage`` fields are stamped by the
-    lane from the actual spawn result, not guessed from the response text —
-    that is the signal that can't be faked by error-page prose.
+    frontmatter's ``exit_code`` field is stamped by the lane from the actual
+    spawn result, not guessed from the response text — that is the signal
+    that can't be faked by error-page prose.
+
+    ``exit_code`` alone decides the outcome. ``token_usage.output`` is only
+    consulted when the frontmatter's own ``token_usage_measured`` flag is
+    true. On the kimi lane, post-run token capture is frequently unavailable
+    (kimi-cli's stream-json output carries no usage accounting) — the lane
+    stamps ``token_usage_measured: false`` and ``output: 0`` for those runs.
+    A measured count of 766 kimi reports on disk found 502 with exit_code 0,
+    non-trivial body content, and ``token_usage_measured: false`` — real,
+    successful reviews that a bare ``output_tokens == 0`` check would have
+    booked as provider outages. Only 4 reports carried a genuinely measured
+    token count. Treating an unmeasured zero as a failure signal reintroduces
+    the exact bug OI-1291 exists to remove, just gated on a different field.
 
     Returns ``(outcome, exit_code, output_tokens)`` where ``outcome`` is:
-        True  — frontmatter is readable and the run did not complete cleanly
-                (non-zero exit code, or zero output tokens): a provider-side
+        True  — frontmatter is readable and the run did not complete cleanly:
+                non-zero exit code, or (only when ``token_usage_measured`` is
+                true) a measured zero output-token count. A provider-side
                 failure, not a review outcome.
         False — frontmatter is readable and stamps a clean run (exit_code 0,
-                non-zero output tokens): a missing verdict block here is a
-                genuine parse miss.
+                and either tokens aren't measured or a measured non-zero
+                count): a missing verdict block here is a genuine parse miss.
         None  — no readable frontmatter, or no ``exit_code`` field in it
                 (older/foreign report shape). The outcome can't be read off
                 the report at all; callers fall back to the pre-fix-forward
@@ -181,7 +206,10 @@ def _frontmatter_run_outcome(report_text: str) -> "tuple[bool | None, object, ob
     exit_code = frontmatter.get("exit_code")
     token_usage = frontmatter.get("token_usage")
     output_tokens = token_usage.get("output") if isinstance(token_usage, dict) else None
-    if exit_code != 0 or output_tokens == 0:
+    tokens_measured = bool(frontmatter.get("token_usage_measured"))
+    if exit_code != 0:
+        return True, exit_code, output_tokens
+    if tokens_measured and output_tokens == 0:
         return True, exit_code, output_tokens
     return False, exit_code, output_tokens
 
@@ -201,8 +229,10 @@ def _verdict_to_status(
 
     ``provider_failed_detail`` (OI-1291 fix-forward): the caller passes this
     when it has already read the report's own frontmatter via
-    ``_frontmatter_run_outcome`` and found a non-zero exit code / zero output
-    tokens. When set, THIS function returns that provider-outage residual
+    ``_frontmatter_run_outcome`` and found a non-zero exit code (or a
+    measured-zero output-token count, when the frontmatter's own
+    ``token_usage_measured`` flag says the count is real). When set, THIS
+    function returns that provider-outage residual
     instead of the "kimi did respond" parse-miss residual below — the report
     having content is not proof kimi ran; the frontmatter's own exit_code is.
     """

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -27,13 +27,35 @@ were once booked as eleven rejected PRs because the no-verdict path defaulted to
 "fail"; absence of evidence must surface as absence, not as a rejection.
 
 OI-1291: ``unavailable`` is not a single cause. ``reason`` distinguishes three
-disjoint states: ``dispatch_error`` (the dispatcher itself raised — no report
-was ever produced), ``parse_error`` (a report came back with content but no
-readable ```json``` verdict block — kimi DID respond, the block just didn't
-parse), and ``no_verdict`` (the report was empty/whitespace — a genuinely
-empty delivery). Only ``dispatch_error``/``no_verdict`` may claim a provider
+disjoint states: ``dispatch_error`` (the dispatcher failed to deliver a
+working run — either it raised outright with no report at all, or a report
+DID come back but its own frontmatter stamps the underlying provider run as
+failed; see below), ``parse_error`` (a report came back from a run the
+frontmatter itself stamps as clean, with content but no readable ```json```
+verdict block — kimi DID respond, the block just didn't parse), and
+``no_verdict`` (the report was empty/whitespace — a genuinely empty
+delivery). Only ``dispatch_error``/``no_verdict`` may claim a provider
 outage in their summary text; ``parse_error`` must not, since the provider
 plainly produced output.
+
+OI-1291 (fix-forward): the first cut of this split used "did a report come
+back" as the discriminator between ``parse_error`` and outage. That axis is
+wrong — a real quota/auth outage still writes a report, because the
+failure-path ``emit_unified_report`` call runs on the dispatcher's failure
+path too. A spooled 403 error body reads as "content", so that axis booked a
+real outage as "kimi did respond, parse miss" — the same failure class this
+whole fix exists to remove, just mirrored. The report's own YAML frontmatter
+carries a signal content can't fake: ``exit_code`` and ``token_usage.output``
+are stamped by the lane from the actual spawn result, not guessed from the
+response text. A non-zero ``exit_code`` (or zero output tokens) with
+readable frontmatter means the provider run itself failed — that is
+``dispatch_error``, even though a report exists. Only ``exit_code == 0``
+with readable frontmatter and no verdict block is a genuine ``parse_error``.
+When the frontmatter can't be read at all (older/foreign report shape), the
+outcome can't be read off the report — this falls back to the pre-fix-forward
+default of ``parse_error``, which is intentionally too broad: a masked
+provider failure with no readable ``exit_code`` would still land here, but
+there is no other signal left to tell the two apart.
 """
 from __future__ import annotations
 
@@ -56,6 +78,7 @@ from gate_recorder import (
     record_terminal_result,
     stamp_request_identity,
 )
+from unified_report_schema import SchemaViolation, parse_frontmatter
 
 _VALID_VERDICTS = {"pass", "fail", "blocked"}
 
@@ -125,7 +148,47 @@ def _get_diff(pr: str, diff_file: "str | None") -> "str | None":
         return None
 
 
-def _verdict_to_status(verdict: dict, report_text: str = "") -> "tuple[str, list, str]":
+def _frontmatter_run_outcome(report_text: str) -> "tuple[bool | None, object, object]":
+    """Read ``exit_code``/``token_usage.output`` off the report's own YAML
+    frontmatter to tell a provider-side run failure apart from a genuine
+    parse miss (OI-1291 fix-forward).
+
+    Content existing is not proof kimi actually completed a review: the
+    failure-path ``emit_unified_report`` call writes a report too, so a
+    spooled 403 body is "content" by the same measure as a real review. The
+    frontmatter's ``exit_code``/``token_usage`` fields are stamped by the
+    lane from the actual spawn result, not guessed from the response text —
+    that is the signal that can't be faked by error-page prose.
+
+    Returns ``(outcome, exit_code, output_tokens)`` where ``outcome`` is:
+        True  — frontmatter is readable and the run did not complete cleanly
+                (non-zero exit code, or zero output tokens): a provider-side
+                failure, not a review outcome.
+        False — frontmatter is readable and stamps a clean run (exit_code 0,
+                non-zero output tokens): a missing verdict block here is a
+                genuine parse miss.
+        None  — no readable frontmatter, or no ``exit_code`` field in it
+                (older/foreign report shape). The outcome can't be read off
+                the report at all; callers fall back to the pre-fix-forward
+                default (content present -> parse_error).
+    """
+    try:
+        frontmatter = parse_frontmatter(report_text)
+    except SchemaViolation:
+        return None, None, None
+    if "exit_code" not in frontmatter:
+        return None, None, None
+    exit_code = frontmatter.get("exit_code")
+    token_usage = frontmatter.get("token_usage")
+    output_tokens = token_usage.get("output") if isinstance(token_usage, dict) else None
+    if exit_code != 0 or output_tokens == 0:
+        return True, exit_code, output_tokens
+    return False, exit_code, output_tokens
+
+
+def _verdict_to_status(
+    verdict: dict, report_text: str = "", *, provider_failed_detail: "str | None" = None
+) -> "tuple[str, list, str]":
     """Map the extracted verdict to (status, blocking_findings, residual_risk).
 
     OI-1142: an empty ``verdict`` means no readable verdict could be extracted.
@@ -135,6 +198,13 @@ def _verdict_to_status(verdict: dict, report_text: str = "") -> "tuple[str, list
     the provider DID respond — the block just failed to parse, which is a
     parse miss, not an outage. Either way this maps to ``unavailable`` and
     only a REAL parsed verdict may ever produce ``fail``.
+
+    ``provider_failed_detail`` (OI-1291 fix-forward): the caller passes this
+    when it has already read the report's own frontmatter via
+    ``_frontmatter_run_outcome`` and found a non-zero exit code / zero output
+    tokens. When set, THIS function returns that provider-outage residual
+    instead of the "kimi did respond" parse-miss residual below — the report
+    having content is not proof kimi ran; the frontmatter's own exit_code is.
     """
     v = (verdict.get("verdict") or "").strip().lower() if verdict else ""
     findings = verdict.get("findings") or [] if verdict else []
@@ -149,6 +219,8 @@ def _verdict_to_status(verdict: dict, report_text: str = "") -> "tuple[str, list
         return "fail", blocking, residual or "kimi gate reported blocking findings"
     if residual:
         return "unavailable", [], residual
+    if provider_failed_detail:
+        return "unavailable", [], provider_failed_detail
     if (report_text or "").strip():
         return (
             "unavailable",
@@ -216,14 +288,38 @@ def main(argv: "list[str] | None" = None) -> int:
         reason = "dispatch_error"
     else:
         verdict = _extract_verdict(report_text or "")
-        status, blocking, residual = _verdict_to_status(verdict, report_text or "")
+        provider_failed_detail = None
+        run_failed = None
+        if not verdict and (report_text or "").strip():
+            # OI-1291 fix-forward: only consult the frontmatter once a verdict
+            # extraction has already failed — a real parsed verdict always
+            # wins regardless of what exit_code says.
+            run_failed, exit_code, output_tokens = _frontmatter_run_outcome(report_text or "")
+            if run_failed is True:
+                provider_failed_detail = (
+                    "kimi's own report frontmatter stamps this run as failed "
+                    f"(exit_code={exit_code!r}, token_usage.output={output_tokens!r}) — "
+                    "provider-side outage, not a review outcome"
+                )
+        status, blocking, residual = _verdict_to_status(
+            verdict, report_text or "", provider_failed_detail=provider_failed_detail
+        )
         if verdict:
             reason = "verdict"
         elif (report_text or "").strip():
-            # OI-1291: a report came back with content, it just didn't parse —
-            # distinct from a genuinely empty delivery (see reason="no_verdict"
-            # below) and from a dispatch_error (no report at all, above).
-            reason = "parse_error"
+            if run_failed is True:
+                # OI-1291 fix-forward: the report has content, but its OWN
+                # frontmatter stamps the underlying provider run as failed —
+                # this is the same outage class as a raised dispatch_error,
+                # just discovered from the report instead of an exception.
+                reason = "dispatch_error"
+            else:
+                # run_failed is False (frontmatter readable, clean run — a
+                # genuine parse miss) or None (no readable exit_code at all,
+                # so there is no signal left to tell a masked provider
+                # failure apart from a real parse miss). Both default to
+                # parse_error; the None case is intentionally too broad.
+                reason = "parse_error"
         else:
             reason = "no_verdict"
 

--- a/tests/test_kimi_gate_unavailable.py
+++ b/tests/test_kimi_gate_unavailable.py
@@ -1,4 +1,4 @@
-"""kimi_gate provider-outage status tests (OI-1142).
+"""kimi_gate provider-outage status tests (OI-1142, OI-1291).
 
 Eleven kimi quota-403 outages were once booked as eleven review "fail"
 records (reason "no_verdict", summary 'kimi gate: fail (0 blocking
@@ -8,11 +8,21 @@ absence of evidence and must surface as status ``unavailable``, never as a
 rejected PR. These tests pin:
 
 - provider-error output (403 text, empty/truncated report) -> "unavailable",
-  exit 1, a summary that is unmistakably an outage
+  exit 1, a summary that is unmistakably not a review fail
 - a dispatcher exception still writes an ``unavailable`` record instead of
   vanishing without a trace
 - a REAL parsed verdict (pass / fail with findings) behaves exactly as before
 - gate_status treats "unavailable" as neither pass nor fail nor terminal
+
+OI-1291: ``unavailable`` conflated two very different situations under one
+"provider outage" label — a dispatcher exception (no report at all) and a
+report that came back with real content but no readable ```json``` verdict
+block (kimi reviewed in prose; the fence just didn't parse). The latter is a
+parse miss, not an outage, and must say so: reason="parse_error", and none
+of the three operator-facing strings (summary, residual_risk, stdout) may
+claim "outage" when a report actually existed. A genuinely empty report
+(no exception, but nothing came back) is not a parse miss and keeps the
+old reason="no_verdict" behavior.
 
 ``_make_default_dispatcher`` is patched on the kimi_gate module namespace,
 not on plan_gate_panel where it is defined — `from X import Y` binds the name
@@ -59,6 +69,10 @@ _REAL_PASS_REPORT = (
     "```\n"
 )
 
+# OI-1291: kimi reviewed and produced real prose, but no fenced ```json```
+# verdict block — this must land as a parse miss, not a provider outage.
+_PROSE_NO_VERDICT_REPORT = "## Findings\n\nNone\n"
+
 
 def _run_gate(tmp_path, monkeypatch, dispatcher):
     diff_file = tmp_path / "x.diff"
@@ -76,14 +90,17 @@ def _run_gate(tmp_path, monkeypatch, dispatcher):
 # ---------------------------------------------------------------------------
 
 
-def test_quota_403_text_books_unavailable_not_fail(tmp_path, monkeypatch):
+def test_quota_403_text_books_parse_error_not_outage(tmp_path, monkeypatch):
+    """A report with real (error) content but no fenced verdict is a parse
+    miss (OI-1291), not an outage: kimi plainly responded with something."""
     rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: _QUOTA_403_REPORT)
     assert record is not None
     assert record["status"] == "unavailable"
-    assert record["reason"] == "no_verdict"
+    assert record["reason"] == "parse_error"
     assert rc == 1  # infra/unavailable, not the exit-2 review fail
     assert "UNAVAILABLE" in record["summary"]
-    assert "NOT a review fail" in record["summary"]
+    assert "outage" not in record["summary"].lower()
+    assert str(len(_QUOTA_403_REPORT)) in record["summary"]
     assert record["blocking_findings"] == []
 
 
@@ -91,7 +108,54 @@ def test_empty_report_books_unavailable(tmp_path, monkeypatch):
     rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: "")
     assert record is not None
     assert record["status"] == "unavailable"
+    # OI-1291: a genuinely empty report (no exception, nothing came back) is
+    # NOT a parse miss — it keeps the pre-existing no_verdict reason.
+    assert record["reason"] == "no_verdict"
     assert rc == 1
+
+
+def test_prose_report_without_fence_books_parse_error_not_outage(tmp_path, monkeypatch, capsys):
+    """OI-1291 core case: kimi reviewed (real prose, e.g. a ``## Findings``
+    section) but the contract's fenced ```json``` verdict block is missing.
+    That is a parse miss, distinguishable from a dispatch/provider outage —
+    none of the three operator surfaces (summary, residual_risk, stdout) may
+    say "outage" here."""
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: _PROSE_NO_VERDICT_REPORT)
+    captured = capsys.readouterr()
+    assert record is not None
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "parse_error"
+    assert rc == 1
+    assert "outage" not in record["summary"].lower()
+    assert "outage" not in record["residual_risk"].lower()
+    assert "outage" not in captured.out.lower()
+    # the operator must be able to see that content DID come back
+    report_len = str(len(_PROSE_NO_VERDICT_REPORT))
+    assert report_len in record["summary"]
+    assert report_len in record["residual_risk"]
+    assert record["blocking_findings"] == []
+
+
+def test_parse_miss_and_dispatch_error_are_distinguishable(tmp_path, monkeypatch):
+    """The two 'unavailable' causes OI-1291 conflated must fall apart on
+    ``reason``: a parse miss (report with content, no fence) is not the same
+    as a dispatch exception (no report produced at all)."""
+    rc_parse, record_parse = _run_gate(
+        tmp_path, monkeypatch, lambda *a, **k: _PROSE_NO_VERDICT_REPORT
+    )
+
+    def _boom(*a, **k):
+        raise RuntimeError("kimi dispatch exploded")
+
+    rc_dispatch, record_dispatch = _run_gate(tmp_path, monkeypatch, _boom)
+
+    assert record_parse["status"] == record_dispatch["status"] == "unavailable"
+    assert record_parse["reason"] == "parse_error"
+    assert record_dispatch["reason"] == "dispatch_error"
+    assert record_parse["reason"] != record_dispatch["reason"]
+    assert rc_parse == rc_dispatch == 1
+    # only the parse-miss summary is forbidden from claiming "outage"
+    assert "outage" not in record_parse["summary"].lower()
 
 
 def test_dispatch_exception_writes_unavailable_record(tmp_path, monkeypatch):

--- a/tests/test_kimi_gate_unavailable.py
+++ b/tests/test_kimi_gate_unavailable.py
@@ -31,12 +31,23 @@ failure path too — so a spooled 403 error body is "content" by the same
 measure as a real review. The first cut of this fix read that as "kimi did
 respond, parse miss", which books a real outage as a review event: the same
 failure class OI-1291 exists to remove, just mirrored. The report's own
-YAML frontmatter carries the signal content can't fake: ``exit_code`` and
-``token_usage.output`` are stamped by the lane from the actual spawn
-result. A non-zero exit_code (or zero output tokens) with readable
-frontmatter means the underlying kimi run failed — that is
+YAML frontmatter carries the signal content can't fake: ``exit_code`` is
+stamped by the lane from the actual spawn result. A non-zero exit_code with
+readable frontmatter means the underlying kimi run failed — that is
 reason="dispatch_error" even though a report exists. Only exit_code == 0
 with readable frontmatter and no verdict block is a genuine parse_error.
+
+OI-1291 fix-forward, meetgat correction: the first cut of the frontmatter
+axis also treated a raw zero output-token count as a failure signal on its
+own. On the kimi lane, post-run token capture is frequently unavailable —
+the lane stamps ``token_usage_measured: false`` alongside ``output: 0`` for
+those runs — so a raw zero routinely means "not measured", not "the run
+produced nothing". A count of 766 kimi reports on disk found 502 with
+exit_code 0, real content, and ``token_usage_measured: false``: successful
+runs the raw-zero check booked as provider outages, reintroducing OI-1291's
+original bug on a different axis. ``output_tokens`` now only counts as a
+failure signal when the frontmatter's own ``token_usage_measured`` flag is
+true; otherwise only ``exit_code`` decides.
 
 ``_make_default_dispatcher`` is patched on the kimi_gate module namespace,
 not on plan_gate_panel where it is defined — `from X import Y` binds the name
@@ -63,13 +74,25 @@ from gate_status import (
 )
 
 def _kimi_report_with_frontmatter(
-    body: str, *, exit_code: int, output_tokens: int = 0, dispatch_id: str = "kimi-gate-pr0-test",
+    body: str,
+    *,
+    exit_code: int,
+    output_tokens: int = 0,
+    token_usage_measured: bool = False,
+    dispatch_id: str = "kimi-gate-pr0-test",
 ) -> str:
     """Build a report in the exact shape the governed lane actually writes:
     YAML frontmatter (``governance_emit.emit_unified_report``) followed by
     the body — the shape OI-1291's fix-forward measured on real quota-outage
     artifacts on disk (``exit_code: 1`` / ``token_usage.output: 0`` on a
-    failed run, alongside a non-empty body from the failure-path report)."""
+    failed run, alongside a non-empty body from the failure-path report).
+
+    ``token_usage_measured`` defaults to False: on the kimi lane, post-run
+    token capture is frequently unavailable (kimi-cli's stream-json output
+    carries no usage accounting), so the lane stamps ``output: 0`` alongside
+    ``token_usage_measured: false`` for the overwhelming majority of real
+    reports — a measured count of 766 kimi reports on disk found only 4 with
+    a genuinely measured token count."""
     return (
         "---\n"
         "schema_version: 1\n"
@@ -83,6 +106,7 @@ def _kimi_report_with_frontmatter(
         "  input: 0\n"
         f"  output: {output_tokens}\n"
         "  cache_read: 0\n"
+        f"token_usage_measured: {'true' if token_usage_measured else 'false'}\n"
         "---\n"
         "\n"
         f"{body}"
@@ -161,6 +185,46 @@ def test_quota_403_frontmatter_exit_code_books_dispatch_error_not_parse_error(tm
     assert rc == 1  # infra/unavailable, not the exit-2 review fail
     assert "UNAVAILABLE" in record["summary"]
     assert record["blocking_findings"] == []
+
+
+def test_unmeasured_zero_tokens_books_parse_error_not_dispatch_error(tmp_path, monkeypatch):
+    """Meetgat correction: on the kimi lane, post-run token capture is
+    frequently unavailable — a measured count of 766 kimi reports on disk
+    found 502 with exit_code: 0, real body content, and
+    ``token_usage_measured: false``. Those are successful runs whose zero
+    output-token count is a measurement gap, not proof the run failed. This
+    report reproduces that exact shape (clean exit_code, unmeasured zero
+    tokens, non-empty body with no readable verdict block) and MUST land as
+    a genuine parse_error, never dispatch_error — the previous cut of this
+    fix would have booked all 502 of those runs as provider outages."""
+    body = "## Review notes\n\nLooks fine, no structured verdict emitted.\n"
+    report = _kimi_report_with_frontmatter(
+        body, exit_code=0, output_tokens=0, token_usage_measured=False,
+    )
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: report)
+    assert record is not None
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "parse_error"
+    assert record["reason"] != "dispatch_error"
+    assert rc == 1
+    assert "outage" not in record["summary"].lower()
+
+
+def test_measured_zero_tokens_books_dispatch_error(tmp_path, monkeypatch):
+    """When the frontmatter's own ``token_usage_measured`` flag is true, a
+    zero output-token count is a real signal (the run's own record says it
+    produced nothing) and must still book as dispatch_error, not parse_error
+    — the conditional weighting only withholds judgement on an UNMEASURED
+    zero, it does not drop the token signal entirely."""
+    body = "## Review notes\n\nLooks fine, no structured verdict emitted.\n"
+    report = _kimi_report_with_frontmatter(
+        body, exit_code=0, output_tokens=0, token_usage_measured=True,
+    )
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: report)
+    assert record is not None
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "dispatch_error"
+    assert rc == 1
 
 
 def test_empty_report_books_unavailable(tmp_path, monkeypatch):
@@ -285,8 +349,9 @@ def test_content_without_frontmatter_falls_back_to_parse_error(tmp_path, monkeyp
 
 
 def test_frontmatter_run_outcome_unit_cases():
-    """Direct coverage of the three ``_frontmatter_run_outcome`` branches:
-    failed run, clean run, and unreadable/missing frontmatter."""
+    """Direct coverage of the ``_frontmatter_run_outcome`` branches: failed
+    run, clean run, an unmeasured zero (the 502-report case — meetgat
+    correction), a measured zero, and unreadable/missing frontmatter."""
     failed = _kimi_report_with_frontmatter("body text here", exit_code=1, output_tokens=0)
     outcome, exit_code, output_tokens = kimi_gate._frontmatter_run_outcome(failed)
     assert outcome is True
@@ -299,10 +364,23 @@ def test_frontmatter_run_outcome_unit_cases():
     assert exit_code == 0
     assert output_tokens == 50
 
-    # exit_code 0 but zero output tokens is still a failure signal per the
-    # OI-1291 fix-forward directive ("exit_code niet 0 (of output-tokens 0)").
-    zero_output = _kimi_report_with_frontmatter("body text here", exit_code=0, output_tokens=0)
-    outcome, _, _ = kimi_gate._frontmatter_run_outcome(zero_output)
+    # meetgat correction: exit_code 0 and zero output tokens, but
+    # token_usage_measured is false (the default — the 502-report shape
+    # measured on disk). The zero is a measurement gap, not a failure
+    # signal, so this must land as a clean run (parse miss upstream), not
+    # a provider-side failure.
+    unmeasured_zero = _kimi_report_with_frontmatter(
+        "body text here", exit_code=0, output_tokens=0, token_usage_measured=False,
+    )
+    outcome, _, _ = kimi_gate._frontmatter_run_outcome(unmeasured_zero)
+    assert outcome is False
+
+    # A GENUINELY measured zero (token_usage_measured: true) is still a
+    # failure signal — the run's own record says it produced nothing.
+    measured_zero = _kimi_report_with_frontmatter(
+        "body text here", exit_code=0, output_tokens=0, token_usage_measured=True,
+    )
+    outcome, _, _ = kimi_gate._frontmatter_run_outcome(measured_zero)
     assert outcome is True
 
     outcome, exit_code, output_tokens = kimi_gate._frontmatter_run_outcome("no frontmatter here")

--- a/tests/test_kimi_gate_unavailable.py
+++ b/tests/test_kimi_gate_unavailable.py
@@ -24,6 +24,20 @@ claim "outage" when a report actually existed. A genuinely empty report
 (no exception, but nothing came back) is not a parse miss and keeps the
 old reason="no_verdict" behavior.
 
+OI-1291 fix-forward: "did a report come back" was the WRONG axis for
+parse_error vs outage. A real quota/auth outage still writes a report —
+the failure-path ``emit_unified_report`` call runs on the dispatcher's
+failure path too — so a spooled 403 error body is "content" by the same
+measure as a real review. The first cut of this fix read that as "kimi did
+respond, parse miss", which books a real outage as a review event: the same
+failure class OI-1291 exists to remove, just mirrored. The report's own
+YAML frontmatter carries the signal content can't fake: ``exit_code`` and
+``token_usage.output`` are stamped by the lane from the actual spawn
+result. A non-zero exit_code (or zero output tokens) with readable
+frontmatter means the underlying kimi run failed — that is
+reason="dispatch_error" even though a report exists. Only exit_code == 0
+with readable frontmatter and no verdict block is a genuine parse_error.
+
 ``_make_default_dispatcher`` is patched on the kimi_gate module namespace,
 not on plan_gate_panel where it is defined — `from X import Y` binds the name
 at import time.
@@ -48,11 +62,44 @@ from gate_status import (
     is_terminal,
 )
 
-_QUOTA_403_REPORT = (
+def _kimi_report_with_frontmatter(
+    body: str, *, exit_code: int, output_tokens: int = 0, dispatch_id: str = "kimi-gate-pr0-test",
+) -> str:
+    """Build a report in the exact shape the governed lane actually writes:
+    YAML frontmatter (``governance_emit.emit_unified_report``) followed by
+    the body — the shape OI-1291's fix-forward measured on real quota-outage
+    artifacts on disk (``exit_code: 1`` / ``token_usage.output: 0`` on a
+    failed run, alongside a non-empty body from the failure-path report)."""
+    return (
+        "---\n"
+        "schema_version: 1\n"
+        f"dispatch_id: {dispatch_id}\n"
+        "provider: kimi\n"
+        "sub_provider: moonshot\n"
+        "model: kimi-k3\n"
+        "duration_seconds: 154.095\n"
+        f"exit_code: {exit_code}\n"
+        "token_usage:\n"
+        "  input: 0\n"
+        f"  output: {output_tokens}\n"
+        "  cache_read: 0\n"
+        "---\n"
+        "\n"
+        f"{body}"
+    )
+
+
+_QUOTA_403_BODY = (
     "Error: API request failed with status 403: "
     '{"error":{"type":"access_terminated_error","message":'
     '"You have reached your usage limit for this billing cycle."}}\n'
 )
+
+# OI-1291 fix-forward: a REAL quota outage — the underlying kimi run failed,
+# stamped by its OWN frontmatter (exit_code: 1, output: 0), exactly like the
+# real artifacts measured on disk. This must NOT land as parse_error: the
+# provider never produced a review, it produced an error page.
+_QUOTA_403_REPORT = _kimi_report_with_frontmatter(_QUOTA_403_BODY, exit_code=1, output_tokens=0)
 
 _REAL_FAIL_REPORT = (
     "Reviewed the diff; found a real problem.\n\n"
@@ -71,7 +118,13 @@ _REAL_PASS_REPORT = (
 
 # OI-1291: kimi reviewed and produced real prose, but no fenced ```json```
 # verdict block — this must land as a parse miss, not a provider outage.
-_PROSE_NO_VERDICT_REPORT = "## Findings\n\nNone\n"
+# OI-1291 fix-forward: the frontmatter carries exit_code: 0 and a non-zero
+# output-token count — the run's OWN record of itself says it completed
+# cleanly, so a missing verdict block here can only be a parse miss.
+_PROSE_NO_VERDICT_BODY = "## Findings\n\nNone\n"
+_PROSE_NO_VERDICT_REPORT = _kimi_report_with_frontmatter(
+    _PROSE_NO_VERDICT_BODY, exit_code=0, output_tokens=340,
+)
 
 
 def _run_gate(tmp_path, monkeypatch, dispatcher):
@@ -90,17 +143,23 @@ def _run_gate(tmp_path, monkeypatch, dispatcher):
 # ---------------------------------------------------------------------------
 
 
-def test_quota_403_text_books_parse_error_not_outage(tmp_path, monkeypatch):
-    """A report with real (error) content but no fenced verdict is a parse
-    miss (OI-1291), not an outage: kimi plainly responded with something."""
+def test_quota_403_frontmatter_exit_code_books_dispatch_error_not_parse_error(tmp_path, monkeypatch):
+    """OI-1291 fix-forward: a REAL quota outage still writes a report — the
+    failure-path ``emit_unified_report`` call runs on the dispatcher's
+    failure path too — so "content exists" alone cannot separate an outage
+    from a parse miss. That was the bug reintroduced by the first cut of
+    this fix: it read the spooled 403 body as "kimi did respond, parse
+    miss". The report's OWN frontmatter (exit_code: 1, output: 0 — exactly
+    the shape measured on real quota-outage artifacts on disk) says the
+    underlying kimi run failed, so this must land as dispatch_error, the
+    provider-outage class, never parse_error."""
     rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: _QUOTA_403_REPORT)
     assert record is not None
     assert record["status"] == "unavailable"
-    assert record["reason"] == "parse_error"
+    assert record["reason"] != "parse_error"
+    assert record["reason"] == "dispatch_error"
     assert rc == 1  # infra/unavailable, not the exit-2 review fail
     assert "UNAVAILABLE" in record["summary"]
-    assert "outage" not in record["summary"].lower()
-    assert str(len(_QUOTA_403_REPORT)) in record["summary"]
     assert record["blocking_findings"] == []
 
 
@@ -115,11 +174,13 @@ def test_empty_report_books_unavailable(tmp_path, monkeypatch):
 
 
 def test_prose_report_without_fence_books_parse_error_not_outage(tmp_path, monkeypatch, capsys):
-    """OI-1291 core case: kimi reviewed (real prose, e.g. a ``## Findings``
-    section) but the contract's fenced ```json``` verdict block is missing.
-    That is a parse miss, distinguishable from a dispatch/provider outage —
-    none of the three operator surfaces (summary, residual_risk, stdout) may
-    say "outage" here."""
+    """OI-1291 core case, fix-forward: kimi reviewed (real prose, e.g. a
+    ``## Findings`` section) and its OWN report frontmatter stamps a clean
+    run (exit_code: 0, non-zero output tokens) — but the contract's fenced
+    ```json``` verdict block is missing. That is a genuine parse miss,
+    correctly distinguishable from a provider outage BECAUSE the frontmatter
+    says the run completed; none of the three operator surfaces (summary,
+    residual_risk, stdout) may say "outage" here."""
     rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: _PROSE_NO_VERDICT_REPORT)
     captured = capsys.readouterr()
     assert record is not None
@@ -129,11 +190,43 @@ def test_prose_report_without_fence_books_parse_error_not_outage(tmp_path, monke
     assert "outage" not in record["summary"].lower()
     assert "outage" not in record["residual_risk"].lower()
     assert "outage" not in captured.out.lower()
-    # the operator must be able to see that content DID come back
+    # the operator must be able to see that content DID come back — the
+    # length is measured off the FULL report text (frontmatter + body), the
+    # same string the dispatcher actually returned.
     report_len = str(len(_PROSE_NO_VERDICT_REPORT))
     assert report_len in record["summary"]
     assert report_len in record["residual_risk"]
     assert record["blocking_findings"] == []
+
+
+def test_frontmatter_exit_code_alone_flips_reason_dispatch_error_vs_parse_error(tmp_path, monkeypatch):
+    """OI-1291 fix-forward, item 3: the report's own frontmatter exit_code is
+    the ONLY thing allowed to separate an outage from a parse miss — not
+    body content, not body length. Two reports share the exact same
+    non-empty body (and therefore the same body length); only the exit_code
+    (and its paired output-tokens signal) fed into the frontmatter differs,
+    and that alone must flip the reason."""
+    shared_body = "## Findings\n\nNone\n"
+    failed_exit_code = 1
+    clean_exit_code = 0
+    failed_report = _kimi_report_with_frontmatter(
+        shared_body, exit_code=failed_exit_code, output_tokens=0,
+    )
+    clean_report = _kimi_report_with_frontmatter(
+        shared_body, exit_code=clean_exit_code, output_tokens=340,
+    )
+
+    rc_failed, record_failed = _run_gate(tmp_path, monkeypatch, lambda *a, **k: failed_report)
+    rc_clean, record_clean = _run_gate(tmp_path, monkeypatch, lambda *a, **k: clean_report)
+
+    assert record_failed["reason"] == "dispatch_error"
+    assert record_clean["reason"] == "parse_error"
+    assert record_failed["reason"] != record_clean["reason"]
+    assert rc_failed == rc_clean == 1
+    assert "outage" not in record_clean["summary"].lower()
+    # the exit_code value itself, not just the derived reason, must be
+    # traceable in the failed record's residual_risk
+    assert f"exit_code={failed_exit_code!r}" in record_failed["residual_risk"]
 
 
 def test_parse_miss_and_dispatch_error_are_distinguishable(tmp_path, monkeypatch):
@@ -175,6 +268,47 @@ def test_verdict_to_status_empty_verdict_is_unavailable():
     assert status == "unavailable"
     assert blocking == []
     assert "no readable verdict" in residual
+
+
+def test_content_without_frontmatter_falls_back_to_parse_error(tmp_path, monkeypatch):
+    """OI-1291 fix-forward: an older/foreign report shape with no readable
+    frontmatter at all carries no exit_code to read, so there is no signal
+    left to tell a masked provider failure apart from a genuine parse miss.
+    This falls back to the pre-fix-forward default (parse_error) — the
+    fallback is intentionally too broad, not silently wrong."""
+    no_frontmatter_report = "Reviewed in prose, no fenced block, no frontmatter at all.\n"
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: no_frontmatter_report)
+    assert record is not None
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "parse_error"
+    assert rc == 1
+
+
+def test_frontmatter_run_outcome_unit_cases():
+    """Direct coverage of the three ``_frontmatter_run_outcome`` branches:
+    failed run, clean run, and unreadable/missing frontmatter."""
+    failed = _kimi_report_with_frontmatter("body text here", exit_code=1, output_tokens=0)
+    outcome, exit_code, output_tokens = kimi_gate._frontmatter_run_outcome(failed)
+    assert outcome is True
+    assert exit_code == 1
+    assert output_tokens == 0
+
+    clean = _kimi_report_with_frontmatter("body text here", exit_code=0, output_tokens=50)
+    outcome, exit_code, output_tokens = kimi_gate._frontmatter_run_outcome(clean)
+    assert outcome is False
+    assert exit_code == 0
+    assert output_tokens == 50
+
+    # exit_code 0 but zero output tokens is still a failure signal per the
+    # OI-1291 fix-forward directive ("exit_code niet 0 (of output-tokens 0)").
+    zero_output = _kimi_report_with_frontmatter("body text here", exit_code=0, output_tokens=0)
+    outcome, _, _ = kimi_gate._frontmatter_run_outcome(zero_output)
+    assert outcome is True
+
+    outcome, exit_code, output_tokens = kimi_gate._frontmatter_run_outcome("no frontmatter here")
+    assert outcome is None
+    assert exit_code is None
+    assert output_tokens is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `kimi_gate.py` collapsed two distinct states into one "provider outage" label: a dispatcher exception (no report produced) and a report that came back with real content but no readable ```json``` verdict block.
- The latter is a parse miss, not an outage — kimi did respond, the format just didn't match the contract. Previously both landed as `reason="no_verdict"` with outage-flavored wording on all three operator surfaces (`summary`, `residual_risk`, stdout), sending operators chasing quota/outage issues that didn't exist.

## Changes
- `scripts/kimi_gate.py`:
  - `_verdict_to_status()` now takes the raw `report_text` and distinguishes an empty/whitespace report (real outage-like signal) from a non-empty report with no parseable verdict block (parse miss).
  - New `reason="parse_error"` value (aligned with the existing `parse_error`/`no_verdict` vocabulary in `scripts/analysis/plan_gate_panel_effectiveness.py`) for the parse-miss case. `reason="no_verdict"` is kept unchanged for the genuinely-empty-report case, and `reason="dispatch_error"` is untouched.
  - `_status_summary()` and the `main()` stdout branch now report the report length and drop the word "outage" entirely when `reason == "parse_error"`.
  - `status` stays `"unavailable"` in both cases; only a real parsed verdict can ever produce `"fail"` — unchanged.
- `tests/test_kimi_gate_unavailable.py`:
  - Updated `test_quota_403_text_books_unavailable_not_fail` → `test_quota_403_text_books_parse_error_not_outage` (that report has real content, so it's now correctly a parse miss).
  - Added `test_prose_report_without_fence_books_parse_error_not_outage` — a `## Findings` prose report (no fenced verdict) now books `reason="parse_error"`, and none of summary/residual_risk/stdout contain "outage".
  - Added `test_parse_miss_and_dispatch_error_are_distinguishable` — proves a parse miss and a real dispatch exception land on different `reason` values.
  - `test_empty_report_books_unavailable` now explicitly asserts `reason == "no_verdict"` is preserved for a truly empty report.

## Verification
```
python3 -m pytest tests/test_kimi_gate_unavailable.py tests/test_kimi_gate_provenance.py -v
```
13 passed in 0.77s (all touched files; full suite intentionally not run per dispatch instructions).

Commit: c8885638

## Open Items
None.