### PR TITLE
feat(glm-gate): add scripts/glm_gate.py review gate runner (DLv1, OI-1435)

### DIFF
--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""glm_gate.py — code-review gate via the GOVERNED glm-harness lane (DLv1 nieuwbouw).
+
+Same shape as ``kimi_gate.py`` — a diff-review gate that routes through the
+governed mechanism ``plan_gate_panel._make_default_dispatcher`` already
+drives for provider lanes: ``provider_dispatch`` runs the glm worker via the
+claude-CLI harness -> local :4141 litellm proxy -> OpenRouter, emits a
+receipt, writes a unified report, and returns its text. The verdict is
+extracted with the SAME parser kimi_gate uses (``_extract_verdict`` — the
+provider-agnostic ```json``` scanner) so the same review, run through either
+gate, reads the same way. Writes a result record via
+``gate_recorder.record_terminal_result``, compatible with the shared
+``gate_status``/``closure_verifier`` evidence contract every other gate
+(codex_gate/ci_gate/kimi_gate) is held to.
+
+``gate_request_handler`` recognizes ``glm_gate`` as a registered ``Gate``
+member and refuses requests with ``reason=gate_runner_missing`` until this
+file exists on disk (``_glm_gate_available``). This is that runner.
+
+Usage:
+    python3 scripts/glm_gate.py --pr 378 --data-dir ~/.vnx-data/<project>
+    python3 scripts/glm_gate.py --diff-file /tmp/x.diff --pr 0   # offline diff source
+
+Exit codes: 0 = pass, 2 = fail/blocked (a REAL parsed review verdict), 1 = infra
+error / provider unavailable / blocked model (no diff, dispatch failed, no
+readable verdict, or a non-glm-5.2 model was requested).
+
+Provider outages are NOT review verdicts (OI-1142, ported from kimi_gate): when
+the glm-harness lane dies on a quota/auth error, times out, or returns output
+without a verdict block, the result status is ``unavailable`` — never
+``fail``. ``reason`` distinguishes three disjoint states, identically to
+kimi_gate: ``dispatch_error`` (the dispatcher raised outright with no report,
+or a report came back but its own frontmatter stamps the underlying provider
+run as failed), ``parse_error`` (a report came back from a run the
+frontmatter itself stamps as clean, with content but no readable ```json```
+verdict block), and ``no_verdict`` (the report was empty/whitespace). Only
+``dispatch_error``/``no_verdict`` may claim a provider outage in their
+summary text; ``parse_error`` must not, since the provider plainly produced
+output. See ``kimi_gate._frontmatter_run_outcome`` (reused verbatim below —
+same governed-report frontmatter shape, same ``exit_code``/
+``token_usage_measured`` discrimination, provider-agnostic) for the full
+reasoning.
+
+OI-1178 / OI-1435: a terminal (pass/fail) record must carry ``contract_hash``
++ ``report_path`` or ``gate_status.has_complete_evidence`` — and therefore
+``closure_verifier``'s merge check — refuses it as evidence, forever. Measured
+on kimi_gate before its own fix: 9 of 9 terminal records lacked both fields,
+and every one of those verdicts was permanently unable to close a PR.
+``contract_hash`` is computed by ``gate_artifacts._compute_contract_hash``
+(the SAME function codex_gate's and kimi_gate's own execution paths call,
+never a second hasher). ``report_path`` points at the governed dispatch's own
+unified report, already on disk by the time the dispatcher call returns.
+
+An ``unavailable`` result carries NEITHER field, and this is more subtle than
+it looks (OI-1435): ``has_complete_evidence`` only checks whether the two
+fields are non-empty — it does not check whether a verdict exists at all. An
+``unavailable`` result (``is_terminal=False``) that carried non-empty
+``contract_hash``/``report_path`` would pass ``has_complete_evidence`` while
+carrying no judgement whatsoever; the separation between "evidence exists"
+and "a verdict exists" holds today only because callers check ``is_terminal``
+first. Leaving both fields empty on every non-terminal status keeps that
+separation intact regardless of check order in any future caller.
+
+Model: GLM-5.2 only (``deprecated-glm-models``, provider_constraints.yaml,
+operator directive 2026-08-03). GLM-4.5, GLM-4.6, base GLM-5, and GLM-5.1 are
+blocked. This gate validates the model at its own entry point — before ever
+reaching the dispatcher — so a blocked version is refused LOUDLY with an
+explicit reason, not silently passed through to fail deep inside the
+provider-dispatch constraint enforcer and surface indistinguishable from any
+other "unavailable" outage.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from plan_gate_panel import _make_default_dispatcher, _resolve_data_dir  # governed provider_dispatch lane
+from gate_recorder import (
+    get_pr_head_branch,
+    get_pr_head_sha,
+    record_terminal_result,
+    stamp_request_identity,
+)
+from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
+from unified_report_schema import SchemaViolation, parse_frontmatter
+
+_VALID_VERDICTS = {"pass", "fail", "blocked"}
+
+
+def _extract_verdict(text: str) -> dict:
+    """Extract the worker's verdict: the LAST ```json``` block whose ``verdict`` is a
+    real verdict (pass/fail/blocked).
+
+    Identical logic to ``kimi_gate._extract_verdict`` — kept as a single copy
+    per gate module (not imported cross-module) so each gate's parser stays
+    self-contained, but the RULE must never diverge: the same review read
+    through kimi_gate and glm_gate must resolve to the same verdict shape.
+    The governed worker report echoes the instruction, so the FIRST ```json```
+    block is our own contract example (its ``verdict`` is the literal
+    "pass|fail|blocked", which is not a valid single verdict and is skipped).
+    Scanning from the end and requiring a real verdict value selects the
+    worker's actual answer, never the echoed template.
+    """
+    blocks = re.findall(r"```json\s*(\{.*?\})\s*```", text or "", re.DOTALL)
+    for block in reversed(blocks):
+        try:
+            obj = json.loads(block)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict) and str(obj.get("verdict", "")).strip().lower() in _VALID_VERDICTS:
+            return obj
+    return {}
+
+
+DEFAULT_MODEL = "glm-5.2"
+DEFAULT_TIMEOUT = 900
+MAX_DIFF_CHARS = 50000
+
+# deprecated-glm-models (provider_constraints.yaml): glm-5.2 is the ONLY
+# admitted GLM version. This is an allowlist, not a blocklist — every other
+# name (including a not-yet-released version) is refused until an operator
+# decision admits it explicitly.
+ALLOWED_MODELS = frozenset({"glm-5.2"})
+
+_VERDICT_CONTRACT = (
+    "When done, end your report with a structured JSON verdict ONLY, in a fenced block:\n"
+    "```json\n"
+    "{\n"
+    '  "verdict": "pass|fail|blocked",\n'
+    '  "findings": [{"severity": "error|warning|info", "message": "..."}],\n'
+    '  "residual_risk": "remaining risk or null"\n'
+    "}\n"
+    "```\n"
+    "verdict=fail/blocked ONLY for a real, blocking correctness/security/governance issue "
+    "introduced by THIS diff. Style nits are severity=info, never blocking.\n"
+)
+
+
+def _validate_model(model: str) -> "str | None":
+    """Return the canonical (lowercase) model string, or None to refuse.
+
+    Operator directive 2026-08-03: only glm-5.2 is admitted. Matching is
+    case-insensitive (accepts "GLM-5.2") but the canonical lowercase form is
+    what actually gets dispatched, so the record's ``model`` field always
+    matches the wave7_models.yaml registry key exactly.
+    """
+    normalized = (model or "").strip().lower()
+    if normalized in ALLOWED_MODELS:
+        return normalized
+    return None
+
+
+def _build_prompt(diff_text: str, pr: str) -> str:
+    if len(diff_text) > MAX_DIFF_CHARS:
+        diff_text = diff_text[:MAX_DIFF_CHARS] + "\n\n[... diff truncated for the gate ...]"
+    return (
+        f"You are a strict code-review gate for PR {pr}. Review ONLY the unified diff "
+        "below. Look for correctness bugs, security issues, governance/contract "
+        "violations, and regressions introduced by THIS diff. Be a skeptic; do not "
+        "rubber-stamp, but do not invent issues.\n\n"
+        f"{_VERDICT_CONTRACT}\n"
+        "DIFF:\n"
+        f"{diff_text}\n"
+    )
+
+
+def _get_diff(pr: str, diff_file: "str | None") -> "str | None":
+    if diff_file:
+        p = Path(diff_file)
+        return p.read_text(encoding="utf-8") if p.is_file() else None
+    try:
+        res = subprocess.run(
+            ["gh", "pr", "diff", pr],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=60,
+        )
+        return res.stdout if res.returncode == 0 and res.stdout.strip() else None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def _frontmatter_run_outcome(report_text: str) -> "tuple[bool | None, object, object]":
+    """Read ``exit_code``/``token_usage.output`` off the report's own YAML
+    frontmatter to tell a provider-side run failure apart from a genuine
+    parse miss (ported from ``kimi_gate._frontmatter_run_outcome`` — the
+    governed unified-report frontmatter shape is provider-agnostic, so the
+    same logic applies unchanged to the glm-harness lane).
+
+    Content existing is not proof glm actually completed a review: the
+    failure-path ``emit_unified_report`` call writes a report too, so a
+    spooled error body is "content" by the same measure as a real review.
+    The frontmatter's ``exit_code`` field is stamped by the lane from the
+    actual spawn result, not guessed from the response text — that is the
+    signal that can't be faked by error-page prose.
+
+    ``exit_code`` alone decides the outcome. ``token_usage.output`` is only
+    consulted when the frontmatter's own ``token_usage_measured`` flag is
+    true — the same conditional weighting kimi_gate uses, so a lane where
+    post-run token capture is unavailable does not get its unmeasured zero
+    read as a failure signal.
+
+    Returns ``(outcome, exit_code, output_tokens)`` where ``outcome`` is:
+        True  — frontmatter is readable and the run did not complete cleanly:
+                non-zero exit code, or (only when ``token_usage_measured`` is
+                true) a measured zero output-token count. A provider-side
+                failure, not a review outcome.
+        False — frontmatter is readable and stamps a clean run (exit_code 0,
+                and either tokens aren't measured or a measured non-zero
+                count): a missing verdict block here is a genuine parse miss.
+        None  — no readable frontmatter, or no ``exit_code`` field in it
+                (older/foreign report shape). Callers fall back to the
+                default (content present -> parse_error).
+    """
+    try:
+        frontmatter = parse_frontmatter(report_text)
+    except SchemaViolation:
+        return None, None, None
+    if "exit_code" not in frontmatter:
+        return None, None, None
+    exit_code = frontmatter.get("exit_code")
+    token_usage = frontmatter.get("token_usage")
+    output_tokens = token_usage.get("output") if isinstance(token_usage, dict) else None
+    tokens_measured = bool(frontmatter.get("token_usage_measured"))
+    if exit_code != 0:
+        return True, exit_code, output_tokens
+    if tokens_measured and output_tokens == 0:
+        return True, exit_code, output_tokens
+    return False, exit_code, output_tokens
+
+
+def _verdict_to_status(
+    verdict: dict, report_text: str = "", *, provider_failed_detail: "str | None" = None
+) -> "tuple[str, list, str]":
+    """Map the extracted verdict to (status, blocking_findings, residual_risk).
+
+    OI-1142: an empty ``verdict`` means no readable verdict could be extracted.
+    If ``report_text`` itself is empty/whitespace, the provider delivered
+    nothing at all (a real outage/empty-completion signal). If ``report_text``
+    has content but no readable ```json``` block, the provider DID respond —
+    the block just failed to parse, which is a parse miss, not an outage.
+    Either way this maps to ``unavailable`` and only a REAL parsed verdict may
+    ever produce ``fail``.
+
+    ``provider_failed_detail``: the caller passes this when it has already
+    read the report's own frontmatter via ``_frontmatter_run_outcome`` and
+    found a non-zero exit code (or a measured-zero output-token count). When
+    set, THIS function returns that provider-outage residual instead of the
+    "glm did respond" parse-miss residual below — the report having content
+    is not proof glm ran; the frontmatter's own exit_code is.
+    """
+    v = (verdict.get("verdict") or "").strip().lower() if verdict else ""
+    findings = verdict.get("findings") or [] if verdict else []
+    blocking = [
+        f for f in findings
+        if isinstance(f, dict) and str(f.get("severity", "")).lower() in {"error", "blocked", "blocker"}
+    ]
+    residual = (verdict.get("residual_risk") if verdict else "") or ""
+    if v == "pass" and not blocking:
+        return "pass", [], residual
+    if v in {"fail", "blocked"} or blocking:
+        return "fail", blocking, residual or "glm gate reported blocking findings"
+    if residual:
+        return "unavailable", [], residual
+    if provider_failed_detail:
+        return "unavailable", [], provider_failed_detail
+    if (report_text or "").strip():
+        return (
+            "unavailable",
+            [],
+            f"glm returned a {len(report_text)}-char report, but it contained no "
+            "readable ```json``` verdict block (parse miss — glm did respond)",
+        )
+    return (
+        "unavailable",
+        [],
+        "glm produced no readable verdict (provider outage/quota/truncation) — not a review outcome",
+    )
+
+
+def _status_summary(status: str, blocking: list, reason: str = "", report_len: int = 0) -> str:
+    """Summary line for the result record — outage vs parse-miss vs verdict must be unmistakable."""
+    if status == "unavailable":
+        if reason == "parse_error":
+            return (
+                f"glm gate: UNAVAILABLE (parse_error — glm returned a {report_len}-char "
+                "report, but it contained no readable verdict block — NOT a review fail)"
+            )
+        return "glm gate: UNAVAILABLE (provider outage/no verdict — NOT a review fail)"
+    return f"glm gate: {status} ({len(blocking)} blocking finding(s))"
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    ap = argparse.ArgumentParser(description="GOVERNED glm-harness review gate.")
+    ap.add_argument("--pr", required=True, help="PR number (use 0 with --diff-file for offline test)")
+    ap.add_argument("--diff-file", default=None, help="read the diff from a file instead of gh")
+    ap.add_argument("--data-dir", default=os.environ.get("VNX_DATA_DIR", ""),
+                    help="VNX data dir; report lands in <data-dir>/unified_reports/ and the "
+                         "result in <data-dir>/state/review_gates/results/")
+    ap.add_argument("--model", default=os.environ.get("VNX_GLM_GATE_MODEL", DEFAULT_MODEL))
+    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    ap.add_argument("--json", action="store_true", help="print the result record as JSON")
+    args = ap.parse_args(argv)
+
+    canonical_model = _validate_model(args.model)
+    if canonical_model is None:
+        print(
+            f"glm_gate: REFUSING model {args.model!r} — only {sorted(ALLOWED_MODELS)} is "
+            "admitted for GLM (deprecated-glm-models: GLM-4.5/4.6/5/5.1 are blocked, "
+            "operator directive 2026-08-03)",
+            file=sys.stderr,
+        )
+        return 1
+    args.model = canonical_model
+
+    diff = _get_diff(args.pr, args.diff_file)
+    if not diff:
+        print(f"glm_gate: no diff for PR {args.pr}", file=sys.stderr)
+        return 1
+
+    data_dir = args.data_dir or None
+    dispatch_id = f"glm-gate-pr{args.pr}-{int(time.time())}"
+    # Resolved once, then handed to the dispatcher as an explicit data_dir so
+    # this function's own report_path reconstruction below and the governed
+    # subprocess's actual write path can never drift apart — both derive from
+    # the SAME resolved base (see provider_dispatch.py's report_path, which is
+    # this exact <data_dir>/unified_reports/<dispatch_id>.md).
+    base_data_dir = _resolve_data_dir(data_dir)
+    dispatcher = _make_default_dispatcher(str(base_data_dir), args.timeout)
+    prompt = _build_prompt(diff, args.pr)
+
+    start = time.monotonic()
+    report_text = ""
+    dispatch_error = ""
+    try:
+        # Governed lane: provider_dispatch runs glm (via the claude-CLI harness
+        # -> local :4141 litellm proxy -> OpenRouter), writes a unified
+        # report, returns its text. "glm-harness" is the real provider string
+        # provider_dispatch.py dispatches on (see plan_gate_panel.py's own
+        # diverse-assurance panel entry: provider="glm-harness").
+        report_text = dispatcher("glm-harness", args.model, prompt, dispatch_id)
+    except Exception as exc:  # noqa: BLE001 — dispatch/report-read failure
+        # OI-1142: do NOT bail without a record — a required gate that cannot fire
+        # must surface as ``unavailable`` in the results dir, not vanish.
+        dispatch_error = str(exc)
+        print(f"glm_gate: governed glm dispatch failed: {exc}", file=sys.stderr)
+    duration = time.monotonic() - start
+
+    if dispatch_error:
+        verdict: dict = {}
+        status, blocking = "unavailable", []
+        residual = f"governed glm dispatch failed: {dispatch_error[:400]}"
+        reason = "dispatch_error"
+    else:
+        verdict = _extract_verdict(report_text or "")
+        provider_failed_detail = None
+        run_failed = None
+        if not verdict and (report_text or "").strip():
+            # Only consult the frontmatter once a verdict extraction has
+            # already failed — a real parsed verdict always wins regardless
+            # of what exit_code says.
+            run_failed, exit_code, output_tokens = _frontmatter_run_outcome(report_text or "")
+            if run_failed is True:
+                provider_failed_detail = (
+                    "glm's own report frontmatter stamps this run as failed "
+                    f"(exit_code={exit_code!r}, token_usage.output={output_tokens!r}) — "
+                    "provider-side outage, not a review outcome"
+                )
+        status, blocking, residual = _verdict_to_status(
+            verdict, report_text or "", provider_failed_detail=provider_failed_detail
+        )
+        if verdict:
+            reason = "verdict"
+        elif (report_text or "").strip():
+            if run_failed is True:
+                # The report has content, but its OWN frontmatter stamps the
+                # underlying provider run as failed — this is the same outage
+                # class as a raised dispatch_error, just discovered from the
+                # report instead of an exception.
+                reason = "dispatch_error"
+            else:
+                # run_failed is False (frontmatter readable, clean run — a
+                # genuine parse miss) or None (no readable exit_code at all,
+                # so there is no signal left to tell a masked provider
+                # failure apart from a real parse miss). Both default to
+                # parse_error; the None case is intentionally too broad.
+                reason = "parse_error"
+        else:
+            reason = "no_verdict"
+
+    # OI-1178 / OI-1435: a terminal verdict must carry the same evidence pair
+    # codex_gate/kimi_gate stamp — contract_hash (gate_artifacts' single
+    # canonical hasher) + report_path (the governed dispatch's own unified
+    # report, already on disk by the time dispatcher() returned above). Only
+    # ``verdict`` ever reaches pass/fail (see _verdict_to_status), so
+    # report_text is guaranteed non-empty here. An unavailable result (no
+    # readable verdict, or the dispatch itself failed) is deliberately left
+    # with neither field: has_complete_evidence only checks non-emptiness, not
+    # whether a verdict exists, so a filled-in unavailable record would pass
+    # the evidence check while carrying no judgement (OI-1435) — leaving both
+    # empty here is what keeps OI-1142's outage/verdict separation intact.
+    if status in {"pass", "fail"}:
+        contract_hash = _compute_contract_hash({"prompt": prompt}, "glm_gate")
+        report_path = str(base_data_dir / "unified_reports" / f"{dispatch_id}.md")
+    else:
+        contract_hash = ""
+        report_path = ""
+
+    record = {
+        "gate": "glm_gate",
+        "pr_id": str(args.pr),
+        "pr_number": int(args.pr) if str(args.pr).isdigit() else None,
+        # Offline runs read the diff from a file (--diff-file) and are NOT tied
+        # to a live GitHub PR; they must never count as gate evidence. The
+        # closure verifier refuses records with test_run: true.
+        "test_run": bool(args.diff_file),
+        "status": status,
+        "reason": reason,
+        "duration_seconds": round(duration, 3),
+        "summary": _status_summary(status, blocking, reason, len(report_text or "")),
+        "contract_hash": contract_hash,
+        "report_path": report_path,
+        "provider": "glm-harness",
+        "model": args.model,
+        "dispatch_id": dispatch_id,
+        "blocking_findings": blocking,
+        "advisory_findings": [
+            f for f in (verdict.get("findings") or []) if f not in blocking
+        ],
+        "required_reruns": [],
+        "residual_risk": residual,
+        "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    # Stamp branch + commit_sha through the shared writer so the merge door
+    # can join a glm_gate result on the PR head (GitHub), not the local
+    # checkout HEAD. Offline runs (--diff-file) are not tied to a live PR and
+    # legitimately carry neither.
+    stamp_request_identity(
+        record,
+        {
+            "gate": record["gate"],
+            "pr_id": record["pr_id"],
+            "branch": "" if record["test_run"] else get_pr_head_branch(record["pr_number"]),
+            "commit_sha": "" if record["test_run"] else get_pr_head_sha(record["pr_number"]),
+        },
+    )
+
+    if data_dir:
+        results_dir = Path(data_dir) / "state" / "review_gates" / "results"
+        out = results_dir / f"pr-{args.pr}-glm_gate.json"
+        record_terminal_result(
+            gate="glm_gate", pr_id=record["pr_id"], result_path=out, payload=record,
+        )
+        print(f"glm_gate: wrote {out}", file=sys.stderr)
+
+    if args.json:
+        print(json.dumps(record, indent=2))
+    elif status == "unavailable":
+        if reason == "parse_error":
+            print(
+                f"VERDICT: UNAVAILABLE  (parse_error — glm returned a {len(report_text or '')}-char "
+                "report, but it contained no readable verdict block — NOT a review fail)"
+            )
+        else:
+            print("VERDICT: UNAVAILABLE  (provider outage/no verdict — NOT a review fail)")
+    else:
+        print(f"VERDICT: {status.upper()}  ({len(blocking)} blocking)")
+        for f in blocking:
+            print(f"  · [{f.get('severity')}] {f.get('message')}")
+
+    # 0 = pass, 2 = a REAL parsed fail/blocked verdict, 1 = unavailable/infra.
+    if status == "pass":
+        return 0
+    return 2 if status == "fail" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dlv1_glm_gate.py
+++ b/tests/test_dlv1_glm_gate.py
@@ -1,0 +1,444 @@
+"""glm_gate.py tests (dispatch beta-dlv1-glm-gate-nieuwbouw).
+
+glm_gate.py is pure nieuwbouw: ``scripts/glm_gate.py`` did not exist before
+this deliverable. ``gate_request_handler`` recognizing "glm_gate" as a
+registered ``Gate`` member and refusing requests for it with
+``reason=gate_runner_missing`` exists ONLY on a separate, not-yet-merged
+branch (``dispatch/beta-dlv45-poortnamen-en-handlers``, commit ``9e6cc3f3``)
+— that wiring (the ``Gate.GLM_GATE`` enum member, the
+``gate_request_handler`` dispatch branch, the
+``closure_verifier._GATE_HANDLERS`` entry) is NOT present on this worktree's
+base and is out of this deliverable's scope
+(``gate_request_handler.py``/``dispatch_spec.py``/``closure_verifier.py`` are
+off-limits here — changed by other, already-merged-or-pending deliverables).
+Requesting "glm_gate" through today's unmodified ``_dispatch_one_review``
+therefore still falls through to the generic ``unknown_review_gate`` branch
+regardless of whether this file exists, so that surface cannot supply the
+before/after behavioral contrast the dispatch instruction describes.
+
+The CLI entrypoint every other gate script exposes (``python3 scripts/
+kimi_gate.py --pr N ...``) is the real substitute: it needs no wiring from
+another deliverable, and its ``--help`` invocation genuinely differs before
+vs. after this file exists (a real interpreter-level "file not found" vs. a
+real usage dump) — see ``test_glm_gate_cli_surface_did_not_exist_before_this_deliverable``
+below.
+
+Every other test that needs the ``glm_gate`` module imports it LAZILY via the
+``glm_gate`` fixture, not at module scope — a bare top-level ``import
+glm_gate`` would fail collection for every test in this file with one
+``ModuleNotFoundError``, masking the distinction between "fails because a
+symbol is missing" (expected for these, before this file existed) and "fails
+on a real returned value" (the CLI-surface test, which needs no glm_gate
+import at all).
+
+``gate_status``/``gate_artifacts``/``closure_verifier`` are pre-existing,
+unmodified modules — importing them at module scope does not gate collection
+on ``glm_gate.py``'s existence.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier
+import gate_artifacts
+from gate_status import has_complete_evidence, is_terminal
+
+
+@pytest.fixture
+def glm_gate():
+    """Lazy import — fails per-test (at call time), not at module collection."""
+    import glm_gate as _glm_gate
+    return _glm_gate
+
+
+_REAL_PASS_REPORT = (
+    "Reviewed the diff, no issues.\n\n"
+    "```json\n"
+    '{"verdict": "pass", "findings": [], "residual_risk": null}\n'
+    "```\n"
+)
+
+_REAL_FAIL_REPORT = (
+    "Reviewed the diff; found a real problem.\n\n"
+    "```json\n"
+    '{"verdict": "fail", "findings": [{"severity": "error", "message": "sql injection"}],'
+    ' "residual_risk": "unsanitized input"}\n'
+    "```\n"
+)
+
+_FAKE_DIFF = "diff --git a/x b/x\n+ok\n"
+
+
+def _write_unified_report(data_dir: Path, dispatch_id: str, text: str) -> Path:
+    """Mimic ``governance_emit.emit_unified_report``'s write path — the real
+    governed dispatch always writes the report before the dispatcher call
+    returns the text; glm_gate.py never writes this file itself, only reads
+    it back."""
+    reports_dir = data_dir / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = reports_dir / f"{dispatch_id}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _fake_dispatcher_factory(data_dir: Path, text: str):
+    """Build a ``_make_default_dispatcher``-shaped double that writes the
+    report to disk exactly like the real governed lane, then returns it."""
+    def _make(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            _write_unified_report(data_dir, dispatch_id, text)
+            return text
+        return _dispatch
+    return _make
+
+
+def _run_glm_gate_for_real_pr(glm_gate, tmp_path, monkeypatch, report_text, *, pr="4242"):
+    """Run glm_gate.main() against a non-offline PR: no --diff-file (so
+    test_run stays False), a stubbed diff source (no network), a dispatcher
+    double that writes the unified report like the real lane does, and
+    stubbed gh-identity lookups (no real `gh` subprocess calls)."""
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, report_text),
+    )
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/dlv1-test")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "cafedeadbeef")
+
+    rc = glm_gate.main(["--pr", pr, "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / f"pr-{pr}-glm_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    return rc, record, data_dir
+
+
+def _run_gate_offline(glm_gate, tmp_path, monkeypatch, dispatcher, *, pr="0"):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(glm_gate, "_make_default_dispatcher", lambda *a, **k: dispatcher)
+    rc = glm_gate.main(["--pr", pr, "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / f"pr-{pr}-glm_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8")) if out.exists() else None
+    return rc, record
+
+
+# ---------------------------------------------------------------------------
+# 0. STRONG red: a real call against the EXISTING, unmodified CLI-script
+#    surface every gate runner uses (kimi_gate.py's own entrypoint
+#    convention). Needs no glm_gate import, so it collects and runs today —
+#    and it genuinely fails on a returned value, not an import error: python3
+#    itself refuses to start with a real "can't open file ... No such file or
+#    directory" and a nonzero exit code before this deliverable ships.
+# ---------------------------------------------------------------------------
+
+
+def test_glm_gate_cli_surface_did_not_exist_before_this_deliverable():
+    """Runs `python3 scripts/glm_gate.py --help` exactly as an operator or CI
+    step would invoke any gate script. Before this deliverable,
+    scripts/glm_gate.py does not exist: python3 exits non-zero with a
+    literal, non-pytest error on stderr and prints nothing usable on stdout.
+    That is the real value this test's first assertion is checked against —
+    it is EXPECTED to fail on unmodified main. Once scripts/glm_gate.py
+    exists, the identical command succeeds (rc=0) and prints real usage
+    text — a different real value, not a resolved import error.
+    """
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "glm_gate.py"), "--help"],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, (
+        "glm_gate.py --help must succeed once the CLI script exists on disk "
+        f"(rc={result.returncode}, stderr={result.stderr!r})"
+    )
+    assert "--pr" in result.stdout
+    assert "--diff-file" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# 1. A real verdict carries complete evidence
+# ---------------------------------------------------------------------------
+
+
+def test_pass_verdict_carries_complete_evidence(glm_gate, tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_glm_gate_for_real_pr(glm_gate, tmp_path, monkeypatch, _REAL_PASS_REPORT)
+
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["gate"] == "glm_gate"
+    assert record["provider"] == "glm-harness"
+    assert record["model"] == "glm-5.2"
+    assert record["contract_hash"], "contract_hash must be non-empty on a terminal verdict"
+    assert record["report_path"], "report_path must be non-empty on a terminal verdict"
+    assert Path(record["report_path"]).is_file(), (
+        "report_path must point at a file that already exists on disk when the record is written"
+    )
+    # The real function, not a reimplementation of its logic.
+    assert has_complete_evidence(record) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. That record clears the merge door's evidence check
+# ---------------------------------------------------------------------------
+
+
+def test_pass_verdict_clears_closure_verifier_merge_check(glm_gate, tmp_path, monkeypatch):
+    rc, record, data_dir = _run_glm_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _REAL_PASS_REPORT, pr="4242",
+    )
+    assert rc == 0
+
+    results_dir = data_dir / "state" / "review_gates" / "results"
+    gate = closure_verifier.check_review_gate_for_merge("4242", "glm_gate", results_dir)
+
+    assert gate["verdict"] == "GO", gate["message"]
+    assert "mist contract_hash" not in gate["message"]
+
+
+# ---------------------------------------------------------------------------
+# 3. unavailable never carries complete evidence, and is never terminal
+#    (OI-1435: has_complete_evidence only checks non-emptiness, not whether a
+#    verdict exists — the separation only holds because BOTH fields stay
+#    empty AND is_terminal is False on an unavailable record)
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_result_never_has_complete_evidence_and_is_not_terminal(glm_gate, tmp_path, monkeypatch):
+    # A provider outage: empty report, no readable verdict, no exception.
+    rc, record = _run_gate_offline(glm_gate, tmp_path, monkeypatch, lambda *a, **k: "")
+
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["contract_hash"] == ""
+    assert record["report_path"] == ""
+    assert is_terminal(record) is False, "an outage is retryable, not a decided pass/fail outcome"
+    assert has_complete_evidence(record) is False, "an outage must never look like complete evidence"
+
+
+def test_unavailable_from_dispatcher_exception_still_writes_a_record(glm_gate, tmp_path, monkeypatch):
+    """A quota/auth outage surfacing as a raised exception (the lane died
+    before any report came back at all) must still leave an unavailable
+    record, not vanish — and must never be booked as a review fail."""
+    def _boom(*a, **k):
+        raise RuntimeError("glm-harness dispatch exploded: 403 access_terminated_error")
+
+    rc, record = _run_gate_offline(glm_gate, tmp_path, monkeypatch, _boom)
+    assert rc == 1
+    assert record is not None, "an outage must leave an unavailable record, not vanish"
+    assert record["status"] == "unavailable"
+    assert record["status"] != "fail"
+    assert record["reason"] == "dispatch_error"
+    assert "access_terminated_error" in record["residual_risk"]
+    assert is_terminal(record) is False
+    assert has_complete_evidence(record) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Content without a readable verdict -> unavailable, never fail
+# ---------------------------------------------------------------------------
+
+
+def test_prose_report_without_verdict_is_unavailable_not_fail(glm_gate, tmp_path, monkeypatch):
+    prose_report = "## Review notes\n\nLooks fine, no structured verdict emitted.\n"
+    rc, record = _run_gate_offline(glm_gate, tmp_path, monkeypatch, lambda *a, **k: prose_report)
+
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["status"] != "fail"
+    assert "UNAVAILABLE" in record["summary"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Offline (--diff-file) runs never count as evidence for a real PR, even
+#    though the record now carries complete evidence fields.
+# ---------------------------------------------------------------------------
+
+
+def test_offline_run_is_test_run_and_rejected_by_merge_check_despite_complete_evidence(
+    glm_gate, tmp_path, monkeypatch,
+):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = glm_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-glm_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["test_run"] is True
+    assert has_complete_evidence(record) is True
+
+    results_dir = data_dir / "state" / "review_gates" / "results"
+    gate = closure_verifier.check_review_gate_for_merge("0", "glm_gate", results_dir)
+    assert gate["verdict"] == "NO-GO"
+    assert "geen review-gate resultaat" in gate["message"]
+
+
+# ---------------------------------------------------------------------------
+# 6. contract_hash: the SAME canonical hasher as every other gate, byte-equal
+#    for the same contract, and DIFFERENT for a different one — an
+#    always-the-same hasher would also clear a same-contract-only check.
+# ---------------------------------------------------------------------------
+
+
+def test_glm_gate_reuses_the_canonical_hasher_not_a_second_implementation(glm_gate):
+    """Identity check, not behavioral: proves there is exactly ONE hashing
+    implementation in the codebase, not two that happen to agree today and
+    can silently diverge tomorrow."""
+    assert glm_gate._compute_contract_hash is gate_artifacts._compute_contract_hash
+
+
+def test_contract_hash_byte_equal_for_same_contract_and_different_for_another(glm_gate, tmp_path, monkeypatch):
+    pr = "777"
+    rc, record, _data_dir = _run_glm_gate_for_real_pr(glm_gate, tmp_path, monkeypatch, _REAL_PASS_REPORT, pr=pr)
+    assert rc == 0
+
+    # Reconstruct the exact prompt glm_gate built for this run, then hash it
+    # via the SAME function the existing (codex_gate) route calls — gate name
+    # only affects the fallback branch (no "prompt" key), so a different gate
+    # name here still proves it is the same hash for the same contract.
+    prompt = glm_gate._build_prompt(_FAKE_DIFF, pr)
+    existing_route_hash = gate_artifacts._compute_contract_hash({"prompt": prompt}, "codex_gate")
+    assert record["contract_hash"] != ""
+    assert record["contract_hash"] == existing_route_hash
+
+    # A DIFFERENT contract must hash differently — a hasher that always
+    # returns the same value would also satisfy the equality assertion
+    # above, proving nothing on its own.
+    different_prompt = glm_gate._build_prompt("diff --git a/y b/y\n+different\n", pr)
+    different_hash = gate_artifacts._compute_contract_hash({"prompt": different_prompt}, "codex_gate")
+    assert different_hash != existing_route_hash
+
+
+# ---------------------------------------------------------------------------
+# 7. GLM model allowlist: a blocked version is refused LOUDLY, never
+#    silently accepted, and never even reaches the dispatcher.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "blocked_model", ["glm-4.5", "glm-4.6", "glm-5", "glm-5.1", "GLM-5.1", "glm-5.3"],
+)
+def test_blocked_glm_model_is_refused_loudly_not_silently_accepted(
+    glm_gate, tmp_path, monkeypatch, capsys, blocked_model,
+):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    data_dir = tmp_path / "data"
+
+    dispatched = []
+
+    def _spy_dispatcher_factory(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            dispatched.append((provider, model_arg))
+            return _REAL_PASS_REPORT
+        return _dispatch
+
+    monkeypatch.setattr(glm_gate, "_make_default_dispatcher", _spy_dispatcher_factory)
+
+    rc = glm_gate.main([
+        "--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir),
+        "--model", blocked_model,
+    ])
+    captured = capsys.readouterr()
+
+    assert rc == 1, "a blocked model must be an infra-level refusal, never exit 0 or exit 2"
+    assert dispatched == [], "a blocked model must never reach the dispatcher"
+    assert "REFUSING" in captured.err
+    assert blocked_model in captured.err
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-glm_gate.json"
+    assert not out.exists(), "a blocked-model refusal must not fabricate a review-gate result record"
+
+
+def test_default_and_case_insensitive_glm_5_2_is_accepted(glm_gate, tmp_path, monkeypatch):
+    dispatched = []
+
+    def _spy_dispatcher_factory(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            dispatched.append((provider, model_arg))
+            return _REAL_PASS_REPORT
+        return _dispatch
+
+    monkeypatch.setattr(glm_gate, "_make_default_dispatcher", _spy_dispatcher_factory)
+    monkeypatch.delenv("VNX_GLM_GATE_MODEL", raising=False)
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    data_dir = tmp_path / "data"
+
+    # No --model: the default must resolve to the canonical glm-5.2.
+    rc = glm_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    assert rc == 0
+    assert dispatched == [("glm-harness", "glm-5.2")]
+
+    # Case-insensitive input still resolves to the canonical lowercase model.
+    dispatched.clear()
+    rc = glm_gate.main([
+        "--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir), "--model", "GLM-5.2",
+    ])
+    assert rc == 0
+    assert dispatched == [("glm-harness", "glm-5.2")]
+
+
+# ---------------------------------------------------------------------------
+# 8. The gate must never write to the working tree it is reviewing.
+# ---------------------------------------------------------------------------
+
+
+def test_run_does_not_touch_the_working_tree(glm_gate, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+    (repo / "a.txt").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "a.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.chdir(repo)
+
+    before = subprocess.run(
+        ["git", "status", "--short"], cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout
+
+    rc = glm_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+
+    after = subprocess.run(
+        ["git", "status", "--short"], cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout
+
+    assert rc == 0
+    assert before == after == "", "glm_gate must never modify the working tree it is reviewing"
+
+
+# ---------------------------------------------------------------------------
+# 9. Real fail verdict + gate_status sanity (unchanged behaviour, ported
+#    from kimi_gate's own coverage so glm_gate's happy/sad paths both hold).
+# ---------------------------------------------------------------------------
+
+
+def test_real_fail_verdict_still_fails_with_exit_2(glm_gate, tmp_path, monkeypatch):
+    rc, record = _run_gate_offline(glm_gate, tmp_path, monkeypatch, lambda *a, **k: _REAL_FAIL_REPORT)
+    assert rc == 2
+    assert record["status"] == "fail"
+    assert record["reason"] == "verdict"
+    assert len(record["blocking_findings"]) == 1

--- a/tests/test_dlv45_gate_recognition.py
+++ b/tests/test_dlv45_gate_recognition.py
@@ -148,13 +148,16 @@ class TestGlmGateSpeakingRejection:
     def test_glm_gate_request_gets_a_speaking_runner_missing_rejection(self, manager_env, monkeypatch):
         """Behavioral red/green pin (dlv45 evidence #2).
 
-        On unmodified main glm_gate also falls through to the generic
-        unknown_review_gate rejection. After this dispatch it must be
-        'not_executable' with reason 'gate_runner_missing' — a distinct,
-        speaking rejection an operator can tell apart from "not a real gate".
+        scripts/glm_gate.py now ships for real (a later dlv1 deliverable), so
+        the "runner missing" state can no longer be produced by the file's
+        actual absence on disk. Force it explicitly via the availability
+        helper instead — the rejection this test guards (speaking,
+        'gate_runner_missing', never the generic 'unknown_review_gate') must
+        still fire whenever the runner is unavailable, regardless of why.
         """
         monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "b" * 40)
         manager = _make_manager()
+        monkeypatch.setattr(manager, "_glm_gate_available", lambda: False)
 
         result = manager._dispatch_one_review(
             "glm_gate", pr_number=9, branch="feature/dlv45",
@@ -166,12 +169,34 @@ class TestGlmGateSpeakingRejection:
         assert result.get("reason") == "gate_runner_missing"
         assert result.get("reason") != "unknown_review_gate"
 
+    def test_glm_gate_request_is_accepted_once_the_runner_exists(self, manager_env, monkeypatch):
+        """The other side of evidence #2: with the runner present (its real,
+        shipped state in this repo since dlv1), the gate must resolve to
+        'requested', not the speaking rejection above. Without this test the
+        suite would stay green even if recognition silently broke again and
+        glm_gate started refusing a runner that is actually there."""
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "d" * 40)
+        manager = _make_manager()
+        monkeypatch.setattr(manager, "_glm_gate_available", lambda: True)
+
+        result = manager._dispatch_one_review(
+            "glm_gate", pr_number=12, branch="feature/dlv45",
+            risk_class="low", changed_files=[],
+            mode="per_pr", dispatch_id="dlv45-glm-available",
+        )
+
+        assert result["status"] == "requested"
+        assert result.get("reason") is None
+        assert result.get("reason") != "gate_runner_missing"
+        assert result.get("reason") != "unknown_review_gate"
+
     def test_kimi_and_glm_rejections_are_distinguishable_side_by_side(self, manager_env, monkeypatch):
         """Evidence #2: the kimi (available) and glm (runner missing) outcomes
         must differ from each other AND from the old unknown_review_gate
         rejection — never collapse to the same string."""
         monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "c" * 40)
         manager = _make_manager()
+        monkeypatch.setattr(manager, "_glm_gate_available", lambda: False)
 
         kimi_result = manager._dispatch_one_review(
             "kimi_gate", pr_number=10, branch="feature/dlv45",


### PR DESCRIPTION
## Summary
- New `scripts/glm_gate.py` — a diff-review gate routed through the governed glm-harness lane (`provider_dispatch --provider glm-harness --model glm-5.2`), modeled on `kimi_gate.py`'s current shape (post-#1669: it already emits `contract_hash`+`report_path` on terminal verdicts).
- Reuses the same verdict parser (`_extract_verdict`), the same canonical hasher (`gate_artifacts._compute_contract_hash`), and the same outage/parse-miss/verdict three-way status split (OI-1142/OI-1291) kimi_gate uses, so the same review read through either gate resolves the same way.
- GLM model validated against the `deprecated-glm-models` allowlist (glm-5.2 only, operator directive 2026-08-03) at the gate's own entry point — a blocked version is refused loudly (stderr + exit 1), never silently dispatched.
- OI-1435: an `unavailable` record deliberately leaves `contract_hash`/`report_path` empty — `has_complete_evidence` only checks non-emptiness, not whether a verdict exists, so a filled-in unavailable record would pass the evidence check while carrying no judgement.

## Scope note
`gate_request_handler` recognizing `glm_gate` as a registered `Gate` member (with a `gate_runner_missing` refusal) exists only on the unmerged `dispatch/beta-dlv45-poortnamen-en-handlers` branch (commit `9e6cc3f3`) — not on this branch's base. `gate_request_handler.py`/`dispatch_spec.py`/`closure_verifier.py` are untouched per this deliverable's boundary; `glm_gate.py` has no import dependency on that wiring, same as `kimi_gate.py`.

## Test plan
- `tests/test_dlv1_glm_gate.py` (18 tests, new): evidence completeness, unavailable never terminal/never complete-evidence, offline `test_run` rejected by the merge door, contract_hash byte-identity to the existing route (+ inequality for a different contract), blocked-model refusal (6 variants), default/case-insensitive `glm-5.2` acceptance, working-tree untouched (`git status` before/after), and one behavior-based (non-import-error) red assertion via the CLI `--help` surface.
- Verified red/green split by temporarily moving `scripts/glm_gate.py` aside: 17 tests error with `ModuleNotFoundError`, 1 fails on a real `AssertionError` (rc=2, OS-level `[Errno 2] No such file or directory`) — restored, all 18 pass green.
- Live end-to-end run against the real governed lane (no local `:4141` litellm proxy running in this sandbox) correctly timed out and booked `status=unavailable`, `reason=dispatch_error`, exit 1, `is_terminal=False`, `has_complete_evidence=False` — not a fabricated fail.
- `scripts/ci/test_exclusions.txt` does not list the new test file (confirmed via grep).
- Confirmed `scripts/glm_gate.py` never touches the working tree (`git status --short` identical before/after a run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)