### PR TITLE
fix(dispatch): speak claude-lane failures, stop borrowing base commit (OI-1367/OI-1363)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1917,6 +1917,14 @@ def _execute_claude(
         isolated_worktree=True,
         requires_mcp=plan.requires_mcp,
     )
+    if not result.success:
+        # Fail-loud: the door must never swallow a claude-lane failure into a
+        # bare exit code - the caller (bin/vnx dispatch) prints nothing else.
+        print(
+            f"[dispatch_cli] claude lane failed: "
+            f"{result.failure_reason or '(no failure_reason captured)'}",
+            file=sys.stderr,
+        )
     return 0 if result.success else 1
 
 

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -811,7 +811,9 @@ def _synthesize(spec: GovernSpec, raw: GovernRaw) -> str:
     status = (raw.receipt or {}).get("status", "unknown") if raw.receipt else "timeout"
 
     # -- ## Summary -----------------------------------------------------------
-    summary = _git_summary(spec, status)
+    delivered = _work_delivered(spec)
+    delivery_verdict = "work_delivered" if delivered else "no_work_delivered"
+    summary = _git_summary(spec, status, delivered=delivered)
 
     # -- ## Changes -----------------------------------------------------------
     changes = _git_changes(spec)
@@ -834,6 +836,7 @@ def _synthesize(spec: GovernSpec, raw: GovernRaw) -> str:
         f"- Lane: tmux_interactive\n"
         f"- Status: {status}\n"
         f"- contract_status: synthesized\n"
+        f"- delivery_verdict: {delivery_verdict}\n"
         f"- {SYNTHESIZED_REPORT_MARKER}\n\n"
         f"## Summary\n\n{summary}\n\n"
         f"## Changes\n\n{changes}\n\n"
@@ -894,8 +897,54 @@ def _run_worktree_git(spec: GovernSpec, args: list, timeout: float) -> Optional[
     return result.stdout.strip() or None
 
 
-def _git_summary(spec: GovernSpec, status: str) -> str:
-    """Return git log subject + body for the worker commit, or a fallback message."""
+def _work_delivered(spec: GovernSpec) -> bool:
+    """Return True iff the worker committed at least one commit onto its base (OI-1363).
+
+    Primary check: ``git rev-list --count <base_sha>..HEAD`` — any count above
+    zero means the worktree's HEAD is a worker commit, not a borrowed base-branch
+    tip. When ``base_sha`` is absent (no baseline to diff against), HEAD cannot be
+    proven to be this dispatch's own commit by position alone, so fall back to the
+    ``Dispatch-ID: <id>`` trailer the worker convention requires in every commit
+    body — its absence means HEAD is not provably this dispatch's work.
+    """
+    if spec.base_sha:
+        try:
+            count = _run_worktree_git(
+                spec, ["rev-list", "--count", f"{spec.base_sha}..HEAD"], timeout=10
+            )
+        except _NoWorktreeError:
+            return False
+        if count is None:
+            return False
+        try:
+            return int(count) > 0
+        except ValueError:
+            return False
+
+    try:
+        msg = _run_worktree_git(spec, ["log", "-1", "--format=%s%n%b"], timeout=10)
+    except _NoWorktreeError:
+        return False
+    return bool(msg) and f"Dispatch-ID: {spec.dispatch_id}" in msg
+
+
+def _git_summary(spec: GovernSpec, status: str, *, delivered: bool) -> str:
+    """Return git log subject + body for the worker commit, or a fallback message.
+
+    When ``delivered`` is False, the worktree's HEAD commit belongs to the base
+    branch (or an earlier dispatch), not this worker — its message is never
+    surfaced here (OI-1363: a borrowed commit message reads as delivered work
+    that never happened).
+    """
+    if not delivered:
+        return (
+            f"No work delivered: the worker did not commit anything on top of "
+            f"the dispatch base ({spec.base_sha or 'no base_sha recorded'}). "
+            f"Worker status: {status}. "
+            f"Body synthesized by governance layer (no worker report file). "
+            f"[{SYNTHESIZED_REPORT_MARKER}]"
+        )
+
     try:
         msg = _run_worktree_git(spec, ["log", "-1", "--format=%s%n%b"], timeout=10)
     except _NoWorktreeError:

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -456,6 +456,69 @@ def test_claude_routes_to_tmux_with_permit(mock_snapshot, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# test_execute_claude_prints_failure_reason_to_stderr (OI-1367)
+# ---------------------------------------------------------------------------
+
+def test_execute_claude_prints_failure_reason_to_stderr(tmp_path, capsys):
+    """OI-1367: the door must never swallow a claude-lane failure into a bare
+    exit code — mirrors the provider lane's fail-loud contract (dispatch_cli.py
+    ~line 2499). A stale rc=1 with no explanation reads as 'lane at capacity',
+    which is the wrong conclusion when the real cause was e.g. a missing tmux
+    binary or a failed worktree add."""
+    instruction_file = _make_instruction(tmp_path)
+    plan = _make_minimal_plan(instruction_file=instruction_file)
+    permit = issue_permit(plan)
+
+    mock_dispatch_result = MagicMock()
+    mock_dispatch_result.success = False
+    mock_dispatch_result.failure_reason = "tmux binary not found in PATH"
+
+    with patch(
+        "tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch",
+        return_value=mock_dispatch_result,
+    ):
+        rc = _execute_claude(
+            plan,
+            permit,
+            state_dir=tmp_path / "state",
+            data_dir=tmp_path,
+        )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "tmux binary not found in PATH" in err
+    print(f"\n--- captured stderr ---\n{err}")
+
+
+def test_execute_claude_falls_back_to_explicit_marker_on_empty_failure_reason(tmp_path, capsys):
+    """A blank failure_reason must never render as silence — it must render as
+    an explicit '(no failure_reason captured)' marker on stderr."""
+    instruction_file = _make_instruction(tmp_path)
+    plan = _make_minimal_plan(instruction_file=instruction_file)
+    permit = issue_permit(plan)
+
+    mock_dispatch_result = MagicMock()
+    mock_dispatch_result.success = False
+    mock_dispatch_result.failure_reason = None
+
+    with patch(
+        "tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch",
+        return_value=mock_dispatch_result,
+    ):
+        rc = _execute_claude(
+            plan,
+            permit,
+            state_dir=tmp_path / "state",
+            data_dir=tmp_path,
+        )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "(no failure_reason captured)" in err
+    print(f"\n--- captured stderr ---\n{err}")
+
+
+# ---------------------------------------------------------------------------
 # test_reject_on_validate_failure
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -28,6 +28,7 @@ from dispatch_govern import (
     _synthesize,
     _git_changes,
     _git_summary,
+    _work_delivered,
 )
 from report_body_contract import validate_body
 
@@ -1666,7 +1667,7 @@ def test_git_summary_with_worktree_calls_subprocess_scoped_to_cwd(tmp_data, tmp_
 
     fake = subprocess.CompletedProcess(["git"], 0, stdout="feat: add foo\n", stderr="")
     with patch("dispatch_govern.subprocess.run", return_value=fake) as mock_run:
-        result = _git_summary(spec, status="done")
+        result = _git_summary(spec, status="done", delivered=True)
 
     assert mock_run.called, "patch on dispatch_govern.subprocess.run did not intercept _git_summary's call"
     _, kwargs = mock_run.call_args
@@ -1682,7 +1683,7 @@ def test_git_summary_no_worktree_never_calls_subprocess(tmp_data, tmp_state):
     spec = _make_spec(tmp_data, tmp_state, worktree_path=None)
 
     with patch("dispatch_govern.subprocess.run") as mock_run:
-        result = _git_summary(spec, status="failed")
+        result = _git_summary(spec, status="failed", delivered=True)
         mock_run.assert_not_called()
 
     assert "No commit on branch" in result
@@ -1741,7 +1742,7 @@ def test_git_summary_and_changes_with_real_worktree_unchanged(tmp_path):
         model="sonnet",
     )
 
-    summary = _git_summary(spec, status="done")
+    summary = _git_summary(spec, status="done", delivered=True)
     assert "feat: add foo" in summary
     assert "Worker status: done" in summary
 
@@ -1758,3 +1759,140 @@ def test_git_summary_and_changes_with_real_worktree_unchanged(tmp_path):
     changes2 = _git_changes(spec)
     assert "foo.py" in changes2
     assert "(no base_sha; showing HEAD~1..HEAD)" in changes2
+
+
+# ---------------------------------------------------------------------------
+# OI-1363: a synthesized report must never borrow the base branch's commit
+# message as if it were the worker's own delivered work.
+# ---------------------------------------------------------------------------
+
+def _make_base_repo(tmp_path: Path) -> "tuple[Path, str]":
+    """Real git repo with two commits; returns (repo_path, base_sha == HEAD)."""
+    repo = tmp_path / "worktree"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "foo.py").write_text("print('hi')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "chore: repo seed"], cwd=repo, check=True)
+    (repo / "foo.py").write_text("print('hi 2')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "feat(prior-dispatch): borrowed base commit message"],
+        cwd=repo, check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, base_sha
+
+
+def test_work_delivered_true_when_commits_on_top_of_base(tmp_path):
+    repo, base_sha = _make_base_repo(tmp_path)
+    (repo / "foo.py").write_text("print('worker change')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "feat(oi-1363): actual worker commit"],
+        cwd=repo, check=True,
+    )
+    spec = GovernSpec(
+        dispatch_id="d-delivered", terminal_id="T1", instruction="Do it.",
+        data_dir=tmp_path / "data", state_dir=tmp_path / "state",
+        worktree_path=repo, base_sha=base_sha, model="sonnet",
+    )
+    assert _work_delivered(spec) is True
+
+
+def test_work_delivered_false_when_head_equals_base(tmp_path):
+    repo, base_sha = _make_base_repo(tmp_path)
+    spec = GovernSpec(
+        dispatch_id="d-no-work", terminal_id="T1", instruction="Do it.",
+        data_dir=tmp_path / "data", state_dir=tmp_path / "state",
+        worktree_path=repo, base_sha=base_sha, model="sonnet",
+    )
+    assert _work_delivered(spec) is False
+
+
+def test_work_delivered_false_no_base_sha_no_dispatch_trailer(tmp_path):
+    repo, _base_sha = _make_base_repo(tmp_path)
+    spec = GovernSpec(
+        dispatch_id="d-no-base-sha", terminal_id="T1", instruction="Do it.",
+        data_dir=tmp_path / "data", state_dir=tmp_path / "state",
+        worktree_path=repo, base_sha=None, model="sonnet",
+    )
+    assert _work_delivered(spec) is False
+
+
+def test_work_delivered_true_no_base_sha_with_dispatch_trailer(tmp_path):
+    repo, _base_sha = _make_base_repo(tmp_path)
+    (repo / "foo.py").write_text("print('worker change')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m",
+         "feat(oi-1363): worker commit\n\nDispatch-ID: d-trailer-match"],
+        cwd=repo, check=True,
+    )
+    spec = GovernSpec(
+        dispatch_id="d-trailer-match", terminal_id="T1", instruction="Do it.",
+        data_dir=tmp_path / "data", state_dir=tmp_path / "state",
+        worktree_path=repo, base_sha=None, model="sonnet",
+    )
+    assert _work_delivered(spec) is True
+
+
+@pytest.mark.parametrize(
+    "status,receipt,failure_reason",
+    [
+        ("timeout", None, "tmux_receipt_deadline_exceeded"),
+        ("awaiting_permission", {"status": "awaiting_permission"}, "tmux_awaiting_permission"),
+        ("no_progress", {"status": "no_progress"}, "interactive_no_progress"),
+    ],
+)
+def test_synthesize_no_work_delivered_never_borrows_base_commit_message(
+    tmp_path, status, receipt, failure_reason,
+):
+    """OI-1363: for all three synthesized-report reasons observed 12-21 aug in the
+    ledger (deadline / awaiting_permission / no_progress), a worker that committed
+    nothing must get an honest 'no work delivered' report — never the base
+    branch's borrowed commit message."""
+    repo, base_sha = _make_base_repo(tmp_path)
+    spec = GovernSpec(
+        dispatch_id=f"d-{status}", terminal_id="T1", instruction="Do it.",
+        data_dir=tmp_path / "data", state_dir=tmp_path / "state",
+        worktree_path=repo, base_sha=base_sha, model="sonnet",
+    )
+    raw = GovernRaw(receipt=receipt, duration_seconds=1.0, failure_reason=failure_reason)
+
+    body = _synthesize(spec, raw)
+
+    assert "- delivery_verdict: no_work_delivered" in body
+    assert "borrowed base commit message" not in body
+    summary_section = body.split("## Summary")[1].split("## Changes")[0]
+    assert "No work delivered" in summary_section
+    print(f"\n--- ## Summary ({status}) ---\n{summary_section}")
+
+
+def test_synthesize_work_delivered_keeps_commit_message_and_verdict(tmp_path):
+    """Positive control: a worker commit on top of base keeps existing behavior —
+    the commit message stays in the Summary and the verdict flips to delivered."""
+    repo, base_sha = _make_base_repo(tmp_path)
+    (repo / "foo.py").write_text("print('worker change')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "feat(oi-1363): real worker delivery"],
+        cwd=repo, check=True,
+    )
+    spec = GovernSpec(
+        dispatch_id="d-delivered-synth", terminal_id="T1", instruction="Do it.",
+        data_dir=tmp_path / "data", state_dir=tmp_path / "state",
+        worktree_path=repo, base_sha=base_sha, model="sonnet",
+    )
+    raw = GovernRaw(receipt={"status": "done"}, duration_seconds=1.0)
+
+    body = _synthesize(spec, raw)
+
+    assert "- delivery_verdict: work_delivered" in body
+    assert "feat(oi-1363): real worker delivery" in body
+    summary_section = body.split("## Summary")[1].split("## Changes")[0]
+    print(f"\n--- ## Summary (work_delivered) ---\n{summary_section}")


### PR DESCRIPTION
## Summary
- OI-1367: `_execute_claude` in `scripts/lib/dispatch_cli.py` now prints `result.failure_reason` to stderr on any of the 17 `success=False` branches from `TmuxInteractiveDispatch.dispatch`, matching the provider lane's existing fail-loud contract (same file, ~line 2499). Falls back to an explicit `(no failure_reason captured)` marker when the field is empty. Exit code (0/1) is unchanged.
- OI-1363: `_git_summary`/`_synthesize` in `scripts/lib/dispatch_govern.py` no longer borrow the base branch's `git log -1` message when a tmux-lane worker committed nothing. A new `_work_delivered()` helper checks `git rev-list --count <base_sha>..HEAD` (falling back to a `Dispatch-ID: <id>` trailer match when `base_sha` is absent) and gates the summary text. Every synthesized report header now carries a machine-readable `- delivery_verdict: work_delivered|no_work_delivered` field. `_git_changes` is untouched.

## Test plan
- [x] `pytest tests/test_dispatch_cli.py -q` — 156 passed (env-clean of `VNX_OVERRIDE_WORKER_CLAUDE`, which leaks into 6 unrelated tests from the dispatch worker's own environment — not caused by this change)
- [x] `pytest tests/test_dispatch_govern.py -q` — 91 passed
- [x] `pytest tests/test_subprocess_dispatch_govern.py tests/test_provider_dispatch_governance_integration.py -q` — 31 passed (direct neighbours)
- [x] New tests cover all 3 measured synthesized-report reasons (`tmux_receipt_deadline_exceeded`/timeout, `tmux_awaiting_permission`, `interactive_no_progress`) plus a positive "work delivered" control

🤖 Generated with [Claude Code](https://claude.com/claude-code)