### PR TITLE
fix(dispatch-serialization): headless claude lane joins the account lock (OI-1417)

### DIFF
--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -336,9 +336,18 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         model = spec.model or "default"
     fired.append("D4")
 
-    # D5 — serialization class; headless lane has no tmux serial lock
+    # D5 — serialization class; the subscription is ONE account-wide resource,
+    # so both claude lanes (tmux + headless) share the SAME slot class. OI-1417:
+    # headless previously fell through to None (no-op) here, which meant a
+    # headless burst of `claude -p` processes was unbounded even though it
+    # runs on the same Max subscription (billing already treats it that way —
+    # see D2's claude_api_metered comment). "claude-tmux" is the class name
+    # dispatch_serialization.py's lock files, force_release(), and the CLI's
+    # --force-release-lock default are keyed on; kept as-is rather than
+    # renamed so the headless lane joins the existing account-wide lock
+    # instead of standing up a second, uncoordinated one.
     serialization_class: Optional[str]
-    if is_claude_lane and not is_claude_headless and snapshot.claude_serial_enabled:
+    if is_claude_lane and snapshot.claude_serial_enabled:
         serialization_class = "claude-tmux"
     else:
         serialization_class = None

--- a/scripts/lib/dispatch_serialization.py
+++ b/scripts/lib/dispatch_serialization.py
@@ -1,8 +1,9 @@
 """dispatch_serialization.py — Claude subscription N-slot serial lock (PR-6 + tmux-concurrency-config).
 
-serialize_lane(serialization_class) context manager: serializes the claude-tmux
-lane to at most N concurrent holders per account; provider + headless lanes
-pass None -> no-op.
+serialize_lane(serialization_class) context manager: serializes BOTH claude
+lanes (claude-tmux and claude_headless) to at most N concurrent holders per
+account, since they authenticate against the same subscription (OI-1417) —
+provider lanes pass None -> no-op.
 
 The serial lock protects the Claude SUBSCRIPTION, not a resource. Running
 multiple subscription-authenticated `claude` processes concurrently risks
@@ -215,7 +216,7 @@ def serialize_lane(
 ):
     """Serialize execution for the given serialization_class across N slots.
 
-    None -> no-op: yield immediately, touch nothing (providers + headless).
+    None -> no-op: yield immediately, touch nothing (provider lanes only).
     "claude-tmux" -> acquire the first free slot among N exclusive flocks on
     <lock_dir>/claude-tmux-slot-{0..N-1}.lock (N = VNX_TMUX_MAX_CONCURRENT,
     default 5) and hold it through the entire with-body (execution +

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -625,14 +625,16 @@ def _make_vspec_headless(
 class TestClaudeHeadlessLane:
     def test_headless_optin_lane_fields(self, tmp_path: Path) -> None:
         """allow_headless=True → lane=claude_headless, adapter=claude_subprocess,
-        billing=subscription (no own key — billing follows auth, not lane)."""
+        billing=subscription (no own key — billing follows auth, not lane).
+        OI-1417: serialization_class joins the SAME "claude-tmux" slot class as
+        the tmux lane — the subscription is one account-wide resource."""
         vspec = _make_vspec_headless(tmp_path=tmp_path)
         plan = compile_plan(vspec, _healthy_snapshot())
         assert isinstance(plan, ExecutionPlan)
         assert plan.lane == "claude_headless"
         assert plan.adapter == "claude_subprocess"
         assert plan.billing == "subscription"
-        assert plan.serialization_class is None
+        assert plan.serialization_class == "claude-tmux"
         assert plan.warmup == "n/a"
         assert plan.target_id == "ephemeral"
 
@@ -661,10 +663,24 @@ class TestClaudeHeadlessLane:
         assert plan.isolation == Isolation.WORKTREE
         assert plan.require_worktree is True
 
-    def test_headless_serial_disabled_still_no_serial_class(self, tmp_path: Path) -> None:
-        """claude_headless never gets serialization_class even when claude_serial_enabled=True."""
+    def test_headless_and_tmux_share_one_serialization_class(self, tmp_path: Path) -> None:
+        """OI-1417: headless and tmux plans resolve to the IDENTICAL
+        serialization_class string when the lock is enabled — one shared
+        account-wide slot pool, not two independent counters."""
+        headless_vspec = _make_vspec_headless(tmp_path=tmp_path)
+        tmux_vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        headless_plan = compile_plan(headless_vspec, _healthy_snapshot(claude_serial_enabled=True))
+        tmux_plan = compile_plan(tmux_vspec, _healthy_snapshot(claude_serial_enabled=True))
+        assert isinstance(headless_plan, ExecutionPlan)
+        assert isinstance(tmux_plan, ExecutionPlan)
+        assert headless_plan.serialization_class == "claude-tmux"
+        assert headless_plan.serialization_class == tmux_plan.serialization_class
+
+    def test_headless_serial_disabled_no_serial_class(self, tmp_path: Path) -> None:
+        """claude_serial_enabled=False disables the lock for headless too, same
+        as it already does for the tmux lane."""
         vspec = _make_vspec_headless(tmp_path=tmp_path)
-        plan = compile_plan(vspec, _healthy_snapshot(claude_serial_enabled=True))
+        plan = compile_plan(vspec, _healthy_snapshot(claude_serial_enabled=False))
         assert isinstance(plan, ExecutionPlan)
         assert plan.serialization_class is None
 

--- a/tests/test_dispatch_serialization.py
+++ b/tests/test_dispatch_serialization.py
@@ -187,47 +187,58 @@ def test_provider_lanes_stay_parallel(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# test_claude_headless_not_locked
+# test_claude_tmux_and_headless_share_lock (OI-1417)
 # ---------------------------------------------------------------------------
 
-def test_claude_headless_not_locked(tmp_path, monkeypatch):
-    """serialize_lane(None) (headless) is a no-op and does not block a concurrent claude-tmux holder."""
+def test_claude_tmux_and_headless_share_lock(tmp_path, monkeypatch):
+    """OI-1417: dispatch_plan.py's D5 resolves BOTH claude lanes (tmux and
+    headless) to the same serialization_class="claude-tmux" string, because
+    both authenticate against the same subscription. This is the door-level
+    call the CLI actually makes for a headless dispatch — serialize_lane(None)
+    is no longer what a headless plan produces. With N=1, a tmux holder must
+    block a concurrent headless caller until it releases; they must not run
+    past each other."""
     monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+    monkeypatch.setenv("VNX_TMUX_MAX_CONCURRENT", "1")
 
     tmux_holding = threading.Event()
-    headless_elapsed = []
+    release_gate = threading.Event()
+    headless_entered = threading.Event()
     errors = []
 
     def claude_tmux_worker():
         try:
             with serialize_lane("claude-tmux", dispatch_id="tmux-holder"):
                 tmux_holding.set()
-                time.sleep(0.3)
+                release_gate.wait(timeout=5)
         except Exception as exc:
             errors.append(("tmux", exc))
 
     def headless_worker():
         tmux_holding.wait(timeout=5)
-        t_start = time.monotonic()
         try:
-            with serialize_lane(None):
-                pass  # should not block
+            with serialize_lane("claude-tmux", dispatch_id="headless-holder"):
+                headless_entered.set()
         except Exception as exc:
             errors.append(("headless", exc))
-        headless_elapsed.append(time.monotonic() - t_start)
 
     t1 = threading.Thread(target=claude_tmux_worker)
     t2 = threading.Thread(target=headless_worker)
     t1.start()
     t2.start()
+
+    tmux_holding.wait(timeout=5)
+    assert not headless_entered.wait(timeout=0.3), (
+        "headless caller acquired the lock while the tmux holder still held it "
+        "— they crossed each other instead of colliding on the shared N"
+    )
+
+    release_gate.set()
     t1.join(timeout=5)
     t2.join(timeout=5)
 
     assert not errors, f"unexpected errors: {errors}"
-    assert headless_elapsed, "headless worker did not complete"
-    assert headless_elapsed[0] < 0.15, (
-        f"headless lane blocked unexpectedly ({headless_elapsed[0]:.3f}s)"
-    )
+    assert headless_entered.is_set(), "headless caller never acquired after tmux released"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `dispatch_plan.py` D5 set `serialization_class=None` for the headless claude lane (`claude -p`), even though D2 already labels that lane `billing=subscription` — both claude lanes authenticate against the same Max subscription, so the account-wide serial lock (`dispatch_serialization.py`) was a no-op for exactly the lane that runs unattended and can burst concurrency the most.
- Headless now resolves to the same `"claude-tmux"` slot class as the tmux lane, sharing ONE account-wide N (`VNX_TMUX_MAX_CONCURRENT`) instead of the tmux lane being bounded while headless ran unbounded. `_max_concurrent()` and the lock-file naming/`force_release()` default are untouched — no PR #1650 registry-backed rework was live at time of writing, so this only wires the existing lane in.
- Updated `dispatch_serialization.py` module/function docstrings to stop saying "providers + headless" pass `None` — only provider lanes do now.

## Changes
- `scripts/lib/dispatch_plan.py` — D5: `is_claude_lane and snapshot.claude_serial_enabled` (dropped the `and not is_claude_headless` exclusion).
- `scripts/lib/dispatch_serialization.py` — docstring updates only, no behavior change (the primitive already took any class string).
- `tests/test_dispatch_plan.py` — flipped the two tests that pinned the old (buggy) `serialization_class is None` behavior for headless; added a test asserting headless and tmux plans resolve to the identical class string.
- `tests/test_dispatch_serialization.py` — replaced `test_claude_headless_not_locked` (which asserted `serialize_lane(None)` doesn't block — no longer what a headless plan produces) with `test_claude_tmux_and_headless_share_lock`, proving a tmux holder and a headless caller collide on the same N=1 slot instead of running past each other.

## Verification
`python -m pytest tests/test_dispatch_plan.py tests/test_dispatch_serialization.py -q` → 136 passed.

Also ran the broader dispatch test surface (`test_dispatch_cli.py`, `test_dispatch_envelope_plan.py`, `test_dispatch_envelope_fail_loud.py`, `test_wiring_completeness.py`, `test_requires_mcp_propagation.py`, `test_dispatch_path_access_provenance.py`, `test_final_prompt_integrity.py`, `test_governance_emit_schema.py`, `test_grounding_shadow.py`, `test_role_scope_outside_triage.py`, `test_unified_report_schema.py`, `test_dispatch_id_collision_resolver.py`). 6-7 pre-existing failures (model-pin/smart-router routing, e.g. `test_build_runtime_snapshot_floor_ignores_explicit_differing_model`) reproduce identically against unmodified `dispatch_plan.py` from `HEAD` — confirmed unrelated to this change (verified by reverting `dispatch_plan.py` to HEAD and re-running, same failures).

## Open Items
None.

**Dispatch-ID**: 20260821-t0-oi1417-headless-in-de-lock
**Model**: sonnet
**Provider**: claude