### PR TITLE
fix(kimi-gate): stamp contract_hash + report_path on terminal verdicts (OI-1178, DLv2)

### DIFF
--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -68,6 +68,18 @@ raw-zero check booked as provider outages, reintroducing OI-1291's original
 bug on a different axis. ``output_tokens`` now only counts as a failure
 signal when the frontmatter's own ``token_usage_measured`` flag is true;
 otherwise only ``exit_code`` decides.
+
+OI-1178 (DLv2): a terminal (pass/fail) record must carry ``contract_hash`` +
+``report_path`` or ``gate_status.has_complete_evidence`` — and therefore
+``closure_verifier``'s merge check — refuses it as evidence, forever, no
+matter how good the review was. ``contract_hash`` is computed by
+``gate_artifacts._compute_contract_hash`` (the SAME function codex_gate's
+own execution path calls), never a second hashing method. ``report_path``
+points at the governed dispatch's own unified report
+(``<data_dir>/unified_reports/<dispatch_id>.md``), already written to disk
+by the time the dispatcher call returns. An ``unavailable`` result (OI-1142)
+carries neither: it is not terminal and must never look like complete
+evidence.
 """
 from __future__ import annotations
 
@@ -83,13 +95,14 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from plan_gate_panel import _make_default_dispatcher  # governed provider_dispatch lane
+from plan_gate_panel import _make_default_dispatcher, _resolve_data_dir  # governed provider_dispatch lane
 from gate_recorder import (
     get_pr_head_branch,
     get_pr_head_sha,
     record_terminal_result,
     stamp_request_identity,
 )
+from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
 from unified_report_schema import SchemaViolation, parse_frontmatter
 
 _VALID_VERDICTS = {"pass", "fail", "blocked"}
@@ -296,14 +309,21 @@ def main(argv: "list[str] | None" = None) -> int:
 
     data_dir = args.data_dir or None
     dispatch_id = f"kimi-gate-pr{args.pr}-{int(time.time())}"
-    dispatcher = _make_default_dispatcher(data_dir, args.timeout)
+    # Resolved once, then handed to the dispatcher as an explicit data_dir so
+    # this function's own report_path reconstruction below and the governed
+    # subprocess's actual write path can never drift apart — both derive from
+    # the SAME resolved base (see provider_dispatch.py's report_path, which is
+    # this exact <data_dir>/unified_reports/<dispatch_id>.md).
+    base_data_dir = _resolve_data_dir(data_dir)
+    dispatcher = _make_default_dispatcher(str(base_data_dir), args.timeout)
+    prompt = _build_prompt(diff, args.pr)
 
     start = time.monotonic()
     report_text = ""
     dispatch_error = ""
     try:
         # Governed lane: provider_dispatch runs kimi, writes a unified report, returns its text.
-        report_text = dispatcher("kimi", args.model, _build_prompt(diff, args.pr), dispatch_id)
+        report_text = dispatcher("kimi", args.model, prompt, dispatch_id)
     except Exception as exc:  # noqa: BLE001 — dispatch/report-read failure
         # OI-1142: do NOT bail without a record — a required gate that cannot fire
         # must surface as ``unavailable`` in the results dir, not vanish.
@@ -353,6 +373,22 @@ def main(argv: "list[str] | None" = None) -> int:
         else:
             reason = "no_verdict"
 
+    # OI-1178 (DLv2): a terminal verdict must carry the same evidence pair
+    # codex_gate/gemini_review stamp — contract_hash (gate_artifacts' single
+    # canonical hasher) + report_path (the governed dispatch's own unified
+    # report, already on disk by the time dispatcher() returned above). Only
+    # ``verdict`` ever reaches pass/fail (see _verdict_to_status), so
+    # report_text is guaranteed non-empty here. An unavailable result (no
+    # readable verdict, or the dispatch itself failed) is deliberately left
+    # with neither field: OI-1142's outage/verdict separation must not be
+    # bypassed by a record that merely LOOKS complete.
+    if status in {"pass", "fail"}:
+        contract_hash = _compute_contract_hash({"prompt": prompt}, "kimi_gate")
+        report_path = str(base_data_dir / "unified_reports" / f"{dispatch_id}.md")
+    else:
+        contract_hash = ""
+        report_path = ""
+
     record = {
         "gate": "kimi_gate",
         "pr_id": str(args.pr),
@@ -365,6 +401,8 @@ def main(argv: "list[str] | None" = None) -> int:
         "reason": reason,
         "duration_seconds": round(duration, 3),
         "summary": _status_summary(status, blocking, reason, len(report_text or "")),
+        "contract_hash": contract_hash,
+        "report_path": report_path,
         "provider": "kimi",
         "model": args.model,
         "dispatch_id": dispatch_id,

--- a/tests/test_dlv2_kimi_gate_evidence.py
+++ b/tests/test_dlv2_kimi_gate_evidence.py
@@ -1,0 +1,229 @@
+"""kimi_gate.py evidence-completeness tests (dispatch beta-dlv2-kimi-gate-bewijs).
+
+Measured on the central store before this fix: every terminal (status=pass)
+kimi_gate result carried neither ``contract_hash`` nor ``report_path`` — 9 of
+9 records. ``gate_status.has_complete_evidence`` requires BOTH non-empty, so
+a recognized kimi gate would have been PERMANENTLY unable to close a PR no
+matter how good the review was, and ``closure_verifier.check_review_gate_
+for_merge`` NO-GOs with "resultaat mist contract_hash en/of report_path".
+
+kimi_gate.py now stamps both fields on a terminal verdict, reusing
+``gate_artifacts._compute_contract_hash`` — the SAME hasher codex_gate's own
+execution path (``gate_runner.run`` -> ``gate_artifacts.materialize_
+artifacts``) calls — never a second hashing method, and pointing
+``report_path`` at the governed dispatch's own unified report
+(``<data_dir>/unified_reports/<dispatch_id>.md``, already on disk by the
+time the dispatcher call returns; see ``governance_emit.emit_unified_report``
+and ``provider_dispatch.py``).
+
+An ``unavailable`` result (OI-1142: provider outage, no readable verdict)
+must never look like complete evidence, and an offline ``--diff-file`` run
+(``test_run: true``) must never count as evidence for a real PR — both
+pre-existing invariants, both re-verified here so this fix cannot have
+quietly broken either one.
+
+``_make_default_dispatcher``/``_get_diff``/``get_pr_head_branch``/
+``get_pr_head_sha`` are patched on the kimi_gate module namespace, not on
+their source modules — ``from X import Y`` binds the name at import time, so
+patching the source module would not affect kimi_gate's already-bound
+reference (same convention as test_kimi_gate_provenance.py /
+test_kimi_gate_unavailable.py).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import kimi_gate
+import closure_verifier
+import gate_artifacts
+from gate_status import has_complete_evidence, is_terminal
+
+
+_REAL_PASS_REPORT = (
+    "Reviewed the diff, no issues.\n\n"
+    "```json\n"
+    '{"verdict": "pass", "findings": [], "residual_risk": null}\n'
+    "```\n"
+)
+
+_FAKE_DIFF = "diff --git a/x b/x\n+ok\n"
+
+
+def _write_unified_report(data_dir: Path, dispatch_id: str, text: str) -> Path:
+    """Mimic ``governance_emit.emit_unified_report``'s write path.
+
+    The real governed dispatch ALWAYS writes the report to
+    ``<data_dir>/unified_reports/<dispatch_id>.md`` before the dispatcher call
+    returns the text; kimi_gate.py never writes this file itself, it only
+    reads the text back. This helper reproduces that ordering so the fake
+    dispatcher below behaves like the real one instead of a bare stub.
+    """
+    reports_dir = data_dir / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = reports_dir / f"{dispatch_id}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _fake_dispatcher_factory(data_dir: Path, text: str):
+    """Build a ``_make_default_dispatcher``-shaped double that writes the
+    report to disk exactly like the real governed lane, then returns it."""
+    def _make(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            _write_unified_report(data_dir, dispatch_id, text)
+            return text
+        return _dispatch
+    return _make
+
+
+def _run_kimi_gate_for_real_pr(tmp_path, monkeypatch, report_text, *, pr="4242"):
+    """Run kimi_gate.main() against a non-offline PR: no --diff-file (so
+    test_run stays False, matching a real governed run), a stubbed diff
+    source (no network), a dispatcher double that writes the unified report
+    like the real lane does, and stubbed gh-identity lookups (no real `gh`
+    subprocess calls)."""
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, report_text),
+    )
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/dlv2-test")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeefcafe")
+
+    rc = kimi_gate.main(["--pr", pr, "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / f"pr-{pr}-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    return rc, record, data_dir
+
+
+# ---------------------------------------------------------------------------
+# 1. A real verdict carries complete evidence — has_complete_evidence(record) is True
+# ---------------------------------------------------------------------------
+
+
+def test_pass_verdict_carries_complete_evidence(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_kimi_gate_for_real_pr(tmp_path, monkeypatch, _REAL_PASS_REPORT)
+
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["contract_hash"], "contract_hash must be non-empty on a terminal verdict"
+    assert record["report_path"], "report_path must be non-empty on a terminal verdict"
+    assert Path(record["report_path"]).is_file(), (
+        "report_path must point at a file that already exists on disk when the record is written"
+    )
+    # The real function, not a reimplementation of its logic.
+    assert has_complete_evidence(record) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. That same record clears the merge door's evidence check — no more NO-GO
+#    on "resultaat mist contract_hash en/of report_path"
+# ---------------------------------------------------------------------------
+
+
+def test_pass_verdict_clears_closure_verifier_merge_check(tmp_path, monkeypatch):
+    rc, record, data_dir = _run_kimi_gate_for_real_pr(tmp_path, monkeypatch, _REAL_PASS_REPORT, pr="4242")
+    assert rc == 0
+
+    results_dir = data_dir / "state" / "review_gates" / "results"
+    gate = closure_verifier.check_review_gate_for_merge("4242", "kimi_gate", results_dir)
+
+    assert gate["verdict"] == "GO", gate["message"]
+    assert "mist contract_hash" not in gate["message"]
+
+
+# ---------------------------------------------------------------------------
+# 3. An unavailable result never counts as complete evidence (OI-1142
+#    separation preserved)
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_result_never_has_complete_evidence(tmp_path, monkeypatch):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    # A provider outage: empty report, no readable verdict.
+    monkeypatch.setattr(kimi_gate, "_make_default_dispatcher", lambda *a, **k: (lambda *a2, **k2: ""))
+
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["contract_hash"] == ""
+    assert record["report_path"] == ""
+    # Either one alone would already keep an outage from closing a PR; both
+    # hold here, and the reason each holds is different (OI-1142 vs OI-1178):
+    assert has_complete_evidence(record) is False, "an outage must never look like a decided verdict"
+    assert is_terminal(record) is False, "an outage is retryable, not a decided pass/fail outcome"
+
+
+# ---------------------------------------------------------------------------
+# 4. An offline (--diff-file) run never counts as evidence for a real PR,
+#    even though it now carries complete evidence fields
+# ---------------------------------------------------------------------------
+
+
+def test_offline_run_is_test_run_and_rejected_by_merge_check_despite_complete_evidence(
+    tmp_path, monkeypatch,
+):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["test_run"] is True
+    # The record DOES carry complete evidence fields now...
+    assert has_complete_evidence(record) is True
+    # ...but the merge door must still refuse it: is_test_run_record is
+    # checked before contract_hash/report_path are ever consulted.
+    results_dir = data_dir / "state" / "review_gates" / "results"
+    gate = closure_verifier.check_review_gate_for_merge("0", "kimi_gate", results_dir)
+    assert gate["verdict"] == "NO-GO"
+    assert "geen review-gate resultaat" in gate["message"]
+
+
+# ---------------------------------------------------------------------------
+# 5. contract_hash is byte-identical to the existing route's hash for the
+#    same prompt — never a second hashing method
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_gate_reuses_the_canonical_hasher_not_a_second_implementation():
+    """kimi_gate imports gate_artifacts._compute_contract_hash directly — this
+    is an identity check, not a behavioral one: it proves there is exactly
+    ONE hashing implementation in the codebase, not two that happen to agree
+    today and can silently diverge tomorrow."""
+    assert kimi_gate._compute_contract_hash is gate_artifacts._compute_contract_hash
+
+
+def test_contract_hash_byte_equal_to_existing_route_for_same_contract(tmp_path, monkeypatch):
+    pr = "777"
+    rc, record, _data_dir = _run_kimi_gate_for_real_pr(tmp_path, monkeypatch, _REAL_PASS_REPORT, pr=pr)
+    assert rc == 0
+
+    # Reconstruct the exact prompt kimi_gate built for this run, then hash it
+    # via the SAME function the existing (codex_gate) route calls — gate name
+    # only affects the fallback branch (no "prompt" key), so a different gate
+    # name here still proves it is the same hash for the same contract.
+    prompt = kimi_gate._build_prompt(_FAKE_DIFF, pr)
+    existing_route_hash = gate_artifacts._compute_contract_hash({"prompt": prompt}, "codex_gate")
+
+    assert record["contract_hash"] != ""
+    assert record["contract_hash"] == existing_route_hash


### PR DESCRIPTION
## Summary
- kimi_gate.py built its terminal (pass/fail) result record without `contract_hash` or `report_path` — the fields were entirely absent, not empty. `gate_status.has_complete_evidence` requires both non-empty, so a recognized kimi gate would be permanently rejected as evidence by `closure_verifier`'s merge check no matter how good the review was. Measured on the central store: 9/9 real kimi_gate records had neither field.
- `contract_hash` is now computed via `gate_artifacts._compute_contract_hash` — the SAME function codex_gate's own execution path (`gate_runner.run` → `gate_artifacts.materialize_artifacts`) calls, never a second hashing method (proven via an identity assertion in the test suite).
- `report_path` points at the governed dispatch's own unified report (`<data_dir>/unified_reports/<dispatch_id>.md`), already written to disk by the time the dispatcher call returns (`governance_emit.emit_unified_report` via `provider_dispatch.py`).
- Both fields stay empty on a non-terminal `unavailable` result, preserving the OI-1142 provider-outage/verdict separation.
- Offline `--diff-file` runs still carry `test_run: true` and are still rejected by the merge check via `is_test_run_record`, unaffected by this change.

## Test plan
- [x] New file `tests/test_dlv2_kimi_gate_evidence.py` (6 tests): pass verdict carries complete evidence + `has_complete_evidence()` is True; that same record clears `closure_verifier.check_review_gate_for_merge` (GO, no more "mist contract_hash en/of report_path"); an `unavailable` result never has complete evidence and is non-terminal; an offline `--diff-file` run carries complete-evidence fields but is still merge-rejected via `test_run`; `kimi_gate._compute_contract_hash is gate_artifacts._compute_contract_hash` (identity check — no second hasher); `contract_hash` is byte-identical to the existing route's hash for the same prompt.
- [x] Verified RED→GREEN: stashed the `scripts/kimi_gate.py` fix, ran the new suite — all 6 failed against unmodified code (mostly `KeyError: 'contract_hash'`, confirming the field is absent, not empty). Restored the fix, re-ran — all 6 pass.
- [x] `python3 -m pytest tests/test_dlv2_kimi_gate_evidence.py tests/test_kimi_gate_provenance.py tests/test_kimi_gate_unavailable.py -v` → 24 passed
- [x] `python3 -m pytest tests/test_gate_unavailable_rollup.py -q` (neighbour touching `has_complete_evidence`/`_compute_contract_hash`) → 33 passed
- [x] Confirmed `tests/test_dlv2_kimi_gate_evidence.py` is NOT present in `scripts/ci/test_exclusions.txt`

## Scope
Only `scripts/kimi_gate.py` and the new test file were touched, per dispatch boundary — `closure_verifier.py` and the `Gate` enum are untouched (separate deliverables).

Dispatch-ID: beta-dlv2-kimi-gate-bewijs

🤖 Generated with [Claude Code](https://claude.com/claude-code)