### PR TITLE
fix(orphan-sweep): sweep completed-dispatch tmux sessions with a live pane (OI-1353)

### DIFF
--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -11,6 +11,36 @@ runtime objects persist forever:
    (``#{pane_dead}`` == 1, or ``#{pane_pid}`` no longer alive). Cleanup:
    ``tmux kill-session`` (idempotent — a missing session is already gone).
 
+1b. **completed-dispatch tmux sessions** (OI-1353) — a session whose worker
+   pane has a LIVE process (``pane_dead`` == 0, PID alive) is never touched by
+   the kind-1 dead-pane check above, even when its dispatch finished days ago
+   with an empty prompt sitting on it — five such zombies filling the
+   ``VNX_TMUX_MAX_CONCURRENT`` slots is exactly what silently starved every
+   new dispatch on 19-08. This is a SEPARATE, stricter conjunction — every
+   condition below must hold; process-liveness or session-age alone is never
+   sufficient:
+     (a) the name matches the canonical dispatch-session pattern (``_SESSION_RE``);
+     (b) the dispatch id is KNOWN to THIS project — present in the project's
+         own ``dispatch_register.ndjson`` (any event). A tmux session listing
+         is account-wide (one shared tmux server across every project on the
+         machine), so this is what keeps a sweep invoked for project X from
+         ever judging — let alone killing — a live session that belongs to
+         project Y;
+     (c) the dispatch is provably COMPLETED — a ``dispatch_completed`` register
+         event, or a terminal (success/failure) receipt in
+         ``t0_receipts.ndjson`` per ``event_outcome_semantics.classify_event_outcome``;
+     (d) its worktree (kind 2, below) is already gone — a surviving worktree
+         means the wrapper may still be about to reap it;
+     (e) its pane does not classify as ``working`` or ``awaiting_permission``
+         (``worker_pane_classifier.classify_worker_pane``) — both are
+         RECOVERABLE states (OI-863) and must never be swept;
+     (f) it is not the invoking dispatch (the same ``protected`` fence as
+         kind 1's dead-pane check).
+   Any condition that cannot be measured (register/receipts unreadable, pane
+   capture fails) fails OPEN — the session is left alone, never guessed dead.
+   Recorded under ``tmux_completed_orphans_killed`` / ``_preserved``, each
+   entry carrying the ground it was decided on.
+
 2. **git worktrees** ``<repo>/.vnx-data/worktrees/dispatch-<dispatch_id>`` — the
    same lane's ephemeral trees. An orphan is a worktree whose tmux session is
    gone (the session is the worktree's lifecycle authority: only its teardown
@@ -68,6 +98,12 @@ logger = logging.getLogger(__name__)
 # direct ``subprocess``→tmux coupling to the adapter files; this module must
 # delegate to ``tmux_adapter._run_tmux`` rather than run ``tmux`` itself.
 from tmux_adapter import _run_tmux as _adapter_run_tmux  # noqa: E402
+from event_outcome_semantics import classify_event_outcome  # noqa: E402
+from worker_pane_classifier import (  # noqa: E402
+    STATE_AWAITING_PERMISSION,
+    STATE_WORKING,
+    classify_worker_pane,
+)
 
 # The three object kinds share one dispatch-id alphabet. Both regexes pin the
 # name to the exact dispatch-id charset so a stray ``vnx-...`` / ``dispatch-...``
@@ -104,6 +140,13 @@ class OrphanSweepResult:
     tmux_killed: list = field(default_factory=list)          # sessions killed
     tmux_skipped_alive: list = field(default_factory=list)   # alive / unknown / kill-failed
     tmux_skipped_protected: list = field(default_factory=list)
+    # kind 1b — completed-dispatch sessions whose pane still has a live
+    # process (OI-1353). Each entry: {"session", "dispatch_id", "reason"} —
+    # ``reason`` is the ground the conjunction was decided on (see module
+    # docstring), so a dry-run shows WHICH condition a session was killed or
+    # spared on, never a bare verdict.
+    tmux_completed_orphans_killed: list = field(default_factory=list)
+    tmux_completed_orphans_preserved: list = field(default_factory=list)
     # kind 2 — worktrees
     worktrees_scanned: list = field(default_factory=list)
     worktrees_removed: list = field(default_factory=list)    # reaped (clean/committed/pushed)
@@ -125,6 +168,8 @@ class OrphanSweepResult:
             "tmux_killed": list(self.tmux_killed),
             "tmux_skipped_alive": list(self.tmux_skipped_alive),
             "tmux_skipped_protected": list(self.tmux_skipped_protected),
+            "tmux_completed_orphans_killed": list(self.tmux_completed_orphans_killed),
+            "tmux_completed_orphans_preserved": list(self.tmux_completed_orphans_preserved),
             "worktrees_scanned": list(self.worktrees_scanned),
             "worktrees_removed": list(self.worktrees_removed),
             "worktrees_preserved": list(self.worktrees_preserved),
@@ -219,6 +264,87 @@ def _real_kill_session(session: str) -> bool:
     return rc == 0
 
 
+def _real_capture_pane(session: str) -> "str | None":
+    """Capture a session's worker pane text; ``None`` when unmeasurable.
+
+    Mirrors ``_real_probe_liveness``'s pane targeting (``session:0.0``). A
+    non-zero exit (session gone mid-check, tmux error) is "cannot measure" —
+    never collapsed into an empty string, which ``classify_worker_pane``
+    would read as a provably-dead (empty) pane.
+    """
+    rc, out, _ = _run_tmux(["capture-pane", "-p", "-t", f"{session}:0.0"])
+    if rc != 0:
+        return None
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Kind 1b — completed-dispatch orphan conjunction (OI-1353)
+# ---------------------------------------------------------------------------
+
+def _evaluate_completed_orphan(
+    session: str,
+    dispatch_id: str,
+    *,
+    worktrees_dir: Path,
+    register_known_ids: "set[str] | None",
+    register_completed_ids: "set[str] | None",
+    receipts_index: "dict[str, list] | None",
+    capture_pane: Callable[[str], "str | None"],
+) -> "tuple[bool, str]":
+    """Evaluate the completed-dispatch/still-alive-pane orphan conjunction.
+
+    Every condition is REQUIRED — see the module docstring's kind-1b list for
+    the full (a)-(f) rationale. Returns ``(is_orphan, reason)``: ``reason`` is
+    always populated, on BOTH branches, so the caller can report the exact
+    ground a session was killed or spared on. Fail-open throughout: any
+    condition this function cannot measure returns ``(False, "..._unmeasurable")``
+    — 'cannot measure' is never read as 'orphaned'.
+
+    (a) is enforced by the caller (only ``_SESSION_RE``-matching names reach
+    here) and (f) by the caller's ``protected`` fence — neither is re-checked.
+    """
+    # (b) the dispatch id must be known to THIS project's own register.
+    if register_known_ids is None:
+        return False, "register_unmeasurable"
+    if dispatch_id not in register_known_ids:
+        return False, "unknown_project"
+
+    # (c) the dispatch must be provably COMPLETED: a dispatch_completed
+    # register event, or a terminal (success/failure) receipt.
+    evidence: "str | None" = None
+    if register_completed_ids is not None and dispatch_id in register_completed_ids:
+        evidence = "register:dispatch_completed"
+    if evidence is None:
+        if receipts_index is None:
+            return False, "receipts_unmeasurable"
+        for rec in receipts_index.get(dispatch_id) or []:
+            outcome = classify_event_outcome(rec.get("event_type"), rec.get("status"))
+            if outcome is not None:
+                evidence = f"receipt:{outcome}"
+                break
+    if evidence is None:
+        return False, "not_completed"
+
+    # (d) the dispatch's worktree must already be gone.
+    if (worktrees_dir / f"dispatch-{dispatch_id}").exists():
+        return False, "worktree_still_exists"
+
+    # (e) the pane must not be actively working or awaiting a permission
+    # prompt — both are RECOVERABLE states (OI-863), never orphans.
+    try:
+        pane_text = capture_pane(session)
+    except Exception:
+        return False, "pane_unmeasurable"
+    if pane_text is None:
+        return False, "pane_unmeasurable"
+    pane_state = classify_worker_pane(pane_text)
+    if pane_state.state in (STATE_WORKING, STATE_AWAITING_PERMISSION):
+        return False, f"pane_{pane_state.state}"
+
+    return True, f"{evidence};pane={pane_state.state}"
+
+
 # ---------------------------------------------------------------------------
 # Sweep orchestration
 # ---------------------------------------------------------------------------
@@ -246,6 +372,7 @@ def sweep(
     probe_liveness: Optional[Callable[[str], "bool | None"]] = None,
     kill_session: Optional[Callable[[str], bool]] = None,
     pid_alive: Optional[Callable[[Optional[int]], bool]] = None,
+    capture_pane: Optional[Callable[[str], "str | None"]] = None,
 ) -> OrphanSweepResult:
     """Clean/mark orphaned teardown leftovers across the three kinds.
 
@@ -264,7 +391,7 @@ def sweep(
                             Defaults to ``$VNX_CURRENT_DISPATCH_ID``.
         max_orphans:        Flood cap for the active-manifest kind.
         dry_run:            Classify everything; mutate nothing.
-        list_sessions / probe_liveness / kill_session / pid_alive:
+        list_sessions / probe_liveness / kill_session / pid_alive / capture_pane:
                             Injectable backends (defaults to real tmux/os).
                             Tests override them; production never does.
                             ``list_sessions`` returning ``None`` means the
@@ -272,6 +399,9 @@ def sweep(
                             kind-1 sees no sessions and kind-2 reaps nothing,
                             with an error recorded in the result instead of
                             treating "cannot measure" as "zero sessions".
+                            ``capture_pane`` feeds the kind-1b completed-
+                            dispatch conjunction (OI-1353) — returning
+                            ``None`` means the pane text was not measurable.
 
     Returns:
         :class:`OrphanSweepResult` — per-object failures are recorded in
@@ -288,12 +418,54 @@ def sweep(
         lambda s: _real_probe_liveness(s, pid_fn)
     )
     kill_fn = kill_session if kill_session is not None else _real_kill_session
+    capture_fn = capture_pane if capture_pane is not None else _real_capture_pane
 
     if current_dispatch_id is None:
         current_dispatch_id = os.environ.get("VNX_CURRENT_DISPATCH_ID", "").strip() or None
 
     result = OrphanSweepResult(dry_run=dry_run)
     protected: set[str] = {current_dispatch_id} if current_dispatch_id else set()
+    worktrees_dir = root / ".vnx-data" / "worktrees"
+
+    # ── kind 1b evidence, preloaded once (bounded — one file read each) ─────
+    # register_known_ids / register_completed_ids: None means the register
+    # itself could not be read this run (defensive — dispatch_register.
+    # read_events is already documented to degrade to an empty list rather
+    # than raise, so this branch is a belt-and-braces guard, not the expected
+    # path). An empty (non-None) result is a real measurement — "this
+    # project's register currently names zero dispatches" — not a failure.
+    try:
+        import dispatch_register
+        register_events = dispatch_register.read_events(state_dir=state_dir)
+    except Exception as exc:
+        register_events = None
+        result.errors.append({
+            "kind": "completed_check",
+            "error": f"dispatch_register read failed: {exc}",
+        })
+    if register_events is None:
+        register_known_ids: "set[str] | None" = None
+        register_completed_ids: "set[str] | None" = None
+    else:
+        register_known_ids = {
+            ev.get("dispatch_id") for ev in register_events if ev.get("dispatch_id")
+        }
+        register_completed_ids = {
+            ev.get("dispatch_id") for ev in register_events
+            if ev.get("event") == "dispatch_completed" and ev.get("dispatch_id")
+        }
+
+    try:
+        import dispatch_outcome_classifier
+        receipts_index: "dict[str, list] | None" = (
+            dispatch_outcome_classifier.load_receipts_index(state_dir)
+        )
+    except Exception as exc:
+        receipts_index = None
+        result.errors.append({
+            "kind": "completed_check",
+            "error": f"t0_receipts.ndjson read failed: {exc}",
+        })
 
     # ── kind 1: dead-pane tmux sessions ──────────────────────────────────────
     # ``surviving_ids`` is the set of dispatch ids whose worktree is still
@@ -331,9 +503,59 @@ def sweep(
             logger.info("orphan_sweep: SKIP tmux %s — protected dispatch", name)
             continue
         verdict = probe_fn(name)
+
+        if verdict is True:
+            # Provably alive: a candidate for the kind-1b completed-dispatch
+            # conjunction (OI-1353) — never evaluated for verdict is None
+            # (liveness itself unmeasurable), since that would stack one
+            # unmeasurable signal on top of another.
+            is_orphan, reason = _evaluate_completed_orphan(
+                name, sid,
+                worktrees_dir=worktrees_dir,
+                register_known_ids=register_known_ids,
+                register_completed_ids=register_completed_ids,
+                receipts_index=receipts_index,
+                capture_pane=capture_fn,
+            )
+            entry = {"session": name, "dispatch_id": sid, "reason": reason}
+            if is_orphan:
+                if dry_run:
+                    result.tmux_completed_orphans_killed.append(entry)
+                    surviving_ids.add(sid)  # session would still exist during dry-run
+                    logger.info(
+                        "orphan_sweep: DRY-RUN would kill completed-orphan tmux "
+                        "session %s (%s)", name, reason,
+                    )
+                    continue
+                try:
+                    killed = kill_fn(name)
+                except Exception as exc:
+                    killed = False
+                    result.errors.append(
+                        {"kind": "tmux_completed", "session": name, "error": str(exc)}
+                    )
+                if killed:
+                    result.tmux_completed_orphans_killed.append(entry)
+                    logger.info(
+                        "orphan_sweep: killed completed-orphan tmux session %s (%s)",
+                        name, reason,
+                    )
+                    continue
+                surviving_ids.add(sid)  # still exists -> keep its worktree
+                result.tmux_skipped_alive.append(name)
+                result.tmux_completed_orphans_preserved.append(
+                    {**entry, "reason": "kill_failed"}
+                )
+                logger.warning(
+                    "orphan_sweep: kill failed for completed-orphan %s; leaving session",
+                    name,
+                )
+                continue
+            result.tmux_completed_orphans_preserved.append(entry)
+
         if verdict is not False:
-            # Alive (True) or unmeasurable (None): never kill what we cannot
-            # prove is dead.
+            # Alive (True, conjunction unmet) or unmeasurable (None): never
+            # kill what we cannot prove is dead.
             surviving_ids.add(sid)
             result.tmux_skipped_alive.append(name)
             continue
@@ -357,7 +579,6 @@ def sweep(
             logger.warning("orphan_sweep: kill failed for %s; leaving session", name)
 
     # ── kind 2: worktrees whose tmux session is gone ─────────────────────────
-    worktrees_dir = root / ".vnx-data" / "worktrees"
     if worktrees_dir.is_dir():
         from tmux_worktree import WorktreeHandle, classify_path, reap
 
@@ -433,11 +654,15 @@ def sweep(
         result.errors.append({"kind": "active", **e})
 
     logger.info(
-        "orphan_sweep: complete — tmux killed=%d skipped=%d protected=%d; "
+        "orphan_sweep: complete — tmux killed=%d skipped=%d protected=%d "
+        "completed_orphans_killed=%d completed_orphans_preserved=%d; "
         "worktrees removed=%d preserved=%d skipped_live=%d; active recovered=%d "
         "scanned=%d capped=%s; dry_run=%s; errors=%d",
         len(result.tmux_killed), len(result.tmux_skipped_alive),
-        len(result.tmux_skipped_protected), len(result.worktrees_removed),
+        len(result.tmux_skipped_protected),
+        len(result.tmux_completed_orphans_killed),
+        len(result.tmux_completed_orphans_preserved),
+        len(result.worktrees_removed),
         len(result.worktrees_preserved), len(result.worktrees_skipped_live),
         len(result.active_recovered), result.active_scanned, result.active_capped,
         result.dry_run, len(result.errors),

--- a/tests/test_orphan_sweep.py
+++ b/tests/test_orphan_sweep.py
@@ -113,6 +113,31 @@ def _alloc(local: Path, dispatch_id: str) -> tmux_worktree.WorktreeHandle:
     return tmux_worktree.allocate(dispatch_id, repo_root=local)
 
 
+def _write_register_event(env: Path, event: str, dispatch_id: str) -> None:
+    """Append a raw register event, bypassing dispatch_register.append_event's
+    identity resolution/VALID_EVENTS gate — this is test data setup, not a
+    call through the write API under test."""
+    path = env / "state" / "dispatch_register.ndjson"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "timestamp": "2026-08-19T00:00:00.000000Z",
+            "event": event,
+            "dispatch_id": dispatch_id,
+        }) + "\n")
+
+
+def _write_receipt(env: Path, dispatch_id: str, *, event_type: str, status: str) -> None:
+    path = env / "state" / "t0_receipts.ndjson"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "dispatch_id": dispatch_id,
+            "event_type": event_type,
+            "status": status,
+        }) + "\n")
+
+
 def _make_active(env: Path, dispatch_id: str, *, worker_pid=None):
     d = env / "dispatches" / "active" / dispatch_id
     d.mkdir(parents=True)
@@ -288,6 +313,368 @@ def test_active_manifest_protected(env):
 
     assert res.active_skipped_protected == ["act-1"]
     assert (env / "dispatches" / "active" / "act-1").exists()
+
+
+# ---------------------------------------------------------------------------
+# Kind 1b — completed-dispatch orphan conjunction (OI-1353)
+#
+# The conjunction: (a) name matches _SESSION_RE [enforced by sweep()'s scan
+# loop, not re-tested here], (b) dispatch id known to this project's own
+# register, (c) dispatch provably completed (register event OR terminal
+# receipt), (d) worktree already gone, (e) pane not working/awaiting_permission,
+# (f) not the invoking dispatch [enforced by the pre-existing `protected`
+# fence]. Unit tests below hit ``_evaluate_completed_orphan`` directly for
+# (b)-(e); integration tests hit ``sweep()`` end-to-end, including (a)/(f).
+# ---------------------------------------------------------------------------
+
+def test_evaluate_completed_orphan_register_unmeasurable(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids=None,
+        register_completed_ids=None,
+        receipts_index={},
+        capture_pane=lambda s: "",
+    )
+    assert (is_orphan, reason) == (False, "register_unmeasurable")
+
+
+def test_evaluate_completed_orphan_unknown_project(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids=set(),  # measured — this project's register is empty
+        register_completed_ids=set(),
+        receipts_index={},
+        capture_pane=lambda s: "",
+    )
+    assert (is_orphan, reason) == (False, "unknown_project")
+
+
+def test_evaluate_completed_orphan_receipts_unmeasurable(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids=set(),  # not completed via register
+        receipts_index=None,           # and receipts could not be read
+        capture_pane=lambda s: "",
+    )
+    assert (is_orphan, reason) == (False, "receipts_unmeasurable")
+
+
+def test_evaluate_completed_orphan_not_completed(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids=set(),
+        receipts_index={},  # measured — no receipt at all for this id
+        capture_pane=lambda s: "",
+    )
+    assert (is_orphan, reason) == (False, "not_completed")
+
+
+def test_evaluate_completed_orphan_worktree_still_exists(tmp_path):
+    (tmp_path / "dispatch-x-1").mkdir()
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids={"x-1"},
+        receipts_index={},
+        capture_pane=lambda s: "",
+    )
+    assert (is_orphan, reason) == (False, "worktree_still_exists")
+
+
+def test_evaluate_completed_orphan_pane_working(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids={"x-1"},
+        receipts_index={},
+        capture_pane=lambda s: "working...\n(12s · ↓ 500 tokens · esc to interrupt)",
+    )
+    assert (is_orphan, reason) == (False, "pane_working")
+
+
+def test_evaluate_completed_orphan_pane_awaiting_permission(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids={"x-1"},
+        receipts_index={},
+        capture_pane=lambda s: "Do you want to proceed?\n1. Yes\n2. No",
+    )
+    assert (is_orphan, reason) == (False, "pane_awaiting_permission")
+
+
+def test_evaluate_completed_orphan_pane_unmeasurable(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids={"x-1"},
+        receipts_index={},
+        capture_pane=lambda s: None,
+    )
+    assert (is_orphan, reason) == (False, "pane_unmeasurable")
+
+
+def test_evaluate_completed_orphan_pane_capture_raises_fails_open(tmp_path):
+    def _raise(session):
+        raise RuntimeError("tmux capture-pane blew up")
+
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids={"x-1"},
+        receipts_index={},
+        capture_pane=_raise,
+    )
+    assert (is_orphan, reason) == (False, "pane_unmeasurable")
+
+
+def test_evaluate_completed_orphan_satisfied_via_register(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids={"x-1"},
+        receipts_index={},
+        capture_pane=lambda s: "",  # empty pane -> classify_worker_pane -> dead
+    )
+    assert is_orphan is True
+    assert reason == "register:dispatch_completed;pane=dead"
+
+
+def test_evaluate_completed_orphan_satisfied_via_receipt(tmp_path):
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},
+        register_completed_ids=set(),  # not completed via register
+        receipts_index={"x-1": [{"event_type": "task_complete", "status": "success"}]},
+        capture_pane=lambda s: "",
+    )
+    assert is_orphan is True
+    assert reason == "receipt:success;pane=dead"
+
+
+# ---------------------------------------------------------------------------
+# Kind 1b — end-to-end via sweep()
+# ---------------------------------------------------------------------------
+
+def test_sweep_kills_completed_orphan_via_register_event(env, tmp_path):
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_completed", "done-1")  # no worktree -> (d) trivially holds
+    killed = []
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-done-1"],
+        probe_liveness=lambda s: True,
+        kill_session=lambda s: (killed.append(s), True)[1],
+        capture_pane=lambda s: "",
+    )
+
+    assert killed == ["vnx-done-1"]
+    assert len(res.tmux_completed_orphans_killed) == 1
+    entry = res.tmux_completed_orphans_killed[0]
+    assert entry["session"] == "vnx-done-1"
+    assert entry["dispatch_id"] == "done-1"
+    assert entry["reason"].startswith("register:dispatch_completed")
+    assert res.tmux_completed_orphans_preserved == []
+    assert "vnx-done-1" not in res.tmux_skipped_alive
+    assert "vnx-done-1" not in res.tmux_killed  # separate key from the dead-pane class
+
+
+def test_sweep_kills_completed_orphan_via_terminal_receipt(env, tmp_path):
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_created", "recv-1")  # known, NOT completed via register
+    _write_receipt(env, "recv-1", event_type="task_complete", status="success")
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-recv-1"],
+        probe_liveness=lambda s: True,
+        kill_session=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert len(res.tmux_completed_orphans_killed) == 1
+    assert res.tmux_completed_orphans_killed[0]["reason"].startswith("receipt:success")
+
+
+def test_sweep_preserves_alive_orphan_with_live_worktree(env, tmp_path):
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "wt-1")
+    _write_register_event(env, "dispatch_completed", "wt-1")
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-wt-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert len(res.tmux_completed_orphans_preserved) == 1
+    assert res.tmux_completed_orphans_preserved[0]["reason"] == "worktree_still_exists"
+    assert "vnx-wt-1" in res.tmux_skipped_alive
+    assert handle.path.is_dir()
+
+
+def test_sweep_preserves_alive_known_but_not_completed(env, tmp_path):
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_created", "inflight-1")  # known, still in flight
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-inflight-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert res.tmux_completed_orphans_preserved[0]["reason"] == "not_completed"
+    assert "vnx-inflight-1" in res.tmux_skipped_alive
+
+
+def test_sweep_preserves_alive_session_unknown_to_project(env, tmp_path):
+    """A live session on the shared tmux server that this project's register
+    has never heard of — e.g. a different project's dispatch — must never be
+    judged, let alone killed, by this project's sweep (condition b)."""
+    local = _git_repo(tmp_path)
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-other-project-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert res.tmux_completed_orphans_preserved[0]["reason"] == "unknown_project"
+
+
+def test_sweep_preserves_alive_completed_orphan_awaiting_permission(env, tmp_path):
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_completed", "perm-1")
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-perm-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "Do you want to proceed?\n1. Yes\n2. No",
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert res.tmux_completed_orphans_preserved[0]["reason"] == "pane_awaiting_permission"
+    assert "vnx-perm-1" in res.tmux_skipped_alive
+
+
+def test_sweep_preserves_alive_completed_orphan_pane_unmeasurable(env, tmp_path):
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_completed", "unmeas-1")
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-unmeas-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: None,
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert res.tmux_completed_orphans_preserved[0]["reason"] == "pane_unmeasurable"
+
+
+def test_sweep_preserves_protected_completed_dispatch(env, tmp_path):
+    """(f): even a session that would otherwise satisfy the full conjunction
+    is never touched when it is the invoking dispatch itself."""
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_completed", "prot-done-1")
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        current_dispatch_id="prot-done-1",
+        list_sessions=lambda: ["vnx-prot-done-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert res.tmux_completed_orphans_preserved == []
+    assert res.tmux_skipped_protected == ["vnx-prot-done-1"]
+
+
+def test_sweep_dry_run_completed_orphan_shows_ground_no_mutation(env, tmp_path):
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_completed", "dry-done-1")
+    killed = []
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        dry_run=True,
+        list_sessions=lambda: ["vnx-dry-done-1"],
+        probe_liveness=lambda s: True,
+        kill_session=lambda s: (killed.append(s), True)[1],
+        capture_pane=lambda s: "",
+    )
+
+    assert res.dry_run
+    assert killed == []  # would-kill only, nothing actually run
+    assert len(res.tmux_completed_orphans_killed) == 1
+    assert res.tmux_completed_orphans_killed[0]["dispatch_id"] == "dry-done-1"
+
+
+def test_sweep_completed_orphan_kill_is_idempotent(env, tmp_path):
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_completed", "idem-done-1")
+    killed = []
+
+    first = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-idem-done-1"],
+        probe_liveness=lambda s: True,
+        kill_session=lambda s: (killed.append(s), True)[1],
+        capture_pane=lambda s: "",
+    )
+    assert killed == ["vnx-idem-done-1"]
+    assert len(first.tmux_completed_orphans_killed) == 1
+
+    second = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: [],  # session is gone now, as real tmux would report
+        probe_liveness=lambda s: True,
+        kill_session=lambda s: (killed.append(s), True)[1],
+        capture_pane=lambda s: "",
+    )
+    assert second.tmux_completed_orphans_killed == []
+    assert second.tmux_sessions_scanned == []
+    assert killed == ["vnx-idem-done-1"]  # not killed twice
+
+
+def test_to_dict_includes_completed_orphan_keys(env):
+    res = osweep.sweep(data_dir=env, list_sessions=lambda: [])
+    d = res.to_dict()
+    assert d["tmux_completed_orphans_killed"] == []
+    assert d["tmux_completed_orphans_preserved"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `orphan_sweep.py`'s kind-1 check only killed tmux sessions whose pane was PROVABLY DEAD (pid gone). Five zombies with a live process sitting on an empty prompt filled all five `VNX_TMUX_MAX_CONCURRENT` slots on 19-08 and silently starved every new dispatch — measured on `20260819-b4-prijzen-en-ladder`.
- Adds a second, stricter conjunction (kind 1b) for "completed-dispatch, still-alive-pane" sessions: orphaned only when **all** of (b) the dispatch id is known to this project's own `dispatch_register.ndjson`, (c) the dispatch is provably completed (`dispatch_completed` register event OR a terminal receipt in `t0_receipts.ndjson`), (d) its worktree is already gone, (e) its pane is neither `working` nor `awaiting_permission` (`worker_pane_classifier`), (f) it isn't the invoking dispatch. (a) is the existing session-name pattern.
- Fail-open throughout: an unreadable register/receipts file or an unmeasurable pane never gets read as "orphaned". Results land in new `tmux_completed_orphans_killed` / `tmux_completed_orphans_preserved` JSON keys, each entry carrying the exact ground it was decided on.

## Changes
- `scripts/lib/orphan_sweep.py`: `_evaluate_completed_orphan()` (pure conjunction), `_real_capture_pane()`, new `OrphanSweepResult` fields + `to_dict()` keys, wired into the kind-1 scan loop (only when the existing liveness probe reads `True`), new injectable `capture_pane` param on `sweep()`.
- `tests/test_orphan_sweep.py`: 22 new tests — 9 unit tests hitting `_evaluate_completed_orphan` directly (one per failing condition b–e, register-unmeasurable, receipts-unmeasurable, pane-capture-raises, and the two ways to satisfy completion), 12 `sweep()` integration tests (kill via register/receipt, preserve on worktree/not-completed/unknown-project/awaiting-permission/pane-unmeasurable/protected, dry-run, idempotency), 1 `to_dict()` key check.
- No other files touched; no new CLI flag needed.

## Verification
- `python3 -m pytest tests/test_orphan_sweep.py tests/test_orphan_sweep_fail_open.py -v` → 41 passed (19 pre-existing + 22 new).
- `python3 -m pytest tests/test_pool_reaper.py -q` (direct neighbor importing orphan_sweep) → 25 passed.
- Live acceptance demo (see dispatch report for full transcript): created two throwaway tmux sessions (`vnx-oi1353demo-orphaned-1`, `vnx-oi1353demo-living-1`) against a scratch `data_dir`/`state_dir` (never touching this project's real `.vnx-data/`), with `list_sessions` restricted to only those two names for safety. Dry-run showed the orphaned one as killable with reason `register:dispatch_completed;pane=stalled` and the living one preserved with reason `pane_working`. The real run then killed exactly the orphaned session (`tmux ls` went from 36→35 sessions, only `vnx-oi1353demo-orphaned-1` missing); the living session and the entire rest of the fleet (34 unrelated sessions, including two that appeared mid-demo from other live orchestrator activity) were untouched. Cleaned up the remaining demo session by name and removed the scratch dir afterward.

## Open Items
None.