### PR TITLE
fix(register-emit): fire on duplicate-skip, make internal failures loud (OI-1425)

### DIFF
--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -519,6 +519,23 @@ def append_receipt_payload(
             "the append lock path exited without a result object",
         )
 
+    # OI-1425: the register emit must fire for a "duplicate" (idempotent-skip)
+    # result too, not only "appended". A duplicate means the identical receipt
+    # content was already durably written earlier in this cache window — that
+    # earlier append is exactly the one whose own register-emit attempt may
+    # have failed (fail-open, per _emit_dispatch_register's contract below),
+    # in which case this is the only remaining chance to record the register
+    # event for this dispatch. Re-emitting for a genuine duplicate is a
+    # harmless repeat of an already-idempotent event (register readers key on
+    # dispatch_id + event, never on a per-emit count), so this is never gated
+    # behind the "appended"-only side effects below (mirror drain, OI
+    # registration, confidence update) — those must still run exactly once.
+    if result.status in ("appended", "duplicate"):
+        try:
+            facade._emit_dispatch_register(receipt)
+        except Exception as exc:
+            _emit("WARN", "dispatch_register_post_hook_failed", error=str(exc))
+
     if result.status == "appended":
         # Phase 6 P3 dual-write: drain persisted mirror debt before attempting
         # the current central write so transient mirror failures are repaired.
@@ -531,15 +548,6 @@ def append_receipt_payload(
             raise
         except Exception as exc:  # noqa: BLE001
             log.warning("payload: central mirror drain failed (best-effort, ignoring): %s", exc)
-        # OI-1105: dispatch-register emit must fire for EVERY appended receipt,
-        # not only those that flow through the non-skip_enrichment path.  The
-        # report_to_receipt_converter is the primary task_complete producer and
-        # passes skip_enrichment=True — without this unconditional call the
-        # register has been dead since the split shipped.
-        try:
-            facade._emit_dispatch_register(receipt)
-        except Exception as exc:
-            _emit("WARN", "dispatch_register_post_hook_failed", error=str(exc))
         if not skip_enrichment:
             _run_post_append_hooks(receipt)
 

--- a/scripts/lib/append_receipt_internals/register_emit.py
+++ b/scripts/lib/append_receipt_internals/register_emit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from .common import REPO_ROOT
+from .common import REPO_ROOT, _emit
 
 
 def _emit_dispatch_register(receipt: dict) -> bool:
@@ -12,19 +12,32 @@ def _emit_dispatch_register(receipt: dict) -> bool:
 
     Maps receipt event_type → dispatch_register event (dispatch_completed,
     dispatch_failed, dispatch_started, gate_requested).  Called unconditionally
-    for every appended receipt (before the skip_enrichment gate).
+    for every appended (or duplicate-skipped, OI-1425) receipt (before the
+    skip_enrichment gate).
 
-    Returns True on success, False on any failure (best-effort, never raises).
+    Returns True on success, False on any failure OR when this event_type
+    carries no register mapping (best-effort, never raises). OI-1425: a
+    `return False` from "nothing to map here" (expected, silent) is no longer
+    indistinguishable from a `return False` caused by a real failure (import
+    error, bad receipt shape, register write failure) — the latter is always
+    logged loud via `_emit(WARN, ...)` first, fail-open on the caller's append
+    path but never silent.
     """
+    dispatch_id = str(receipt.get("dispatch_id", ""))
+
     try:
         sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
         from dispatch_register import append_event
         from event_outcome_semantics import classify_event_outcome, COMPLETION_EVENT_TYPES
+    except Exception as exc:
+        _emit("WARN", "dispatch_register_emit_failed", stage="import",
+              dispatch_id=dispatch_id, error=str(exc))
+        return False
 
+    try:
         event_type = str(receipt.get("event_type") or receipt.get("event") or "").lower()
         status = str(receipt.get("status", "")).lower()
         gate = str(receipt.get("gate", "")).lower()
-        dispatch_id = str(receipt.get("dispatch_id", ""))
         terminal = str(receipt.get("terminal", ""))
         feature_id = str(receipt.get("feature_id", ""))
         pr_number = receipt.get("pr_number")
@@ -57,16 +70,21 @@ def _emit_dispatch_register(receipt: dict) -> bool:
             elif outcome == "success":
                 register_event = "dispatch_completed"
             else:
-                return False
+                return False  # no outcome signal yet — expected, not an error
         elif event_type in ("task_started", "task_start", "dispatch_start"):
             register_event = "dispatch_started"
         elif event_type == "review_gate_request":
             if gate != "codex_gate":
-                return False
+                return False  # other gates intentionally not register-tracked
             register_event = "gate_requested"
         else:
-            return False
+            return False  # event_type has no register mapping — expected, not an error
+    except Exception as exc:
+        _emit("WARN", "dispatch_register_emit_failed", stage="classify",
+              dispatch_id=dispatch_id, error=str(exc))
+        return False
 
+    try:
         return append_event(
             register_event,
             dispatch_id=dispatch_id,
@@ -75,5 +93,7 @@ def _emit_dispatch_register(receipt: dict) -> bool:
             terminal=terminal,
             gate=gate,
         )
-    except Exception:
+    except Exception as exc:
+        _emit("WARN", "dispatch_register_emit_failed", stage="append",
+              dispatch_id=dispatch_id, register_event=register_event, error=str(exc))
         return False

--- a/tests/test_append_receipt_register_emit.py
+++ b/tests/test_append_receipt_register_emit.py
@@ -242,6 +242,63 @@ def test_exception_in_append_event_returns_false_never_raises(ar):
     assert result is False
 
 
+# ── OI-1425: a failure must be LOUD (never silently swallowed) ──────────────
+
+def test_exception_in_append_event_is_logged_loud_not_silent(ar, capsys):
+    """Pre-fix: the whole function was wrapped in one `except Exception:
+    return False`, so a real failure (append_event raising) was
+    indistinguishable from the expected "nothing to map here" no-op —
+    both vanished with zero trace. Post-fix: a real failure is still
+    fail-open (returns False, never raises) but is logged loud on stderr."""
+    def _boom(*args, **kwargs):
+        raise RuntimeError("register exploded")
+
+    fake_register = types.ModuleType("dispatch_register")
+    fake_register.append_event = _boom
+
+    receipt = _make_receipt("task_complete", status="success", dispatch_id="DISP-LOUD-001")
+    with patch.dict(sys.modules, {"dispatch_register": fake_register}):
+        result = ar._emit_dispatch_register(receipt)
+    assert result is False
+
+    err = capsys.readouterr().err
+    assert "dispatch_register_emit_failed" in err
+    assert "DISP-LOUD-001" in err
+    assert "register exploded" in err
+
+
+def test_import_failure_is_logged_loud_not_silent(ar, capsys):
+    """A register module that fails to import (e.g. a broken sys.path or a
+    genuine ImportError) must also surface loud, not vanish into the same
+    `return False` as an intentional no-op."""
+    receipt = _make_receipt("task_complete", status="success", dispatch_id="DISP-LOUD-002")
+    # sys.modules[name] = None forces `from dispatch_register import ...`
+    # to raise ImportError, the standard way to simulate an unimportable
+    # module without touching the real one on disk.
+    with patch.dict(sys.modules, {"dispatch_register": None}):
+        result = ar._emit_dispatch_register(receipt)
+    assert result is False
+
+    err = capsys.readouterr().err
+    assert "dispatch_register_emit_failed" in err
+    assert "DISP-LOUD-002" in err
+
+
+def test_no_mapping_no_op_stays_silent(ar, capsys):
+    """The expected 'nothing to emit for this event_type' path (unrelated to
+    any failure) must NOT be logged as a warning — only real failures are
+    loud. A gemini_review gate request is exactly the existing 'no mapping'
+    no-op (test 9 above)."""
+    captured: list = []
+    receipt = _make_receipt("review_gate_request", gate="gemini_review", dispatch_id="DISP-QUIET-001")
+    result = _run_emit(ar, receipt, captured)
+    assert result is False
+    assert captured == []
+
+    err = capsys.readouterr().err
+    assert "dispatch_register_emit_failed" not in err
+
+
 # ── Test 15: contract_invalid status → dispatch_failed (OI-1105 gap) ──────────
 
 def test_task_complete_contract_invalid_emits_dispatch_failed(ar):
@@ -1160,6 +1217,78 @@ def test_duplicate_receipt_does_not_mutate_open_items_store(tmp_path: Path, ar):
         f"_register_quality_open_items must run once (post-append) and NOT again on duplicate. "
         f"Got register calls: {register_calls!r}"
     )
+
+
+# ── OI-1425: register emit must fire on 'duplicate' too, not just 'appended' ─
+
+def test_duplicate_receipt_still_emits_dispatch_register(tmp_path: Path, ar):
+    """OI-1425: pre-fix, `_emit_dispatch_register` was only called inside the
+    `if result.status == "appended":` block — a receipt that hits the
+    idempotency cache and lands as 'duplicate' fired nothing at all. If the
+    ORIGINAL "appended" call's own register-emit attempt failed (e.g. a
+    transient register-write error), that was the only chance ever taken —
+    the duplicate is the sole remaining shot at recording the register event
+    for this dispatch. Both the 'appended' and the 'duplicate' write must
+    call the emitter; the OI-registration side effect (previous test) must
+    still run exactly once."""
+    receipts_file = tmp_path / "receipts_dup_emit.ndjson"
+    receipt = {
+        "timestamp": "2026-04-28T12:00:00Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "DISP-DUPEMIT-001",
+        "terminal": "T1",
+        "schema_version": 1,
+    }
+
+    emit_calls: list = []
+
+    def _record_emit(r):
+        emit_calls.append(r.get("dispatch_id"))
+        return True
+
+    with patch.object(ar, "_enrich_completion_receipt", side_effect=lambda r, **kw: dict(r)), \
+         patch.object(ar, "_register_quality_open_items", return_value=0), \
+         patch.object(ar, "_update_confidence_from_receipt"), \
+         patch.object(ar, "_emit_dispatch_register", side_effect=_record_emit), \
+         patch.object(ar, "_maybe_trigger_state_rebuild"):
+        first = ar.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+        second = ar.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+
+    assert first.status == "appended"
+    assert second.status == "duplicate"
+    assert emit_calls == ["DISP-DUPEMIT-001", "DISP-DUPEMIT-001"], (
+        f"Expected _emit_dispatch_register to fire for BOTH the 'appended' and "
+        f"the 'duplicate' write, got calls: {emit_calls!r}"
+    )
+
+
+def test_never_appended_status_does_not_emit(tmp_path: Path, ar):
+    """Sanity check for the OI-1425 fix's scope: only 'appended' and
+    'duplicate' fire the register emit. This receipt is fresh (no prior
+    write), so only the single 'appended' emit is expected -- proves the fix
+    didn't accidentally make the emit unconditional regardless of status."""
+    receipts_file = tmp_path / "receipts_single.ndjson"
+    receipt = {
+        "timestamp": "2026-04-28T12:00:00Z",
+        "event_type": "task_complete",
+        "status": "success",
+        "dispatch_id": "DISP-SINGLE-001",
+        "terminal": "T1",
+        "schema_version": 1,
+    }
+    emit_calls: list = []
+
+    with patch.object(ar, "_enrich_completion_receipt", side_effect=lambda r, **kw: dict(r)), \
+         patch.object(ar, "_register_quality_open_items", return_value=0), \
+         patch.object(ar, "_update_confidence_from_receipt"), \
+         patch.object(ar, "_emit_dispatch_register",
+                      side_effect=lambda r: emit_calls.append(r.get("dispatch_id")) or True), \
+         patch.object(ar, "_maybe_trigger_state_rebuild"):
+        result = ar.append_receipt_payload(receipt, receipts_file=str(receipts_file))
+
+    assert result.status == "appended"
+    assert emit_calls == ["DISP-SINGLE-001"]
 
 
 # ── OI-1074 / OI-1105: NDJSON-first ordering + flag consistency ──────────────


### PR DESCRIPTION
## Summary

OI-1425: the dispatch register (`dispatch_register.ndjson`) misses a terminal event for most dispatches that have a terminal receipt. Two concrete defects in `scripts/lib/append_receipt_internals/`, both fixed:

- `payload.py` only called `_emit_dispatch_register` when `result.status == "appended"`. An idempotent-skipped duplicate (same receipt content within the 300s cache window) never got a chance to emit — including as the last resort if the original "appended" call's own emit attempt had failed.
- `register_emit.py` wrapped its entire body in one `except Exception: return False`, so a real failure (import error, bad receipt shape, `append_event` raising) was indistinguishable from the expected "this event_type has no register mapping" no-op — both vanished silently.

Fix: the emit now fires for both `"appended"` and `"duplicate"` results (all other appended-only side effects — mirror drain, OI registration, confidence update — are unchanged and still gated to `"appended"` only). Real failures inside `register_emit.py` now log a structured `WARN` (`dispatch_register_emit_failed`, with `stage`/`dispatch_id`/`error`) via the existing `_emit()` helper, while staying fail-open on the caller's append path (never raises, never blocks the receipt append).

## Stage 1 — dry count first (mandatory per dispatch)

Read-only measurement against the real central store (`~/.vnx-data/vnx-dev/state/{dispatch_register,t0_receipts}.ndjson`), no cleanup executed:

```
dispatch_register.ndjson: 1673 events, 622 unique dispatch_ids
t0_receipts.ndjson: 28136 receipts, 5831 dispatches with >=1 terminal receipt
```

Per reader (upper bound on verdict flips if the fix ships):

| reader | flips |
|---|---|
| `orphan_sweep.py` kind-1b (`_evaluate_completed_orphan`) | 5360 dispatches move from "gate-b `unknown_project`, categorically un-assessable" to "assessable" (historical upper bound, dominated by May–Jul when the emitter was fully dead per OI-1425's own table). Only a **verdict-string** change (`receipt:` → `register:`) for another 342 that were already covered via the `receipts_index` fallback — 0 behavioral flip there. |
| `pr_queue_state.py` `_build_queued_features` | 326 of 467 currently-shown "queued/stuck" dispatches would correctly disappear (they actually completed) |
| `t0_decision_reconcile.py` | 208 of 661 pending decisions would newly resolve |
| `build_t0_state.py` `_build_feature_state` | 299 dispatches flip status from active/queued/unknown → completed/failed; 5360 gain visibility for the first time |
| `dispatch_lifecycle_tracker.py`, `state_aggregator.py` | **Verified not actual readers** — neither consumes `dispatch_register.ndjson` at all (tracker reads a live `ReceiptTail` stream directly; aggregator has its own independent push API). Same event-name strings, unrelated data path. |

**Live-risk check for the dangerous one (`orphan_sweep`):** ran `orphan_sweep.sweep(dry_run=True)` against the real fleet (never mutates — verified all 3 kinds gate every real action behind `if dry_run`). The 5 currently-alive `vnx-*` tmux sessions all have **zero receipts at all** (still running) — none can be flipped by this fix today. The 5360-count is a historical upper bound gated by tmux-session survivability (sessions from May–Jul don't survive months of uptime); going forward this only switches on the kind-1b safety mechanism for lanes it could never evaluate before (OI-1353's intent), it doesn't weaken any of the other conjunction conditions (live session + worktree gone + pane idle).

Conclusion: proceeded to stage 2 — no mass-delete risk demonstrated today, and the structural historical exposure is inherent to the mechanism working correctly for the first time on previously-invisible lanes.

## Verification

- `python3 -m pytest tests/test_append_receipt_register_emit.py tests/test_payload_exception_handling.py tests/test_receipt_mirror_isolation.py tests/test_event_outcome_semantics.py tests/test_append_receipt_reroute.py tests/test_append_receipt_dual_write.py tests/test_subprocess_dispatch_dedup.py -q` → **135 passed** (5 new regression tests added: duplicate-fires-emit, single-append-still-single-emit, exception-is-loud, import-failure-is-loud, no-mapping-stays-silent).
- `python3 scripts/ci_lint_patterns.py --files-from-stdin` on both changed files → clean (no Pattern A/B findings).
- `grep -n "test_append_receipt_register_emit" scripts/ci/test_exclusions.txt` → no match (test file is not excluded from CI).
- Demonstrated live (temp ledger under `/tmp`, own `VNX_STATE_DIR`/`VNX_DATA_DIR` env, real central store never touched): a provider-lane-shaped receipt (`subprocess_completion`/`success`, `source=None`) and a headless-lane-shaped receipt (`task_complete`/`done`) both land a `dispatch_completed` register event; a non-terminal receipt (`review_gate_request`/`gemini_review`) lands none; a simulated register-write failure surfaces as `{"code":"dispatch_register_emit_failed","dispatch_id":"DEMO-REGISTERFAIL-001","error":"simulated register write failure (disk full)","level":"WARN","register_event":"dispatch_completed","stage":"append", ...}` on stderr while the receipt append itself still returns `status="appended"` and is physically durable in the ledger.
- A broader `pytest tests/ -k "append_receipt or register_emit or payload or dispatch_register"` sweep surfaced 11 failures in `test_dispatch_register.py`/`test_dispatch_register_path.py`/`test_pool_state_repo.py` — verified **pre-existing and unrelated**: none of those files touch either changed module; `test_dispatch_register.py`/`test_dispatch_register_path.py` pass 100% in isolation (cross-file pollution from the broad `-k` run, not from this change); `test_pool_state_repo.py` fails identically (6/9, `sqlite3.IntegrityError: FOREIGN KEY constraint failed`) in full isolation, reproduced twice, unrelated to receipts/register entirely.

## Open Items

None. Per dispatch instructions, only `scripts/lib/append_receipt_internals/` and test files were touched — the reader modules (`orphan_sweep.py`, `pr_queue_state.py`, `t0_decision_reconcile.py`, `build_t0_state.py`) were read and measured but not modified. T0 may want to re-run `orphan_sweep.sweep(dry_run=True)` once after this ships and periodically thereafter, since the 5360-dispatch historical bucket will keep gaining register footprint going forward as those lanes complete new work — worth a follow-up OI if a live orphan candidate ever does show up in that bucket, to confirm the other conjunction conditions still hold as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)