### PR TITLE
fix(deliberation-panel): base coverage split on seat outcome, not sentinel text (OI-1358)

### DIFF
--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -145,6 +145,16 @@ class DeliberationResult:
         failed = ", ".join(f"{s['provider']} ({s['lens']})" for s in self.failed_seats)
         return f"{present}/{total} lenses present; {failed} failed"
 
+    @property
+    def zero_seats_delivered(self) -> bool:
+        """True when NOT ONE seat produced usable content (OI-1358). ``min_seats``/
+        ``allow_degraded`` govern whether the SYNTHESIS proceeds below the floor — at
+        0/N delivered, a caller with no floor set (or with ``--allow-degraded``) still
+        gets a synthesis run over nothing. This flag is the independent signal a caller
+        checks WITHOUT parsing the report to know the run produced no real content, so
+        ``scripts/panel.py`` can exit non-zero even when the gate let the run through."""
+        return len(self.fan_out) > 0 and len(self.present_lenses) == 0
+
     def to_report(self) -> str:
         lines = [
             f"# Deliberation panel — {self.mode}",
@@ -517,7 +527,56 @@ def _pick(roster: List[Tuple[str, str]], prefer: Tuple[str, ...]) -> Tuple[str, 
     return _ordered_seats(roster, prefer)[0]
 
 
+def _seat_exit_code(text: str) -> Optional[int]:
+    """Read a seat's real outcome from the ``exit_code`` in its unified-report frontmatter
+    (OI-1358), when present. Returns ``None`` when there is nothing to read: no frontmatter
+    block, malformed YAML, or an ``exit_code`` that isn't an int — the caller must then fall
+    back to the sentinel-text check, since the outcome cannot be read off this text.
+
+    Why frontmatter carries the outcome and sentinel text doesn't: a seat that fail-closed
+    REFUSES does so BEFORE inference and never writes its own report, so the lane wrapper
+    writes the unified report itself — WITH frontmatter, carrying the real ``exit_code``.
+    ``emit_unified_report`` is idempotent, so a seat that ran inference and wrote its OWN
+    report (worker-authored) leaves that report untouched — WITHOUT frontmatter. Measured
+    live: a refused glm-harness seat's report on disk
+    (``panel-sweep-diverge-3-e4bafa.md``) carries ``exit_code: 1`` in frontmatter, with a
+    2.6-14KB non-empty body (the generic instruction-echo wrapper) that matches none of the
+    sentinel markers below — this is exactly how 4/5 dead seats in a real 0/5 panel run
+    were miscounted as present before this fix.
+
+    ``token_usage`` is deliberately NEVER used as a discriminator here: for 14 of 47
+    measured failed seats (all kimi), post-run token capture is itself unavailable
+    (``token_usage_measured: false``) even when the seat produced real, verified analysis
+    (e.g. ``panel-research-diverge-1-fadf0e.partial.md``, 6.1KB of real panel content
+    alongside ``token_usage.output: 0``). Gating presence on output-token count would trade
+    the false-positive failure mode this fix repairs for a false-negative one on exactly the
+    seats that did the work — ``exit_code`` alone is the reliable signal.
+    """
+    try:
+        from unified_report_schema import parse_frontmatter, SchemaViolation  # noqa: PLC0415
+    except ImportError:
+        return None
+    try:
+        frontmatter = parse_frontmatter(text or "")
+    except SchemaViolation:
+        return None
+    exit_code = frontmatter.get("exit_code")
+    return exit_code if isinstance(exit_code, int) else None
+
+
 def _is_error(text: str) -> bool:
+    """A seat counts as failed when its OUTCOME says so, not the shape of its text
+    (OI-1358). Prefers the real ``exit_code`` carried in the seat's own unified-report
+    frontmatter (see ``_seat_exit_code``): a dispatch that REFUSES but still emits a
+    non-empty report body (the generic wrapper) used to slip through as "present" because
+    it matched none of the three sentinel strings below. Falls back to the sentinel-text
+    check ONLY when no frontmatter is present (no report on disk, or a worker-authored
+    report without frontmatter) — this is the pre-existing behaviour, not a regression: a
+    report with no frontmatter carries no readable outcome, so it stays exactly as
+    permissive as it was before this fix."""
+    exit_code = _seat_exit_code(text)
+    if exit_code is not None:
+        return exit_code != 0
     t = (text or "").strip()
     return (not t) or t.startswith("[dispatch error") or t == "[empty]"
 

--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -126,6 +126,15 @@ def main(argv: "list[str] | None" = None) -> int:
     if result.synthesis_refused_reason:
         print(f"[panel] SYNTHESIS REFUSED: {result.synthesis_refused_reason}", file=sys.stderr)
         return 1
+    # OI-1358: 0/N seats delivering real content must never exit 0, even when no
+    # min_seats floor is configured (or --allow-degraded let the synthesis run anyway) —
+    # a caller must be able to detect a phantom-full panel without parsing the report.
+    # getattr(..., False) keeps this safe against older/fake DeliberationResult doubles
+    # in tests that predate this attribute.
+    if getattr(result, "zero_seats_delivered", False):
+        total = len(getattr(result, "fan_out", []))
+        print(f"[panel] ZERO SEATS DELIVERED: 0/{total} lenses produced real content", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_deliberation_panel.py
+++ b/tests/test_deliberation_panel.py
@@ -53,6 +53,50 @@ class _HugeRecorder:
 ROSTER = [("codex", "gpt-5.5"), ("kimi", "k2"), ("claude", "sonnet")]
 
 
+def _fake_report(dispatch_id, provider, exit_code, body, *, token_output=0, token_input=0, measured=None):
+    """Build a realistic unified-report text (frontmatter + body), matching what
+    ``_read_report`` hands back to a panel dispatcher on disk (OI-1358). ``exit_code``
+    and the token fields are passed in as DATA, never hardcoded per-test, so a test can
+    assert on the value it fed in rather than a literal string echoed on both sides."""
+    lines = [
+        "---",
+        "schema_version: 1",
+        f"dispatch_id: {dispatch_id}",
+        f"provider: {provider}",
+        "sub_provider: none",
+        "model: sonnet",
+        "terminal_id: T0",
+        "pool_id: headless",
+        "role: deliberation-panelist",
+        "task_class: implementation",
+        "pr_id: none",
+        "duration_seconds: 12.34",
+        f"exit_code: {exit_code}",
+        "token_usage:",
+        f"  input: {token_input}",
+        f"  output: {token_output}",
+        "  cache_read: 0",
+        "cost_usd: 0.0",
+    ]
+    if measured is not None:
+        lines.append(f"token_usage_measured: {'true' if measured else 'false'}")
+    lines.append("---")
+    lines.append("")
+    lines.append(body)
+    return "\n".join(lines)
+
+
+# The measured shape of a refused seat (panel-sweep-diverge-3-e4bafa.md, OI-1358): the
+# lane wrapper's generic instruction-echo body, non-empty, matching none of the three
+# sentinel markers _is_error used to rely on.
+REFUSAL_BODY = (
+    "# Dispatch panel-refused-seat\n\n"
+    "## Instruction\n\n"
+    "You are one seat on a deliberation panel. Analyse the question through your lens.\n"
+    "This dispatch was refused before inference ran; no analysis was produced.\n"
+)
+
+
 class TestFourStageFlow:
     def test_runs_all_four_stages(self):
         rec = _Recorder()
@@ -576,6 +620,174 @@ class TestSynthesisCoverageGate:
         res = dp.run_deliberation(
             "sweep", "q", dispatcher=one_of_five, roster=FIVE_ROSTER, max_workers=5,
         )
+        assert res.synthesis_refused_reason == ""
+        assert not res.degraded_synthesis
+        assert res.synthesis
+
+
+class TestOutcomeBasedCoverage:
+    """OI-1358: coverage must be decided from the seat's real OUTCOME (``exit_code``,
+    read from its unified-report frontmatter) — not from matching its text against
+    three sentinel strings. A seat that fail-closed REFUSES but still emits a non-empty
+    report body (the lane wrapper's generic instruction-echo) used to slip through
+    ``_is_error`` and get counted as a contributing lens."""
+
+    def test_refused_seat_with_non_empty_body_does_not_count_as_present(self):
+        """The exact bug, reproduced with a fake dispatcher: every seat gets a
+        frontmatter report whose BODY is non-empty prose matching none of the three
+        sentinels. ONE seat's ``exit_code`` is fed in as data (1, the refused seat); the
+        rest are 0. Show the OLD sentinel-only tally and the NEW outcome-based tally
+        side by side, and that they differ."""
+        exit_codes = {"codex": 0, "kimi": 0, "claude": 1}  # claude: refused, non-empty body
+
+        def dispatcher(provider, model, prompt, did):
+            code = exit_codes[provider]
+            body = REFUSAL_BODY if code != 0 else "real analysis body, cites file:line"
+            return _fake_report(did, provider, code, body)
+
+        res = dp.run_deliberation("sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3)
+
+        # OLD tally: the pre-fix _is_error only looked at text shape (empty / sentinel
+        # prefix) -- every seat's text here is non-empty prose matching no sentinel, so
+        # the old check would have called ALL THREE present.
+        def _old_is_error(text):
+            t = (text or "").strip()
+            return (not t) or t.startswith("[dispatch error") or t == "[empty]"
+
+        old_present = sum(1 for fo in res.fan_out if not _old_is_error(fo["text"]))
+        assert old_present == 3, "sanity: the old sentinel-only check misses the refusal"
+
+        # NEW tally: exactly the seats whose real exit_code (fed in as data above) is 0.
+        expected_present = sum(1 for code in exit_codes.values() if code == 0)
+        assert expected_present == 2
+        assert len(res.present_lenses) == expected_present
+        assert len(res.failed_seats) == 1
+        assert res.failed_seats[0]["provider"] == "claude"
+        assert "2/3" in res.coverage and "claude" in res.coverage and "failed" in res.coverage
+
+        # the refused seat's real exit_code is independently readable off its own text
+        claude_text = next(fo["text"] for fo in res.fan_out if fo["provider"] == "claude")
+        assert dp._seat_exit_code(claude_text) == exit_codes["claude"]
+        codex_text = next(fo["text"] for fo in res.fan_out if fo["provider"] == "codex")
+        assert dp._seat_exit_code(codex_text) == exit_codes["codex"]
+
+    def test_measurement_gap_seat_still_counts_as_present(self):
+        """A seat with ``exit_code=0`` but ``token_usage.output=0`` AND
+        ``token_usage_measured=false`` (the measured shape of 14 real failed-panel kimi
+        seats, 8 of which carried real content in a ``.partial.md`` sidecar) MUST count
+        as present. Gating presence on output-token count instead of exit_code would
+        flip this exact seat to failed -- the false-negative mirror of the bug this
+        fix repairs."""
+
+        def dispatcher(provider, model, prompt, did):
+            if provider == "kimi":
+                return _fake_report(
+                    did, provider, 0, "real panel analysis text, cites source X",
+                    token_output=0, measured=False,
+                )
+            return _fake_report(did, provider, 0, "ok")
+
+        res = dp.run_deliberation("sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3)
+
+        assert len(res.present_lenses) == 3
+        assert res.failed_seats == []
+        kimi_text = next(fo["text"] for fo in res.fan_out if fo["provider"] == "kimi")
+        assert dp._seat_exit_code(kimi_text) == 0
+
+    def test_no_frontmatter_falls_back_to_sentinel_check(self):
+        """A report with NO frontmatter (e.g. a worker-authored report that
+        ``emit_unified_report``'s idempotent no-overwrite path left in place) carries no
+        readable outcome. The discriminator must fall back to exactly the pre-fix
+        sentinel check -- no worse than today, per the dispatch instruction."""
+
+        def dispatcher(provider, model, prompt, did):
+            if provider == "kimi":
+                return "[dispatch error: boom]"       # no frontmatter -> sentinel path
+            if provider == "codex":
+                return ""                              # no frontmatter -> sentinel path
+            return "plain worker-authored report body, no frontmatter block at all"
+
+        res = dp.run_deliberation("sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3)
+
+        assert dp._seat_exit_code("[dispatch error: boom]") is None
+        assert dp._seat_exit_code("plain worker-authored report body, no frontmatter block at all") is None
+        assert len(res.present_lenses) == 1
+        assert {s["provider"] for s in res.failed_seats} == {"kimi", "codex"}
+
+
+class TestZeroSeatsDelivered:
+    """OI-1358: a caller must be able to detect "0/N seats delivered real content"
+    WITHOUT parsing the report -- independent of the min_seats gate, since a run with
+    no floor configured (or with --allow-degraded) still lets a 0/N synthesis proceed."""
+
+    def test_true_when_every_seat_is_refused(self):
+        def all_refused(provider, model, prompt, did):
+            return _fake_report(did, provider, 1, REFUSAL_BODY)
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=all_refused, roster=ROSTER, max_workers=3, allow_degraded=True,
+        )
+        assert res.present_lenses == []
+        assert res.zero_seats_delivered is True
+
+    def test_false_on_a_normal_run(self):
+        rec = _Recorder()
+        res = dp.run_deliberation("sweep", "q", dispatcher=rec, roster=ROSTER, max_workers=3)
+        assert res.zero_seats_delivered is False
+
+    def test_true_even_when_the_min_seats_floor_already_refused_the_synthesis(self):
+        """zero_seats_delivered must still read True on the early-return path (the floor
+        refusal returns before stages 2-4 run) -- present_lenses is populated before the
+        gate check, so this flag is available regardless of which path returned."""
+
+        def all_refused(provider, model, prompt, did):
+            return _fake_report(did, provider, 1, REFUSAL_BODY)
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=all_refused, roster=ROSTER, max_workers=3, min_seats=1,
+        )
+        assert res.synthesis_refused_reason
+        assert res.zero_seats_delivered is True
+
+
+class TestMinSeatsFloorWithOutcomeBasedCounting:
+    """The min_seats floor and allow_degraded must keep working the same way after
+    switching the discriminator to outcome-based counting -- a stricter tally means the
+    floor bites on real failures it used to miss (an intended behavior change per the
+    dispatch's scope, not a regression), but the floor mechanics themselves are
+    unaffected."""
+
+    def test_floor_now_correctly_catches_refused_seats_with_non_empty_bodies(self):
+        exit_codes = {"codex": 0, "kimi": 1, "claude": 1, "glm-harness": 1, "deepseek-harness": 0}
+
+        def dispatcher(provider, model, prompt, did):
+            code = exit_codes[provider]
+            body = "real content, cites file:line" if code == 0 else REFUSAL_BODY
+            return _fake_report(did, provider, code, body)
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=FIVE_ROSTER, max_workers=5, min_seats=3,
+        )
+        # 2/5 really delivered (codex, deepseek-harness) -- below the floor of 3, and the
+        # 3 refused seats all carried non-empty bodies that the OLD check would have
+        # counted as present (which would have wrongly cleared this same floor).
+        assert len(res.present_lenses) == 2
+        assert res.synthesis_refused_reason
+        assert "2/5" in res.synthesis_refused_reason
+        assert "minimum 3" in res.synthesis_refused_reason
+
+    def test_floor_still_proceeds_at_exactly_the_floor(self):
+        exit_codes = {"codex": 0, "kimi": 0, "claude": 0, "glm-harness": 1, "deepseek-harness": 1}
+
+        def dispatcher(provider, model, prompt, did):
+            code = exit_codes[provider]
+            body = "real content, cites file:line" if code == 0 else REFUSAL_BODY
+            return _fake_report(did, provider, code, body)
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=FIVE_ROSTER, max_workers=5, min_seats=3,
+        )
+        assert len(res.present_lenses) == 3
         assert res.synthesis_refused_reason == ""
         assert not res.degraded_synthesis
         assert res.synthesis

--- a/tests/test_panel_cli.py
+++ b/tests/test_panel_cli.py
@@ -182,3 +182,54 @@ def test_panel_refusal_returns_nonzero_and_loud(tmp_path, monkeypatch, capsys):
     assert rc == 1
     assert "SYNTHESIS REFUSED" in captured.err
     assert "1/5" in captured.err
+
+
+def test_panel_zero_seats_delivered_returns_nonzero_and_loud(tmp_path, monkeypatch, capsys):
+    """OI-1358: a run where ZERO seats delivered real content must not exit 0, even when
+    no min_seats floor caught it (synthesis_refused_reason stays empty, e.g. no floor
+    configured or --allow-degraded let it through) -- the caller must be able to detect
+    a phantom-full panel without parsing the report."""
+    panel = _load_panel_cli()
+
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    class _ZeroDeliveredResult:
+        synthesis_refused_reason = ""
+        zero_seats_delivered = True
+        fan_out = [{"provider": f"p{i}", "lens": "x", "text": "refused"} for i in range(5)]
+
+        def to_report(self) -> str:
+            return "# fake panel report\n"
+
+    def fake_run_deliberation(*args, **kwargs):
+        return _ZeroDeliveredResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main(["sweep", "audit src/", "--out", str(tmp_path / "report.md")])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "ZERO SEATS DELIVERED" in captured.err
+    assert "0/5" in captured.err
+
+
+def test_panel_normal_run_with_content_stays_exit_zero(tmp_path, monkeypatch):
+    """Sanity/regression guard: a normal successful run must still exit 0. Uses the
+    pre-existing ``_FakeResult`` double, which has no ``zero_seats_delivered`` attribute
+    at all -- the CLI's getattr(..., False) default must not treat that as a failure."""
+    panel = _load_panel_cli()
+
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    def fake_run_deliberation(*args, **kwargs):
+        return _FakeResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main(["sweep", "audit src/", "--out", str(tmp_path / "report.md")])
+    assert rc == 0


### PR DESCRIPTION
## Summary
- `_is_error()` in `scripts/lib/deliberation_panel.py` only matched three sentinel strings (empty, `[dispatch error`, `[empty]`). A seat that fail-closed refuses but still emits a non-empty report body (the lane wrapper's generic instruction-echo) slipped through as a "present" lens — measured live: a run where 0/5 seats produced content rendered as "4/5 lenses present".
- Coverage now reads the seat's real `exit_code` off its own unified-report YAML frontmatter when present, falling back to the pre-existing sentinel check when there is no frontmatter to read (worker-authored reports, or no report at all) — not a regression on that path.
- `token_usage` is deliberately never used as a discriminator: 14 measured real failed-panel kimi seats carry `token_usage_measured: false` even when they produced verified real content, so gating on output-token count would trade one false-positive failure mode for a false-negative one on exactly the seats that did the work.
- Added `DeliberationResult.zero_seats_delivered` and wired it into `scripts/panel.py`'s exit code, so a 0/N run exits non-zero even when no `min_seats` floor caught it (e.g. no floor configured, or `--allow-degraded`).

## Test plan
- [x] `tests/test_deliberation_panel.py` — new `TestOutcomeBasedCoverage`, `TestZeroSeatsDelivered`, `TestMinSeatsFloorWithOutcomeBasedCounting` classes; goal-criterion test shows the old sentinel-only tally vs the new outcome-based tally on the same fixture and asserts they differ; separate test covers the kimi `token_usage_measured: false` measurement gap; separate test covers the no-frontmatter fallback; separate tests confirm `min_seats`/`allow_degraded` mechanics are unaffected.
- [x] `tests/test_panel_cli.py` — new tests for `panel.py` exiting non-zero on zero-seats-delivered, and staying exit-0 on a normal run (including against the pre-existing `_FakeResult` double with no `zero_seats_delivered` attribute).
- [x] `python3 -m pytest tests/test_deliberation_panel.py tests/test_panel_cli.py -q` → 55 passed
- [x] Verified against real on-disk evidence (`~/.vnx-data/vnx-dev/unified_reports/panel-sweep-diverge-3-e4bafa.md`, `panel-research-diverge-1-fadf0e.md`) before implementing, per dispatch instruction.

Dispatch-ID: alpha-1358-coverage-op-uitkomst

🤖 Generated with [Claude Code](https://claude.com/claude-code)