### PR TITLE
fix(governance-emit): lift the real reason out of the lane log on an empty response (OI-1433)

### DIFF
--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -23,7 +23,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Ensure the sibling scripts/lib modules resolve even when a caller imports
 # governance_emit by path without scripts/lib already on sys.path.
@@ -400,6 +400,175 @@ def _validate_report_frontmatter(content: str, dispatch_id: str, report_path: Op
         )
 
 
+# OI-1433: lane-log lift. When response_text is empty, the generic body
+# wrapper below used to write the contentless "(no response captured)"
+# placeholder even when the real reason (a provider 403/402 billing/quota
+# rejection) was already sitting on disk in the per-dispatch raw lane log
+# (``logs/conversations/<dispatch_id>.log`` — the same file kimi_spawn.py's
+# heartbeat tees to, see its ``_resolve_heartbeat_log_path``). Measured
+# 22-08: 20 of 20 empty-response reports with a 403 body in that log said
+# "(no response captured)" — the operator read "unknown error" where the log
+# said the account was out of quota.
+#
+# NEVER read ``~/.kimi/logs/kimi.log`` here: that single file is shared by
+# every concurrent kimi dispatch (kimi_spawn.py ~L720-728) and would mask one
+# dispatch's outcome with another's. The per-dispatch tee under
+# logs/conversations/ is the only correct source.
+_LANE_LOG_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+_LANE_LOG_DISPLAY_MAX_CHARS = 4000
+_LANE_LOG_READ_MAX_BYTES = 2_000_000
+
+# Reason-label markers actually observed in raw provider bodies (22-08
+# measurement) for a permanent billing/quota rejection. Matched narrowly on
+# the provider's own distinguishing phrase/type label — never on a generic
+# parser-side "msg" field. kimi's raw 403 body rides in the SAME log line as
+# an unrelated JSON-decode-failure message (the CLI's own drainer trying and
+# failing to parse the non-JSON error text as an event); a classifier keyed
+# on that "msg=" text would read the parse failure and call this
+# `unreadable_verdict` instead of `lane_exhausted`. Scanning the whole raw
+# text for the provider's own label/phrase side-steps that trap entirely.
+_LANE_EXHAUSTED_MARKERS = (
+    "access_terminated_error",              # kimi 403
+    "insufficient balance",                 # deepseek 402
+    "insufficient_balance",
+    "insufficient credits",
+    "requires more credits",                # glm/openrouter 402-in-500
+    "add more credits",
+    "openrouter_credits",
+    "usage limit for this billing cycle",   # kimi 403 prose
+    "reached your usage limit",
+)
+
+
+def _resolve_lane_log_path(dispatch_id: str, data_dir: Path) -> Optional[Path]:
+    """Path-safe resolve of logs/conversations/<dispatch_id>.log.
+
+    Mirrors kimi_spawn.py::_resolve_heartbeat_log_path's shape: a regex check
+    on dispatch_id (no "/" is legal, so no path-segment injection is even
+    possible) followed by a `relative_to` escape check as defense in depth.
+    Returns None (refuse, no read) on anything unsafe or unresolvable — a bad
+    lookup must never block report emission.
+    """
+    if not dispatch_id or not _LANE_LOG_ID_SAFE_RE.match(dispatch_id):
+        logger.warning(
+            "governance_emit: lane-log lift refused — unsafe dispatch_id %r", dispatch_id,
+        )
+        return None
+    log_dir = Path(data_dir) / "logs" / "conversations"
+    candidate = (log_dir / f"{dispatch_id}.log").resolve()
+    try:
+        candidate.relative_to(log_dir.resolve())
+    except ValueError:
+        logger.warning(
+            "governance_emit: lane-log lift refused — path %s escaped %s", candidate, log_dir,
+        )
+        return None
+    return candidate
+
+
+def _read_lane_log_text(dispatch_id: str, data_dir: Path) -> Optional[str]:
+    """Best-effort raw-text read of the per-dispatch lane log.
+
+    Returns None (never raises) when the path is unsafe, the file is
+    missing/not a regular file, is empty/whitespace-only, or cannot be read —
+    every one of those collapses to the same `no_response` state upstream.
+    """
+    path = _resolve_lane_log_path(dispatch_id, data_dir)
+    if path is None:
+        return None
+    try:
+        if not path.is_file():
+            return None
+        raw = path.read_bytes()[:_LANE_LOG_READ_MAX_BYTES]
+    except OSError as exc:
+        logger.warning(
+            "governance_emit: lane-log read failed dispatch=%s path=%s: %s",
+            dispatch_id, path, exc,
+        )
+        return None
+    text = raw.decode("utf-8", errors="replace")
+    return text if text.strip() else None
+
+
+def _bounded_snippet(text: str, max_len: int = 300) -> str:
+    """Collapse whitespace and cap length — same shape as failure_classification.py's
+    _extract_detail, so a lifted reason never carries a multi-KB blob."""
+    snippet = " ".join(text.split())
+    if len(snippet) > max_len:
+        snippet = snippet[:max_len].rstrip() + "…"
+    return snippet
+
+
+def _classify_lane_log_text(text: str) -> Tuple[str, Optional[str]]:
+    """Classify non-empty raw lane-log content into (state, reason).
+
+    state is 'lane_exhausted' (a permanent billing/quota rejection — matched
+    on a narrow provider-owned label, see _LANE_EXHAUSTED_MARKERS) or
+    'unreadable_verdict' (the lane produced content but no recognizable
+    billing/quota signal — the model may have answered, but no verdict could
+    be read out of it). reason is only populated for lane_exhausted.
+    """
+    lowered = text.lower()
+    for marker in _LANE_EXHAUSTED_MARKERS:
+        if marker in lowered:
+            return "lane_exhausted", _bounded_snippet(text)
+    return "unreadable_verdict", None
+
+
+def _lift_lane_log_for_report(
+    dispatch_id: str, data_dir: Path
+) -> Optional[Tuple[str, str, Optional[str]]]:
+    """Build (state, response_block, reason) to substitute for an empty
+    response_text, or None when there is nothing usable (log missing/empty) —
+    the caller treats None as the `no_response` state and keeps the standard
+    placeholder. Never raises: any failure here falls back to the placeholder
+    and logs loudly rather than breaking report emission — a failed lift must
+    never become a second failure on top of the one it was trying to explain.
+    """
+    try:
+        text = _read_lane_log_text(dispatch_id, data_dir)
+        if not text:
+            return None
+        state, reason = _classify_lane_log_text(text)
+
+        display = text
+        truncated_note = ""
+        if len(text) > _LANE_LOG_DISPLAY_MAX_CHARS:
+            cut = len(text) - _LANE_LOG_DISPLAY_MAX_CHARS
+            display = text[:_LANE_LOG_DISPLAY_MAX_CHARS]
+            truncated_note = (
+                f"\n\n_[lane log truncated — {cut} additional characters omitted]_"
+            )
+
+        state_note = {
+            "lane_exhausted": (
+                "diagnosed as **lane_exhausted** — the provider rejected the "
+                "call for billing/quota reasons; this is permanent until the "
+                "account is topped up or the quota resets, not a transient error."
+            ),
+            "unreadable_verdict": (
+                "diagnosed as **unreadable_verdict** — the lane produced "
+                "content but no usable verdict could be read out of it."
+            ),
+        }[state]
+
+        block = (
+            "_No response text was captured from the model. The text below is "
+            f"lifted from this dispatch's raw LANE LOG "
+            f"(`logs/conversations/{dispatch_id}.log`) — it is NOT a model "
+            f"reply. {state_note}_\n\n"
+            f"```\n{display}\n```"
+            f"{truncated_note}"
+        )
+        return state, block, reason
+    except Exception as exc:  # noqa: BLE001 — a lift failure must never break report emission
+        logger.warning(
+            "governance_emit: lane-log lift failed dispatch=%s: %s", dispatch_id, exc,
+        )
+        return None
+
+
 def emit_unified_report(
     dispatch_id: str,
     terminal_id: str,
@@ -524,10 +693,29 @@ def emit_unified_report(
         ])
         identity_block = "\n".join(identity_lines)
 
+        # OI-1433: an empty response_text gets one chance to explain itself
+        # from the per-dispatch raw lane log before falling back to the bare
+        # placeholder — see _lift_lane_log_for_report above.
+        response_block = response_text
+        if not (response_text or "").strip():
+            lift = _lift_lane_log_for_report(dispatch_id, data_dir)
+            if lift is not None:
+                empty_response_state, response_block, lane_reason = lift
+            else:
+                empty_response_state, response_block, lane_reason = "no_response", None, None
+            if frontmatter is not None:
+                frontmatter.setdefault("empty_response_state", empty_response_state)
+                # Canonical field (OI-1415/#1666): stamp the SAME failure_reason
+                # key generic failure readers already look for — never a
+                # lane-log-only field name — and never clobber a reason the
+                # caller already computed upstream.
+                if lane_reason and not frontmatter.get("failure_reason"):
+                    frontmatter["failure_reason"] = lane_reason
+
         body = (
             f"# Dispatch {dispatch_id}\n\n"
             f"{identity_block}\n\n"
-            f"## Response\n\n{response_text or '(no response captured)'}\n"
+            f"## Response\n\n{response_block or '(no response captured)'}\n"
         )
 
         # findings=None means "not captured": the section is omitted entirely,

--- a/tests/fixtures/lane_logs/content_no_verdict.log
+++ b/tests/fixtures/lane_logs/content_no_verdict.log
@@ -1,0 +1,4 @@
+{"event_type": "TurnBegin"}
+{"event_type": "StepBegin"}
+{"event_type": "ContentPart", "content": "Let me check the file structure first."}
+{"event_type": "ContentPart", "content": "Reading scripts/lib/governance_emit.py..."}

--- a/tests/fixtures/lane_logs/kimi_403_quota.log
+++ b/tests/fixtures/lane_logs/kimi_403_quota.log
@@ -1,0 +1,1 @@
+Error code: 403 - {'error': {'message': "You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle. To continue now, purchase extra usage or upgrade your plan: https://platform.moonshot.ai/console", 'type': 'access_terminated_error'}}

--- a/tests/test_oi1433_lane_log_lift.py
+++ b/tests/test_oi1433_lane_log_lift.py
@@ -1,0 +1,247 @@
+"""tests/test_oi1433_lane_log_lift.py — an empty response gets one honest look at the
+raw lane log before governance_emit falls back to "(no response captured)" (OI-1433).
+
+Measured 22-08 on the central store: 20 of 20 empty-response reports with a 403 body
+sitting in their per-dispatch raw lane log (``logs/conversations/<dispatch_id>.log``)
+said "(no response captured)" — the operator read "unknown error" where the log said
+the provider account was out of quota.
+
+These tests are RED against the pre-fix ``emit_unified_report`` (the fixed body is a
+new code path added in this same PR, not present before it — see the dispatch report
+for the before/after pytest run demonstrating this).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+for _p in (str(_LIB), str(_SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from governance_emit import (  # noqa: E402
+    emit_unified_report,
+    _classify_lane_log_text,
+    _read_lane_log_text,
+    _resolve_lane_log_path,
+)
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "lane_logs"
+
+
+@pytest.fixture()
+def data_dir(tmp_path):
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+def _write_log(data_dir: Path, dispatch_id: str, fixture_name: str) -> Path:
+    log_dir = data_dir / "logs" / "conversations"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    content = (_FIXTURES / fixture_name).read_bytes()
+    log_path = log_dir / f"{dispatch_id}.log"
+    log_path.write_bytes(content)
+    return log_path
+
+
+def _emit_kwargs(data_dir, dispatch_id, **overrides):
+    kwargs = dict(
+        dispatch_id=dispatch_id,
+        terminal_id="T1",
+        provider="kimi",
+        instruction="do the thing",
+        response_text="",
+        findings=None,
+        duration_seconds=3.2,
+        data_dir=data_dir,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+# ── State 1: lane_exhausted — a 403/402 billing/quota body sitting in the log ──────
+
+
+def test_empty_response_with_403_log_lifts_body_as_lane_exhausted(data_dir):
+    dispatch_id = "20260822-oi1433-quota"
+    _write_log(data_dir, dispatch_id, "kimi_403_quota.log")
+    frontmatter = {}
+
+    path = emit_unified_report(**_emit_kwargs(data_dir, dispatch_id, frontmatter=frontmatter))
+    content = path.read_text(encoding="utf-8")
+
+    assert "(no response captured)" not in content, (
+        "an empty response with a real 403 body sitting in the lane log must not fall "
+        "back to the contentless placeholder"
+    )
+    assert "access_terminated_error" in content, (
+        "the raw 403 body must be lifted verbatim into the report body"
+    )
+    assert "NOT a model reply" in content, (
+        "the lifted text must be labeled as coming from the lane log, never as a model reply"
+    )
+    assert frontmatter["empty_response_state"] == "lane_exhausted"
+    assert "usage limit" in frontmatter["failure_reason"].lower(), (
+        "the canonical failure_reason field (OI-1415/#1666) must carry the real quota "
+        "reason extracted from the log, not a lane-log-only field name"
+    )
+
+
+def test_lane_exhausted_reads_reason_label_not_msg_field(data_dir):
+    """Regression for the specific kimi trap: the raw log line that carries the real
+    403 body ALSO trips a generic JSON-decode-failure message elsewhere in the
+    pipeline (msg='Expecting value: line 1...'). The classifier must never be fooled
+    by that noise into downgrading a real quota rejection to 'unreadable_verdict'.
+    """
+    text = (
+        "[quota_or_auth] provider=kimi reason=quota_or_auth "
+        "msg='Expecting value: line 1 column 1 (char 0)' "
+        "raw='Error code: 403 - {\\'error\\': {\\'message\\': \"you are done\", "
+        "\\'type\\': \\'access_terminated_error\\'}}'"
+    )
+    state, reason = _classify_lane_log_text(text)
+    assert state == "lane_exhausted"
+    assert reason is not None
+
+
+# ── State 3: no_response — log missing or empty, cause genuinely unknown ───────────
+
+
+def test_empty_response_with_empty_log_keeps_placeholder_and_no_response_state(data_dir):
+    dispatch_id = "20260822-oi1433-empty"
+    _write_log(data_dir, dispatch_id, "empty.log")
+    frontmatter = {}
+
+    path = emit_unified_report(**_emit_kwargs(data_dir, dispatch_id, frontmatter=frontmatter))
+    content = path.read_text(encoding="utf-8")
+
+    assert "(no response captured)" in content, (
+        "an empty log must never be presented as if something explanatory was found"
+    )
+    assert frontmatter["empty_response_state"] == "no_response"
+    assert "failure_reason" not in frontmatter
+
+
+def test_empty_response_with_no_log_file_at_all_keeps_placeholder(data_dir):
+    dispatch_id = "20260822-oi1433-missing"
+    frontmatter = {}
+
+    path = emit_unified_report(**_emit_kwargs(data_dir, dispatch_id, frontmatter=frontmatter))
+    content = path.read_text(encoding="utf-8")
+
+    assert "(no response captured)" in content
+    assert frontmatter["empty_response_state"] == "no_response"
+
+
+# ── State 2: unreadable_verdict — content exists, but no billing/quota signal ──────
+
+
+def test_empty_response_with_content_but_no_verdict(data_dir):
+    dispatch_id = "20260822-oi1433-noverdict"
+    _write_log(data_dir, dispatch_id, "content_no_verdict.log")
+    frontmatter = {}
+
+    path = emit_unified_report(**_emit_kwargs(data_dir, dispatch_id, frontmatter=frontmatter))
+    content = path.read_text(encoding="utf-8")
+
+    assert "(no response captured)" not in content
+    assert "Let me check the file structure first." in content
+    assert "NOT a model reply" in content
+    assert frontmatter["empty_response_state"] == "unreadable_verdict"
+    assert "failure_reason" not in frontmatter, (
+        "unreadable_verdict has no extracted reason — the canonical field must stay untouched"
+    )
+
+
+# ── State 4: a real response — unchanged behavior, log is never read ──────────────
+
+
+def test_non_empty_response_never_reads_the_log(data_dir):
+    dispatch_id = "20260822-oi1433-realresponse"
+    _write_log(data_dir, dispatch_id, "kimi_403_quota.log")
+    frontmatter = {}
+    real_response = "The implementation is complete and tests pass."
+
+    path = emit_unified_report(
+        **_emit_kwargs(
+            data_dir, dispatch_id, response_text=real_response, frontmatter=frontmatter,
+        )
+    )
+    content = path.read_text(encoding="utf-8")
+
+    assert real_response in content
+    assert "access_terminated_error" not in content, (
+        "a non-empty response must never trigger a lane-log read, even when a "
+        "quota-shaped log happens to exist for the same dispatch_id"
+    )
+    assert "empty_response_state" not in frontmatter
+
+
+# ── State 5: dispatch_id trying to escape the log directory ───────────────────────
+
+
+def test_path_escaping_dispatch_id_is_refused_no_read(data_dir, caplog):
+    log_dir = data_dir / "logs" / "conversations"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    # A sibling file that a naive join could be tricked into reaching.
+    secret = data_dir / "logs" / "secret.log"
+    secret.write_text("top secret content", encoding="utf-8")
+
+    evil_id = "../secret"
+    with caplog.at_level("WARNING", logger="governance_emit"):
+        assert _resolve_lane_log_path(evil_id, data_dir) is None
+        assert _read_lane_log_text(evil_id, data_dir) is None
+
+    assert any("refused" in record.getMessage() for record in caplog.records), (
+        "a refused lane-log lookup must be logged loudly, not silently swallowed"
+    )
+
+
+def test_unsafe_dispatch_id_characters_are_refused(data_dir):
+    for evil_id in ("../../etc/passwd", "foo/bar", "foo\x00bar", ""):
+        assert _resolve_lane_log_path(evil_id, data_dir) is None
+
+
+# ── State 6: a log bigger than the display limit is truncated, visibly ────────────
+
+
+def test_oversized_log_is_truncated_with_visible_notice(data_dir):
+    dispatch_id = "20260822-oi1433-huge"
+    log_dir = data_dir / "logs" / "conversations"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    huge_text = "filler line without any quota keywords in it\n" * 400  # > 4000 chars
+    (log_dir / f"{dispatch_id}.log").write_text(huge_text, encoding="utf-8")
+    frontmatter = {}
+
+    path = emit_unified_report(**_emit_kwargs(data_dir, dispatch_id, frontmatter=frontmatter))
+    content = path.read_text(encoding="utf-8")
+
+    assert "truncated" in content.lower(), (
+        "a log larger than the display limit must carry a visible truncation notice"
+    )
+    assert "additional characters omitted" in content
+    assert frontmatter["empty_response_state"] == "unreadable_verdict"
+
+
+def test_unreadable_log_never_crashes_report_emission(data_dir, monkeypatch):
+    dispatch_id = "20260822-oi1433-unreadable"
+    log_dir = data_dir / "logs" / "conversations"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{dispatch_id}.log"
+    log_path.write_text("some content", encoding="utf-8")
+
+    import governance_emit
+
+    def _boom(*_a, **_kw):
+        raise OSError("simulated unreadable file")
+
+    monkeypatch.setattr(governance_emit.Path, "read_bytes", _boom)
+
+    path = emit_unified_report(**_emit_kwargs(data_dir, dispatch_id))
+    content = path.read_text(encoding="utf-8")
+    assert "(no response captured)" in content


### PR DESCRIPTION
## Summary
- `emit_unified_report` wrote the contentless `(no response captured)` placeholder whenever `response_text` was empty, even when the real reason (a provider 403/402 billing/quota rejection) was already sitting on disk in the per-dispatch raw lane log. Measured 22-08 on the central store: 20 of 20 empty-response reports with a 403 body in `logs/conversations/<dispatch_id>.log` said "(no response captured)".
- When `response_text` is empty, `emit_unified_report` now path-safely reads `logs/conversations/<dispatch_id>.log` (same shape as `kimi_spawn.py::_resolve_heartbeat_log_path`: regex check + `relative_to` escape check), classifies what it finds into one of three states, and lifts the content into the report body — explicitly labeled as coming from the lane log, never as a model reply.
- Three states, stamped into `frontmatter["empty_response_state"]`:
  - `lane_exhausted` — a permanent billing/quota rejection (kimi 403 `access_terminated_error`, deepseek 402 `insufficient balance`, glm/openrouter 402-wrapped-in-500). Also stamps the **canonical** `failure_reason` field (the same field OI-1415/#1666 wired up for phantom_guard/pr_enforcement) with the extracted reason — never a lane-log-only field name, and never clobbers a reason the caller already set.
  - `unreadable_verdict` — the lane produced content but no recognizable billing/quota signal.
  - `no_response` — log missing/empty/unreadable; placeholder stays untouched. Never upgraded to the other two states.
- Classification matches on the provider's own reason-label/type phrase (e.g. `access_terminated_error`), never on generic parser-side `msg=` noise — kimi's raw 403 body rides in the same log line as an unrelated JSON-decode-failure message, which would otherwise misclassify a real quota rejection as `unreadable_verdict`.
- A log larger than 4000 chars is truncated with a visible notice of how much was cut. Any read/classify failure falls back to the existing placeholder and logs loudly — never crashes report emission.
- Never reads `~/.kimi/logs/kimi.log` (shared across concurrent kimi dispatches, would mask outcomes).
- Scope held to `scripts/lib/governance_emit.py`, the new test file, and a new fixture dir — no spawn-module changes.

## Test plan
- [x] New file `tests/test_oi1433_lane_log_lift.py` (10 tests) using 3 fixtures under `tests/fixtures/lane_logs/` built from the measured raw forms (403 kimi body, empty log, content-without-verdict).
- [x] Confirmed RED on unmodified `main`: reverted the `governance_emit.py` change (via saved patch + `git checkout --`) and re-ran — import error, tests don't even collect (proves these assert genuinely new behavior, not tautologies).
- [x] Reapplied the fix — all 10 tests green again.
- [x] `pytest tests/test_governance_emit*.py tests/test_oi1433_lane_log_lift.py` — 82 passed.
- [x] `pytest tests/test_kimi_spawn_heartbeat.py tests/test_ringbuffer_truncate_oi858.py tests/test_envelope_govern_contract_enforce.py tests/test_emit_governance_retry.py tests/test_dispatch_govern.py tests/test_dispatch_envelope.py` — 167 passed (neighbours most likely to exercise empty-response/placeholder paths).
- [x] `grep test_oi1433 scripts/ci/test_exclusions.txt` — no match, so this test file is not CI-excluded.
- [x] `ruff check` on both touched files — 0 new findings (the 7 pre-existing E402s on `governance_emit.py`'s existing import block are unchanged from baseline).
- [x] `python3 scripts/ci_lint_patterns.py --files-from-stdin` on `governance_emit.py` — clean (all new `except Exception` blocks log before returning, so none are silent).

Dispatch-ID: beta-1433-lane-log-lift