### PR TITLE
fix(orphan-sweep): resolve register/receipts/active store via fabric resolver

### DIFF
--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -474,9 +474,9 @@ def sweep(
     # itself resolved correctly. When `central_resolve_error` is set above,
     # an empty result here is read from a fallback store instead and must be
     # cross-checked against that error, never trusted on its own as "zero
-    # dispatches known" (this is exactly how a repo-local, never-populated
-    # `.vnx-data/state/` used to read as a silent, valid zero — OI-1353
-    # follow-up).
+    # dispatches known" (this is exactly how the repo-local, never-populated
+    # state directory next to the checkout used to read as a silent, valid
+    # zero — OI-1353 follow-up).
     try:
         import dispatch_register
         register_events = dispatch_register.read_events(state_dir=state_dir)

--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -380,11 +380,25 @@ def sweep(
         repo_root:          Main repo root whose ``.vnx-data/worktrees/`` holds
                             the dispatch worktrees (defaults to the resolved
                             project root).
-        data_dir:           ``.vnx-data`` directory for the active-manifest kind
-                            (defaults to ``$VNX_DATA_DIR``). Worktrees live under
-                            ``repo_root``; manifests live under ``data_dir``.
-        state_dir:          Runtime state dir override for crash-recovery
-                            (defaults to ``data_dir / "state"``).
+        data_dir:           ``.vnx-data`` directory for the register/receipts
+                            (kind 1b) and active-manifest (kind 3) reads.
+                            When omitted (together with ``state_dir``), this
+                            is resolved via the fabric's canonical resolver
+                            (``vnx_paths.resolve_paths()["VNX_DATA_DIR"]``) —
+                            almost always the CENTRAL store
+                            (``~/.vnx-data/<project_id>``), never a
+                            repo-local ``.vnx-data/``. Worktrees (kind 2)
+                            live under ``repo_root`` regardless of this value
+                            — ``worktrees_dir`` below is always derived from
+                            ``repo_root``, never from ``data_dir``.
+        state_dir:          Runtime state dir for the register/receipts reads
+                            and crash-recovery. An explicit value always wins.
+                            When omitted together with ``data_dir``, resolved
+                            via the same fabric resolver
+                            (``vnx_paths.resolve_paths()["VNX_STATE_DIR"]``).
+                            When only ``data_dir`` is given explicitly,
+                            defaults to ``data_dir / "state"`` (unchanged
+                            operator/test override path).
         project_id:         Project id for the lease PID lookup.
         current_dispatch_id: Dispatch id to fence off — never touched by any
                             kind, even if its liveness signal reads dead.
@@ -410,8 +424,22 @@ def sweep(
     import crash_recovery_sweep
 
     root = _resolve_repo_root(repo_root)
-    data_dir = data_dir if data_dir is not None else _default_data_dir(root)
-    state_dir = state_dir if state_dir is not None else (data_dir / "state")
+    data_dir_explicit = data_dir is not None
+    central_resolve_error: "str | None" = None
+    if not data_dir_explicit:
+        # Neither data_dir nor (necessarily) state_dir was given — the CLI's
+        # real no-flags invocation. Resolve BOTH via the fabric's canonical
+        # resolver so the register/receipts/active-manifest reads land on the
+        # CENTRAL store, never a repo-local `.vnx-data/` that may not exist
+        # or may simply never have heard of this project's dispatches.
+        data_dir, central_state_dir, central_resolve_error = _resolve_central_paths(root)
+        if state_dir is None:
+            state_dir = central_state_dir
+    elif state_dir is None:
+        # data_dir given explicitly, state_dir not — derive under it
+        # (unchanged operator/test override path; explicit data_dir always
+        # wins over central resolution).
+        state_dir = data_dir / "state"
     pid_fn = pid_alive if pid_alive is not None else crash_recovery_sweep.is_pid_alive
     list_fn = list_sessions if list_sessions is not None else _real_list_sessions
     probe_fn = probe_liveness if probe_liveness is not None else (
@@ -424,6 +452,15 @@ def sweep(
         current_dispatch_id = os.environ.get("VNX_CURRENT_DISPATCH_ID", "").strip() or None
 
     result = OrphanSweepResult(dry_run=dry_run)
+    if central_resolve_error:
+        # The central-store resolver failed and a fallback path was used
+        # instead (see _resolve_central_paths). That fallback's register may
+        # be a repo-local store that has never heard of this project's
+        # dispatches — a resolver failure is a MEASUREMENT FAILURE and must
+        # never be conflated with "this project's register genuinely names
+        # zero dispatches" below.
+        result.errors.append({"kind": "data_dir_resolution", "error": central_resolve_error})
+        logger.warning("orphan_sweep: %s", central_resolve_error)
     protected: set[str] = {current_dispatch_id} if current_dispatch_id else set()
     worktrees_dir = root / ".vnx-data" / "worktrees"
 
@@ -433,7 +470,13 @@ def sweep(
     # read_events is already documented to degrade to an empty list rather
     # than raise, so this branch is a belt-and-braces guard, not the expected
     # path). An empty (non-None) result is a real measurement — "this
-    # project's register currently names zero dispatches" — not a failure.
+    # project's register currently names zero dispatches" — PROVIDED state_dir
+    # itself resolved correctly. When `central_resolve_error` is set above,
+    # an empty result here is read from a fallback store instead and must be
+    # cross-checked against that error, never trusted on its own as "zero
+    # dispatches known" (this is exactly how a repo-local, never-populated
+    # `.vnx-data/state/` used to read as a silent, valid zero — OI-1353
+    # follow-up).
     try:
         import dispatch_register
         register_events = dispatch_register.read_events(state_dir=state_dir)
@@ -670,9 +713,48 @@ def sweep(
     return result
 
 
-def _default_data_dir(repo_root: Path) -> Path:
-    """Resolve the ``.vnx-data`` dir for the active-manifest kind (issue #225)."""
-    env = os.environ.get("VNX_DATA_DIR", "").strip()
-    if env:
-        return Path(env).expanduser()
-    return repo_root / ".vnx-data"
+def _resolve_central_paths(repo_root: Path) -> "tuple[Path, Path, str | None]":
+    """Resolve the register/receipts/active-manifest store via the fabric's
+    canonical path resolver (mirrors ``dispatch_register._register_path``'s
+    own resolution chain), NOT this repo's own ``.vnx-data/``.
+
+    The kind-1b conjunction reads ``dispatch_register.ndjson`` and
+    ``t0_receipts.ndjson``, and kind 3 (delegated to ``crash_recovery_sweep``)
+    reads ``dispatches/active/`` — all three live in the CENTRAL store
+    (``vnx_paths.resolve_paths()["VNX_DATA_DIR"]``, typically
+    ``~/.vnx-data/<project_id>``), never in a repo-local ``.vnx-data/``.
+    That repo-local directory holds only this repo's own dispatch
+    WORKTREES — see ``worktrees_dir`` in :func:`sweep`, which is deliberately
+    derived from ``repo_root`` directly and never passes through here.
+
+    Measured on main 4b7d7b2f (OI-1353 follow-up): invoking this module
+    without ``--state-dir`` read a repo-local, EMPTY register and silently
+    treated every completed-dispatch session as ``unknown_project`` — the
+    fabric's own resolver, run against the same repo with no flags, found
+    1651 register events at the correct central path.
+
+    Returns ``(data_dir, state_dir, error)``. ``error`` is ``None`` on a
+    successful resolve. A resolver failure (no ``vnx_paths`` importable, or
+    it raises) is a genuine MEASUREMENT FAILURE — the caller records it in
+    ``errors`` rather than silently trusting the repo-relative fallback below
+    as though it were a valid "zero dispatches known".
+    """
+    try:
+        from vnx_paths import resolve_paths
+        paths = resolve_paths()
+        return Path(paths["VNX_DATA_DIR"]), Path(paths["VNX_STATE_DIR"]), None
+    except Exception as exc:
+        env = os.environ.get("VNX_DATA_DIR", "").strip()
+        if env:
+            fallback = Path(env).expanduser()
+            chain = "$VNX_DATA_DIR"
+        else:
+            fallback = repo_root / ".vnx-data"
+            chain = "repo-relative .vnx-data"
+        return (
+            fallback,
+            fallback / "state",
+            f"central path resolver (vnx_paths.resolve_paths) unavailable "
+            f"({exc}); fell back to {chain} — register/receipts/"
+            "active-manifest reads below may be scoped to the wrong store",
+        )

--- a/scripts/orphan_sweep.py
+++ b/scripts/orphan_sweep.py
@@ -45,13 +45,6 @@ if str(_LIB) not in sys.path:
 from orphan_sweep import DEFAULT_MAX_ORPHANS, sweep  # noqa: E402
 
 
-def _default_data_dir() -> Path:
-    env = os.environ.get("VNX_DATA_DIR", "").strip()
-    if env:
-        return Path(env).expanduser()
-    return _HERE.parent / ".vnx-data"
-
-
 def main(argv: "list[str] | None" = None) -> int:
     parser = argparse.ArgumentParser(
         prog="orphan_sweep",
@@ -69,12 +62,16 @@ def main(argv: "list[str] | None" = None) -> int:
     parser.add_argument(
         "--data-dir",
         default=None,
-        help="Path to .vnx-data for active manifests (default: $VNX_DATA_DIR or repo .vnx-data).",
+        help="Path to .vnx-data for register/receipts/active-manifest reads "
+             "(default: resolved via the fabric's canonical central-store "
+             "resolver, typically ~/.vnx-data/<project_id>).",
     )
     parser.add_argument(
         "--state-dir",
         default=None,
-        help="Path to runtime state dir (default: <data-dir>/state).",
+        help="Path to runtime state dir (default: <data-dir>/state when "
+             "--data-dir is given; otherwise the fabric's canonical "
+             "central-store resolver, same as --data-dir).",
     )
     parser.add_argument(
         "--project-id",
@@ -119,7 +116,12 @@ def main(argv: "list[str] | None" = None) -> int:
         parser.error("--max-orphans must be >= 1")
 
     repo_root = Path(args.repo_root).expanduser() if args.repo_root else None
-    data_dir = Path(args.data_dir).expanduser() if args.data_dir else _default_data_dir()
+    # Neither flag defaults eagerly here: an explicit --data-dir/--state-dir
+    # always wins, but omitting BOTH must reach sweep() as None so it resolves
+    # the register/receipts/active-manifest store via the fabric's canonical
+    # central-store resolver (scripts/lib/orphan_sweep.py::_resolve_central_paths)
+    # instead of this CLI's own (formerly repo-relative) guess.
+    data_dir = Path(args.data_dir).expanduser() if args.data_dir else None
     state_dir = Path(args.state_dir).expanduser() if args.state_dir else None
 
     result = sweep(

--- a/tests/test_orphan_sweep.py
+++ b/tests/test_orphan_sweep.py
@@ -35,6 +35,7 @@ sys.path.insert(0, str(_SCRIPT_DIR / "lib"))
 
 import orphan_sweep as osweep  # noqa: E402  (the lib module)
 import tmux_worktree  # noqa: E402
+import vnx_paths  # noqa: E402
 
 # scripts/ and scripts/lib both define an orphan_sweep module; the lib one wins
 # for `import orphan_sweep` (scripts/lib is inserted last). Import the CLI
@@ -122,6 +123,20 @@ def _write_register_event(env: Path, event: str, dispatch_id: str) -> None:
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps({
             "timestamp": "2026-08-19T00:00:00.000000Z",
+            "event": event,
+            "dispatch_id": dispatch_id,
+        }) + "\n")
+
+
+def _write_register_event_in_state_dir(state_dir: Path, event: str, dispatch_id: str) -> None:
+    """Like _write_register_event, but writes directly under a given
+    state_dir instead of an ``env``-fixture data_dir — for tests that pin an
+    explicit state_dir independent of data_dir/central resolution."""
+    path = state_dir / "dispatch_register.ndjson"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "timestamp": "2026-08-21T00:00:00.000000Z",
             "event": event,
             "dispatch_id": dispatch_id,
         }) + "\n")
@@ -675,6 +690,198 @@ def test_to_dict_includes_completed_orphan_keys(env):
     d = res.to_dict()
     assert d["tmux_completed_orphans_killed"] == []
     assert d["tmux_completed_orphans_preserved"] == []
+
+
+# ---------------------------------------------------------------------------
+# Central-store resolution (OI-1353 follow-up) — sweep() reads the register/
+# receipts/active-manifest store via the fabric's canonical resolver when
+# neither data_dir nor state_dir is given, NOT via a repo-relative guess.
+# Worktrees stay repo-relative regardless of where that store resolves.
+# ---------------------------------------------------------------------------
+
+def test_resolve_central_paths_uses_fabric_resolver(monkeypatch, tmp_path):
+    """_resolve_central_paths must defer entirely to vnx_paths.resolve_paths()
+    — not read $VNX_DATA_DIR itself — so it stays in lockstep with every
+    other canonical caller (dispatch_register._register_path included)."""
+    fake_data_dir = tmp_path / "central" / "vnx-dev"
+    fake_state_dir = fake_data_dir / "some-other-state-subdir"
+    monkeypatch.setattr(
+        vnx_paths, "resolve_paths",
+        lambda: {"VNX_DATA_DIR": str(fake_data_dir), "VNX_STATE_DIR": str(fake_state_dir)},
+    )
+    # A real $VNX_DATA_DIR is ALSO set (by the autouse isolation fixture) to a
+    # DIFFERENT path — proves the resolver's answer wins, not a raw env read.
+    assert os.environ.get("VNX_DATA_DIR") != str(fake_data_dir)
+
+    data_dir, state_dir, error = osweep._resolve_central_paths(tmp_path / "some-repo")
+
+    assert (data_dir, state_dir, error) == (fake_data_dir, fake_state_dir, None)
+
+
+def test_resolve_central_paths_failure_records_error_and_falls_back(monkeypatch, tmp_path):
+    def _raise():
+        raise RuntimeError("no vnx runtime installed")
+
+    monkeypatch.setattr(vnx_paths, "resolve_paths", _raise)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    repo_root = tmp_path / "repo"
+
+    data_dir, state_dir, error = osweep._resolve_central_paths(repo_root)
+
+    assert error is not None and "no vnx runtime installed" in error
+    assert data_dir == repo_root / ".vnx-data"
+    assert state_dir == repo_root / ".vnx-data" / "state"
+
+
+def test_sweep_resolves_register_from_central_store_when_dirs_omitted(env, tmp_path):
+    """Reproduces the measured bug (main 4b7d7b2f): a repo_root with NO
+    .vnx-data/state of its own must still find a completed dispatch's
+    register event, because sweep() resolves the register from the fabric's
+    central store (here, the `env` fixture's pinned VNX_DATA_DIR_EXPLICIT=1)
+    when --data-dir/--state-dir are both omitted — never from a repo-local
+    fallback that has never heard of this project's dispatches."""
+    local = _git_repo(tmp_path)  # repo_root has no .vnx-data/state of its own
+    _write_register_event(env, "dispatch_completed", "central-1")
+
+    res = osweep.sweep(
+        repo_root=local,
+        dry_run=True,
+        list_sessions=lambda: ["vnx-central-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert len(res.tmux_completed_orphans_killed) == 1
+    assert res.tmux_completed_orphans_killed[0]["dispatch_id"] == "central-1"
+    assert res.tmux_completed_orphans_preserved == []
+    assert not any(e.get("kind") == "data_dir_resolution" for e in res.errors)
+
+
+def test_sweep_preserves_unknown_project_when_dirs_omitted_and_register_elsewhere(env, tmp_path):
+    """The flip side of the reproduction above: a session whose dispatch id
+    is NOT in the (correctly-resolved) central register must still read as
+    unknown_project — proving the fix does not just turn every read into a
+    hit, it resolves to the correct store and applies the same conjunction."""
+    local = _git_repo(tmp_path)
+
+    res = osweep.sweep(
+        repo_root=local,
+        dry_run=True,
+        list_sessions=lambda: ["vnx-never-registered-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert res.tmux_completed_orphans_preserved[0]["reason"] == "unknown_project"
+
+
+def test_sweep_records_error_when_central_resolver_fails(tmp_path, monkeypatch):
+    """A failed central-store resolution must show up as a measurement error
+    in ``errors`` — never pass silently as though the (possibly wrong)
+    fallback store's emptiness were a valid 'zero dispatches known'."""
+    def _raise():
+        raise RuntimeError("vnx runtime not installed")
+
+    monkeypatch.setattr(vnx_paths, "resolve_paths", _raise)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    local = _git_repo(tmp_path)
+
+    res = osweep.sweep(repo_root=local, list_sessions=lambda: [])
+
+    matches = [e for e in res.errors if e.get("kind") == "data_dir_resolution"]
+    assert matches, (
+        "a failed central-path resolution must be recorded as a measurement "
+        "error, never silently treated as 'zero dispatches known'"
+    )
+    assert "vnx runtime not installed" in matches[0]["error"]
+
+
+def test_explicit_state_dir_wins_over_central_resolution(monkeypatch, tmp_path):
+    """An explicit state_dir always wins, even when data_dir is left to
+    resolve via the fabric — the bogus resolver answer below must never be
+    consulted for state_dir once it is given explicitly."""
+    explicit_state_dir = tmp_path / "explicit-state"
+    explicit_state_dir.mkdir()
+    _write_register_event_in_state_dir(explicit_state_dir, "dispatch_completed", "explicit-1")
+    local = _git_repo(tmp_path)
+
+    bogus_central = tmp_path / "wrong-central-store"
+    monkeypatch.setattr(
+        vnx_paths, "resolve_paths",
+        lambda: {
+            "VNX_DATA_DIR": str(bogus_central),
+            "VNX_STATE_DIR": str(bogus_central / "state"),
+        },
+    )
+
+    res = osweep.sweep(
+        repo_root=local,
+        state_dir=explicit_state_dir,
+        dry_run=True,
+        list_sessions=lambda: ["vnx-explicit-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert len(res.tmux_completed_orphans_killed) == 1
+    assert res.tmux_completed_orphans_killed[0]["dispatch_id"] == "explicit-1"
+    assert not bogus_central.exists()  # resolver's answer was never touched
+
+
+def test_explicit_data_dir_still_derives_state_dir_unchanged(env, monkeypatch, tmp_path):
+    """An explicit data_dir (no state_dir) must still derive
+    ``data_dir / "state"`` exactly as before — the central resolver must not
+    even be consulted in this case (operator/test override path)."""
+    local = _git_repo(tmp_path)
+    _write_register_event(env, "dispatch_completed", "explicit-data-1")
+
+    def _fail_if_called():
+        raise AssertionError(
+            "central resolver must not be consulted when data_dir is explicit"
+        )
+
+    monkeypatch.setattr(vnx_paths, "resolve_paths", lambda: _fail_if_called())
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        dry_run=True,
+        list_sessions=lambda: ["vnx-explicit-data-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert len(res.tmux_completed_orphans_killed) == 1
+    assert res.tmux_completed_orphans_killed[0]["dispatch_id"] == "explicit-data-1"
+
+
+def test_worktree_kind_stays_repo_relative_when_central_store_differs(monkeypatch, tmp_path):
+    """kind 2 (worktrees) must be derived from repo_root regardless of where
+    data_dir/state_dir resolve to — only the register/receipts (1b) and
+    active-manifest (3) kinds should ever follow the central store."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "wt-central-1")
+
+    central_dir = tmp_path / "elsewhere-central"
+    monkeypatch.setattr(
+        vnx_paths, "resolve_paths",
+        lambda: {"VNX_DATA_DIR": str(central_dir), "VNX_STATE_DIR": str(central_dir / "state")},
+    )
+
+    res = osweep.sweep(repo_root=local, list_sessions=lambda: [])
+
+    assert len(res.worktrees_scanned) == 1
+    assert str(handle.path) in res.worktrees_removed
+    assert not handle.path.exists()
+    assert str(handle.path).startswith(str(local)), (
+        "worktree path must stay under repo_root even though data_dir "
+        "resolved to a completely different central store"
+    )
+    assert not central_dir.exists(), (
+        "the (bogus) central store must never be created/touched by the "
+        "worktree kind"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The kind-1b completed-orphan sweep from #1656 was inert against a bare invocation: `sweep()` defaulted `data_dir`/`state_dir` to a repo-relative `.vnx-data/`, which has no `dispatch_register.ndjson` of its own — an empty read silently classified every completed-dispatch session as `unknown_project`.
- `sweep()` now resolves `data_dir`/`state_dir` via `vnx_paths.resolve_paths()` (the fabric's canonical resolver, the same one `dispatch_register.py` itself falls back to) when neither is given explicitly. An explicit `data_dir`/`state_dir` still always wins, unchanged.
- The CLI (`scripts/orphan_sweep.py`) no longer eagerly defaults `--data-dir` to a repo-relative guess; omitting both flags now reaches `sweep()` as `None`, triggering the central resolution.
- A resolver failure is recorded in `errors` (`kind: "data_dir_resolution"`), never silently read as "zero dispatches known".
- The worktree kind (2) is unaffected by design: `worktrees_dir` was already derived from `repo_root`, never from `data_dir`, and stays that way — proven live (see Test plan).

## Test plan
- [x] `pytest tests/test_orphan_sweep.py tests/test_orphan_sweep_fail_open.py -q` → 49 passed (8 new tests added for the central-resolution fix, all others unchanged/green).
- [x] Live reproduction against the real fleet (read-only `--dry-run`, no `--state-dir`, `VNX_DATA_DIR*` env vars cleared to force the fabric's branch-3 resolution against the real `~/.vnx-data/vnx-dev`): this project's own completed dispatch (`vnx-beta-1367-1363-deur-en-rapport-spreken`) correctly classified `receipt:success;pane=dead` (would-kill); three other-project (mission-control) sessions (`vnx-D-*`) correctly stayed `unknown_project`; 0 errors.
- [x] Live full-conjunction demo with two throwaway tmux sessions (`vnx-zzproof1353a`/`b`, register events written only to a disposable `/tmp` scratch store via the sanctioned `dispatch_register.append_event` API — never to any real `.vnx-data/`): dry-run and real run both correctly killed `zzproof1353a` (full conjunction) and preserved `zzproof1353b` (fails only `not_completed`); `tmux ls` before/after confirms only `zzproof1353a` was removed, every other real session (incl. mission-control's) untouched.
- [x] Confirmed live: 5 real worktrees exist under `<repo>/.vnx-data/worktrees/` (repo-relative) and the central store (`~/.vnx-data/vnx-dev`) has no `worktrees/` directory at all — the worktree kind's repo-relative behavior is architecturally unaffected by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)