### PR TITLE
chore(ci): drop 30 stale test exclusions, let PR sweep confirm (OI-1420)

### DIFF
--- a/scripts/ci/test_exclusions.txt
+++ b/scripts/ci/test_exclusions.txt
@@ -116,8 +116,6 @@ tests/test_busy_terminal_certification.py  # OI-1227: red solo — rc_check_term
 tests/test_claude_github_review_linkage.py  # OI-1227: red solo — MagicMock not JSON serializable in request handler (3 failed, 33 passed)
 tests/test_cleanup_stale_vnx_sessions.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
 tests/test_cli_flag_forwarding.py  # OI-1227: red solo — RGM lambda got unexpected kwarg 'strict' (1 failed, 17 passed)
-tests/test_cli_init.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
-tests/test_close_track_if_done.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_codex_pr311_findings.py  # OI-1227: red solo — IntelligenceSelector._record_pattern_usage missing (3 failed, 12 passed)
 tests/test_codex_r2_fixes.py  # OI-1227: red solo — ((count++)) post-increment still present in dispatcher loop (1 failed, 11 passed)
 tests/test_constraint_enforcer.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
@@ -137,7 +135,6 @@ tests/test_future_state_reconciliation.py  # OI-1227: red solo — health-beacon
 tests/test_gate_dispatch_id.py  # OI-1227: red solo — dispatch-id propagation to claude-github assert False (1 failed, 11 passed)
 tests/test_gate_evidence_accuracy.py  # OI-1227: red solo — verdict='fail' with non-terminal status must still enforce report_path (4 failed, 16 passed)
 tests/test_gate_execution_certification.py  # OI-1227: red solo — MagicMock vs int comparison in evidence-chain lifecycle (10 failed, 3 passed)
-tests/test_gate_runner.py  # OI-1227: red solo — default stall threshold 180 != expected 60 (1 failed, 29 passed)
 tests/test_gate_status_schema.py  # OI-1227: red solo — status=completed not accepted as pass (1 failed, 25 passed)
 tests/test_gemini_prompt_no_duplicate.py  # OI-1227: red solo — FILE: markers appear >once in inlined prompt (3 failed, 1 passed)
 tests/test_governance_blockers_fix.py  # OI-1227: red solo — recorded_ts not assigned from now_ts (2 failed, 28 passed)
@@ -151,27 +148,18 @@ tests/test_headless_inspect.py  # OI-1227: red solo — HealthSummary.status_lab
 # now rejoins the Profile A sweep so new drift fails the PR, not a red suite
 # nobody reads. No heavy-dep stack (sqlite3 + in-repo modules only).
 tests/test_horizon_schema_migration_fix.py  # OI-1227: red solo — pre-27 store migration to horizon fails (8 failed, 27 passed)
-tests/test_horizon_skill_alias.py  # OI-951: doc/content drift the test already asserts against, red on main too
-tests/test_init_migrate_bootstrap.py  # OI-1133 group-check: 18/32 failed in PR#1458 Profile A sweep (vnx init/migrate exit non-zero on the CI image; OI-946 class). Not OI-1213 (2026-08-15): autouse fixture already isolates _PREFLIGHT_HOOKS; 56 green clean-env solo+neighbour
 tests/test_installer_no_template_leak.py  # OI-1227: red solo — developer machine paths found in shipped sources (2 failed, 6 passed)
 tests/test_intelligence_ab_framework.py  # OI-1227: red solo — AB-framework conn lambda unexpected kwarg 'timeout' (2 failed, 9 passed)
-tests/test_intelligence_pipeline_e2e.py  # OI-947: learning_loop.ensure_env AttributeError, red on main too
-tests/test_learning_feature.py  # OI-947: learning_loop.ensure_env AttributeError, red on main too
-tests/test_learning_loop_exception_handling.py  # OI-947: learning_loop.ensure_env AttributeError, red on main too
-tests/test_learning_loop_tz.py  # OI-947: learning_loop.ensure_env AttributeError, red on main too
 tests/test_litellm_agentic_runner.py  # OI-1227: red solo — full-loop subprocess rc != 0 (1 failed, 17 passed)
 tests/test_llm_decision_router.py  # OI-1227: red solo — decision comparison failed (1 failed, 18 passed)
 tests/test_migrate_future_system.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
-tests/test_migrate_pool_seed.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_observability_linkage.py  # OI-1227: red solo — events-dir guard NotADirectoryError (4 failed, 13 passed)
 tests/test_open_items_gate_certification.py  # OI-1227: red solo — serve_dashboard._read_gate_config missing (2 failed, 8 passed)
 tests/test_pattern_id_stability.py  # OI-1227: red solo — IntelligenceSelector._record_pattern_usage missing (1 failed, 8 passed)
 tests/test_pattern_matching.py  # OI-1227: red solo — ModuleNotFoundError: cli_output (1 collection error)
 tests/test_per_pr_closure.py  # OI-1227: red solo — 'contradiction_gemini_review' missing from evidence set (9 failed, 13 passed)
 tests/test_plan_gate_panel.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
-tests/test_planning_api.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_planning_cli.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
-tests/test_planning_cli_objective.py  # OI-1227: red solo — objective list missing feat-b (2 failed, 13 passed)
 tests/test_pool_manager_real_spawn.py  # OI-1227: red solo — sqlite3 FOREIGN KEY constraint failed (1 failed, 9 passed)
 tests/test_pool_provider_mix_integration.py  # OI-1227: red solo — terminal_leases has no column 'state' (1 failed, 15 passed)
 tests/test_pool_state_repo.py  # OI-1227: red solo — sqlite3 FOREIGN KEY constraint failed (6 failed, 3 passed)
@@ -181,15 +169,11 @@ tests/test_project_status_hook.py  # OI-1227: red solo — project-status hook s
 tests/test_provider_dispatch_contract_integration.py  # OI-1227: red solo — litellm tool-shape lane None != 'openai_tools' (2 failed, 17 passed)
 tests/test_provider_dispatch_deepseek_harness.py  # OI-1227: red solo — missing-key handler writes no receipt line (1 failed, 9 passed)
 tests/test_provider_dispatch_entry.py  # OI-1227: red solo — litellm route subprocess rc != 0 (1 failed, 17 passed)
-tests/test_quality_advisory_pipeline.py  # OI-1133 group-check: 2/43 failed in PR#1458 Profile A sweep (NoneType .status; OI-948 class). Not OI-1213 (2026-08-15): no migration fixture; 67 green clean-env solo+neighbour
 tests/test_queue_reconciliation_certification.py  # OI-1227: red solo — 'hash_gemini_review' missing from evidence keys (4 failed, 34 passed)
-tests/test_quickstart_validation.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_receipt_classifier.py  # OI-1227: red solo — classifier_providers.ollama_provider.subprocess missing (1 failed, 15 passed)
 tests/test_receipt_instruction_hash.py  # OI-1227: red solo — manifest sha256 read failed (2 failed, 7 passed)
 tests/test_receipt_t0_view_filter.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_receipt_v2_pr4_wiring.py  # OI-948: receipt v2 PR4/PR5: NoneType has no attribute status, red on main too
-tests/test_receipt_v2_pr5_schema_cutover.py  # OI-948: receipt v2 PR4/PR5: NoneType has no attribute status, red on main too
-tests/test_repo_map.py  # CI image: red in the minimal image on two measured stacks — without tree-sitter repo_map.py raises NameError (_TSParser, latent scripts/lib bug, repair needs own dispatch; scripts/lib is out of scope here), and the networkx PageRank tests need the undeclared networkx+numpy+scipy stack. Installing networkx alone makes it WORSE (27 failed vs 13): repo_map leaves its positional fallback and nx.pagerank crashes on missing numpy, which also breaks the green test_repo_map_provider_coverage.py.
 tests/test_review_adapters.py  # OI-1227: red solo — ValueError not raised for unknown adapter (7 failed, 28 passed)
 tests/test_roadmap_consistency.py  # OI-1227: red solo — PR_QUEUE.md stale vs build_pr_queue.py (1 failed, 3 passed)
 tests/test_routing_policy.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
@@ -200,7 +184,6 @@ tests/test_schema_init_view_ordering.py  # OI-1227: red solo — legacy v21 boot
 tests/test_semantics_cleanup.py  # OI-1227: red solo — ValueError: substring not found in 8 setup errors (5 passed)
 tests/test_serve_dashboard_api.py  # OI-1227: red solo — serve_dashboard._read_gate_config missing (4 failed, 63 passed)
 tests/test_session_ids_staleness.py  # OI-1227: red solo — read_events_with_timeout does not refresh session_id (1 failed, 5 passed)
-tests/test_sessionstart_hook.py  # OI-951: doc/content drift the test already asserts against, red on main too
 tests/test_strategy_roadmap.py  # OI-1227: red solo — roadmap file not found (RoadmapValidationError) (1 failed, 33 passed)
 tests/test_strategy_roadmap_real_file.py  # OI-1227: red solo — committed roadmap not found (RoadmapValidationError) (1 failed)
 tests/test_subprocess_adapter_pr3.py  # OI-1227: red solo — session-id extraction 'ses_other' != 'ses_abc123' (1 failed, 25 passed)
@@ -208,28 +191,15 @@ tests/test_subprocess_cheap_lane.py  # OI-1227: red solo — cheap-lane routes t
 tests/test_subprocess_dispatch_identity.py  # OI-1227: red solo — delivered env leaks ANTHROPIC_AUTH_TOKEN (1 failed, 5 passed)
 tests/test_subprocess_health.py  # OI-1227: red solo — deliver-with-recovery file not found (3 failed, 13 passed)
 tests/test_subprocess_w3e_robustness.py  # OI-1227: red solo — cannot import _classify_completion from delivery (3 failed, 14 passed)
-tests/test_t0_decision_log.py  # OI-1133 group-check: 2/60 failed in PR#1458 Profile A sweep (same-length source-replacement cursor detection). Not OI-1213 (2026-08-15): no migration fixture; green clean-env solo+neighbour
-tests/test_t0_escalations_log.py  # OI-1133 group-check: 1/60 failed in PR#1458 Profile A sweep (same-length source-replacement cursor detection). Not OI-1213 (2026-08-15): no migration fixture; green clean-env solo+neighbour
 tests/test_t0_skill_consistency.py  # OI-1227: red solo — no bash blocks found in CLAUDE.md (2 failed, 6 passed)
-tests/test_t0_skill_slim.py  # OI-951: doc/content drift the test already asserts against, red on main too
-tests/test_tenant_stamp_fail_closed.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_terminal_state_reconciler.py  # OI-1227: red solo — reconciler 'idle' != 'blocked' (2 failed, 10 passed)
 tests/test_tmux_adapter.py  # OI-1227: red solo — ModuleNotFoundError: tmux_adapter_cli (3 failed, 42 passed)
 tests/test_tmux_adapter_interface.py  # OI-1227: red solo — TmuxAdapter.shutdown() unexpected kwarg 'graceful' (2 failed, 27 passed)
-tests/test_tmux_interactive_dispatch.py  # fails / exceeds per-test timeout (OI-906)
 tests/test_tmux_worktree.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
 tests/test_track_cli.py  # OI-1227: red solo — track db file not found (15 failed, 3 passed)
 tests/test_track_v23_cli.py  # OI-1227: red solo — track v23 subprocess ret != 0 (4 failed, 6 passed)
-tests/test_vnx_cli.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_vnx_start_runtime.py  # OI-1227: red solo — VNX var set mismatch (1 failed, 46 passed)
-tests/test_w5b_small_fixes.py  # OI-947: learning_loop.ensure_env AttributeError, red on main too
 tests/test_w_init_project_id_threading.py  # OI-1227: red solo — migration linter flags new DEFAULT 'vnx-dev' (1 failed, 26 passed)
-tests/test_wave4_central_install_e2e.py  # OI-950: wave4 central-install assumes GH Actions runner HOME layout, red on main too
-tests/test_wave4_cmd_update.py  # OI-950: wave4 central-install assumes GH Actions runner HOME layout, red on main too
-tests/test_wave4_path_resolver.py  # OI-950: wave4 central-install assumes GH Actions runner HOME layout, red on main too
-tests/test_wave4_regen_settings_target.py  # OI-950: wave4 central-install assumes GH Actions runner HOME layout, red on main too
-tests/test_wave4_save_restore.py  # OI-950: wave4 central-install assumes GH Actions runner HOME layout, red on main too
-tests/test_wave4_write_guard.py  # OI-950: wave4 central-install assumes GH Actions runner HOME layout, red on main too
 tests/test_wave7_deepseek_smoke.py  # OI-1227: smoke routes litellm:deepseek on dispatch_allowed:false (OI-867 deepseek proxy/harness split)
 tests/test_week_1_skills.py  # OI-1227: red solo — vendored vnx-system dispatcher file not found (1 failed, 3 passed)
 tests/test_wheel_install.py  # OI-1227: red solo — wheel-install smoke exit 1 (1 failed)

--- a/scripts/ci/test_exclusions.txt
+++ b/scripts/ci/test_exclusions.txt
@@ -116,6 +116,7 @@ tests/test_busy_terminal_certification.py  # OI-1227: red solo — rc_check_term
 tests/test_claude_github_review_linkage.py  # OI-1227: red solo — MagicMock not JSON serializable in request handler (3 failed, 33 passed)
 tests/test_cleanup_stale_vnx_sessions.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
 tests/test_cli_flag_forwarding.py  # OI-1227: red solo — RGM lambda got unexpected kwarg 'strict' (1 failed, 17 passed)
+tests/test_cli_init.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (29 failed) op ADR-007 fail-closed: project_id conflict for init backfill (marker=<testnaam>, env:VNX_PROJECT_ID='vnx-dev')
 tests/test_codex_pr311_findings.py  # OI-1227: red solo — IntelligenceSelector._record_pattern_usage missing (3 failed, 12 passed)
 tests/test_codex_r2_fixes.py  # OI-1227: red solo — ((count++)) post-increment still present in dispatcher loop (1 failed, 11 passed)
 tests/test_constraint_enforcer.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
@@ -148,17 +149,21 @@ tests/test_headless_inspect.py  # OI-1227: red solo — HealthSummary.status_lab
 # now rejoins the Profile A sweep so new drift fails the PR, not a red suite
 # nobody reads. No heavy-dep stack (sqlite3 + in-repo modules only).
 tests/test_horizon_schema_migration_fix.py  # OI-1227: red solo — pre-27 store migration to horizon fails (8 failed, 27 passed)
+tests/test_init_migrate_bootstrap.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (18 failed) op hetzelfde ADR-007 project_id-conflict — zowel de "DB bootstrap failed" init-backfill vorm als "refusing to migrate a split-tenant store" (cli-derived project vs env:VNX_PROJECT_ID='vnx-dev')
 tests/test_installer_no_template_leak.py  # OI-1227: red solo — developer machine paths found in shipped sources (2 failed, 6 passed)
 tests/test_intelligence_ab_framework.py  # OI-1227: red solo — AB-framework conn lambda unexpected kwarg 'timeout' (2 failed, 9 passed)
+tests/test_learning_feature.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (5 failed) — ANDERE oorzaak dan ADR-007: de autouse _vnx_data_dir_isolation-fixture (tests/conftest.py) pint VNX_DATA_DIR op een per-test map die learning_loop's eigen ensure_env()-call in de archive/log-helpers gebruikt i.p.v. de test's patch("learning_loop.ensure_env", ...); het schrijfpad ontbreekt en de FileNotFoundError wordt stil geslikt door `except OSError: pass`
 tests/test_litellm_agentic_runner.py  # OI-1227: red solo — full-loop subprocess rc != 0 (1 failed, 17 passed)
 tests/test_llm_decision_router.py  # OI-1227: red solo — decision comparison failed (1 failed, 18 passed)
 tests/test_migrate_future_system.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
+tests/test_migrate_pool_seed.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (8 failed) op dezelfde ADR-007 "refusing to migrate a split-tenant store" refusal (cli-derived project vs env:VNX_PROJECT_ID='vnx-dev'); de DB wordt daardoor nooit aangemaakt, latere seed/resolver-asserts falen mee
 tests/test_observability_linkage.py  # OI-1227: red solo — events-dir guard NotADirectoryError (4 failed, 13 passed)
 tests/test_open_items_gate_certification.py  # OI-1227: red solo — serve_dashboard._read_gate_config missing (2 failed, 8 passed)
 tests/test_pattern_id_stability.py  # OI-1227: red solo — IntelligenceSelector._record_pattern_usage missing (1 failed, 8 passed)
 tests/test_pattern_matching.py  # OI-1227: red solo — ModuleNotFoundError: cli_output (1 collection error)
 tests/test_per_pr_closure.py  # OI-1227: red solo — 'contradiction_gemini_review' missing from evidence set (9 failed, 13 passed)
 tests/test_plan_gate_panel.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
+tests/test_planning_api.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (9 failed) — ANDERE vorm dan ADR-007's fail-closed refusal: dashboard/api_planning.py::_resolve_project_id() leest env VNX_PROJECT_ID='vnx-dev' eerst en query't tracks met dat project_id, terwijl de test zijn eigen rijen seedt onder project_id='test-proj' — 0 resultaten i.p.v. de geseedde rijen
 tests/test_planning_cli.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_pool_manager_real_spawn.py  # OI-1227: red solo — sqlite3 FOREIGN KEY constraint failed (1 failed, 9 passed)
 tests/test_pool_provider_mix_integration.py  # OI-1227: red solo — terminal_leases has no column 'state' (1 failed, 15 passed)
@@ -170,10 +175,12 @@ tests/test_provider_dispatch_contract_integration.py  # OI-1227: red solo — li
 tests/test_provider_dispatch_deepseek_harness.py  # OI-1227: red solo — missing-key handler writes no receipt line (1 failed, 9 passed)
 tests/test_provider_dispatch_entry.py  # OI-1227: red solo — litellm route subprocess rc != 0 (1 failed, 17 passed)
 tests/test_queue_reconciliation_certification.py  # OI-1227: red solo — 'hash_gemini_review' missing from evidence keys (4 failed, 34 passed)
+tests/test_quickstart_validation.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (2 failed) op hetzelfde ADR-007 init-backfill project_id-conflict (env:VNX_PROJECT_ID='vnx-dev'); mode.json en .vnx-data/state worden nooit aangemaakt omdat `vnx init` fail-closed weigert
 tests/test_receipt_classifier.py  # OI-1227: red solo — classifier_providers.ollama_provider.subprocess missing (1 failed, 15 passed)
 tests/test_receipt_instruction_hash.py  # OI-1227: red solo — manifest sha256 read failed (2 failed, 7 passed)
 tests/test_receipt_t0_view_filter.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_receipt_v2_pr4_wiring.py  # OI-948: receipt v2 PR4/PR5: NoneType has no attribute status, red on main too
+tests/test_repo_map.py  # OI-1420 gemeten 21-08: valt onder volle sweep (13 failed), ANDERE oorzaak dan ADR-007 — CI image mist tree-sitter (_TSParser NameError) en networkx (ModuleNotFoundError), bewust niet geïnstalleerd (zie het "networkx is deliberately NOT installed" commentaar in vnx-ci.yml's "Install Python deps" stap); een "CI image"-reden zoals elders in dit bestand
 tests/test_review_adapters.py  # OI-1227: red solo — ValueError not raised for unknown adapter (7 failed, 28 passed)
 tests/test_roadmap_consistency.py  # OI-1227: red solo — PR_QUEUE.md stale vs build_pr_queue.py (1 failed, 3 passed)
 tests/test_routing_policy.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
@@ -191,15 +198,23 @@ tests/test_subprocess_cheap_lane.py  # OI-1227: red solo — cheap-lane routes t
 tests/test_subprocess_dispatch_identity.py  # OI-1227: red solo — delivered env leaks ANTHROPIC_AUTH_TOKEN (1 failed, 5 passed)
 tests/test_subprocess_health.py  # OI-1227: red solo — deliver-with-recovery file not found (3 failed, 13 passed)
 tests/test_subprocess_w3e_robustness.py  # OI-1227: red solo — cannot import _classify_completion from delivery (3 failed, 14 passed)
+tests/test_t0_decision_log.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (2 failed) — ANDERE oorzaak dan ADR-007: TestProcessEventsFileCursorStaleness verwacht dat unlink()+herschrijven-met-gelijke-regeltelling een nieuwe inode oplevert zodat de cursor reset; onder sweep-belasting wordt dat niet gedetecteerd (written==0 i.p.v. verwacht), order/load-dependent (OI-658-klasse)
+tests/test_t0_escalations_log.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (1 failed) — zelfde cursor-staleness/inode-hergebruik klasse als test_t0_decision_log.py, order/load-dependent (OI-658-klasse)
 tests/test_t0_skill_consistency.py  # OI-1227: red solo — no bash blocks found in CLAUDE.md (2 failed, 6 passed)
+tests/test_tenant_stamp_fail_closed.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (1 failed) op de letterlijke bron-quote: "ADR-007 fail-closed: project_id conflict for init backfill — db-path='mission-control', env:VNX_PROJECT_ID='vnx-dev'. All sources must agree."
 tests/test_terminal_state_reconciler.py  # OI-1227: red solo — reconciler 'idle' != 'blocked' (2 failed, 10 passed)
 tests/test_tmux_adapter.py  # OI-1227: red solo — ModuleNotFoundError: tmux_adapter_cli (3 failed, 42 passed)
 tests/test_tmux_adapter_interface.py  # OI-1227: red solo — TmuxAdapter.shutdown() unexpected kwarg 'graceful' (2 failed, 27 passed)
 tests/test_tmux_worktree.py  # OI-952: order/load-dependent flake, passes solo on both main and branch (OI-658 class)
 tests/test_track_cli.py  # OI-1227: red solo — track db file not found (15 failed, 3 passed)
 tests/test_track_v23_cli.py  # OI-1227: red solo — track v23 subprocess ret != 0 (4 failed, 6 passed)
+tests/test_vnx_cli.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (2 failed) op hetzelfde ADR-007 init-backfill project_id-conflict (env:VNX_PROJECT_ID='vnx-dev'); .vnx-data/state wordt nooit aangemaakt omdat `vnx init` fail-closed weigert
 tests/test_vnx_start_runtime.py  # OI-1227: red solo — VNX var set mismatch (1 failed, 46 passed)
 tests/test_w_init_project_id_threading.py  # OI-1227: red solo — migration linter flags new DEFAULT 'vnx-dev' (1 failed, 26 passed)
+tests/test_wave4_central_install_e2e.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (3 failed) — ANDERE oorzaak dan ADR-007: in de CI-omgeving staat VNX_DATA_DIR al gepind op /home/runner/.vnx-data/vnx-dev (central-install pad) i.p.v. het project-lokale pad dat de test verwacht
+tests/test_wave4_path_resolver.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (1 failed) — zelfde VNX_DATA_DIR-pin naar /home/runner/.vnx-data/vnx-dev als test_wave4_central_install_e2e.py; test_resolve_paths_end_to_end_central roept resolve_paths() in-process aan zonder de ambient env te wissen
+tests/test_wave4_save_restore.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (1 failed) — zelfde VNX_DATA_DIR-pin naar /home/runner/.vnx-data/vnx-dev
+tests/test_wave4_write_guard.py  # OI-1420 gemeten 21-08: slaagt solo, valt onder volle sweep (1 failed) — zelfde VNX_DATA_DIR-pin naar /home/runner/.vnx-data/vnx-dev
 tests/test_wave7_deepseek_smoke.py  # OI-1227: smoke routes litellm:deepseek on dispatch_allowed:false (OI-867 deepseek proxy/harness split)
 tests/test_week_1_skills.py  # OI-1227: red solo — vendored vnx-system dispatcher file not found (1 failed, 3 passed)
 tests/test_wheel_install.py  # OI-1227: red solo — wheel-install smoke exit 1 (1 failed)


### PR DESCRIPTION
## Summary

`scripts/ci/test_exclusions.txt` counted 136 active exclusions (3126 test
functions). On 2026-08-21, every excluded file was re-run SOLO on main, in
its own pytest process with a sandbox state dir: 33 passed solo, 99 red, 4
timed out. Four of the 33 solo-green files were kept excluded because their
own recorded reason already says "PASSES SOLO" — a solo run confirms that
reason instead of refuting it.

That leaves 29 stale exclusions (824 test functions), plus a 30th,
`tests/test_gate_runner.py`, which has been fully green on main since #1651
and #1655 (33 passed).

This PR removes exactly those 30 lines. No other line is touched — the other
106 exclusions were measured the same day and are still accurate.

## The real experiment is this PR's own CI run

Solo measurement can't see what happens under the full sweep, where test
order and shared machine state matter — that's precisely why the 4 "PASSES
SOLO" files stayed excluded. This PR's CI sweep runs the full suite **with**
these 30 back in. Green means they're genuinely safe. Red points at exactly
which ones fall over under load, measured instead of guessed.

`tests/test_tmux_interactive_dispatch.py` is the one to watch first if CI
goes red: it alone carries 232 of the 824 test functions and touches tmux,
i.e. shared machine state.

## test_gate_runner.py — not drift, wrong from commit one

Its assertion (default stall threshold 60) wasn't a regression from doc
drift. It was written against `docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md`
§4.2 instead of `GATE_STALL_DEFAULTS` in `scripts/lib/headless_adapter.py`,
and was wrong from its first commit. That contract table still disagrees
with the code today (OI-1421) — until that's fixed, the next person who
drafts a test from the contract doc lands back on this exclusion list.

## Cluster breakdown

The large OI-1227 batch (96 lines) had exactly one solo-green today, so
that measurement still holds — this isn't a stale batch. The stale tail is
entirely in the older, smaller clusters: OI-946, OI-947, OI-948, OI-950,
OI-951, OI-1133, plus one OI-906 entry.

## Changes

- `scripts/ci/test_exclusions.txt`: removed the 30 lines listed in the
  dispatch instruction. Nothing else touched.

## Verification

`git diff --stat`:
```
 scripts/ci/test_exclusions.txt | 30 ------------------------------
 1 file changed, 30 deletions(-)
```

Active exclusion count: `grep -cvE '^\s*#|^\s*$' scripts/ci/test_exclusions.txt` → **106** (was 136).

Exclusion-format gate: `check_test_exclusions.py` → `PASS — every exclusion carries a reason, paths resolve, no duplicates.`

Full suite was **not** run locally per dispatch instruction — this PR's CI sweep is the measurement.

## Open Items

None — pending CI outcome on this PR. If CI comes back red, only the
files that demonstrably fail under load should be re-added, each with its
measured reason (not the old, now-refuted one).

Dispatch-ID: 20260821-t0-oi1420-uitsluitingen-opruimen