### PR TITLE
fix(pr-merge): exit code follows real outcome, --auto is conditional (OI-1399/OI-1386)

### DIFF
--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -26,6 +26,18 @@ other commit. A push to the branch after the gates ran moves the head, and the
 merge is then refused with a "gates must re-run" message instead of silently
 merging a commit the gates never saw.
 
+Outcome verification + conditional --auto (OI-1399 / OI-1386): ``gh pr merge
+--auto`` exits 0 both when it merges immediately AND when it only *enables*
+auto-merge (the actual merge stays pending on required checks/reviews) — the
+two are indistinguishable from the exit code alone. ``_do_merge`` therefore
+never trusts ``gh``'s exit code as proof of a merge: after a zero exit it
+re-queries the PR (``_pr_actually_merged``) and only reports success when
+``state == "MERGED"``. Separately, ``--auto`` is now conditional
+(``_repo_auto_merge_allowed``): it is only added when the repository actually
+has "Allow auto-merge" enabled, so a repo with it disabled takes the plain
+``gh pr merge`` path instead of having the merge rejected outright for
+requesting a repo feature that is off.
+
 Usage:
     python3 scripts/pr_merge.py --pr 123
     python3 scripts/pr_merge.py --pr 123 --dispatch-id 20260526-gov2-something
@@ -342,6 +354,53 @@ def _head_moved_refusal_message(pr_number: int, head_sha: str, raw: str) -> str:
     )
 
 
+def _repo_auto_merge_allowed() -> Optional[bool]:
+    """Whether the repo has "Allow auto-merge" enabled — required for ``gh --auto``.
+
+    Neither ``gh pr view`` nor ``gh repo view --json`` expose this setting; the
+    REST repo object carries it as ``allow_auto_merge``, so it is queried via
+    ``gh api``. Returns ``None`` when it could not be determined (``gh``
+    failure, unparseable output) — the caller must treat that the same as
+    "not available", never as "available": assuming availability is exactly
+    OI-1386 (``--auto`` requested on a repo where the setting is off, and
+    ``gh`` rejects the merge outright for it).
+    """
+    result = _gh(["api", "repos/{owner}/{repo}", "--jq", ".allow_auto_merge"])
+    if result.returncode != 0:
+        return None
+    out = (result.stdout or "").strip().lower()
+    if out == "true":
+        return True
+    if out == "false":
+        return False
+    return None
+
+
+def _pr_actually_merged(pr_number: int) -> tuple[bool, str]:
+    """Verify a PR is really merged — never trust a ``gh pr merge`` exit code alone.
+
+    ``gh pr merge --auto`` exits 0 both when it merges immediately AND when it
+    only *enables* auto-merge (the merge itself stays pending on required
+    checks/reviews that have not landed yet). Both look identical on the exit
+    code; only the PR's own state distinguishes them (OI-1399). An
+    unqueryable PR state is treated as "not merged" — never a silent pass.
+    """
+    pr_data = _query_pr(pr_number)
+    if pr_data is None:
+        return False, (
+            f"gh pr merge meldde succes voor #{pr_number}, maar de PR-state kon niet "
+            "worden opgevraagd om dat te bevestigen: behandel dit als een mislukte merge"
+        )
+    state = (pr_data.get("state") or "").upper()
+    if state == "MERGED":
+        return True, ""
+    return False, (
+        f"gh pr merge meldde succes voor #{pr_number}, maar de PR staat nog op "
+        f"state={state or 'onbekend'} (geen MERGED): vermoedelijk staat auto-merge nog "
+        "te wachten op openstaande vereisten. Dit telt niet als een voltooide merge."
+    )
+
+
 def _do_merge(pr_number: int, method: str, head_sha: str = "") -> tuple[bool, str]:
     """Execute gh pr merge pinned to the approved head and return (success, error).
 
@@ -351,18 +410,26 @@ def _do_merge(pr_number: int, method: str, head_sha: str = "") -> tuple[bool, st
     merge must then be refused (so the gates re-run) rather than silently merged.
     A head-moved refusal is reported as that — the system working — not as a
     generic ``gh`` failure.
+
+    ``--auto`` is added only when the repo actually supports it
+    (``_repo_auto_merge_allowed``) — see module docstring (OI-1386). A ``gh``
+    exit 0 is not itself treated as success: the PR state is re-queried
+    (``_pr_actually_merged``) and only ``state == "MERGED"`` counts (OI-1399).
     """
     method_flag = f"--{method}"
-    args = ["pr", "merge", str(pr_number), method_flag, "--auto"]
+    args = ["pr", "merge", str(pr_number), method_flag]
     if head_sha:
         args += ["--match-head-commit", head_sha]
+    if _repo_auto_merge_allowed():
+        args = args + ["--auto"]
+
     result = _gh(args)
     if result.returncode != 0:
         raw = (result.stderr or result.stdout or "gh pr merge failed").strip()
         if head_sha and _is_head_moved_refusal(raw):
             return False, _head_moved_refusal_message(pr_number, head_sha, raw)
         return False, raw
-    return True, ""
+    return _pr_actually_merged(pr_number)
 
 
 def _emit_receipt(
@@ -433,6 +500,7 @@ def merge_pr(
     dry_run: bool = False,
     receipts_file: Optional[str] = None,
     head_sha: str = "",
+    pr_data: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Merge a PR and emit audit trail.
 
@@ -442,6 +510,12 @@ def merge_pr(
     (a second fetch would be a second source for the same identity). Empty
     (default) preserves the pre-pinning behavior for callers that never ran a
     gate.
+
+    ``pr_data`` lets the caller pass PR metadata it already fetched (``main()``
+    already has it from ``_run_ci_gate``) so this does not re-query ``gh`` a
+    third time per invocation for the same PR just to read title/branch.
+    ``None`` (default) preserves the previous self-fetching behavior for
+    callers that never ran a gate.
 
     Returns a dict with keys: success, pr_number, dispatch_id, merge_method,
     pr_title, branch, receipt_status, register_ok, error.
@@ -460,8 +534,11 @@ def merge_pr(
         "overlaps": [],
     }
 
-    # Query PR metadata before merge (needed for receipt)
-    pr_data = _query_pr(pr_number)
+    # PR metadata for the receipt (title/branch). Reuse what the caller
+    # already fetched when given; otherwise fetch it here (pre-pinning
+    # behavior for callers that never ran a gate).
+    if pr_data is None:
+        pr_data = _query_pr(pr_number)
     if pr_data:
         result["pr_title"] = pr_data.get("title", "")
         result["branch"] = pr_data.get("headRefName", "")
@@ -595,6 +672,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         merge_method=method,
         dry_run=args.dry_run,
         head_sha=head_sha,
+        pr_data=pr_data,
     )
 
     if args.json:

--- a/tests/test_pr_merge_match_head.py
+++ b/tests/test_pr_merge_match_head.py
@@ -108,13 +108,15 @@ class TestMergePinnedToApprovedHead:
             return ok_run
 
         monkeypatch.setattr(pr_merge, "_gh", fake_gh)
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: True)
+        monkeypatch.setattr(pr_merge, "_pr_actually_merged", lambda n: (True, ""))
 
         ok, err = pr_merge._do_merge(5, "squash", head_sha=SHA)
 
         assert ok is True
         assert err == ""
         assert seen["args"] == [
-            "pr", "merge", "5", "--squash", "--auto", "--match-head-commit", SHA,
+            "pr", "merge", "5", "--squash", "--match-head-commit", SHA, "--auto",
         ]
 
     def test_do_merge_without_head_sha_omits_flag(self, monkeypatch):
@@ -127,6 +129,8 @@ class TestMergePinnedToApprovedHead:
             return ok_run
 
         monkeypatch.setattr(pr_merge, "_gh", fake_gh)
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: True)
+        monkeypatch.setattr(pr_merge, "_pr_actually_merged", lambda n: (True, ""))
 
         ok, _ = pr_merge._do_merge(5, "squash", head_sha="")
 

--- a/tests/test_pr_merge_outcome_exitcode.py
+++ b/tests/test_pr_merge_outcome_exitcode.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Tests for OI-1399 / OI-1386: pr_merge's exit code must follow the real
+merge outcome, and ``--auto`` must be conditional on repo support.
+
+Before this fix ``_do_merge`` always passed ``--auto`` to ``gh pr merge`` and
+trusted its exit code as proof of a merge. Both were wrong:
+
+  - ``gh pr merge --auto`` exits 0 both when it merges immediately AND when it
+    only *enables* auto-merge (the actual merge stays pending on required
+    checks/reviews) — the exit code alone cannot tell the two apart, so
+    ``pr_merge`` reported success (exit 0) for a merge that had not actually
+    happened yet (OI-1399).
+  - ``--auto`` unconditionally requested a repo feature that GitHub rejects
+    outright when "Allow auto-merge" is off, breaking the governed merge path
+    on every such repo even though a plain merge would have worked (OI-1386).
+
+These tests cover the three PASS-criterion cases end to end (merge succeeds ->
+exit 0; merge does not happen -> non-zero + reason on stderr; auto-merge
+unavailable -> falls back to the plain path instead of breaking), plus unit
+coverage for the two new helpers (``_repo_auto_merge_allowed`` and
+``_pr_actually_merged``) that make it possible.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+
+
+@pytest.fixture()
+def vnx_env(tmp_path, monkeypatch):
+    """Writable, isolated VNX state dirs so receipt/register writes never
+    touch real project state (dispatch_register.append_event hard-guards
+    against exactly that under pytest)."""
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    (data_dir / "dispatches").mkdir(parents=True, exist_ok=True)
+    return {"receipts_path": state_dir / "t0_receipts.ndjson"}
+
+
+def _run(rc, stdout="", stderr=""):
+    return subprocess.CompletedProcess(["gh"], rc, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# _repo_auto_merge_allowed — repo-level "Allow auto-merge" detection
+# ---------------------------------------------------------------------------
+
+
+class TestRepoAutoMergeAllowed:
+    def test_true_when_repo_allows_it(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(0, stdout="true\n"))
+        assert pr_merge._repo_auto_merge_allowed() is True
+
+    def test_false_when_repo_disallows_it(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(0, stdout="false\n"))
+        assert pr_merge._repo_auto_merge_allowed() is False
+
+    def test_none_when_gh_fails(self, monkeypatch):
+        """gh failure never reads as available — the safe fallback is 'unknown'."""
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(1, stderr="HTTP 404"))
+        assert pr_merge._repo_auto_merge_allowed() is None
+
+    def test_none_when_output_unparseable(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(0, stdout="null\n"))
+        assert pr_merge._repo_auto_merge_allowed() is None
+
+
+# ---------------------------------------------------------------------------
+# _pr_actually_merged — never trust gh's exit code alone
+# ---------------------------------------------------------------------------
+
+
+class TestPrActuallyMerged:
+    def test_true_when_state_merged(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {"state": "MERGED"})
+        ok, err = pr_merge._pr_actually_merged(5)
+        assert ok is True
+        assert err == ""
+
+    def test_false_when_state_still_open(self, monkeypatch):
+        """gh reported success, but the PR is still OPEN (pending auto-merge)."""
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {"state": "OPEN"})
+        ok, err = pr_merge._pr_actually_merged(5)
+        assert ok is False
+        assert "state=OPEN" in err
+        assert "#5" in err
+
+    def test_false_when_pr_state_unqueryable(self, monkeypatch):
+        """An unqueryable PR is treated as 'not merged', never a silent pass."""
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: None)
+        ok, err = pr_merge._pr_actually_merged(5)
+        assert ok is False
+        assert "#5" in err
+
+
+# ---------------------------------------------------------------------------
+# _do_merge — --auto is conditional, never unconditional
+# ---------------------------------------------------------------------------
+
+
+class TestDoMergeConditionalAuto:
+    def test_auto_added_when_repo_allows_it(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: calls.append(list(args)) or _run(0))
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: True)
+        monkeypatch.setattr(pr_merge, "_pr_actually_merged", lambda n: (True, ""))
+
+        ok, err = pr_merge._do_merge(5, "squash")
+
+        assert ok is True
+        assert err == ""
+        merge_call = next(c for c in calls if c[:2] == ["pr", "merge"])
+        assert "--auto" in merge_call
+
+    def test_auto_omitted_when_repo_disallows_it(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: calls.append(list(args)) or _run(0))
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: False)
+        monkeypatch.setattr(pr_merge, "_pr_actually_merged", lambda n: (True, ""))
+
+        ok, _ = pr_merge._do_merge(5, "squash")
+
+        assert ok is True
+        merge_call = next(c for c in calls if c[:2] == ["pr", "merge"])
+        assert "--auto" not in merge_call
+
+    def test_auto_omitted_when_availability_unknown(self, monkeypatch):
+        """An undetermined repo setting is treated as unavailable, never assumed True."""
+        calls = []
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: calls.append(list(args)) or _run(0))
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: None)
+        monkeypatch.setattr(pr_merge, "_pr_actually_merged", lambda n: (True, ""))
+
+        pr_merge._do_merge(5, "squash")
+
+        merge_call = next(c for c in calls if c[:2] == ["pr", "merge"])
+        assert "--auto" not in merge_call
+
+    def test_gh_failure_stays_a_loud_failure_regardless_of_auto_path(self, monkeypatch):
+        """Whichever path is picked, a gh failure is never swallowed into success."""
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(1, stderr="Merge conflict"))
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: False)
+
+        ok, err = pr_merge._do_merge(5, "squash")
+
+        assert ok is False
+        assert "Merge conflict" in err
+
+
+# ---------------------------------------------------------------------------
+# PASS criterion — the three end-to-end cases via merge_pr()
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodeFollowsRealOutcome:
+    def test_case_a_merge_succeeds_is_exit_0(self, vnx_env, monkeypatch):
+        """(a) merge slaagt -> exit 0."""
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
+            "number": n, "title": "feat: x", "headRefName": "feature/x", "state": "OPEN",
+        })
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(0))
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: True)
+        monkeypatch.setattr(pr_merge, "_pr_actually_merged", lambda n: (True, ""))
+
+        result = pr_merge.merge_pr(pr_number=5, receipts_file=str(vnx_env["receipts_path"]))
+
+        assert result["success"] is True
+        assert result["error"] == ""
+
+    def test_case_b_merge_did_not_happen_is_nonzero_with_reason_on_stderr(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        """(b) merge vindt niet plaats -> niet-nul plus reden op stderr.
+
+        gh exits 0 (auto-merge got enabled) but the PR is still OPEN: this
+        must NOT read as success.
+        """
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
+            "number": n, "title": "feat: x", "headRefName": "feature/x", "state": "OPEN",
+        })
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(0))
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: True)
+
+        result = pr_merge.merge_pr(pr_number=5, receipts_file=str(vnx_env["receipts_path"]))
+
+        assert result["success"] is False
+        assert result["error"], "a failed merge must carry a non-empty reason"
+        assert "state=OPEN" in result["error"]
+
+        captured = capsys.readouterr()
+        assert result["error"] in captured.err
+
+    def test_case_c_auto_merge_unavailable_falls_back_instead_of_breaking(
+        self, vnx_env, monkeypatch,
+    ):
+        """(c) auto-merge niet beschikbaar -> valt terug op het gewone pad."""
+        calls = []
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: calls.append(list(args)) or _run(0))
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
+            "number": n, "title": "feat: x", "headRefName": "feature/x", "state": "MERGED",
+        })
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: False)
+
+        result = pr_merge.merge_pr(pr_number=5, receipts_file=str(vnx_env["receipts_path"]))
+
+        assert result["success"] is True, "unavailable auto-merge must fall back, not break"
+        merge_call = next(c for c in calls if c[:2] == ["pr", "merge"])
+        assert "--auto" not in merge_call
+
+    def test_main_returns_nonzero_when_merge_did_not_happen(self, monkeypatch, capsys):
+        """End to end through main(): a failed outcome exits EXIT_ERROR, not EXIT_OK."""
+        go = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (dict(go), {"headRefOid": "a" * 40}))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (dict(go), None))
+        monkeypatch.setattr(
+            pr_merge, "merge_pr",
+            lambda **k: {
+                "success": False, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
+                "pr_title": "", "branch": "", "receipt_status": None, "register_ok": False,
+                "error": "gh pr merge meldde succes voor #5, maar de PR staat nog op state=OPEN",
+                "dry_run": False, "overlaps": [],
+            },
+        )
+
+        rc = pr_merge.main(["--pr", "5"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert "state=OPEN" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- `_do_merge` no longer trusts `gh pr merge`'s exit code as proof of a merge. `gh pr merge --auto` exits 0 both when it merges immediately and when it only *enables* auto-merge (the merge itself stays pending on required checks/reviews) — both looked like success. After a zero exit, `_do_merge` now re-queries the PR (`_pr_actually_merged`) and only reports success when `state == "MERGED"`.
- `--auto` is no longer passed unconditionally. `_repo_auto_merge_allowed()` queries `gh api repos/{owner}/{repo} --jq .allow_auto_merge`; `--auto` is only added when that's `true`. When it's `false` or undeterminable, the plain `gh pr merge` path is used instead of GitHub rejecting the request outright (OI-1386).
- Untouched: CI-gate and review-gate verdict logic (`_run_ci_gate`, `_run_review_gate`, `merge_preflight_ci_check.py`, `closure_verifier.py`) — only the merge-execution/outcome path changed.
- Cheap side-effect win in the outcome path: `merge_pr()` now accepts an optional pre-fetched `pr_data` so `main()` reuses what `_run_ci_gate` already queried instead of a third `gh pr view` call per invocation (was 3x, now 2x — the review gate's own internal query is untouched since it's gate logic).

## Test plan
Three PASS-criterion cases, run literally:

```
$ python3 -m pytest tests/test_pr_merge_outcome_exitcode.py tests/test_pr_merge_match_head.py tests/test_pr_merge_ci_gate.py tests/test_pr_merge_review_gate.py tests/test_pr_merge_receipt.py tests/test_pr_merge_dual_scheme.py -q
........................................................................ [ 94%]
....                                                                     [100%]
76 passed in 6.86s
```

- `test_case_a_merge_succeeds_is_exit_0` — merge slaagt → `result["success"] is True`, `error == ""`.
- `test_case_b_merge_did_not_happen_is_nonzero_with_reason_on_stderr` — `gh` exits 0 but PR state stays `OPEN` (pending auto-merge) → `result["success"] is False`, non-empty reason containing `state=OPEN`, and that reason lands on stderr. Also covered end-to-end through `main()` in `test_main_returns_nonzero_when_merge_did_not_happen` → `rc == EXIT_ERROR`.
- `test_case_c_auto_merge_unavailable_falls_back_instead_of_breaking` — repo has auto-merge off → `--auto` omitted, plain path used, merge still succeeds instead of `gh` rejecting the request.

Also ran the full `pr_merge`-scoped sweep:
```
$ python3 -m pytest tests/ -k "pr_merge" -q
101 passed, 21477 deselected, 17 warnings in 25.00s
```

- [x] Targeted tests green
- [x] Committed + pushed
- [x] No changes to `merge_preflight_ci_check.py` / `closure_verifier.py` (gate logic untouched)