### PR TITLE
fix(open-items): let the ledger correct itself (OI-1416)

### DIFF
--- a/scripts/open_items_manager.py
+++ b/scripts/open_items_manager.py
@@ -329,6 +329,18 @@ def close_item(args):
         item["closed_at"] = datetime.now().isoformat()
         item["updated_at"] = datetime.now().isoformat()
 
+        evidence = getattr(args, 'evidence', None)
+        if evidence:
+            item["closed_evidence"] = evidence
+
+        # OI-1416: the dispatch that RESOLVES the item, not the one that
+        # discovered it. Fall back to origin_dispatch_id only when no
+        # --dispatch-id was given, so the existing trail (manually-created
+        # items with no explicit closer) still resolves to something.
+        resolving_dispatch_id = (
+            getattr(args, 'dispatch_id', None) or item.get("origin_dispatch_id")
+        )
+
         save_items(data)
 
         audit_log_entry(
@@ -337,15 +349,16 @@ def close_item(args):
             from_status=old_status,
             to_status=args.status,
             reason=args.reason,
-            dispatch_id=item.get("origin_dispatch_id"),
-            pr_id=item.get("pr_id")
+            dispatch_id=resolving_dispatch_id,
+            pr_id=item.get("pr_id"),
+            evidence=evidence,
         )
 
     _log_oi_close_decision(
         oi_id=args.item_id,
         status=args.status,
         reason=args.reason,
-        dispatch_id=item.get("origin_dispatch_id"),
+        dispatch_id=resolving_dispatch_id,
     )
 
     print(f"✅ Closed {args.item_id} as {args.status}")
@@ -422,21 +435,45 @@ def list_items(args):
                 print(f"     Closed: {item['closed_reason']}")
 
 def attach_evidence(args):
-    """Attach evidence from a report to all open items for a PR (does NOT close them)."""
+    """Attach evidence from a report to open items (does NOT close them).
+
+    Two addressing modes, at least one required (OI-1416):
+      --pr ITEM_ID: bulk-attach to every OPEN item for that PR (legacy mode).
+      --item ID: attach to exactly that item, in ANY status — evidence that
+                 isn't PR-shaped (a measurement, a ledger line, a manual
+                 verification) needs somewhere to hang that doesn't require
+                 a PR to exist.
+    """
+    pr_id = getattr(args, 'pr', None)
+    item_id = getattr(args, 'item_id', None)
+
+    if not pr_id and not item_id:
+        print("❌ attach-evidence requires --pr and/or --item", file=sys.stderr)
+        return 1
+
+    report_path = args.report or ""
+    dispatch_id = args.dispatch or ""
+
     with _with_items_lock():
         data = load_items()
 
-        pr_id = args.pr
-        report_path = args.report or ""
-        dispatch_id = args.dispatch or ""
+        if item_id:
+            matched_items = [i for i in data["items"] if i["id"] == item_id]
+            if not matched_items:
+                print(f"❌ Item {item_id} not found", file=sys.stderr)
+                return 1
+        else:
+            matched_items = [
+                i for i in data["items"]
+                if i["status"] == "open" and i.get("pr_id") == pr_id
+            ]
 
-        matched = 0
-        for item in data["items"]:
-            if item["status"] != "open":
-                continue
-            if item.get("pr_id") != pr_id:
-                continue
+        if not matched_items:
+            label = item_id or pr_id
+            print(f"ℹ️  No items found for {label}")
+            return 0
 
+        for item in matched_items:
             if "evidence" not in item:
                 item["evidence"] = []
             item["evidence"].append({
@@ -445,25 +482,115 @@ def attach_evidence(args):
                 "attached_at": datetime.now().isoformat()
             })
             item["updated_at"] = datetime.now().isoformat()
-            matched += 1
 
-        if matched == 0:
-            print(f"ℹ️  No open items found for {pr_id}")
-            return 0
-
+        matched = len(matched_items)
         save_items(data)
 
         audit_log_entry(
             "attach_evidence",
             pr_id=pr_id,
+            item_id=item_id,
             report_path=report_path,
             dispatch_id=dispatch_id,
             items_matched=matched
         )
 
-    print(f"📎 Attached evidence to {matched} open items for {pr_id}")
+    target = item_id or pr_id
+    print(f"📎 Attached evidence to {matched} item(s) for {target}")
     print(f"   Report: {report_path}")
     print(f"   T0 must review and close items manually")
+
+    generate_digest()
+    return 0
+
+
+def _resolve_text_arg(value: Optional[str], file_path: Optional[str],
+                       flag_name: str) -> Optional[str]:
+    """Resolve a text value from either a direct argument or a file.
+
+    Reading from a file lets callers pass text containing backticks or
+    quotes without a shell ever tokenizing it (OI-1416: OI-1291's closure
+    text was mangled because backticks in a --reason shell argument were
+    executed as command substitution).
+    """
+    if value is not None and file_path is not None:
+        raise SystemExit(
+            f"--{flag_name} and --{flag_name}-file are mutually exclusive"
+        )
+    if file_path is not None:
+        return Path(file_path).read_text(encoding="utf-8")
+    return value
+
+
+def amend_item(args):
+    """Correct title/closed_reason on an existing item, in ANY status.
+
+    Unlike close/defer/wontfix, amend does not require the item to be
+    'open' — its purpose is fixing text on items that are already closed
+    (OI-1416: OI-1291's closure text was truncated at write time and there
+    was no command to repair it). The correction itself is logged as a new
+    audit entry carrying old and new values; prior entries are never
+    rewritten.
+    """
+    new_title = _resolve_text_arg(args.title, args.title_file, "title")
+    new_closed_reason = _resolve_text_arg(
+        args.closed_reason, args.closed_reason_file, "closed-reason"
+    )
+
+    if new_title is None and new_closed_reason is None:
+        print(
+            "❌ Nothing to amend: provide --title/--title-file or "
+            "--closed-reason/--closed-reason-file",
+            file=sys.stderr,
+        )
+        return 1
+
+    with _with_items_lock():
+        data = load_items()
+
+        item = None
+        for i in data["items"]:
+            if i["id"] == args.item_id:
+                item = i
+                break
+
+        if not item:
+            print(f"❌ Item {args.item_id} not found", file=sys.stderr)
+            return 1
+
+        changes = {}
+        if new_title is not None:
+            changes["title"] = {"old": item.get("title"), "new": new_title}
+            item["title"] = new_title
+        if new_closed_reason is not None:
+            changes["closed_reason"] = {
+                "old": item.get("closed_reason"), "new": new_closed_reason
+            }
+            item["closed_reason"] = new_closed_reason
+
+        item["updated_at"] = datetime.now().isoformat()
+        item["amended_count"] = item.get("amended_count", 0) + 1
+
+        resolving_dispatch_id = (
+            getattr(args, 'dispatch_id', None) or item.get("origin_dispatch_id")
+        )
+
+        save_items(data)
+
+        audit_log_entry(
+            "amend",
+            item_id=args.item_id,
+            status=item["status"],
+            reason=args.reason,
+            dispatch_id=resolving_dispatch_id,
+            changes=changes,
+        )
+
+    print(f"✅ Amended {args.item_id}")
+    for field, change in changes.items():
+        old_len = len(change["old"] or "")
+        new_len = len(change["new"] or "")
+        print(f"   {field}: {old_len} chars -> {new_len} chars")
 
     generate_digest()
     return 0
@@ -910,6 +1037,8 @@ def main():
                              choices=['done'], help='Close status')
     close_parser.add_argument('--reason', required=True, help='Closure reason')
     close_parser.add_argument('--dispatch-id', dest='dispatch_id', default=None, help='Dispatch ID that resolved this item')
+    close_parser.add_argument('--evidence', default=None,
+                             help='Optional free-text evidence for the closure (measurement, ledger line, manual verification)')
 
     # Defer command
     defer_parser = subparsers.add_parser('defer', help='Defer item')
@@ -924,10 +1053,23 @@ def main():
     wontfix_parser.add_argument('--dispatch-id', dest='dispatch_id', default=None, help='Dispatch ID that marked this wontfix')
 
     # Attach evidence command
-    evidence_parser = subparsers.add_parser('attach-evidence', help='Attach report evidence to PR open items')
-    evidence_parser.add_argument('--pr', required=True, help='PR ID to attach evidence to')
+    evidence_parser = subparsers.add_parser('attach-evidence', help='Attach report evidence to PR open items, or to a single item')
+    evidence_parser.add_argument('--pr', default=None, help='PR ID to attach evidence to (all matching open items)')
+    evidence_parser.add_argument('--item', dest='item_id', default=None, help='Specific item ID to attach evidence to (any status)')
     evidence_parser.add_argument('--report', help='Path to the completion report')
     evidence_parser.add_argument('--dispatch', help='Dispatch ID that generated the report')
+
+    # Amend command
+    amend_parser = subparsers.add_parser('amend', help='Correct title/closed_reason on an existing item, in any status')
+    amend_parser.add_argument('item_id', help='Item ID to amend')
+    amend_parser.add_argument('--title', default=None, help='New title text')
+    amend_parser.add_argument('--title-file', dest='title_file', default=None,
+                             help='Path to a file containing the new title text (avoids shell quoting of backticks/quotes)')
+    amend_parser.add_argument('--closed-reason', dest='closed_reason', default=None, help='New closed_reason text')
+    amend_parser.add_argument('--closed-reason-file', dest='closed_reason_file', default=None,
+                             help='Path to a file containing the new closed_reason text (avoids shell quoting of backticks/quotes)')
+    amend_parser.add_argument('--reason', required=True, help='Why this item is being amended (recorded in the audit trail)')
+    amend_parser.add_argument('--dispatch-id', dest='dispatch_id', default=None, help='Dispatch ID performing the amendment')
 
     # Digest command
     digest_parser = subparsers.add_parser('digest', help='Generate digest')
@@ -998,6 +1140,7 @@ def main():
         return 1
 
     # Route commands
+    result = 0
     if args.command == 'list':
         list_items(args)
     elif args.command == 'add':
@@ -1015,7 +1158,9 @@ def main():
         args.status = 'wontfix'
         close_item(args)
     elif args.command == 'attach-evidence':
-        attach_evidence(args)
+        result = attach_evidence(args)
+    elif args.command == 'amend':
+        result = amend_item(args)
     elif args.command == 'digest':
         if getattr(args, 'rescan', False):
             rescan_items(args)
@@ -1027,7 +1172,7 @@ def main():
     elif args.command == 'wontfix-pattern':
         wontfix_pattern(args)
 
-    return 0
+    return result or 0
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_oi1416_open_items_amend.py
+++ b/tests/test_oi1416_open_items_amend.py
@@ -1,0 +1,350 @@
+"""Tests for OI-1416: the ledger can now correct itself.
+
+Covers three defects in scripts/open_items_manager.py:
+
+  (a) close_item logged the ORIGIN dispatch (the one that discovered the
+      item) instead of the RESOLVING dispatch (the one that fixed it) on
+      both the audit-log entry and the t0_decision_log fan-out. Falls back
+      to origin_dispatch_id only when no --dispatch-id was given.
+  (b) there was no command to correct a closed item's text. `amend` fixes
+      that, reading replacement text from a file so shell metacharacters
+      (backticks, quotes) never get tokenized -- the exact failure mode
+      that mangled OI-1291's closure text.
+  (c) attach-evidence required --pr, so evidence not shaped like a PR
+      (a measurement, a ledger line, a manual check) had nowhere to attach.
+      --pr is now optional as long as --item is given instead.
+
+All tests run against a temporary, monkeypatched state dir -- never the
+real central store.
+
+Dispatch-ID: beta-1416-oi-correctie
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import open_items_manager as oim  # noqa: E402
+
+
+def _make_item(item_id, title, *, severity="warn", status="open",
+                origin_dispatch_id="origin-disp", pr_id="", closed_reason=None):
+    now = datetime.now().isoformat()
+    return {
+        "id": item_id,
+        "status": status,
+        "severity": severity,
+        "title": title,
+        "details": "",
+        "origin_dispatch_id": origin_dispatch_id,
+        "origin_report_path": "",
+        "pr_id": pr_id,
+        "created_at": now,
+        "updated_at": now,
+        "closed_reason": closed_reason,
+    }
+
+
+def _write_items(oi_file, items):
+    data = {"schema_version": "1.0", "items": items, "next_id": len(items) + 1}
+    with open(oi_file, "w") as f:
+        json.dump(data, f)
+    return data
+
+
+def _read_items(oi_file):
+    with open(oi_file) as f:
+        return json.load(f)
+
+
+def _read_audit_lines(audit_file):
+    if not audit_file.exists():
+        return []
+    return [json.loads(l) for l in audit_file.read_text().splitlines() if l.strip()]
+
+
+@pytest.fixture
+def oi_state(tmp_path, monkeypatch):
+    """Point every open_items_manager path constant at a tmp dir and stub
+    the decision-log fan-out so nothing touches the real central store."""
+    state = tmp_path / "state"
+    state.mkdir()
+    oi_file = state / "open_items.json"
+    monkeypatch.setattr(oim, "STATE_DIR", state)
+    monkeypatch.setattr(oim, "OPEN_ITEMS_FILE", oi_file)
+    monkeypatch.setattr(oim, "DIGEST_FILE", state / "open_items_digest.json")
+    monkeypatch.setattr(oim, "MARKDOWN_FILE", state / "open_items.md")
+    monkeypatch.setattr(oim, "AUDIT_LOG", state / "open_items_audit.jsonl")
+
+    decision_calls = []
+
+    def _fake_log_oi_close_decision(**kwargs):
+        decision_calls.append(kwargs)
+
+    monkeypatch.setattr(oim, "_log_oi_close_decision", _fake_log_oi_close_decision)
+
+    return argparse.Namespace(state=state, oi_file=oi_file, decision_calls=decision_calls)
+
+
+# ---------------------------------------------------------------------------
+# 1. close with explicit --dispatch-id: audit carries THAT id, not origin
+# ---------------------------------------------------------------------------
+
+def test_close_with_explicit_dispatch_id_overrides_origin(oi_state):
+    items = [_make_item("OI-001", "Something is broken",
+                         origin_dispatch_id="origin-disp-A")]
+    _write_items(oi_state.oi_file, items)
+
+    args = argparse.Namespace(
+        item_id="OI-001", status="done", reason="Fixed in PR #500",
+        dispatch_id="resolver-disp-B", evidence=None,
+    )
+    oim.close_item(args)
+
+    audit = _read_audit_lines(oi_state.state / "open_items_audit.jsonl")
+    assert len(audit) == 1
+    entry = audit[0]
+    assert entry["action"] == "close"
+    # The two ids must differ -- otherwise this test measures nothing.
+    assert entry["dispatch_id"] != "origin-disp-A"
+    assert entry["dispatch_id"] == "resolver-disp-B"
+
+    # The decision-log fan-out gets the same resolving id.
+    assert len(oi_state.decision_calls) == 1
+    assert oi_state.decision_calls[0]["dispatch_id"] == "resolver-disp-B"
+
+    print(f"audit entry dispatch_id={entry['dispatch_id']!r} "
+          f"origin_dispatch_id='origin-disp-A' -> resolved, not origin")
+
+
+def test_defer_and_wontfix_inherit_the_same_fix(oi_state):
+    """defer/wontfix route through close_item in main() -- confirm the fix
+    applies there too, since they share the exact same code path."""
+    items = [
+        _make_item("OI-002", "Deferred thing", origin_dispatch_id="origin-disp-X"),
+        _make_item("OI-003", "Wontfix thing", origin_dispatch_id="origin-disp-Y"),
+    ]
+    _write_items(oi_state.oi_file, items)
+
+    defer_args = argparse.Namespace(
+        item_id="OI-002", status="deferred", reason="not now",
+        dispatch_id="resolver-disp-DEFER", evidence=None,
+    )
+    oim.close_item(defer_args)
+
+    wontfix_args = argparse.Namespace(
+        item_id="OI-003", status="wontfix", reason="not doing this",
+        dispatch_id="resolver-disp-WONTFIX", evidence=None,
+    )
+    oim.close_item(wontfix_args)
+
+    audit = _read_audit_lines(oi_state.state / "open_items_audit.jsonl")
+    assert len(audit) == 2
+    by_item = {e["item_id"]: e for e in audit}
+    assert by_item["OI-002"]["dispatch_id"] == "resolver-disp-DEFER"
+    assert by_item["OI-002"]["dispatch_id"] != "origin-disp-X"
+    assert by_item["OI-003"]["dispatch_id"] == "resolver-disp-WONTFIX"
+    assert by_item["OI-003"]["dispatch_id"] != "origin-disp-Y"
+    print("defer + wontfix both call close_item() -- same fix, confirmed via audit log")
+
+
+# ---------------------------------------------------------------------------
+# 2. close --evidence: text lands on the item AND in the audit line
+# ---------------------------------------------------------------------------
+
+def test_close_with_evidence_lands_on_item_and_audit(oi_state):
+    items = [_make_item("OI-004", "Needs a measurement")]
+    _write_items(oi_state.oi_file, items)
+
+    evidence_text = "Measured: 3195 chars before, 3642 chars after (see /tmp/oi1291-fixed.txt)"
+    args = argparse.Namespace(
+        item_id="OI-004", status="done", reason="Verified by measurement",
+        dispatch_id="resolver-disp-EV", evidence=evidence_text,
+    )
+    oim.close_item(args)
+
+    data = _read_items(oi_state.oi_file)
+    item = next(i for i in data["items"] if i["id"] == "OI-004")
+    assert item["closed_evidence"] == evidence_text
+
+    audit = _read_audit_lines(oi_state.state / "open_items_audit.jsonl")
+    assert audit[0]["evidence"] == evidence_text
+    print(f"item.closed_evidence={item['closed_evidence']!r}")
+    print(f"audit[0].evidence={audit[0]['evidence']!r}")
+
+
+# ---------------------------------------------------------------------------
+# 3. amend on a CLOSED item, replacement text read from a file with backticks
+# ---------------------------------------------------------------------------
+
+def test_amend_closed_item_from_file_preserves_backticks(oi_state, tmp_path):
+    mangled_text = "PR merged. Migration applied"  # truncated, as OI-1291 was
+    items = [_make_item(
+        "OI-005", "OI-1291 style item", status="done",
+        closed_reason=mangled_text,
+    )]
+    _write_items(oi_state.oi_file, items)
+
+    fixed_text = (
+        "PR merged. Migration applied via `alembic upgrade head`, "
+        "verified with `SELECT count(*) FROM open_items` returning the "
+        "expected row count. Rollback path documented in `docs/rollback.md`. "
+        "Closing as done."
+    )
+    text_file = tmp_path / "oi1291-fixed.txt"
+    text_file.write_text(fixed_text, encoding="utf-8")
+
+    before_len = len(mangled_text)
+
+    args = argparse.Namespace(
+        item_id="OI-005", title=None, title_file=None,
+        closed_reason=None, closed_reason_file=str(text_file),
+        reason="restore text lost to shell backtick execution (OI-1291)",
+        dispatch_id="resolver-disp-AMEND",
+    )
+    result = oim.amend_item(args)
+    assert result == 0
+
+    data = _read_items(oi_state.oi_file)
+    item = next(i for i in data["items"] if i["id"] == "OI-005")
+    after_len = len(item["closed_reason"])
+
+    # amend must work on a CLOSED item -- status is untouched, not reopened.
+    assert item["status"] == "done"
+    assert item["closed_reason"] == fixed_text
+    assert "`alembic upgrade head`" in item["closed_reason"]
+    assert "`SELECT count(*) FROM open_items`" in item["closed_reason"]
+    assert "`docs/rollback.md`" in item["closed_reason"]
+    assert before_len != after_len
+
+    audit = _read_audit_lines(oi_state.state / "open_items_audit.jsonl")
+    assert len(audit) == 1
+    assert audit[0]["action"] == "amend"
+    assert audit[0]["changes"]["closed_reason"]["old"] == mangled_text
+    assert audit[0]["changes"]["closed_reason"]["new"] == fixed_text
+
+    print(f"closed_reason length before={before_len} after={after_len}")
+    print(f"backticks intact: {'`alembic upgrade head`' in item['closed_reason']}")
+
+
+def test_amend_title_and_mutual_exclusion_guard(oi_state, tmp_path):
+    items = [_make_item("OI-006", "Old title", status="open")]
+    _write_items(oi_state.oi_file, items)
+
+    args = argparse.Namespace(
+        item_id="OI-006", title="New title text", title_file=None,
+        closed_reason=None, closed_reason_file=None,
+        reason="typo fix", dispatch_id=None,
+    )
+    result = oim.amend_item(args)
+    assert result == 0
+    data = _read_items(oi_state.oi_file)
+    item = next(i for i in data["items"] if i["id"] == "OI-006")
+    assert item["title"] == "New title text"
+    # status untouched by amend
+    assert item["status"] == "open"
+
+    # Passing both --title and --title-file is a loud, immediate error.
+    bad_file = tmp_path / "x.txt"
+    bad_file.write_text("irrelevant")
+    bad_args = argparse.Namespace(
+        item_id="OI-006", title="conflicting value", title_file=str(bad_file),
+        closed_reason=None, closed_reason_file=None,
+        reason="x", dispatch_id=None,
+    )
+    with pytest.raises(SystemExit):
+        oim.amend_item(bad_args)
+
+
+def test_amend_unknown_item_fails_loud(oi_state, capsys):
+    _write_items(oi_state.oi_file, [])
+    args = argparse.Namespace(
+        item_id="OI-999", title="x", title_file=None,
+        closed_reason=None, closed_reason_file=None,
+        reason="x", dispatch_id=None,
+    )
+    result = oim.amend_item(args)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "OI-999" in err
+    assert "not found" in err
+
+
+# ---------------------------------------------------------------------------
+# 4. attach-evidence: --item without --pr succeeds; neither given fails loud
+# ---------------------------------------------------------------------------
+
+def test_attach_evidence_by_item_without_pr_succeeds(oi_state):
+    items = [_make_item("OI-007", "Closed thing needing evidence", status="done")]
+    _write_items(oi_state.oi_file, items)
+
+    args = argparse.Namespace(
+        pr=None, item_id="OI-007", report="claudedocs/measurement.md",
+        dispatch="resolver-disp-ATTACH",
+    )
+    result = oim.attach_evidence(args)
+    assert result == 0
+
+    data = _read_items(oi_state.oi_file)
+    item = next(i for i in data["items"] if i["id"] == "OI-007")
+    assert len(item["evidence"]) == 1
+    assert item["evidence"][0]["report_path"] == "claudedocs/measurement.md"
+    assert item["evidence"][0]["dispatch_id"] == "resolver-disp-ATTACH"
+    print(f"item.evidence={item['evidence']!r}")
+
+
+def test_attach_evidence_without_pr_or_item_fails_loud(oi_state, capsys):
+    args = argparse.Namespace(pr=None, item_id=None, report=None, dispatch=None)
+    result = oim.attach_evidence(args)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "--pr" in err and "--item" in err
+    print(f"stderr={err!r}")
+
+
+def test_attach_evidence_pr_only_still_works(oi_state):
+    """Backward compatibility: the legacy --pr-only bulk mode is unchanged."""
+    items = [_make_item("OI-008", "PR item", status="open", pr_id="PR-42")]
+    _write_items(oi_state.oi_file, items)
+
+    args = argparse.Namespace(
+        pr="PR-42", item_id=None, report="report.md", dispatch="disp-legacy",
+    )
+    result = oim.attach_evidence(args)
+    assert result == 0
+    data = _read_items(oi_state.oi_file)
+    item = next(i for i in data["items"] if i["id"] == "OI-008")
+    assert len(item["evidence"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Fallback: close WITHOUT explicit --dispatch-id still carries origin_id
+# ---------------------------------------------------------------------------
+
+def test_close_without_dispatch_id_falls_back_to_origin(oi_state):
+    items = [_make_item("OI-009", "Manually created item",
+                         origin_dispatch_id="origin-disp-C")]
+    _write_items(oi_state.oi_file, items)
+
+    args = argparse.Namespace(
+        item_id="OI-009", status="done", reason="Fixed",
+        dispatch_id=None, evidence=None,
+    )
+    oim.close_item(args)
+
+    audit = _read_audit_lines(oi_state.state / "open_items_audit.jsonl")
+    assert audit[0]["dispatch_id"] == "origin-disp-C"
+
+    assert oi_state.decision_calls[0]["dispatch_id"] == "origin-disp-C"
+    print(f"no --dispatch-id given -> audit dispatch_id={audit[0]['dispatch_id']!r} "
+          f"(fell back to origin_dispatch_id)")


### PR DESCRIPTION
## Summary
- `close_item` audited the *discovering* dispatch (`origin_dispatch_id`) instead of the *resolving* one on both the audit-log entry and the `t0_decision_log` fan-out. Now uses `--dispatch-id` when given, falling back to `origin_dispatch_id` only when none was passed (existing trail for manually-created items stays intact). `defer`/`wontfix` inherit the fix since they route through `close_item` — verified, not assumed.
- New `amend` subcommand corrects `title`/`closed_reason` on an item in **any** status, including closed. Text can be read from a file (`--title-file`/`--closed-reason-file`) so shell metacharacters (backticks, quotes) never get tokenized — the exact failure mode that mangled OI-1291's closure text. Every amendment writes a new audit entry with old/new values; nothing is overwritten in place.
- `close --evidence <text>` adds optional free-text evidence to a closure, landing on the item (`closed_evidence`) and in the audit line.
- `attach-evidence --pr` is now optional as long as `--item <id>` is given instead, so evidence that isn't PR-shaped (a measurement, a ledger line, a manual verification) has somewhere to attach. Calling with neither fails loudly (stderr + exit 1). The one production call site (`scripts/lib/receipt_processor/rp_dispatch.sh`) always passes `--pr`, so it's unaffected.

## Test plan
- [x] New file `tests/test_oi1416_open_items_amend.py` (10 tests, all against a monkeypatched tmp state dir, never the real central store) — `python3 -m pytest tests/test_oi1416_open_items_amend.py -v` → 10 passed
- [x] Confirmed `tests/test_oi1416_open_items_amend.py` is **not** present in `scripts/ci/test_exclusions.txt` (`grep` exit code 1 / no match)
- [x] Neighbouring open_items_manager tests unaffected: `test_governance_blockers_fix.py`, `test_open_items_acceptance_criterion_guard.py`, `test_oi_auto_close.py`, `test_open_items_state_dir_resolution.py`, `test_warning_destination.py`, `test_open_items_from_report.py`, `test_open_items_dedup_status.py`, `tests/oi/test_pattern_subcommands.py` → 124 passed (2 pre-existing failures in `test_governance_blockers_fix.py` are unrelated to this change — `governance_emit.py`/`coordination_db.py`, files this PR does not touch)
- [x] End-to-end CLI smoke test against a throwaway `/tmp` state dir: add → close (explicit `--dispatch-id` + `--evidence`) → `amend --closed-reason-file` with backticks → `attach-evidence --item` (no `--pr`) → `attach-evidence` with neither (exit 1) — verified backticks survive intact through the real CLI, not just the direct function calls in pytest. Temp dir cleaned up after.

Does not touch OI-1291 itself — that repair is a post-merge acceptance test for T0 using the new `amend` command, per the dispatch instruction.

Dispatch-ID: beta-1416-oi-correctie

🤖 Generated with [Claude Code](https://claude.com/claude-code)