### PR TITLE
feat(permission-relay): scan live workers for an unmeasured stall (OI-1324, OI-1344)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -344,6 +344,7 @@ Permission relay (detached-worker prompt governance):
   permission escalations [--all] [--json]            List pending escalations
   permission approve <dispatch_id>                   Approve + relay "1" to the worker
   permission deny <dispatch_id>                      Deny an escalation
+  permission scan [--json]                           Scan LIVE workers for an unmeasured permission stall
 
 Gate commands (pre-merge verification):
   gate-check --pr <ID>  Run deterministic pre-merge gate checks (GO/HOLD verdict)

--- a/scripts/lib/worker_permission_relay.py
+++ b/scripts/lib/worker_permission_relay.py
@@ -45,6 +45,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from worker_pane_classifier import classify_worker_pane
+
 logger = logging.getLogger(__name__)
 
 # Window file lives directly under the state dir; escalation records under a
@@ -700,3 +702,203 @@ class RelayHandle:
 
     thread: object
     stop_event: object
+
+
+# ---------------------------------------------------------------------------
+# Live scan (OI-1324 / OI-1344) — surface an unmeasured permission stall
+# ---------------------------------------------------------------------------
+# Detection (classify_worker_pane) and the escalation record (write_escalation)
+# already exist and work. The gap: nothing SURFACES a stall on a pane that is
+# live RIGHT NOW — the relay only escalates a session it already has a
+# background tick attached to, and ``vnx permission escalations`` only ever
+# shows records a tick already wrote. A worker that never got a tick attached
+# (or whose tick died) can sit on a permission prompt indefinitely with no
+# record anywhere. ``scan_live_awaiting_permission`` closes that gap by
+# actively enumerating THIS project's live dispatch sessions on demand.
+
+
+def _default_tmux_runner():
+    """Real tmux runner, imported lazily so this module never hard-depends on
+    the (heavy) tmux_interactive_dispatch import chain unless actually used."""
+    from tmux_interactive_dispatch import TmuxCommandRunner  # noqa: PLC0415
+
+    return TmuxCommandRunner()
+
+
+def _list_dispatch_sessions(runner) -> "tuple[list[str] | None, str | None]":
+    """List tmux session names; tri-state on failure.
+
+    Mirrors orphan_sweep's OI-1286 tri-state contract (a listing that cannot
+    be trusted must never collapse into "no sessions"), adapted to the
+    injected object-runner interface (``runner.run(args) -> result`` with
+    ``.returncode``/``.stdout``/``.stderr``) used throughout this module.
+
+    Returns ``(names, error)``: ``names`` is ``None`` when the listing could
+    not be trusted (tmux unavailable, the runner raised, or an unrecognized
+    non-zero exit) — the caller must treat that as "cannot measure", never as
+    "zero sessions". A genuine empty fleet ("no server running", or a connect
+    failure against a socket that does not exist on disk — the same OI-1286
+    shape) returns ``([], None)``.
+    """
+    if hasattr(runner, "available"):
+        try:
+            if not runner.available():
+                return None, "tmux not available"
+        except Exception as exc:  # noqa: BLE001 — must surface, not swallow
+            return None, f"availability check raised: {exc}"
+    try:
+        res = runner.run(["list-sessions", "-F", "#{session_name}"])
+    except Exception as exc:  # noqa: BLE001
+        return None, f"list-sessions raised: {exc}"
+    rc = getattr(res, "returncode", 1)
+    if rc == 0:
+        out = getattr(res, "stdout", "") or ""
+        return [ln.strip() for ln in out.splitlines() if ln.strip()], None
+    err_lower = (getattr(res, "stderr", "") or "").lower()
+    if "no server running" in err_lower:
+        return [], None
+    if "error connecting to" in err_lower and "no such file or directory" in err_lower:
+        return [], None
+    return None, f"list-sessions failed rc={rc} stderr={getattr(res, 'stderr', '')!r}"
+
+
+def _capture_pane_or_error(runner, session_id: str) -> "tuple[str | None, str | None]":
+    """Capture *session_id*'s pane, returning ``(text, None)`` or ``(None, error)``.
+
+    Deliberately distinct from ``_capture_pane`` (used by the always-retrying
+    relay tick, where a failed capture is quietly treated as "nothing on the
+    pane this tick" and retried next tick): the scan must never read a failed
+    capture as "clean" — a capture failure is "cannot measure", not "no
+    stall" — so it is reported here instead of swallowed.
+    """
+    try:
+        res = runner.run(["capture-pane", "-t", session_id, "-p"])
+    except Exception as exc:  # noqa: BLE001 — must surface, not swallow
+        return None, f"capture-pane raised: {exc}"
+    rc = getattr(res, "returncode", 1)
+    if rc != 0:
+        return None, f"capture-pane failed rc={rc} stderr={getattr(res, 'stderr', '')!r}"
+    return getattr(res, "stdout", "") or "", None
+
+
+def scan_live_awaiting_permission(
+    runner=None,
+    *,
+    state_dir: "str | Path | None" = None,
+    write_escalations: bool = True,
+) -> dict:
+    """READ-ONLY scan of THIS project's live dispatch tmux sessions for a
+    worker stalled on a permission prompt (OI-1324 / OI-1344).
+
+    Project scoping (hard requirement, never relaxed): a tmux session name
+    matching the dispatch-session pattern ``vnx-<dispatch_id>`` is only
+    in-scope when THIS project's state dir has a
+    ``tmux_interactive/<dispatch_id>.json`` handle file for that dispatch id.
+    That file is written by THIS project's own dispatch lane at spawn time
+    (``TmuxInteractiveDispatch._persist_handle``) and is the exact file
+    ``permission_relay_cli._relay_keystroke_to_worker`` already reads to find
+    a dispatch's session for ``approve``/``deny``. Reusing it as the scoping
+    signal means a session spawned by a different project's fabric — a
+    different process, writing handles into a different (per-project) state
+    dir — can never have a handle here, so it can never be scanned or
+    touched. A session whose name merely matches the pattern but has no
+    handle here is recorded in ``sessions_skipped_foreign`` and is never
+    captured.
+
+    READ-ONLY on tmux: only ``list-sessions`` and ``capture-pane`` are ever
+    issued — no ``send-keys``, no ``kill-session``.
+
+    A failed measurement (tmux unavailable, the session listing itself
+    unmeasurable, or a single session's capture-pane failing) is recorded in
+    ``errors`` and MUST be treated as "could not fully measure" by the
+    caller, never as "no stall" (OI-1324/1344: a measurement gap is not
+    evidence of a clean fleet).
+
+    Returns:
+        dict with keys:
+          - ``sessions_scanned``: in-scope session names successfully captured
+          - ``sessions_skipped_foreign``: name matched the pattern, no handle
+            for that dispatch id in this project's state dir
+          - ``hits``: list of ``{session, dispatch_id, command, matched_marker,
+            escalation_written}`` for every pane classified awaiting_permission
+          - ``errors``: list of ``{scope, session, dispatch_id, error}``
+          - ``measured``: False only when the session listing itself could not
+            be trusted (see ``_list_dispatch_sessions``)
+
+    Idempotent escalation: a hit whose dispatch already has a PENDING
+    escalation with the SAME command is left untouched by ``write_escalation``
+    — one file per dispatch id already makes a second record structurally
+    impossible; a hit with no pending record (or a changed command) gets a
+    fresh ``reason="awaiting_permission"`` record.
+    """
+    from orphan_sweep import _SESSION_RE as _DISPATCH_SESSION_RE  # noqa: PLC0415 — reuse, never duplicate
+
+    sd = _coerce_state_dir(state_dir)
+    rn = runner if runner is not None else _default_tmux_runner()
+    handle_dir = sd / "tmux_interactive"
+
+    result: dict = {
+        "sessions_scanned": [],
+        "sessions_skipped_foreign": [],
+        "hits": [],
+        "errors": [],
+        "measured": True,
+    }
+
+    names, list_err = _list_dispatch_sessions(rn)
+    if names is None:
+        result["measured"] = False
+        result["errors"].append(
+            {"scope": "list-sessions", "session": None, "dispatch_id": None, "error": list_err}
+        )
+        logger.error("permission_relay: scan could not list tmux sessions: %s", list_err)
+        return result
+
+    for name in sorted(names):
+        m = _DISPATCH_SESSION_RE.match(name)
+        if not m:
+            continue
+        dispatch_id = m.group("id")
+        if not (handle_dir / f"{dispatch_id}.json").is_file():
+            result["sessions_skipped_foreign"].append(name)
+            continue
+
+        pane_text, cap_err = _capture_pane_or_error(rn, name)
+        if cap_err is not None:
+            result["errors"].append(
+                {"scope": "capture-pane", "session": name, "dispatch_id": dispatch_id, "error": cap_err}
+            )
+            logger.warning("permission_relay: scan capture failed session=%s (%s)", name, cap_err)
+            continue
+        result["sessions_scanned"].append(name)
+
+        state = classify_worker_pane(pane_text)
+        if not state.is_awaiting_permission:
+            continue
+
+        command = parse_pending_command(pane_text) or ""
+        escalation_written = False
+        if write_escalations:
+            try:
+                write_escalation(dispatch_id, command, "awaiting_permission", state_dir=sd)
+                escalation_written = True
+            except ValueError as exc:
+                result["errors"].append(
+                    {"scope": "write_escalation", "session": name, "dispatch_id": dispatch_id, "error": str(exc)}
+                )
+
+        result["hits"].append(
+            {
+                "session": name,
+                "dispatch_id": dispatch_id,
+                "command": command,
+                "matched_marker": state.matched_marker,
+                "escalation_written": escalation_written,
+            }
+        )
+        logger.warning(
+            "permission_relay: SCAN found live stall dispatch=%s cmd=%r marker=%r",
+            dispatch_id, command, state.matched_marker,
+        )
+
+    return result

--- a/scripts/permission_relay_cli.py
+++ b/scripts/permission_relay_cli.py
@@ -9,8 +9,19 @@ Subcommands (wired to scripts/lib/worker_permission_relay.py):
   vnx permission escalations                              list pending escalations
   vnx permission approve <dispatch_id>                    approve + relay "1" to the worker
   vnx permission deny <dispatch_id>                       deny (operator handles the worker)
+  vnx permission scan                                     scan LIVE workers for an unmeasured stall
 
 All subcommands accept ``--json`` for machine-readable output.
+
+``scan`` (OI-1324 / OI-1344): read-only tmux scan of this project's live
+dispatch sessions for a pane classified ``awaiting_permission`` that has not
+yet surfaced anywhere — writes an escalation record for each new find
+(idempotent) so ``escalations`` becomes a current view instead of an archive.
+Exit code encodes the verdict for a supervisor tick / operator script:
+  0 = measured cleanly, zero stalls found
+  1 = at least one live stall found (see the printed dispatch id + command)
+  2 = could not fully measure (tmux missing/unmeasurable, or a capture
+      failed) — never conflated with "clean"
 
 The relay model: outside an open window every worker permission prompt escalates;
 inside the window routine prompts auto-approve; catastrophic ops always escalate.
@@ -104,6 +115,46 @@ def _cmd_escalations(args, sd: Path) -> int:
             f"      cmd: {rec.get('command')}"
         )
     print("\nResolve with: vnx permission approve <dispatch_id>  |  deny <dispatch_id>")
+    return 0
+
+
+def _cmd_scan(args, sd: Path) -> int:
+    """OI-1324 / OI-1344: scan live worker panes; alarm loudly, never silently.
+
+    Exit code: 0 clean, 1 at least one live stall found, 2 could not fully
+    measure (tmux unavailable, listing unmeasurable, or a capture failed) —
+    a measurement gap is reported distinctly and is NEVER read as "clean".
+    """
+    result = relay.scan_live_awaiting_permission(state_dir=sd)
+    hits = result.get("hits") or []
+    errors = result.get("errors") or []
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        if hits:
+            print(f"[!] {len(hits)} worker(s) awaiting permission:")
+            for h in hits:
+                print(
+                    f"  - {h.get('dispatch_id')}  cmd: {h.get('command')}  "
+                    f"(session={h.get('session')}, marker={h.get('matched_marker')!r})"
+                )
+        elif errors:
+            print("[x] scan could not fully measure the live fleet")
+        else:
+            print("[ok] no worker is awaiting permission")
+        if errors:
+            print(f"\n[!] {len(errors)} measurement error(s):")
+            for e in errors:
+                print(
+                    f"  - scope={e.get('scope')} session={e.get('session')} "
+                    f"dispatch_id={e.get('dispatch_id')}: {e.get('error')}"
+                )
+
+    if hits:
+        return 1
+    if errors:
+        return 2
     return 0
 
 
@@ -289,6 +340,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_deny = sub.add_parser("deny", parents=[common], help="deny an escalation")
     p_deny.add_argument("dispatch_id")
     p_deny.set_defaults(func=_cmd_deny)
+
+    p_scan = sub.add_parser(
+        "scan", parents=[common],
+        help="read-only scan of live worker panes for an unmeasured permission stall",
+    )
+    p_scan.set_defaults(func=_cmd_scan)
 
     return parser
 

--- a/tests/test_worker_permission_relay.py
+++ b/tests/test_worker_permission_relay.py
@@ -28,6 +28,7 @@ from worker_permission_relay import (  # noqa: E402
     read_escalation,
     relay_tick,
     resolve_escalation,
+    scan_live_awaiting_permission,
     write_escalation,
 )
 
@@ -632,3 +633,257 @@ class TestManualApproveSurfacesSendFailure:
             "noux", tmp_path, runner=FakeRunner(tmux_available=False)
         )
         assert status == "error"
+
+
+# ---------------------------------------------------------------------------
+# OI-1324 / OI-1344 — live scan for an unmeasured permission stall
+# ---------------------------------------------------------------------------
+# Three distinct real-world prompt shapes (per the dispatch's measured
+# stalls): a decorated box (rm -rf), the newer numbered-menu-only form with
+# no prose line (git worktree), and the OI-863 prose form (chmod).
+GIT_WORKTREE_OI1007_PANE = (
+    "1. Yes / 2. Yes, and don't ask again for: "
+    "git worktree remove --force /tmp/wt-demo / 3. No"
+)
+
+CHMOD_PERMISSION_PANE = (
+    "Permission rule Bash(chmod:*) requires confirmation for this command.\n"
+    "\n"
+    "Do you want to proceed?\n"
+    "  1. Yes\n"
+    "  2. Yes, and don't ask again for this project\n"
+    "  3. No\n"
+)
+
+
+class FakeScanRunner:
+    """Fake tmux runner for scan tests: scripted list-sessions + per-session panes.
+
+    ``capture_fail_sessions`` makes capture-pane fail (rc!=0) for the named
+    sessions so the "capture failure is an error, not clean" contract can be
+    exercised without a real tmux.
+    """
+
+    def __init__(
+        self,
+        sessions,
+        panes,
+        *,
+        list_rc=0,
+        list_stderr="",
+        tmux_available=True,
+        capture_fail_sessions=None,
+    ):
+        self.sessions = list(sessions)
+        self.panes = dict(panes)
+        self.list_rc = list_rc
+        self.list_stderr = list_stderr
+        self._tmux_available = tmux_available
+        self.capture_fail_sessions = set(capture_fail_sessions or [])
+        self.calls = []
+
+    def available(self):
+        return self._tmux_available
+
+    def run(self, args, **kwargs):
+        self.calls.append(list(args))
+        if args[:1] == ["list-sessions"]:
+            if self.list_rc != 0:
+                return _FakeResult(returncode=self.list_rc, stderr=self.list_stderr)
+            stdout = "".join(f"{s}\n" for s in self.sessions)
+            return _FakeResult(returncode=0, stdout=stdout)
+        if args[:1] == ["capture-pane"]:
+            session = args[2] if len(args) > 2 else None
+            if session in self.capture_fail_sessions:
+                return _FakeResult(returncode=1, stderr="capture-pane failed")
+            return _FakeResult(returncode=0, stdout=self.panes.get(session, ""))
+        # No send-keys / kill-session should ever be issued by the scan.
+        raise AssertionError(f"scan issued an unexpected/writing tmux call: {args}")
+
+
+class TestScanLiveAwaitingPermission:
+    def test_finds_three_prompt_forms_in_one_call(self, tmp_path):
+        sessions = ["vnx-rmrf-demo", "vnx-worktree-demo", "vnx-chmod-demo"]
+        for dispatch_id in ("rmrf-demo", "worktree-demo", "chmod-demo"):
+            _write_handle(tmp_path, dispatch_id, f"vnx-{dispatch_id}")
+        panes = {
+            "vnx-rmrf-demo": PROMPT_PANE,
+            "vnx-worktree-demo": GIT_WORKTREE_OI1007_PANE,
+            "vnx-chmod-demo": CHMOD_PERMISSION_PANE,
+        }
+        runner = FakeScanRunner(sessions, panes)
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path)
+
+        assert result["measured"] is True
+        assert result["errors"] == []
+        by_dispatch = {h["dispatch_id"]: h for h in result["hits"]}
+        assert set(by_dispatch) == {"rmrf-demo", "worktree-demo", "chmod-demo"}
+        assert by_dispatch["rmrf-demo"]["command"] == "rm -rf /tmp/scratch"
+        assert by_dispatch["worktree-demo"]["command"] == "git worktree remove --force /tmp/wt-demo"
+        assert by_dispatch["chmod-demo"]["command"] == "chmod:*"
+        for hit in by_dispatch.values():
+            assert hit["escalation_written"] is True
+            assert hit["matched_marker"]
+
+        # No send-keys / kill-session ever issued — read-only on tmux.
+        assert all(c[:1] in (["list-sessions"], ["capture-pane"]) for c in runner.calls)
+
+        # Escalation records actually landed on disk.
+        for dispatch_id in ("rmrf-demo", "worktree-demo", "chmod-demo"):
+            rec = read_escalation(dispatch_id, state_dir=tmp_path)
+            assert rec is not None
+            assert rec["status"] == "pending"
+            assert rec["reason"] == "awaiting_permission"
+
+    def test_ignores_working_pane(self, tmp_path):
+        _write_handle(tmp_path, "busy", "vnx-busy")
+        runner = FakeScanRunner(
+            ["vnx-busy"],
+            {"vnx-busy": "✢ Working… (3s · ↓ 120 tokens) · esc to interrupt"},
+        )
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path)
+        assert result["hits"] == []
+        assert result["sessions_scanned"] == ["vnx-busy"]
+        assert read_escalation("busy", state_dir=tmp_path) is None
+
+    def test_ignores_foreign_session_without_handle(self, tmp_path):
+        # Session name matches the dispatch-session pattern, but no handle
+        # file exists under THIS project's state dir -> must never be
+        # captured, scanned, or written to.
+        runner = FakeScanRunner(
+            ["vnx-foreign-project-disp"],
+            {"vnx-foreign-project-disp": PROMPT_PANE},
+        )
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path)
+        assert result["hits"] == []
+        assert result["sessions_scanned"] == []
+        assert result["sessions_skipped_foreign"] == ["vnx-foreign-project-disp"]
+        # Only list-sessions was called -- capture-pane never touched the
+        # foreign session.
+        assert all(c[:1] == ["list-sessions"] for c in runner.calls)
+        assert read_escalation("foreign-project-disp", state_dir=tmp_path) is None
+
+    def test_idempotent_on_existing_pending_escalation(self, tmp_path):
+        _write_handle(tmp_path, "dupe", "vnx-dupe")
+        runner = FakeScanRunner(["vnx-dupe"], {"vnx-dupe": PROMPT_PANE})
+
+        scan_live_awaiting_permission(runner, state_dir=tmp_path)
+        rec1 = read_escalation("dupe", state_dir=tmp_path)
+        assert rec1["status"] == "pending"
+
+        # Second scan of the same still-stalled pane must not create a
+        # second/different record.
+        runner2 = FakeScanRunner(["vnx-dupe"], {"vnx-dupe": PROMPT_PANE})
+        scan_live_awaiting_permission(runner2, state_dir=tmp_path)
+        rec2 = read_escalation("dupe", state_dir=tmp_path)
+        assert rec2["captured_at"] == rec1["captured_at"]
+        assert rec2 == rec1
+
+    def test_capture_failure_is_error_not_clean(self, tmp_path):
+        _write_handle(tmp_path, "flaky", "vnx-flaky")
+        runner = FakeScanRunner(
+            ["vnx-flaky"],
+            {},
+            capture_fail_sessions={"vnx-flaky"},
+        )
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path)
+        assert result["hits"] == []
+        assert result["sessions_scanned"] == []
+        assert result["measured"] is True  # listing itself succeeded
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["scope"] == "capture-pane"
+        assert result["errors"][0]["dispatch_id"] == "flaky"
+        assert read_escalation("flaky", state_dir=tmp_path) is None
+
+    def test_list_sessions_unmeasurable_is_error_not_clean(self, tmp_path):
+        runner = FakeScanRunner([], {}, tmux_available=False)
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path)
+        assert result["measured"] is False
+        assert result["hits"] == []
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["scope"] == "list-sessions"
+
+    def test_no_server_running_is_clean_not_error(self, tmp_path):
+        # A genuinely empty tmux fleet (no server) is a measured clean scan,
+        # not a measurement error (OI-1286 tri-state contract).
+        runner = FakeScanRunner([], {}, list_rc=1, list_stderr="no server running")
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path)
+        assert result["measured"] is True
+        assert result["errors"] == []
+        assert result["hits"] == []
+
+
+# ---------------------------------------------------------------------------
+# `vnx permission scan` CLI exit codes
+# ---------------------------------------------------------------------------
+class _ScanArgs:
+    def __init__(self, as_json=False):
+        self.json = as_json
+
+
+class TestCmdScanExitCodes:
+    def test_hits_exit_1(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            relay,
+            "scan_live_awaiting_permission",
+            lambda **kw: {
+                "sessions_scanned": ["vnx-x"],
+                "sessions_skipped_foreign": [],
+                "hits": [
+                    {
+                        "session": "vnx-x",
+                        "dispatch_id": "x",
+                        "command": "rm -rf /tmp/x",
+                        "matched_marker": "do you want to proceed",
+                        "escalation_written": True,
+                    }
+                ],
+                "errors": [],
+                "measured": True,
+            },
+        )
+        assert cli._cmd_scan(_ScanArgs(), tmp_path) == 1
+
+    def test_clean_exit_0(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            relay,
+            "scan_live_awaiting_permission",
+            lambda **kw: {
+                "sessions_scanned": [],
+                "sessions_skipped_foreign": [],
+                "hits": [],
+                "errors": [],
+                "measured": True,
+            },
+        )
+        assert cli._cmd_scan(_ScanArgs(), tmp_path) == 0
+
+    def test_measurement_error_exit_2(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            relay,
+            "scan_live_awaiting_permission",
+            lambda **kw: {
+                "sessions_scanned": [],
+                "sessions_skipped_foreign": [],
+                "hits": [],
+                "errors": [
+                    {"scope": "list-sessions", "session": None, "dispatch_id": None, "error": "tmux not available"}
+                ],
+                "measured": False,
+            },
+        )
+        assert cli._cmd_scan(_ScanArgs(), tmp_path) == 2
+
+    def test_json_output_emits_full_result(self, tmp_path, monkeypatch, capsys):
+        payload = {
+            "sessions_scanned": [],
+            "sessions_skipped_foreign": [],
+            "hits": [],
+            "errors": [],
+            "measured": True,
+        }
+        monkeypatch.setattr(relay, "scan_live_awaiting_permission", lambda **kw: payload)
+        rc = cli._cmd_scan(_ScanArgs(as_json=True), tmp_path)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out == payload


### PR DESCRIPTION
## Summary
- The `awaiting_permission` classifier and `write_escalation` record already existed and worked, but nothing surfaced a stall live: `vnx permission escalations` only ever showed records a background relay tick had already written (21 pending, oldest 19 days, zero resolved), and no command let an operator ask "is anything stuck right now."
- Adds `scan_live_awaiting_permission()` in `scripts/lib/worker_permission_relay.py`: a read-only tmux scan (only `list-sessions` + `capture-pane`, never `send-keys`/`kill-session`) of THIS project's live dispatch sessions. Scoping reuses the `tmux_interactive/<dispatch_id>.json` handle file the dispatch lane already writes at spawn (the same file `approve`/`deny` reads) — a session from a different project's fabric never has a handle here and can never be scanned or touched.
- Every `awaiting_permission` hit gets an idempotent escalation via the existing `write_escalation` (one file per dispatch id already makes a second record structurally impossible).
- Wires it up as `vnx permission scan [--json]`: exit 0 clean, 1 found a stall, 2 could not fully measure (tmux unavailable, listing unmeasurable, or a capture failed) — a measurement gap is never read as "no stall."

## Test plan
- [x] `pytest tests/test_worker_permission_relay.py tests/test_worker_pane_classifier.py tests/test_runtime_adapter_certification.py -q` — 137 passed
- [x] `bash -n bin/vnx`
- [x] Live demonstration against real tmux with an isolated sandbox `VNX_STATE_DIR` (production 21-escalation ledger verified untouched before/after): one throwaway session with a real permission prompt (exit 1, escalation written), then three throwaway sessions in one scan call covering `rm -rf` (box form), `git worktree remove --force` (numbered-menu-only form, no prose line), and `chmod` (OI-863 prose form) — all three surfaced correctly in a single `vnx permission scan` run. All demo sessions killed by exact name; sandbox dirs removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)