### PR TITLE
feat(permission-scan): triage worktree risk on live permission stalls

### DIFF
--- a/scripts/lib/worker_permission_relay.py
+++ b/scripts/lib/worker_permission_relay.py
@@ -813,11 +813,38 @@ def _capture_pane_or_error(runner, session_id: str) -> "tuple[str | None, str | 
     return getattr(res, "stdout", "") or "", None
 
 
+# Worktree-risk sort priority for hits (OI-1414 follow-up): 0 = urgent (the
+# stall is holding uncommitted/unpushed work that is lost if the stall is
+# abandoned), 1 = cannot be measured (never conflated with "clean" — see the
+# docstring below), 2 = confirmed clean/pushed. An absent/unrecognized
+# classification sorts as unmeasured (1), the same conservative default
+# ``classify_for_release`` itself falls back to when it cannot resolve a base.
+_WORKTREE_RISK_PRIORITY = {
+    "committable": 0,
+    "unpushed_commits": 0,
+    "both": 0,
+    "unreachable": 1,
+    "error": 1,
+    "detached": 1,
+    "releasable": 2,
+}
+
+
+def _dispatch_worktree_path(repo_root: Path, dispatch_id: str) -> Path:
+    """The dispatch worktree path for *dispatch_id*, mirroring the EXACT
+    convention ``orphan_sweep`` already uses
+    (``<repo_root>/.vnx-data/worktrees/dispatch-<dispatch_id>``) — never a
+    second path convention.
+    """
+    return repo_root / ".vnx-data" / "worktrees" / f"dispatch-{dispatch_id}"
+
+
 def scan_live_awaiting_permission(
     runner=None,
     *,
     state_dir: "str | Path | None" = None,
     write_escalations: bool = True,
+    repo_root: "str | Path | None" = None,
 ) -> dict:
     """READ-ONLY scan of THIS project's live dispatch tmux sessions for a
     worker stalled on a permission prompt (OI-1324 / OI-1344).
@@ -846,13 +873,48 @@ def scan_live_awaiting_permission(
     caller, never as "no stall" (OI-1324/1344: a measurement gap is not
     evidence of a clean fleet).
 
+    Worktree triage (OI-1414 follow-up): detection alone does not say how
+    URGENT a stall is — a worker stalled on a permission prompt with fully
+    committed-and-pushed work is an inconvenience; the same stall holding
+    uncommitted or unpushed work is a deadline. Every hit now also carries
+    the state of its dispatch worktree, resolved at
+    ``<repo_root>/.vnx-data/worktrees/dispatch-<dispatch_id>`` — the EXACT
+    path convention ``orphan_sweep`` already uses (see
+    ``_dispatch_worktree_path`` — never a second convention) — and classified
+    by REUSING ``worktree_release.classify_for_release`` (the same
+    releasable/committable/unpushed_commits/both/detached/unreachable/error
+    taxonomy the release path already uses), never a second, driftable
+    classifier. ``repo_root`` defaults to the same repo-root resolution
+    ``orphan_sweep``/``tmux_worktree`` already use
+    (``tmux_worktree._resolve_repo_root``). Every hit carries:
+      - ``worktree_path``: the resolved path (str)
+      - ``worktree_classification``: one of classify_for_release's states
+      - ``worktree_detail``: its human-readable detail string
+      - ``worktree_at_risk``: True for committable/unpushed_commits/both —
+        the stall is holding work that would be LOST if abandoned
+      - ``worktree_measured``: False for unreachable/error — the worktree
+        could not be read at all. An unmeasurable worktree is NEVER read as
+        "clean": it is reported explicitly instead of collapsing into
+        releasable.
+    ``hits`` is sorted worktree_at_risk-first, then unmeasured, then
+    confirmed-clean last — a triage priority order, not discovery order — so
+    the most urgent stall is always first regardless of scan order. This step
+    is entirely READ-ONLY git (``rev-parse``, ``status --porcelain``,
+    ``merge-base``, ``rev-list``, ``ls-remote``) run against the worktree —
+    the exact commands ``classify_for_release`` already runs for the (also
+    read-only, dry-run-default) release-report path. Nothing here ever writes
+    to the worktree, and the only write anywhere in this function remains the
+    existing idempotent ``write_escalation`` call below.
+
     Returns:
         dict with keys:
           - ``sessions_scanned``: in-scope session names successfully captured
           - ``sessions_skipped_foreign``: name matched the pattern, no handle
             for that dispatch id in this project's state dir
           - ``hits``: list of ``{session, dispatch_id, command, matched_marker,
-            escalation_written}`` for every pane classified awaiting_permission
+            escalation_written, worktree_path, worktree_classification,
+            worktree_detail, worktree_at_risk, worktree_measured}`` for every
+            pane classified awaiting_permission, sorted urgent-first
           - ``errors``: list of ``{scope, session, dispatch_id, error}``
           - ``measured``: False only when the session listing itself could not
             be trusted (see ``_list_dispatch_sessions``)
@@ -864,10 +926,14 @@ def scan_live_awaiting_permission(
     fresh ``reason="awaiting_permission"`` record.
     """
     from orphan_sweep import _SESSION_RE as _DISPATCH_SESSION_RE  # noqa: PLC0415 — reuse, never duplicate
+    from tmux_worktree import _resolve_repo_root as _tw_resolve_repo_root  # noqa: PLC0415 — reuse, never duplicate
+    from tmux_worktree import _current_branch as _tw_current_branch  # noqa: PLC0415 — reuse, never duplicate
+    from worktree_release import classify_for_release  # noqa: PLC0415 — reuse, never duplicate
 
     sd = _coerce_state_dir(state_dir)
     rn = runner if runner is not None else _default_tmux_runner()
     handle_dir = sd / "tmux_interactive"
+    root = Path(repo_root) if repo_root is not None else _tw_resolve_repo_root(None)
 
     result: dict = {
         "sessions_scanned": [],
@@ -919,6 +985,12 @@ def scan_live_awaiting_permission(
                     {"scope": "write_escalation", "session": name, "dispatch_id": dispatch_id, "error": str(exc)}
                 )
 
+        wt_path = _dispatch_worktree_path(root, dispatch_id)
+        branch = _tw_current_branch(wt_path) if wt_path.exists() else ""
+        wt_class, wt_detail = classify_for_release(str(wt_path), branch)
+        wt_at_risk = wt_class in ("committable", "unpushed_commits", "both")
+        wt_measured = wt_class not in ("unreachable", "error")
+
         result["hits"].append(
             {
                 "session": name,
@@ -926,11 +998,19 @@ def scan_live_awaiting_permission(
                 "command": command,
                 "matched_marker": state.matched_marker,
                 "escalation_written": escalation_written,
+                "worktree_path": str(wt_path),
+                "worktree_classification": wt_class,
+                "worktree_detail": wt_detail,
+                "worktree_at_risk": wt_at_risk,
+                "worktree_measured": wt_measured,
             }
         )
         logger.warning(
-            "permission_relay: SCAN found live stall dispatch=%s cmd=%r marker=%r",
-            dispatch_id, command, state.matched_marker,
+            "permission_relay: SCAN found live stall dispatch=%s cmd=%r marker=%r "
+            "worktree=%s(%s) at_risk=%s",
+            dispatch_id, command, state.matched_marker, wt_class, wt_detail, wt_at_risk,
         )
+
+    result["hits"].sort(key=lambda h: _WORKTREE_RISK_PRIORITY.get(h["worktree_classification"], 1))
 
     return result

--- a/scripts/permission_relay_cli.py
+++ b/scripts/permission_relay_cli.py
@@ -18,6 +18,10 @@ All subcommands accept ``--json`` for machine-readable output.
 dispatch sessions for a pane classified ``awaiting_permission`` that has not
 yet surfaced anywhere — writes an escalation record for each new find
 (idempotent) so ``escalations`` becomes a current view instead of an archive.
+Each hit also carries its dispatch worktree's risk state (OI-1414 follow-up):
+a stall holding uncommitted or unpushed work is flagged ``[!! WORK AT RISK]``
+and sorted to the top, distinct from a stall whose worktree is clean or
+whose worktree could not be measured (never silently reported as clean).
 Exit code encodes the verdict for a supervisor tick / operator script:
   0 = measured cleanly, zero stalls found
   1 = at least one live stall found (see the printed dispatch id + command)
@@ -125,12 +129,68 @@ def _cmd_escalations(args, sd: Path) -> int:
     return 0
 
 
+def _worktree_risk_label(hit: dict) -> str:
+    """One-glance label distinguishing a stall holding unsaved work from one
+    that does not — the label a triaging operator scans for first (OI-1414
+    follow-up). Never reads a missing/unmeasured worktree as clean."""
+    if hit.get("worktree_at_risk"):
+        return "[!! WORK AT RISK]"
+    if not hit.get("worktree_measured", True):
+        return "[?  worktree unmeasured]"
+    return "[   worktree clean   ]"
+
+
+def _format_scan_human(result: dict) -> str:
+    """Human-readable rendering of a ``scan_live_awaiting_permission`` result.
+
+    Shared by ``_cmd_scan`` and any ad-hoc scan (e.g. an evidence run against
+    an isolated state/repo root) so both read off the identical formatting —
+    never a second, driftable rendering. ``hits`` is already sorted
+    urgent-first by ``scan_live_awaiting_permission``; this function renders
+    that order as-is rather than re-sorting.
+    """
+    hits = result.get("hits") or []
+    errors = result.get("errors") or []
+    lines: "list[str]" = []
+
+    if hits:
+        lines.append(f"[!] {len(hits)} worker(s) awaiting permission:")
+        for h in hits:
+            lines.append(
+                f"  - {_worktree_risk_label(h)} {h.get('dispatch_id')}  cmd: {h.get('command')}  "
+                f"(session={h.get('session')}, marker={h.get('matched_marker')!r})"
+            )
+            lines.append(
+                f"      worktree: {h.get('worktree_classification')} — "
+                f"{h.get('worktree_detail')} ({h.get('worktree_path')})"
+            )
+    elif errors:
+        lines.append("[x] scan could not fully measure the live fleet")
+    else:
+        lines.append("[ok] no worker is awaiting permission")
+
+    if errors:
+        lines.append(f"\n[!] {len(errors)} measurement error(s):")
+        for e in errors:
+            lines.append(
+                f"  - scope={e.get('scope')} session={e.get('session')} "
+                f"dispatch_id={e.get('dispatch_id')}: {e.get('error')}"
+            )
+
+    return "\n".join(lines)
+
+
 def _cmd_scan(args, sd: Path) -> int:
     """OI-1324 / OI-1344: scan live worker panes; alarm loudly, never silently.
 
     Exit code: 0 clean, 1 at least one live stall found, 2 could not fully
     measure (tmux unavailable, listing unmeasurable, or a capture failed) —
     a measurement gap is reported distinctly and is NEVER read as "clean".
+
+    Each hit also carries its dispatch worktree's risk state (OI-1414
+    follow-up: is there unsaved work behind this stall?) — see
+    ``_worktree_risk_label`` / ``_format_scan_human``. Hits are pre-sorted
+    urgent-first by ``scan_live_awaiting_permission``.
     """
     result = relay.scan_live_awaiting_permission(state_dir=sd)
     hits = result.get("hits") or []
@@ -139,24 +199,7 @@ def _cmd_scan(args, sd: Path) -> int:
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
     else:
-        if hits:
-            print(f"[!] {len(hits)} worker(s) awaiting permission:")
-            for h in hits:
-                print(
-                    f"  - {h.get('dispatch_id')}  cmd: {h.get('command')}  "
-                    f"(session={h.get('session')}, marker={h.get('matched_marker')!r})"
-                )
-        elif errors:
-            print("[x] scan could not fully measure the live fleet")
-        else:
-            print("[ok] no worker is awaiting permission")
-        if errors:
-            print(f"\n[!] {len(errors)} measurement error(s):")
-            for e in errors:
-                print(
-                    f"  - scope={e.get('scope')} session={e.get('session')} "
-                    f"dispatch_id={e.get('dispatch_id')}: {e.get('error')}"
-                )
+        print(_format_scan_human(result))
 
     if hits:
         return 1

--- a/tests/test_worker_permission_relay.py
+++ b/tests/test_worker_permission_relay.py
@@ -8,6 +8,7 @@ EXPLICIT-session send-keys contract.
 """
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -961,3 +962,205 @@ class TestCmdScanExitCodes:
         assert rc == 0
         out = json.loads(capsys.readouterr().out)
         assert out == payload
+
+
+# ---------------------------------------------------------------------------
+# Worktree-risk triage on scan hits (OI-1414 follow-up) — is there unsaved
+# work behind a live permission stall?
+# ---------------------------------------------------------------------------
+def _make_git_repo(path: Path, *, dirty: bool = False) -> None:
+    """A minimal REAL git repo for classify_for_release to read.
+
+    No remote is configured, which exercises classify_for_release's own
+    "base unresolvable" fallback (``git merge-base origin/main HEAD`` fails)
+    — exactly what a dispatch worktree with no reachable origin/main degrades
+    to. That fallback still correctly distinguishes dirty (-> committable)
+    from clean (-> releasable), which is all this scan needs.
+    """
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(
+        [
+            "git", "-C", str(path),
+            "-c", "user.email=t@t.local", "-c", "user.name=t",
+            "commit", "--allow-empty", "-q", "-m", "seed",
+        ],
+        check=True,
+    )
+    if dirty:
+        (path / "scratch.txt").write_text("dirty\n", encoding="utf-8")
+
+
+class TestScanWorktreeRisk:
+    def test_dirty_worktree_classified_committable_and_at_risk(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        wt = repo_root / ".vnx-data" / "worktrees" / "dispatch-dirty-demo"
+        _make_git_repo(wt, dirty=True)
+        _write_handle(tmp_path, "dirty-demo", "vnx-dirty-demo")
+        runner = FakeScanRunner(["vnx-dirty-demo"], {"vnx-dirty-demo": PROMPT_PANE})
+
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path, repo_root=repo_root)
+
+        hit = result["hits"][0]
+        assert hit["dispatch_id"] == "dirty-demo"
+        assert hit["worktree_classification"] == "committable"
+        assert hit["worktree_at_risk"] is True
+        assert hit["worktree_measured"] is True
+        assert hit["worktree_path"] == str(wt)
+
+    def test_clean_worktree_classified_releasable_not_at_risk(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        wt = repo_root / ".vnx-data" / "worktrees" / "dispatch-clean-demo"
+        _make_git_repo(wt, dirty=False)
+        _write_handle(tmp_path, "clean-demo", "vnx-clean-demo")
+        runner = FakeScanRunner(["vnx-clean-demo"], {"vnx-clean-demo": PROMPT_PANE})
+
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path, repo_root=repo_root)
+
+        hit = result["hits"][0]
+        assert hit["worktree_classification"] == "releasable"
+        assert hit["worktree_at_risk"] is False
+        assert hit["worktree_measured"] is True
+
+    def test_missing_worktree_is_unmeasured_never_clean(self, tmp_path):
+        repo_root = tmp_path / "repo"  # no worktree created at all
+        _write_handle(tmp_path, "gone-demo", "vnx-gone-demo")
+        runner = FakeScanRunner(["vnx-gone-demo"], {"vnx-gone-demo": PROMPT_PANE})
+
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path, repo_root=repo_root)
+
+        hit = result["hits"][0]
+        assert hit["worktree_classification"] == "unreachable"
+        assert hit["worktree_classification"] != "releasable"
+        assert hit["worktree_measured"] is False
+        assert hit["worktree_at_risk"] is False
+
+    def test_corrupted_worktree_is_unmeasured_error_never_clean(self, tmp_path):
+        # A ".git" that exists but points nowhere real: every git read fails,
+        # never conflated with "clean" (an unreadable worktree is not schoon).
+        repo_root = tmp_path / "repo"
+        wt = repo_root / ".vnx-data" / "worktrees" / "dispatch-broken-demo"
+        wt.mkdir(parents=True)
+        (wt / ".git").write_text("gitdir: /nonexistent-gitdir\n", encoding="utf-8")
+        _write_handle(tmp_path, "broken-demo", "vnx-broken-demo")
+        runner = FakeScanRunner(["vnx-broken-demo"], {"vnx-broken-demo": PROMPT_PANE})
+
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path, repo_root=repo_root)
+
+        hit = result["hits"][0]
+        assert hit["worktree_classification"] == "error"
+        assert hit["worktree_classification"] != "releasable"
+        assert hit["worktree_measured"] is False
+        assert hit["worktree_at_risk"] is False
+
+    def test_at_risk_hit_sorts_first(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        clean_wt = repo_root / ".vnx-data" / "worktrees" / "dispatch-aaa-clean"
+        dirty_wt = repo_root / ".vnx-data" / "worktrees" / "dispatch-zzz-dirty"
+        _make_git_repo(clean_wt, dirty=False)
+        _make_git_repo(dirty_wt, dirty=True)
+        for did in ("aaa-clean", "zzz-dirty"):
+            _write_handle(tmp_path, did, f"vnx-{did}")
+        # Discovery order (sorted session names) visits the CLEAN one first —
+        # the risk-sort must still put the dirty (at-risk) one first in `hits`.
+        runner = FakeScanRunner(
+            ["vnx-aaa-clean", "vnx-zzz-dirty"],
+            {"vnx-aaa-clean": PROMPT_PANE, "vnx-zzz-dirty": ROUTINE_PROMPT_PANE},
+        )
+
+        result = scan_live_awaiting_permission(runner, state_dir=tmp_path, repo_root=repo_root)
+
+        assert [h["dispatch_id"] for h in result["hits"]] == ["zzz-dirty", "aaa-clean"]
+
+    def test_scan_never_mutates_the_worktree(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        wt = repo_root / ".vnx-data" / "worktrees" / "dispatch-untouched-demo"
+        _make_git_repo(wt, dirty=True)
+        _write_handle(tmp_path, "untouched-demo", "vnx-untouched-demo")
+        runner = FakeScanRunner(["vnx-untouched-demo"], {"vnx-untouched-demo": PROMPT_PANE})
+
+        before = subprocess.run(
+            ["git", "-C", str(wt), "status", "--porcelain"], capture_output=True, text=True
+        ).stdout
+        scan_live_awaiting_permission(runner, state_dir=tmp_path, repo_root=repo_root)
+        after = subprocess.run(
+            ["git", "-C", str(wt), "status", "--porcelain"], capture_output=True, text=True
+        ).stdout
+
+        assert before == after
+        # No writing tmux call was ever issued (FakeScanRunner asserts this
+        # itself on any unexpected call, but assert the shape explicitly too).
+        assert all(c[:1] in (["list-sessions"], ["capture-pane"]) for c in runner.calls)
+
+
+# ---------------------------------------------------------------------------
+# Human-readable scan output visually distinguishes an at-risk stall
+# ---------------------------------------------------------------------------
+class TestScanHumanOutputRiskLabel:
+    def test_at_risk_hit_visually_distinct_from_clean(self, capsys, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            relay,
+            "scan_live_awaiting_permission",
+            lambda **kw: {
+                "sessions_scanned": ["vnx-risky", "vnx-safe"],
+                "sessions_skipped_foreign": [],
+                "hits": [
+                    {
+                        "session": "vnx-risky", "dispatch_id": "risky", "command": "x",
+                        "matched_marker": "m", "escalation_written": True,
+                        "worktree_classification": "committable",
+                        "worktree_detail": "1 uncommitted change(s)",
+                        "worktree_at_risk": True, "worktree_measured": True,
+                        "worktree_path": "/tmp/x/dispatch-risky",
+                    },
+                    {
+                        "session": "vnx-safe", "dispatch_id": "safe", "command": "x",
+                        "matched_marker": "m", "escalation_written": True,
+                        "worktree_classification": "releasable",
+                        "worktree_detail": "clean",
+                        "worktree_at_risk": False, "worktree_measured": True,
+                        "worktree_path": "/tmp/x/dispatch-safe",
+                    },
+                ],
+                "errors": [],
+                "measured": True,
+            },
+        )
+        rc = cli._cmd_scan(_ScanArgs(), tmp_path)
+        assert rc == 1
+        lines = capsys.readouterr().out.splitlines()
+        risky_line = next(l for l in lines if "risky" in l and "cmd:" in l)
+        safe_line = next(l for l in lines if "safe" in l and "cmd:" in l)
+        risky_label = risky_line.split("risky")[0]
+        safe_label = safe_line.split("safe")[0]
+        assert risky_label != safe_label
+        assert "RISK" in risky_label.upper()
+        assert "RISK" not in safe_label.upper()
+
+    def test_unmeasured_hit_never_labeled_clean(self, capsys, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            relay,
+            "scan_live_awaiting_permission",
+            lambda **kw: {
+                "sessions_scanned": ["vnx-gone"],
+                "sessions_skipped_foreign": [],
+                "hits": [
+                    {
+                        "session": "vnx-gone", "dispatch_id": "gone", "command": "x",
+                        "matched_marker": "m", "escalation_written": True,
+                        "worktree_classification": "unreachable",
+                        "worktree_detail": "worktree directory does not exist",
+                        "worktree_at_risk": False, "worktree_measured": False,
+                        "worktree_path": "/tmp/x/dispatch-gone",
+                    },
+                ],
+                "errors": [],
+                "measured": True,
+            },
+        )
+        cli._cmd_scan(_ScanArgs(), tmp_path)
+        lines = capsys.readouterr().out.splitlines()
+        gone_line = next(l for l in lines if "gone" in l and "cmd:" in l)
+        label = gone_line.split("gone")[0]
+        assert "clean" not in label.lower()
+        assert "unmeasured" in label.lower()


### PR DESCRIPTION
## Summary
- `scan_live_awaiting_permission` now resolves each hit's dispatch worktree at `<repo_root>/.vnx-data/worktrees/dispatch-<id>` — the exact path convention `orphan_sweep` already uses (`_dispatch_worktree_path`, no second convention).
- The worktree is classified by reusing `worktree_release.classify_for_release` directly (releasable/committable/unpushed_commits/both/detached/unreachable/error) — never a second, driftable classifier.
- Each hit gains `worktree_path`, `worktree_classification`, `worktree_detail`, `worktree_at_risk` (True for committable/unpushed_commits/both), and `worktree_measured` (False for unreachable/error — never silently reported as clean).
- `hits` is sorted at-risk-first, then unmeasured, then confirmed-clean, regardless of discovery order.
- CLI human output (`permission_relay_cli._format_scan_human`, extracted from `_cmd_scan` so it's shared/reusable) labels an at-risk hit `[!! WORK AT RISK]`, distinct from `[?  worktree unmeasured]` and `[   worktree clean   ]`.
- The scan remains fully read-only: only `list-sessions`/`capture-pane` on tmux, and read-only git (`rev-parse`, `status --porcelain`, `merge-base`, `rev-list`, `ls-remote`) via the reused classifier — no writes anywhere except the pre-existing idempotent `write_escalation`.
- Exit-code contract unchanged (0/1/2).

## Test plan
- [x] `pytest tests/test_worker_permission_relay.py -q` — 108 passed (new `TestScanWorktreeRisk` + `TestScanHumanOutputRiskLabel` classes cover dirty/clean/missing/corrupted worktree classification, at-risk-first sorting, no-mutation, and visual distinctness of the human output).
- [x] `pytest tests/test_orphan_sweep_fail_open.py tests/test_orphan_sweep.py tests/test_worktree_release_repo_root.py tests/test_worktree_release.py -q` — 76 passed (neighbours, unmodified, reused not duplicated).
- [x] Manual evidence run: 3 throwaway tmux sessions (`vnx-wtcheck-{dirty,clean,gone}-demo`) against a fully sandboxed state-dir + repo-root under the system tempdir. Single scan call produced correct classification for all three (dirty→committable/at-risk sorted first, clean→releasable sorted last, gone→unreachable/unmeasured, never "clean"). Real project's `permission_escalations` ledger confirmed unchanged at 21 records with none of the demo ids; `tmux ls | wc -l` confirmed 32→35→32 (3 added, 3 killed by exact name, fleet restored). Sandbox + throwaway driver script removed afterward via the guarded-delete pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)