### PR TITLE
feat(gate): recognize kimi_gate and glm_gate as governed review gates

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -730,6 +730,69 @@ def _gate_ci_gate(
     return CheckResult(f"gate_{gate}", "FAIL", f"ci_gate not passing — {reason}")
 
 
+def _gate_full_evidence_pass(gate: str, result: Optional[Dict[str, Any]]) -> CheckResult:
+    """Shared terminal + complete-evidence + pass check (dlv45: kimi_gate/glm_gate).
+
+    Unlike codex_gate, neither kimi_gate nor glm_gate has a risk-conditional
+    "required" policy — they are only checked when present in the review
+    stack, so there is no not-required PASS branch. Modeled on
+    ``_gate_codex_gate``'s terminal + report_path requirements, plus
+    ``gate_has_complete_evidence`` (contract_hash AND report_path, mirroring
+    ``_gate_ci_gate``) so a kimi/glm result cannot pass on report_path alone —
+    a kimi_gate result must carry the same evidence discipline as codex,
+    never less.
+
+    ``unavailable`` (OI-1142 provider outage) is deliberately not terminal
+    (``gate_status.is_terminal``), so it is rejected here before
+    ``gate_is_pass`` is ever consulted — an outage can never be booked as a
+    review PASS.
+    """
+    if result is None:
+        return CheckResult(f"gate_{gate}", "FAIL", f"no {gate} result found")
+    if not gate_is_terminal(result):
+        status = result.get("status", "unknown")
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            f"{gate} result is not terminal (status={status}) — incomplete evidence",
+        )
+    if not gate_has_complete_evidence(result):
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            f"{gate} result is missing contract_hash and/or report_path",
+        )
+    passed, reason = gate_is_pass(result)
+    if passed:
+        advisory_count = result.get("advisory_count")
+        if not isinstance(advisory_count, int):
+            advisory_count = len(result.get("advisory_findings") or [])
+        return CheckResult(
+            f"gate_{gate}",
+            "PASS",
+            f"{gate} passed ({advisory_count} advisory, 0 blocking)",
+        )
+    return CheckResult(f"gate_{gate}", "FAIL", f"{gate} not passing — {reason}")
+
+
+def _gate_kimi_gate(
+    contract: ReviewContract,
+    result: Optional[Dict[str, Any]],
+    results_dir: Path,
+    branch: Optional[str],
+) -> CheckResult:
+    return _gate_full_evidence_pass("kimi_gate", result)
+
+
+def _gate_glm_gate(
+    contract: ReviewContract,
+    result: Optional[Dict[str, Any]],
+    results_dir: Path,
+    branch: Optional[str],
+) -> CheckResult:
+    return _gate_full_evidence_pass("glm_gate", result)
+
+
 # Table-driven dispatch: one entry per gate the closure verifier implements.
 # Adding a gate means adding one handler here plus (if excluded) an entry in
 # _GATES_NOT_IMPLEMENTED_BY_CLOSURE — not a new branch in _check_single_gate,
@@ -739,6 +802,8 @@ _GATE_HANDLERS: Dict[str, Any] = {
     "codex_gate": _gate_codex_gate,
     "gemini_review": _gate_gemini_review,
     "ci_gate": _gate_ci_gate,
+    "kimi_gate": _gate_kimi_gate,
+    "glm_gate": _gate_glm_gate,
 }
 
 

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -42,12 +42,21 @@ class Gate(str, Enum):
     dispatch on; this is the canonical enum they lacked. An empty string means
     "no gate assigned" and is handled separately by callers — it is not a member
     here so ``Gate("")`` fails the same as any other unknown value.
+
+    KIMI_GATE and GLM_GATE (dlv45) extend the closed set with the same
+    discipline as every other member: each has a ``gate_request_handler``
+    dispatch branch and a ``closure_verifier._GATE_HANDLERS`` entry, pinned by
+    ``test_closure_verifier_gate_enum_drift.py``. Extending the enum without
+    both is what OI-1094 exists to catch — see that test module before adding
+    another member.
     """
     GEMINI_REVIEW           = "gemini_review"
     CODEX_GATE              = "codex_gate"
     CLAUDE_GITHUB_OPTIONAL  = "claude_github_optional"
     CI_GATE                 = "ci_gate"
     WIRING_GATE             = "wiring_gate"
+    KIMI_GATE               = "kimi_gate"
+    GLM_GATE                = "glm_gate"
 
 
 # Legacy lifecycle PHASE names that leak into the spec ``gate`` field but are not

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import subprocess
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 from auto_merge_policy import codex_final_gate_required
@@ -41,6 +42,18 @@ class GateRequestHandlerMixin:
     def _ci_gate_available(self) -> bool:
         import config_runtime
         return config_runtime.get_bool("VNX_CI_GATE_REQUIRED") and shutil.which("gh") is not None
+
+    def _kimi_gate_runner_path(self) -> Path:
+        return Path(__file__).resolve().parent.parent / "kimi_gate.py"
+
+    def _kimi_gate_available(self) -> bool:
+        return self._kimi_gate_runner_path().exists()
+
+    def _glm_gate_runner_path(self) -> Path:
+        return Path(__file__).resolve().parent.parent / "glm_gate.py"
+
+    def _glm_gate_available(self) -> bool:
+        return self._glm_gate_runner_path().exists()
 
     def _dispatch_one_review(
         self,
@@ -78,6 +91,10 @@ class GateRequestHandlerMixin:
             return self._request_ci_gate(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
         if gate == "wiring_gate":
             return self._request_wiring_gate(pr_number, branch, dispatch_id)
+        if gate == "kimi_gate":
+            return self._request_kimi(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+        if gate == "glm_gate":
+            return self._request_glm(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
         return {"gate": gate, "status": "blocked", "reason": "unknown_review_gate"}
 
     def request_reviews(
@@ -508,6 +525,95 @@ class GateRequestHandlerMixin:
                 dispatch_id=dispatch_id,
             )
         self._request_path("codex_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def _request_kimi(
+        self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str,
+        dispatch_id: str = "",
+    ) -> Dict[str, Any]:
+        from review_gate_manager import _utc_now
+
+        available = self._kimi_gate_available()
+        requested_at = _utc_now()
+        payload = {
+            "gate": "kimi_gate",
+            "status": "requested" if available else "not_executable",
+            "provider": "kimi",
+            "branch": branch,
+            "pr_number": pr_number,
+            "review_mode": mode,
+            "risk_class": risk_class,
+            "changed_files": changed_files,
+            "requested_at": requested_at,
+            "commit_sha": get_pr_head_sha(pr_number),
+            "report_path": self._build_report_path(
+                gate="kimi_gate",
+                requested_at=requested_at,
+                pr_number=pr_number,
+            ),
+        }
+        if dispatch_id:
+            payload["dispatch_id"] = dispatch_id
+        if not available:
+            self._mark_gate_unavailable(
+                payload, gate="kimi_gate", binary_name="kimi_gate.py",
+                pr_number=pr_number, pr_id="",
+                dispatch_id=dispatch_id,
+            )
+        self._request_path("kimi_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def _request_glm(
+        self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str,
+        dispatch_id: str = "",
+    ) -> Dict[str, Any]:
+        """glm_gate is a recognised Gate.GLM_GATE member whose runner
+        (scripts/glm_gate.py) has not shipped yet — a separate deliverable adds
+        it. Until then this must refuse with a reason distinct from
+        ``unknown_review_gate`` (dispatch_spec Gate rejects that request before
+        it ever reaches here) so an operator can tell "not a real gate" apart
+        from "real gate, runner not implemented yet".
+        """
+        from review_gate_manager import _utc_now
+
+        available = self._glm_gate_available()
+        requested_at = _utc_now()
+        payload: Dict[str, Any] = {
+            "gate": "glm_gate",
+            "status": "requested" if available else "not_executable",
+            "provider": "glm",
+            "branch": branch,
+            "pr_number": pr_number,
+            "review_mode": mode,
+            "risk_class": risk_class,
+            "changed_files": changed_files,
+            "requested_at": requested_at,
+            "commit_sha": get_pr_head_sha(pr_number),
+            "report_path": self._build_report_path(
+                gate="glm_gate",
+                requested_at=requested_at,
+                pr_number=pr_number,
+            ) if available else "",
+        }
+        if dispatch_id:
+            payload["dispatch_id"] = dispatch_id
+        if not available:
+            reason = "gate_runner_missing"
+            reason_detail = "scripts/glm_gate.py does not exist yet — ships in a separate deliverable"
+            payload["reason"] = reason
+            payload["reason_detail"] = reason_detail
+            payload["resolved_at"] = payload["requested_at"]
+            self._write_not_executable_result(
+                gate="glm_gate", pr_number=pr_number, pr_id="",
+                reason=reason, reason_detail=reason_detail,
+                dispatch_id=dispatch_id,
+            )
+            self._write_skip_rationale(
+                gate="glm_gate", pr_id=str(pr_number),
+                reason=reason, reason_detail=reason_detail,
+                binary_name="glm_gate.py",
+            )
+        self._request_path("glm_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return payload
 
     def _apply_claude_github_configured_state(

--- a/tests/test_closure_verifier_gate_enum_drift.py
+++ b/tests/test_closure_verifier_gate_enum_drift.py
@@ -103,3 +103,19 @@ class TestKnownGatesDerivedFromEnum:
         assert not stray, (
             f"_GATE_HANDLERS entries for gates not in _KNOWN_GATES: {sorted(stray)}"
         )
+
+    @pytest.mark.parametrize("gate_name", ["kimi_gate", "glm_gate"])
+    def test_dlv45_new_gate_is_known_and_has_a_handler(self, gate_name):
+        """kimi_gate and glm_gate (dlv45) must land as real Gate members —
+        recognised by name, in _KNOWN_GATES, and with a closure handler — not
+        parked on _GATES_NOT_IMPLEMENTED_BY_CLOSURE, which would let
+        _check_single_gate route them to UNVERIFIED forever and make closure
+        for either gate structurally unreachable."""
+        enum_values = {g.value for g in Gate}
+        assert gate_name in enum_values, f"{gate_name} must be a Gate enum member"
+        assert gate_name in cv._KNOWN_GATES, f"{gate_name} must be in _KNOWN_GATES"
+        assert gate_name not in cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE, (
+            f"{gate_name} must not be parked on _GATES_NOT_IMPLEMENTED_BY_CLOSURE — "
+            "that would make closure for it structurally unreachable"
+        )
+        assert gate_name in cv._GATE_HANDLERS, f"{gate_name} must have a _GATE_HANDLERS entry"

--- a/tests/test_closure_verifier_unknown_gate.py
+++ b/tests/test_closure_verifier_unknown_gate.py
@@ -194,12 +194,18 @@ def _run_closure(verifier_env, contract, results_dir, monkeypatch):
 
 
 class TestUnknownGateNeverPasses:
+    """dlv45: these tests used ``kimi_gate`` as the "unknown gate" example.
+    kimi_gate is now a recognised Gate member with its own closure handler
+    (see test_dlv45_gate_recognition.py), so it can no longer stand in for
+    "a gate the verifier does not implement" — ``totally_unknown_gate`` takes
+    over that role, preserving the original DoD-1 intent unchanged."""
+
     def test_unknown_gate_with_pass_record_does_not_pass_closure(self, verifier_env, monkeypatch, tmp_path):
         """Fabricated gate name + status=pass record must not yield a PASS."""
-        contract = _make_contract(review_stack=["kimi_gate"])
+        contract = _make_contract(review_stack=["totally_unknown_gate"])
         results_dir = tmp_path / "results"
-        _write_gate_result(results_dir, "kimi_gate", "PR-0", {
-            "gate": "kimi_gate",
+        _write_gate_result(results_dir, "totally_unknown_gate", "PR-0", {
+            "gate": "totally_unknown_gate",
             "pr_id": "PR-0",
             "status": "pass",
             "blocking_count": 0,
@@ -211,33 +217,35 @@ class TestUnknownGateNeverPasses:
         result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
 
         assert result["verdict"] == "fail"
-        check = next(c for c in result["checks"] if c["name"] == "gate_kimi_gate")
+        check = next(c for c in result["checks"] if c["name"] == "gate_totally_unknown_gate")
         assert check["status"] == "UNVERIFIED"
         assert check["status"] != "PASS"
 
     def test_unknown_gate_without_record_is_undecided_not_pass(self, verifier_env, monkeypatch, tmp_path):
         """Even with no result file, an unknown gate is undecided (not silently green)."""
-        contract = _make_contract(review_stack=["kimi_gate"])
+        contract = _make_contract(review_stack=["totally_unknown_gate"])
         results_dir = tmp_path / "results"
         results_dir.mkdir(parents=True)
 
         result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
 
         assert result["verdict"] == "fail"
-        check = next(c for c in result["checks"] if c["name"] == "gate_kimi_gate")
+        check = next(c for c in result["checks"] if c["name"] == "gate_totally_unknown_gate")
         assert check["status"] == "UNVERIFIED"
 
-    def test_production_shape_kimi_gate_record_never_passes(self, verifier_env, monkeypatch, tmp_path):
-        """A real kimi_gate result (no test_run field) for an unknown gate is still refused.
+    def test_production_shape_unregistered_gate_record_never_passes(self, verifier_env, monkeypatch, tmp_path):
+        """A real free-form-gate result (no test_run field) for an unknown gate is still refused.
 
-        Mirrors the nine records currently in ~/.vnx-data/vnx-dev/state/review_gates/results/:
-        they carry no test_run flag but kimi_gate is unregistered, so the record
-        must be ignored, not treated as a passing gate.
+        Mirrors the nine kimi_gate records that used to live in
+        ~/.vnx-data/vnx-dev/state/review_gates/results/ before kimi_gate was
+        promoted to a registered gate (dlv45): they carried no test_run flag
+        but the gate name was unregistered, so the record was ignored, not
+        treated as a passing gate. Same shape, generic unknown-gate name.
         """
-        contract = _make_contract(review_stack=["kimi_gate"])
+        contract = _make_contract(review_stack=["totally_unknown_gate"])
         results_dir = tmp_path / "results"
-        _write_gate_result(results_dir, "kimi_gate", "PR-0", {
-            "gate": "kimi_gate",
+        _write_gate_result(results_dir, "totally_unknown_gate", "PR-0", {
+            "gate": "totally_unknown_gate",
             "pr_id": "0",
             "pr_number": 0,
             "status": "pass",
@@ -253,20 +261,20 @@ class TestUnknownGateNeverPasses:
         result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
 
         assert result["verdict"] == "fail"
-        check = next(c for c in result["checks"] if c["name"] == "gate_kimi_gate")
+        check = next(c for c in result["checks"] if c["name"] == "gate_totally_unknown_gate")
         assert check["status"] == "UNVERIFIED"
 
     def test_check_single_gate_unknown_returns_unverified(self, tmp_path):
         """Direct unit check: unknown gate is UNVERIFIED regardless of record presence."""
-        contract = _make_contract(review_stack=["kimi_gate"])
+        contract = _make_contract(review_stack=["totally_unknown_gate"])
         results_dir = tmp_path / "results"
 
-        absent = cv._check_single_gate("kimi_gate", contract, None, results_dir, "feature/demo")
+        absent = cv._check_single_gate("totally_unknown_gate", contract, None, results_dir, "feature/demo")
         assert absent.status == "UNVERIFIED"
 
         present = cv._check_single_gate(
-            "kimi_gate", contract,
-            {"gate": "kimi_gate", "status": "pass"},
+            "totally_unknown_gate", contract,
+            {"gate": "totally_unknown_gate", "status": "pass"},
             results_dir, "feature/demo",
         )
         assert present.status == "UNVERIFIED"

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -664,6 +664,8 @@ class TestRule16GateName:
         "claude_github_optional",
         "ci_gate",
         "wiring_gate",
+        "kimi_gate",         # dlv45: promoted from free-form (OI-1093) to a governed gate
+        "glm_gate",          # dlv45: recognised gate name; runner ships separately
     ])
     def test_accepts_known_gate(self, tmp_path, monkeypatch, valid_gate):
         ifile = _write_instruction(tmp_path)
@@ -683,7 +685,7 @@ class TestRule16GateName:
 
     @pytest.mark.parametrize("bad_gate", [
         "codex_gat",        # typo of codex_gate
-        "kimi_gate",        # real script but NOT a governed review gate (free-form, OI-1093)
+        "totally_unknown_gate",  # never an enum member, never will be
         "human-promoted",   # legacy test placeholder, never an enum member
     ])
     def test_rejects_unknown_gate(self, tmp_path, monkeypatch, bad_gate):

--- a/tests/test_dlv45_gate_recognition.py
+++ b/tests/test_dlv45_gate_recognition.py
@@ -1,0 +1,374 @@
+"""dlv45 — kimi_gate and glm_gate as recognised Gate enum members with handlers.
+
+Before this dispatch, ``Gate`` (scripts/lib/dispatch_spec.py) was a closed set
+of five names. kimi_gate had a real runner (scripts/kimi_gate.py, nine
+historical result records) but was not in the enum, so
+``gate_request_handler._dispatch_one_review`` fell through its branch chain to
+the generic ``unknown_review_gate`` rejection for ANY requested kimi_gate — the
+runner existed, recognition did not. glm_gate had neither a runner nor
+recognition.
+
+This module proves, on behavior (not on a missing symbol):
+
+1. A requested kimi_gate no longer resolves to ``unknown_review_gate``.
+2. A requested glm_gate resolves to a distinct, speaking "runner missing"
+   rejection — never the generic ``unknown_review_gate`` — because glm_gate
+   IS a recognised gate (Gate.GLM_GATE), it just has no runner yet (a separate
+   deliverable ships scripts/glm_gate.py).
+3. ``closure_verifier._KNOWN_GATES`` and ``_GATE_HANDLERS`` stay synchronised
+   for both new names.
+4. A kimi_gate result with full evidence (contract_hash + report_path + an
+   existing report file) passes the closure handler; the same result missing
+   those fields is refused, exactly like codex_gate.
+5. An ``unavailable`` kimi_gate result (OI-1142 provider outage) is never
+   booked as a PASS — it is not even terminal, so it can never reach the
+   pass/fail decision at all.
+
+``test_kimi_gate_request_no_longer_resolves_to_unknown_review_gate`` and
+``test_glm_gate_request_gets_a_speaking_runner_missing_rejection`` are the two
+assertions that are RED on unmodified main *on behavior*: both calls succeed
+and return a plain dict there too (no ImportError, no AttributeError) — main
+simply answers ``{"status": "blocked", "reason": "unknown_review_gate"}`` for
+both, so the assertions on the returned value fail with a real
+AssertionError, not a collection error. That is the strong form of red this
+dispatch calls for.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv
+import gate_request_handler
+from dispatch_spec import Gate
+from review_contract import ReviewContract
+
+
+# ---------------------------------------------------------------------------
+# gate_request_handler: kimi_gate / glm_gate routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / "unified_reports"
+    for d in (
+        state_dir / "review_gates" / "requests",
+        state_dir / "review_gates" / "results",
+        reports_dir,
+    ):
+        d.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(reports_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    return {
+        "project_root": project_root,
+        "state_dir": state_dir,
+        "requests_dir": state_dir / "review_gates" / "requests",
+        "results_dir": state_dir / "review_gates" / "results",
+    }
+
+
+def _make_manager():
+    import review_gate_manager as rgm
+    return rgm.ReviewGateManager()
+
+
+class TestKimiGateNoLongerUnknown:
+    def test_kimi_gate_request_no_longer_resolves_to_unknown_review_gate(self, manager_env, monkeypatch):
+        """Behavioral red/green pin (dlv45 evidence #1).
+
+        On unmodified main, ``_dispatch_one_review`` has no kimi_gate branch,
+        so this call reaches the fallback and returns
+        ``{"gate": "kimi_gate", "status": "blocked", "reason": "unknown_review_gate"}``
+        — a real dict, not an exception. The assertion below fails there with
+        a plain AssertionError on the VALUE, which is the point: this is red
+        on behavior, not on a missing symbol.
+        """
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "f" * 40)
+        manager = _make_manager()
+
+        result = manager._dispatch_one_review(
+            "kimi_gate", pr_number=7, branch="feature/dlv45",
+            risk_class="low", changed_files=["scripts/foo.py"],
+            mode="per_pr", dispatch_id="dlv45-kimi-pin",
+        )
+
+        assert result.get("reason") != "unknown_review_gate", (
+            f"kimi_gate must no longer fall through to unknown_review_gate, got: {result}"
+        )
+        assert result["status"] != "blocked"
+        assert result["gate"] == "kimi_gate"
+
+    def test_kimi_gate_request_is_requested_because_runner_exists(self, manager_env, monkeypatch):
+        """scripts/kimi_gate.py exists in this repo, so the request must be
+        marked 'requested', not 'not_executable' — the runner-presence check
+        actually inspects the filesystem, it is not hardcoded true."""
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "a" * 40)
+        manager = _make_manager()
+
+        result = manager._dispatch_one_review(
+            "kimi_gate", pr_number=8, branch="feature/dlv45",
+            risk_class="low", changed_files=[],
+            mode="per_pr", dispatch_id="dlv45-kimi-available",
+        )
+
+        assert result["status"] == "requested"
+        req_file = manager_env["requests_dir"] / "pr-8-kimi_gate.json"
+        assert req_file.exists()
+        payload = json.loads(req_file.read_text())
+        assert payload["gate"] == "kimi_gate"
+        assert payload["commit_sha"] == "a" * 40
+
+
+class TestGlmGateSpeakingRejection:
+    def test_glm_gate_request_gets_a_speaking_runner_missing_rejection(self, manager_env, monkeypatch):
+        """Behavioral red/green pin (dlv45 evidence #2).
+
+        On unmodified main glm_gate also falls through to the generic
+        unknown_review_gate rejection. After this dispatch it must be
+        'not_executable' with reason 'gate_runner_missing' — a distinct,
+        speaking rejection an operator can tell apart from "not a real gate".
+        """
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "b" * 40)
+        manager = _make_manager()
+
+        result = manager._dispatch_one_review(
+            "glm_gate", pr_number=9, branch="feature/dlv45",
+            risk_class="low", changed_files=[],
+            mode="per_pr", dispatch_id="dlv45-glm-pin",
+        )
+
+        assert result["status"] == "not_executable"
+        assert result.get("reason") == "gate_runner_missing"
+        assert result.get("reason") != "unknown_review_gate"
+
+    def test_kimi_and_glm_rejections_are_distinguishable_side_by_side(self, manager_env, monkeypatch):
+        """Evidence #2: the kimi (available) and glm (runner missing) outcomes
+        must differ from each other AND from the old unknown_review_gate
+        rejection — never collapse to the same string."""
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "c" * 40)
+        manager = _make_manager()
+
+        kimi_result = manager._dispatch_one_review(
+            "kimi_gate", pr_number=10, branch="feature/dlv45",
+            risk_class="low", changed_files=[], mode="per_pr", dispatch_id="dlv45-side-kimi",
+        )
+        glm_result = manager._dispatch_one_review(
+            "glm_gate", pr_number=11, branch="feature/dlv45",
+            risk_class="low", changed_files=[], mode="per_pr", dispatch_id="dlv45-side-glm",
+        )
+
+        assert kimi_result["status"] == "requested"
+        assert glm_result["status"] == "not_executable"
+        assert glm_result["reason"] == "gate_runner_missing"
+        assert {kimi_result["status"], glm_result.get("reason")} & {"unknown_review_gate"} == set()
+
+
+# ---------------------------------------------------------------------------
+# dispatch_spec.Gate: enum membership
+# ---------------------------------------------------------------------------
+
+
+class TestGateEnumMembership:
+    def test_kimi_gate_and_glm_gate_are_gate_enum_members(self):
+        assert Gate("kimi_gate") is Gate.KIMI_GATE
+        assert Gate("glm_gate") is Gate.GLM_GATE
+
+    def test_gate_enum_stays_a_closed_set(self):
+        """OI-845 discipline: the enum grew by exactly two, everything else
+        that was legal stays legal, nothing else was silently added."""
+        values = {g.value for g in Gate}
+        assert values == {
+            "gemini_review", "codex_gate", "claude_github_optional",
+            "ci_gate", "wiring_gate", "kimi_gate", "glm_gate",
+        }
+
+
+# ---------------------------------------------------------------------------
+# closure_verifier: _KNOWN_GATES / _GATE_HANDLERS synchronisation (evidence #3)
+# ---------------------------------------------------------------------------
+
+
+class TestKnownGatesHandlersSynchronised:
+    def test_kimi_and_glm_are_known_and_have_handlers(self):
+        assert {"kimi_gate", "glm_gate"} <= cv._KNOWN_GATES
+        assert {"kimi_gate", "glm_gate"} <= set(cv._GATE_HANDLERS.keys())
+
+    def test_known_gates_and_handlers_are_symmetric(self):
+        """Both directions of the diff must be empty — a known gate with no
+        handler would KeyError at runtime; a handler for a gate not in
+        _KNOWN_GATES is dead/stray code the enum does not authorise."""
+        known_without_handler = cv._KNOWN_GATES - set(cv._GATE_HANDLERS.keys())
+        handler_without_known = set(cv._GATE_HANDLERS.keys()) - cv._KNOWN_GATES
+        assert known_without_handler == set(), f"known gates missing handlers: {known_without_handler}"
+        assert handler_without_known == set(), f"handlers for gates outside _KNOWN_GATES: {handler_without_known}"
+
+    def test_kimi_and_glm_not_parked_on_not_implemented(self):
+        """Neither name may sit on _GATES_NOT_IMPLEMENTED_BY_CLOSURE — that
+        route satisfies the drift test while making closure structurally
+        unreachable (routes to UNVERIFIED forever). Explicitly ruled out by
+        the dispatch."""
+        assert "kimi_gate" not in cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE
+        assert "glm_gate" not in cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE
+
+
+# ---------------------------------------------------------------------------
+# closure_verifier: kimi_gate handler evidence discipline (evidence #5, #6)
+# ---------------------------------------------------------------------------
+
+
+def _contract(review_stack):
+    return ReviewContract(
+        pr_id="PR-0",
+        branch="feature/dlv45",
+        risk_class="medium",
+        review_stack=list(review_stack),
+        content_hash="abcdef1234567890",
+    )
+
+
+class TestKimiGateClosureHandlerEvidenceDiscipline:
+    def test_full_evidence_kimi_result_passes(self, tmp_path):
+        """contract_hash + report_path + an existing report file + status
+        pass -> PASS, exactly the same bar codex_gate is held to."""
+        report_file = tmp_path / "kimi_report.md"
+        report_file.write_text("# kimi_gate report\nAll clear.\n", encoding="utf-8")
+        result = {
+            "gate": "kimi_gate",
+            "status": "pass",
+            "contract_hash": "abcdef1234567890",
+            "report_path": str(report_file),
+            "blocking_findings": [],
+            "advisory_findings": [],
+        }
+
+        check = cv._check_single_gate(
+            "kimi_gate", _contract(["kimi_gate"]), result, tmp_path, "feature/dlv45",
+        )
+
+        assert check.status == "PASS", check.detail
+
+    def test_result_missing_contract_hash_and_report_path_is_refused(self, tmp_path):
+        """The same status=pass result, but with neither contract_hash nor
+        report_path, must be refused — mirrors codex_gate's report_path
+        requirement, extended to contract_hash (gate_has_complete_evidence)."""
+        result = {
+            "gate": "kimi_gate",
+            "status": "pass",
+            "pr_id": "0",
+            "provider": "kimi",
+            "dispatch_id": "kimi-gate-pr0-1782546770",
+            "blocking_findings": [],
+            "advisory_findings": [],
+        }
+
+        check = cv._check_single_gate(
+            "kimi_gate", _contract(["kimi_gate"]), result, tmp_path, "feature/dlv45",
+        )
+
+        assert check.status == "FAIL"
+        assert check.status != "PASS"
+
+    def test_result_missing_only_report_path_is_refused(self, tmp_path):
+        result = {
+            "gate": "kimi_gate",
+            "status": "pass",
+            "contract_hash": "abcdef1234567890",
+            "blocking_findings": [],
+        }
+
+        check = cv._check_single_gate(
+            "kimi_gate", _contract(["kimi_gate"]), result, tmp_path, "feature/dlv45",
+        )
+
+        assert check.status == "FAIL"
+
+    def test_unavailable_kimi_result_is_never_a_pass(self, tmp_path):
+        """OI-1142: a provider outage (status='unavailable'), even with full
+        evidence fields present, must never be booked as PASS. unavailable is
+        deliberately not terminal, so it is refused before gate_is_pass is
+        ever consulted."""
+        report_file = tmp_path / "kimi_report_unavailable.md"
+        report_file.write_text("kimi dispatch failed\n", encoding="utf-8")
+        result = {
+            "gate": "kimi_gate",
+            "status": "unavailable",
+            "contract_hash": "abcdef1234567890",
+            "report_path": str(report_file),
+            "reason": "dispatch_error",
+            "blocking_findings": [],
+        }
+
+        check = cv._check_single_gate(
+            "kimi_gate", _contract(["kimi_gate"]), result, tmp_path, "feature/dlv45",
+        )
+
+        assert check.status != "PASS"
+        assert check.status == "FAIL"
+
+    def test_no_result_is_refused_not_silently_passed(self, tmp_path):
+        check = cv._check_single_gate(
+            "kimi_gate", _contract(["kimi_gate"]), None, tmp_path, "feature/dlv45",
+        )
+        assert check.status == "FAIL"
+
+
+class TestGlmGateClosureHandlerSameDiscipline:
+    """glm_gate has no runner yet, but its closure handler must hold results
+    (once any exist) to the same bar as kimi_gate/codex_gate — the handler is
+    generic evidence discipline, independent of whether a runner ships it."""
+
+    def test_full_evidence_glm_result_passes(self, tmp_path):
+        report_file = tmp_path / "glm_report.md"
+        report_file.write_text("# glm_gate report\nAll clear.\n", encoding="utf-8")
+        result = {
+            "gate": "glm_gate",
+            "status": "pass",
+            "contract_hash": "abcdef1234567890",
+            "report_path": str(report_file),
+            "blocking_findings": [],
+        }
+
+        check = cv._check_single_gate(
+            "glm_gate", _contract(["glm_gate"]), result, tmp_path, "feature/dlv45",
+        )
+
+        assert check.status == "PASS", check.detail
+
+    def test_not_executable_glm_result_is_refused(self, tmp_path):
+        result = {
+            "gate": "glm_gate",
+            "status": "not_executable",
+            "reason": "gate_runner_missing",
+            "reason_detail": "scripts/glm_gate.py does not exist yet",
+        }
+
+        check = cv._check_single_gate(
+            "glm_gate", _contract(["glm_gate"]), result, tmp_path, "feature/dlv45",
+        )
+
+        assert check.status == "FAIL"

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -597,19 +597,26 @@ def test_gates_incomplete_branch_less_result(roadmap_env, monkeypatch):
     assert result["verdict"] == "gates_incomplete", "branch-less result must be rejected as stale"
 
 
-def _write_roadmap_with_kimi_gate(project_root: Path) -> Path:
+def _write_roadmap_with_unregistered_gate(project_root: Path) -> Path:
     """A feature whose review_stack includes a gate outside closure_verifier's
-    _KNOWN_GATES — reuses feature-a's FEATURE_PLAN.md (same single PR-0)."""
-    roadmap_file = project_root / "ROADMAP_KIMI.yaml"
+    _KNOWN_GATES — reuses feature-a's FEATURE_PLAN.md (same single PR-0).
+
+    dlv45: kimi_gate moved into _KNOWN_GATES (it is now Gate.KIMI_GATE with a
+    closure handler), so it can no longer stand in for "gate outside
+    _KNOWN_GATES" here. ``totally_unknown_gate`` takes over that role — this
+    OI-1093 producer-identity check is about free-form gate names generically,
+    not about kimi_gate specifically.
+    """
+    roadmap_file = project_root / "ROADMAP_UNREGISTERED.yaml"
     roadmap_file.write_text(
         """features:
-  - feature_id: feature-kimi
-    title: Feature Kimi
+  - feature_id: feature-unregistered
+    title: Feature Unregistered
     plan_path: roadmap/features/feature-a/FEATURE_PLAN.md
     branch_name: feature/a
     risk_class: low
     merge_policy: conditional_auto
-    review_stack: [kimi_gate]
+    review_stack: [totally_unknown_gate]
     depends_on: []
     status: planned
 """,
@@ -618,16 +625,17 @@ def _write_roadmap_with_kimi_gate(project_root: Path) -> Path:
     return roadmap_file
 
 
-def _write_kimi_gate_result(gate_results_dir: Path, *, dispatch_id: str = "") -> None:
-    """Write a kimi_gate result shaped like the OI-1093 mission-control records:
-    contract_hash + report_path + branch + project_id all present. Only
-    dispatch_id varies between the hand-authored and real-writer shapes."""
+def _write_unregistered_gate_result(gate_results_dir: Path, *, dispatch_id: str = "") -> None:
+    """Write a totally_unknown_gate result shaped like the OI-1093 mission-control
+    kimi_gate records: contract_hash + report_path + branch + project_id all
+    present. Only dispatch_id varies between the hand-authored and real-writer
+    shapes."""
     gate_results_dir.mkdir(parents=True, exist_ok=True)
-    report_file = gate_results_dir / "pr0-kimi_gate-report.md"
-    report_file.write_text("# kimi_gate report for PR-0\n", encoding="utf-8")
+    report_file = gate_results_dir / "pr0-totally_unknown_gate-report.md"
+    report_file.write_text("# totally_unknown_gate report for PR-0\n", encoding="utf-8")
     data = {
         "pr_id": "PR-0",
-        "gate": "kimi_gate",
+        "gate": "totally_unknown_gate",
         "status": "passed",
         "project_id": "vnx-dev",
         "branch": "feature/a",
@@ -636,25 +644,25 @@ def _write_kimi_gate_result(gate_results_dir: Path, *, dispatch_id: str = "") ->
     }
     if dispatch_id:
         data["dispatch_id"] = dispatch_id
-    (gate_results_dir / "pr0-kimi_gate-contract.json").write_text(
+    (gate_results_dir / "pr0-totally_unknown_gate-contract.json").write_text(
         json.dumps(data), encoding="utf-8",
     )
 
 
 def test_gates_incomplete_unknown_gate_without_producer_identity(roadmap_env, monkeypatch):
-    """OI-1093: a kimi_gate result with contract_hash + report_path but no
-    dispatch_id must NOT satisfy advance — mirrors the three hand-authored
+    """OI-1093: an unregistered-gate result with contract_hash + report_path but
+    no dispatch_id must NOT satisfy advance — mirrors the three hand-authored
     mission-control records that had every field except producer identity."""
     manager = rm.RoadmapManager()
-    manager.init_roadmap(_write_roadmap_with_kimi_gate(roadmap_env["project_root"]))
-    manager.load_feature("feature-kimi")
+    manager.init_roadmap(_write_roadmap_with_unregistered_gate(roadmap_env["project_root"]))
+    manager.load_feature("feature-unregistered")
     monkeypatch.setattr(
         rm, "verify_closure",
         lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
     )
 
     gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
-    _write_kimi_gate_result(gate_results_dir, dispatch_id="")
+    _write_unregistered_gate_result(gate_results_dir, dispatch_id="")
 
     result = manager.reconcile()
     assert result["verdict"] == "gates_incomplete", (
@@ -664,17 +672,18 @@ def test_gates_incomplete_unknown_gate_without_producer_identity(roadmap_env, mo
 
 def test_advance_unknown_gate_with_producer_identity_satisfies(roadmap_env, monkeypatch):
     """OI-1093: the same record shape, but with a real dispatch_id, satisfies
-    advance unchanged — mirrors the nine real vnx-dev kimi_gate writes."""
+    advance unchanged — mirrors the nine real vnx-dev kimi_gate writes from
+    before kimi_gate was promoted to a registered gate (dlv45)."""
     manager = rm.RoadmapManager()
-    manager.init_roadmap(_write_roadmap_with_kimi_gate(roadmap_env["project_root"]))
-    manager.load_feature("feature-kimi")
+    manager.init_roadmap(_write_roadmap_with_unregistered_gate(roadmap_env["project_root"]))
+    manager.load_feature("feature-unregistered")
     monkeypatch.setattr(
         rm, "verify_closure",
         lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
     )
 
     gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
-    _write_kimi_gate_result(gate_results_dir, dispatch_id="kimi-gate-pr0-1782239641")
+    _write_unregistered_gate_result(gate_results_dir, dispatch_id="kimi-gate-pr0-1782239641")
 
     result = manager.reconcile()
     assert result["verdict"] == "pass", (


### PR DESCRIPTION
## Summary
- Extends the closed `Gate` enum (OI-845, `scripts/lib/dispatch_spec.py`) with `KIMI_GATE`/`GLM_GATE`.
- `gate_request_handler._dispatch_one_review` now routes both to their own request builders instead of falling through to `unknown_review_gate`. `kimi_gate`'s runner (`scripts/kimi_gate.py`) already exists, so requests resolve to `status: requested`; `glm_gate`'s runner ships in a separate deliverable, so requests resolve to a distinct, speaking `not_executable` / `gate_runner_missing` rejection — never the generic unknown-gate one.
- Adds `closure_verifier._gate_kimi_gate` / `_gate_glm_gate` handlers (shared `_gate_full_evidence_pass` helper) enforcing the same terminal + `contract_hash` + `report_path` discipline as `codex_gate`/`ci_gate`. An `unavailable` (OI-1142 provider outage) result is never booked as PASS — it isn't even terminal.
- `_KNOWN_GATES` is derived from the enum automatically, so both new gates are known and neither sits on `_GATES_NOT_IMPLEMENTED_BY_CLOSURE` (that route would make closure structurally unreachable).

## Downstream test fixes
Several pre-existing tests used `kimi_gate` as their stand-in example for "a gate name the verifier does not implement" — that premise breaks once `kimi_gate` is registered. Updated to a synthetic `totally_unknown_gate` name, preserving the original test intent unchanged:
- `tests/test_dispatch_spec.py` — moved `kimi_gate` from the `bad_gate` to the `valid_gate` parametrization; added `glm_gate` too.
- `tests/test_closure_verifier_unknown_gate.py` — `TestUnknownGateNeverPasses` now uses `totally_unknown_gate`.
- `tests/test_roadmap_manager.py` — OI-1093 producer-identity tests now use `totally_unknown_gate`.

## New/extended tests
- `tests/test_closure_verifier_gate_enum_drift.py` — added `test_dlv45_new_gate_is_known_and_has_a_handler` parametrized over both new gates.
- `tests/test_dlv45_gate_recognition.py` (new) — 16 tests covering: kimi_gate no longer resolves to `unknown_review_gate`; glm_gate gets a speaking `gate_runner_missing` rejection; enum closed-set membership; `_KNOWN_GATES`/`_GATE_HANDLERS` bidirectional sync; full-evidence PASS vs missing-evidence FAIL for the closure handler; `unavailable` never PASS.

## Test plan
- [x] `pytest tests/test_dlv45_gate_recognition.py tests/test_closure_verifier_gate_enum_drift.py tests/test_closure_verifier_unknown_gate.py tests/test_dispatch_spec.py tests/test_roadmap_manager.py -q` → 174 passed
- [x] Neighbour sweep: `test_gate_obligations.py`, `test_gate_recorder_provenance.py`, `test_producer_freshness.py`, `test_kimi_gate_provenance.py`, `test_kimi_gate_unavailable.py`, `test_oi1394_gate_indicator_scope.py`, `test_gate_status_schema.py`, `test_review_gate_manager.py`, `test_gate_evidence_enforcement.py`, `test_gate_dispatch_id.py`, `test_review_gate_dispatch_id.py` → same result with and without this change (2 pre-existing failures confirmed unrelated, verified by stashing production changes and re-running).
- [x] Verified `git status --short scripts/kimi_gate.py` stays empty — untouched, as required by the deliverable boundary.
- [x] Verified new red assertions fail with `AssertionError` (not `ImportError`) against unmodified production code, by stashing only the three production files and re-running the new test file (14/16 red on behavior).
- [x] `grep` confirmed none of the touched/new test files are in `scripts/ci/test_exclusions.txt`.

Dispatch-ID: beta-dlv45-poortnamen-en-handlers