### PR TITLE
fix(tests): correct stale stall-threshold expectations (OI-1227)

### DIFF
--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -817,8 +817,17 @@ class TestGateTimeoutConfig:
 
     def test_default_stall_threshold(self):
         from headless_adapter import gate_stall_threshold
-        assert gate_stall_threshold("gemini_review") == 60
-        assert gate_stall_threshold("codex_gate") == 120
+        # Literals, not GATE_STALL_DEFAULTS lookups: comparing the function's
+        # output to the dict it reads from would pass no matter what the dict
+        # said. gemini_review's 180s (not the 60s in
+        # 180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md §4.2, which was never
+        # reconciled against the code) has shipped since the gate runner's
+        # introduction (c0957d22) and every OI-105 triage since treats it as
+        # the accepted value (Gemini CLI's stdout-flush stalls, OI-048).
+        assert gate_stall_threshold("gemini_review") == 180
+        assert gate_stall_threshold("codex_gate") == 300
+        assert gate_stall_threshold("claude_github_optional") == 60
+        assert gate_stall_threshold("ci_gate") == 30
 
     def test_env_override_stall_threshold(self, monkeypatch):
         from headless_adapter import gate_stall_threshold


### PR DESCRIPTION
## Summary

`tests/test_gate_runner.py::TestGateTimeoutConfig::test_default_stall_threshold` asserted `gemini_review == 60` and (masked by pytest stopping at the first failed assert in that test) `codex_gate == 120`. Neither matches `GATE_STALL_DEFAULTS` in `scripts/lib/headless_adapter.py` (`180` / `300`). The whole file was on `scripts/ci/test_exclusions.txt` because of it, keeping 33 tests out of CI.

## History check (per dispatch instruction — don't assume the test is wrong)

- `GATE_STALL_DEFAULTS["gemini_review"] = 180` shipped in the commit that introduced the gate runner (`c0957d22`, 2026-04-01) — the **same commit** that added the test expecting `60`. The test was wrong from day one, not a later regression.
- `180` has never changed since.
- `docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md` §4.2 does say `60s` for `gemini_review`, but that table was written in the same commit and never reconciled against the shipped code — a separate, out-of-scope doc-drift issue, not evidence the code is the regression.
- Four independent OI-105 triage docs from 2026-08-01 (`20260801-oi-triage-t6-ledger-existence.md`, `20260801-t8-oi-triage-ledger-existence.md`, `20260801-r1-oi-triage.md`, `20260801-oi-triage-ledger-existence.md`) all independently cite `180s` as the accepted, intentional stall threshold (raised to absorb Gemini CLI's known stdout-flush stalls, OI-048).

Conclusion: the code is correct, the test was stale. Fixed the test only.

## Changes

- `tests/test_gate_runner.py`: `test_default_stall_threshold` now pins all four known `GATE_STALL_DEFAULTS` gate types as literals (`gemini_review=180`, `codex_gate=300`, `claude_github_optional=60`, `ci_gate=30`) instead of the two stale values. Kept as literals rather than reading back from `GATE_STALL_DEFAULTS` — comparing the function's output to the dict it sources from would be tautological and prove nothing if someone silently changed a default.

## Verification

```
python3 -m pytest tests/test_gate_runner.py -v
...
30 passed in 0.48s
```

Direct neighbors also checked (not modified):
- `tests/test_review_gate_manager.py`: 16/16 passed.
- `tests/test_gate_execution_certification.py`: 10 pre-existing failures, unrelated `MagicMock vs int` bug, its own separate `test_exclusions.txt` line — untouched by this change.

Commit: `c27b7a6a`

## Open Items

- `scripts/ci/test_exclusions.txt` line 140 (`tests/test_gate_runner.py`) is out of this PR's scope per the dispatch instruction — removing it is a separate follow-up PR.
- `docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md` §4.2 still documents `60s`/`120s` for `gemini_review`/`codex_gate`, diverging from the actual `180`/`300` shipped in code since 2026-04-01. Worth a doc-drift fix in a separate PR.

**Dispatch-ID**: alpha-1227-gate-runner-assertie
**Model**: sonnet
**Provider**: claude