### PR TITLE
fix(gate-obligations): provider_not_installed is temporary, action mirrors record (OI-1400 residu)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -85,32 +85,44 @@ _UNRESOLVABLE_ESCALATION_ATTEMPTS = 96
 # A gate RESULT can itself report a TEMPORARY refusal rather than a real
 # verdict on the code: ``status=running`` means a CI check is still in flight
 # (gate_executor's ci_gate path — not all checks reached a terminal bucket
-# yet), ``status=not_executable`` with ``reason=provider_disabled`` means
-# the gate is parked by config (e.g. VNX_CI_GATE_REQUIRED=0 —
-# gate_result_parser._classify_unavailable / gate_request_handler
-# ._mark_gate_unavailable), and ``status=unavailable`` (gate_status.py's
-# UNAVAILABLE_STATES — gate_recorder.record_failure books this for an
-# execution failure: crash, timeout, stall, a failed worktree checkout) means
-# the provider never produced a verdict at all. None of the three says
-# anything about the code; all are "not yet", not "no". Treating any of them
-# as terminal burns the obligation forever — measured live against PR #1627
-# (OI-1384): CI had actually passed, but the recorded obligation was a dead
-# not_executable/provider_disabled with no report_path, no contract_hash, no
-# branch, no commit_sha. A consumer project separately measured the
-# ``unavailable`` case (OI-1400): PR #966/#967 booked ``fulfilled`` off a
-# not_executable/provider-not-installed and an unavailable/worktree-checkout-
-# failed result respectively, both with empty contract_hash and report_path —
-# because the fallback below defaulted every non-terminal, non-temporary
-# status to fulfilled. All three temporary cases stay pending under a bounded
-# retry term, then escalate to the loud terminal not_executable — a temporary
-# refusal that recurs forever must still eventually alarm someone, just not
-# on the first attempt. Anything left over — a status this runner has never
-# seen — takes the SAME pending/escalate path (OI-1400): the fallback used to
-# read "anything I don't recognise as terminal is a pass," which is how the
-# two obligations above landed silently fulfilled with zero evidence. The
-# fallback now reads "anything I don't recognise as a pass is NOT a pass."
+# yet), ``status=not_executable`` with a reason in
+# ``_TEMPORARY_NOT_EXECUTABLE_REASONS`` means the gate could not run for a
+# reason that can change by itself (gate_result_parser._classify_unavailable /
+# gate_request_handler._mark_gate_unavailable), and ``status=unavailable``
+# (gate_status.py's UNAVAILABLE_STATES — gate_recorder.record_failure books
+# this for an execution failure: crash, timeout, stall, a failed worktree
+# checkout) means the provider never produced a verdict at all. None of these
+# says anything about the code; all are "not yet", not "no". Treating any of
+# them as terminal burns the obligation forever — measured live against PR
+# #1627 (OI-1384): CI had actually passed, but the recorded obligation was a
+# dead not_executable/provider_disabled with no report_path, no contract_hash,
+# no branch, no commit_sha. A consumer project separately measured two more
+# shapes of the same bug (OI-1400): PR #967 booked ``fulfilled`` off an
+# unavailable/worktree-checkout-failed result (fixed by the
+# _GATE_RESULT_UNAVAILABLE_STATES branch below, and by the "anything I don't
+# recognise as a pass is NOT a pass" fallback for a status this runner has
+# never seen at all), and PR #966 booked ``fulfilled`` off a
+# not_executable/provider-not-installed result — both with empty
+# contract_hash and empty report_path. PR #966's shape survived that first
+# OI-1400 fix: ``not_executable`` is already a known TERMINAL_STATUSES member,
+# so it never reached the unknown-status fallback; it fell straight into the
+# terminal branch because ``provider_not_installed`` was not yet in this
+# frozenset (OI-1400 residu). A provider missing today can be installed
+# tomorrow — exactly as fixable as the ``provider_disabled`` config flag — so
+# it gets the identical bounded pending/escalate treatment. All temporary
+# cases stay pending under a bounded retry term, then escalate to the loud
+# terminal not_executable — a temporary refusal that recurs forever must
+# still eventually alarm someone, just not on the first attempt.
 _TEMPORARY_RESULT_STATUSES = frozenset({"running"})
-_TEMPORARY_NOT_EXECUTABLE_REASONS = frozenset({"provider_disabled"})
+_TEMPORARY_NOT_EXECUTABLE_REASONS = frozenset({
+    # OI-1384: parked by config (e.g. VNX_CI_GATE_REQUIRED=0) — flipping the
+    # flag is an operator action that can happen at any time, not a verdict.
+    "provider_disabled",
+    # OI-1400 residu: the CLI binary is not on PATH right now. A provider that
+    # is not installed today can be installed tomorrow, so this is a bounded
+    # wait for the environment to catch up, not a permanent refusal.
+    "provider_not_installed",
+})
 _TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
 
 # PR-resolution outcomes. The runner must tell "no PR yet" (a wait) apart from
@@ -654,10 +666,14 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
             )
         elif result_status == STATUS_NOT_EXECUTABLE and result_reason in _TEMPORARY_NOT_EXECUTABLE_REASONS:
             temp_reason = "gate_parked"
+            if result_reason == "provider_not_installed":
+                temp_cause = "the provider binary is not on PATH in this environment yet"
+            else:
+                temp_cause = "a config flag has it disabled"
             temp_detail = (
-                f"{gate} is parked ({result_reason}: a config flag has it disabled), "
-                "not broken — the obligation waits for it to be re-enabled or for a "
-                "future run, not permanently refused"
+                f"{gate} is parked ({result_reason}: {temp_cause}), "
+                "not broken — the obligation waits for it to be re-enabled/installed "
+                "or for a future run, not permanently refused"
             )
         elif result_status in _GATE_RESULT_UNAVAILABLE_STATES:
             temp_reason = "gate_run_unavailable"
@@ -749,7 +765,11 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
             reason=None if not result.get("has_required_failure") else "required_failure",
             reason_detail=None if terminal == STATUS_FULFILLED else f"result status: {result_status}",
         )
-        outcome["action"] = "fulfilled"
+        # Mirror the status actually persisted to disk — never a hardcoded
+        # "fulfilled" label, which would lie about a not_executable/failed
+        # record and let a caller reading only the label count a burned
+        # obligation as vervuld (OI-1400 residu, defect 2).
+        outcome["action"] = updated.get("status", terminal)
         outcome["request_path"] = updated.get("request_path")
         outcome["result_path"] = updated.get("result_path")
         outcome["has_required_failure"] = bool(result.get("has_required_failure"))

--- a/tests/test_gate_obligation_runner.py
+++ b/tests/test_gate_obligation_runner.py
@@ -10,6 +10,7 @@ message instead of writing to a fabricated or unattributable store.
 
 from __future__ import annotations
 
+import json
 import sys
 import types
 from pathlib import Path
@@ -23,6 +24,14 @@ for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
 
 import vnx_paths  # noqa: E402
 import gate_obligation_runner as runner  # noqa: E402
+from gate_obligations import (  # noqa: E402
+    STATUS_FULFILLED,
+    STATUS_NOT_EXECUTABLE,
+    STATUS_PENDING,
+    obligation_path,
+    register_obligation,
+    update_obligation,
+)
 
 
 class TestDefaultStateDirGuard:
@@ -200,3 +209,197 @@ class TestPlistHasNoHardcodedProject:
         assert "~/.vnx-data" not in content
         assert "VNX_PROJECT_ID" in content
         assert "${VNX_PROJECT_ID}" in content
+
+
+# ---------------------------------------------------------------------------
+# OI-1400 residu — two defects, both driven through the real
+# fulfill_obligation() against a real obligation file under
+# review_gates/obligations/ and a real result file under
+# review_gates/results/, with the status read back FROM DISK afterwards.
+#
+# Defect 1: a not_executable/provider_not_installed gate result used to burn
+# the obligation terminal on the first attempt. A provider that is not
+# installed today can be installed tomorrow — same class of "temporary"
+# refusal as provider_disabled — and must take the same bounded
+# pending/escalate route.
+#
+# Defect 2: the terminal branch always set outcome["action"] = "fulfilled",
+# even when the record it had just written to disk carried status
+# "not_executable" or "failed". The label must mirror the persisted record.
+# ---------------------------------------------------------------------------
+
+
+class _FakeReviewGateManager:
+    """Writes real request+result JSON files — no gate actually runs.
+
+    Mirrors ``tests/test_gate_obligations.py::_FakeManager`` (OI-1384/OI-1400
+    fixtures for the runner's temporary-vs-permanent-refusal distinction),
+    duplicated locally so this file's harness is self-contained.
+    """
+
+    def __init__(self, state_dir: Path, *, result_status: str, result_reason: str | None = None) -> None:
+        self.state_dir = Path(state_dir)
+        self.result_status = result_status
+        self.result_reason = result_reason
+        self.calls = []
+
+    def _request_path(self, gate: str, pr_number: int) -> Path:
+        return self.state_dir / "review_gates" / "requests" / f"pr-{pr_number}-{gate}.json"
+
+    def _result_path(self, gate: str, pr_number: int) -> Path:
+        return self.state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+
+    def request_and_execute(self, *, pr_number, branch, review_stack, risk_class,
+                             changed_files, mode, dispatch_id=""):
+        self.calls.append(
+            {"pr_number": pr_number, "branch": branch, "review_stack": list(review_stack)}
+        )
+        for gate in review_stack:
+            self._request_path(gate, pr_number).write_text(
+                json.dumps({"gate": gate, "pr_number": pr_number, "status": "completed"}),
+                encoding="utf-8",
+            )
+            result_payload = {"gate": gate, "pr_number": pr_number, "status": self.result_status}
+            if self.result_reason is not None:
+                result_payload["reason"] = self.result_reason
+            self._result_path(gate, pr_number).write_text(
+                json.dumps(result_payload), encoding="utf-8",
+            )
+        return {"pr_number": pr_number, "branch": branch, "gates": [], "has_required_failure": False}
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "vnx-data" / "state"
+    (state_dir / "review_gates" / "requests").mkdir(parents=True, exist_ok=True)
+    (state_dir / "review_gates" / "results").mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _patch_manager(monkeypatch, manager: "_FakeReviewGateManager") -> None:
+    """Hermetic patch: no git, no gh, no real gate — only the fake manager."""
+    monkeypatch.setattr(runner, "_build_manager", lambda state_dir: manager)
+    monkeypatch.setattr(runner, "_branch_from_github", lambda pr, owner_repo: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda state_dir: "Vinix24/vnx-orchestration")
+    fake_rgm = types.ModuleType("review_gate_manager")
+    fake_rgm._compute_changed_files = lambda branch: ["scripts/lib/foo.py"]
+    monkeypatch.setitem(sys.modules, "review_gate_manager", fake_rgm)
+
+
+def _read_obligation(state_dir: Path, dispatch_id: str) -> dict:
+    return json.loads(obligation_path(state_dir, dispatch_id).read_text(encoding="utf-8"))
+
+
+class TestProviderNotInstalledIsTemporary:
+    """Defect 1: ``provider_not_installed`` must take the same bounded
+    pending/escalate route as ``provider_disabled`` — not burn terminal on
+    the first attempt.
+
+    RED on unfixed main (measured 2026-08-23 against ``main@3cdadba4``):
+    ``result_status='not_executable' reason='provider_not_installed' ->
+    action=fulfilled record.status='not_executable' record.reason=None`` —
+    an obligation with an empty contract_hash and empty report_path landed
+    permanently closed on the very first attempt.
+    """
+
+    def test_stays_pending_not_terminal_on_first_attempt(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260823-oi1400r-not-installed", gate="codex_gate",
+            project_id="vnx-dev", pr_number=9661,
+        )
+        manager = _FakeReviewGateManager(
+            state_dir, result_status="not_executable", result_reason="provider_not_installed",
+        )
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 1, (
+            "a provider that is merely not installed yet must not burn the "
+            "obligation terminal on the first attempt"
+        )
+        record = _read_obligation(state_dir, "20260823-oi1400r-not-installed")
+        assert record["status"] == STATUS_PENDING
+        assert record["attempts"] == 1
+        assert record["reason"] == "gate_parked"
+        assert "provider_not_installed" in record["reason_detail"]
+        assert "not broken" in record["reason_detail"]
+        # The stale wording ("a config flag has it disabled") does not apply
+        # to a missing binary — the detail text must say so accurately.
+        assert "config flag" not in record["reason_detail"]
+
+    def test_escalates_to_not_executable_after_threshold(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        path = register_obligation(
+            state_dir, dispatch_id="20260823-oi1400r-not-installed-escalate", gate="codex_gate",
+            project_id="vnx-dev", pr_number=9664,
+        )
+        update_obligation(path, attempts=runner._TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS - 1)
+        manager = _FakeReviewGateManager(
+            state_dir, result_status="not_executable", result_reason="provider_not_installed",
+        )
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 0
+        record = _read_obligation(state_dir, "20260823-oi1400r-not-installed-escalate")
+        assert record["status"] == STATUS_NOT_EXECUTABLE
+        assert record["reason"] == "gate_parked_timeout"
+        assert record["attempts"] == runner._TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS
+
+
+class TestOutcomeActionMirrorsRecordStatus:
+    """Defect 2: ``outcome["action"]`` must mirror the status just persisted
+    to the obligation record — never a hardcoded ``"fulfilled"``.
+
+    RED on unfixed main (measured 2026-08-23 against ``main@3cdadba4``): a
+    ``not_executable/provider_not_configured`` result (a reason outside the
+    temporary set, so it still resolves through the terminal branch even
+    after the defect-1 fix) produced ``outcome["action"] == "fulfilled"``
+    while the obligation record written to disk carried
+    ``status == "not_executable"``.
+    """
+
+    def test_action_label_says_not_executable_when_record_does(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260823-oi1400r-action-label", gate="codex_gate",
+            project_id="vnx-dev", pr_number=9662,
+        )
+        manager = _FakeReviewGateManager(
+            state_dir, result_status="not_executable", result_reason="provider_not_configured",
+        )
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        outcome = summary["outcomes"][0]
+        record = _read_obligation(state_dir, "20260823-oi1400r-action-label")
+        assert record["status"] == STATUS_NOT_EXECUTABLE
+        assert outcome["action"] == record["status"], (
+            "the returned action label must mirror the status actually "
+            "written to the obligation record, not a hardcoded 'fulfilled'"
+        )
+        assert outcome["action"] == STATUS_NOT_EXECUTABLE
+
+    def test_control_a_real_pass_still_reports_fulfilled(self, tmp_path, monkeypatch):
+        """Must-pass control: without this, a fix that routes everything to
+        pending would still make the two tests above pass for the wrong
+        reason. A genuine pass verdict must still land fulfilled with an
+        action label that says so."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260823-oi1400r-control-pass", gate="ci_gate",
+            project_id="vnx-dev", pr_number=9663,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 0
+        outcome = summary["outcomes"][0]
+        record = _read_obligation(state_dir, "20260823-oi1400r-control-pass")
+        assert record["status"] == STATUS_FULFILLED
+        assert outcome["action"] == STATUS_FULFILLED

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -474,15 +474,24 @@ def test_runner_leaves_pending_on_running_result(tmp_path, monkeypatch):
 
 def test_runner_still_terminates_a_genuinely_permanent_refusal(tmp_path, monkeypatch):
     """The fix narrows what burns the obligation — it must not widen what
-    stays pending. A gate that is not_executable for a structural reason
-    (the provider binary is not installed, not "disabled by a flag") is a
-    real, permanent refusal and must still terminate on the first attempt."""
+    stays pending. A gate that is not_executable for a reason outside the
+    explicit temporary set (here: the gate provider is not configured at
+    all, distinct from merely "not installed" or "disabled by a flag") is a
+    real, permanent refusal and must still terminate on the first attempt.
+
+    ``provider_not_installed`` used to be exactly this case, but OI-1400
+    residu moved it into the temporary set (see
+    ``tests/test_gate_obligation_runner.py::
+    TestProviderNotInstalledIsTemporary``) — a missing binary can be
+    installed later, same as a config flag can be flipped.
+    ``provider_not_configured`` stays outside the set on purpose so this
+    test keeps covering a genuinely permanent refusal."""
     state_dir = _make_state_dir(tmp_path)
     register_obligation(
         state_dir, dispatch_id="20260821-oi1384-real-refusal", gate="codex_gate",
         project_id="vnx-dev", pr_number=1629,
     )
-    manager = _FakeManager(state_dir, result_status="not_executable", result_reason="provider_not_installed")
+    manager = _FakeManager(state_dir, result_status="not_executable", result_reason="provider_not_configured")
     _patch_manager(monkeypatch, manager)
 
     summary = runner.run(state_dir)


### PR DESCRIPTION
## Summary

OI-1400 residu: two defects in `scripts/gate_obligation_runner.py`, both measured on `main@3cdadba4` with a harness that drives the real `fulfill_obligation()` against a real obligation file under `review_gates/obligations/` and a real result file under `review_gates/results/`, status read back from disk.

**Defect 1** — `_TEMPORARY_NOT_EXECUTABLE_REASONS` only carried `provider_disabled`. A gate result `status="not_executable"` / `reason="provider_not_installed"` fell into the terminal branch and burned the obligation permanently on the first attempt, with empty `contract_hash`/`report_path`. A provider missing today can be installed tomorrow — same class of temporary refusal as `provider_disabled` — so it now takes the identical bounded pending/escalate route (OI-1384's route).

**Defect 2** — the terminal branch hardcoded `outcome["action"] = "fulfilled"` regardless of what status was actually written to the record. Measured: `record.status == "not_executable"` while `outcome["action"] == "fulfilled"`. Now mirrors the persisted status (`updated.get("status", terminal)`).

## Changes

- `scripts/gate_obligation_runner.py`:
  - `_TEMPORARY_NOT_EXECUTABLE_REASONS` now a frozenset with `provider_disabled` and `provider_not_installed`, each with its own comment explaining why it's temporary (explicit reasons, not a broadened "anything non-terminal" match).
  - `temp_detail` message is now reason-aware ("provider binary is not on PATH" vs "a config flag has it disabled") instead of always claiming a config flag.
  - `outcome["action"]` mirrors `updated.get("status", terminal)` instead of a hardcoded `"fulfilled"`.
  - Updated the module-level comment block to accurately describe OI-1384 vs OI-1400 vs this OI-1400-residu fix (the prior comment conflated PR #966's provider-not-installed case with the unknown-status fallback fix, which never actually covered it).
- `tests/test_gate_obligation_runner.py`: new `TestProviderNotInstalledIsTemporary` (pending on first attempt + escalation after threshold) and `TestOutcomeActionMirrorsRecordStatus` (action mirrors record status + a real-pass control case), all driven through real `fulfill_obligation()` calls against real on-disk obligation/result files.
- `tests/test_gate_obligations.py`: `test_runner_still_terminates_a_genuinely_permanent_refusal` now uses `provider_not_configured` (still outside the temporary set) instead of `provider_not_installed`, since the latter is no longer a permanent refusal after this fix. Docstring updated to explain why and point at the new tests.

## Verification

RED confirmed on unfixed `main` (temporarily reverted the source fix, kept new tests, re-ran):
```
tests/test_gate_obligation_runner.py::TestProviderNotInstalledIsTemporary::test_stays_pending_not_terminal_on_first_attempt FAILED
tests/test_gate_obligation_runner.py::TestProviderNotInstalledIsTemporary::test_escalates_to_not_executable_after_threshold FAILED
tests/test_gate_obligation_runner.py::TestOutcomeActionMirrorsRecordStatus::test_action_label_says_not_executable_when_record_does FAILED
tests/test_gate_obligation_runner.py::TestOutcomeActionMirrorsRecordStatus::test_control_a_real_pass_still_reports_fulfilled PASSED
tests/test_gate_obligations.py::test_runner_still_terminates_a_genuinely_permanent_refusal PASSED
3 failed, 2 passed
```

GREEN after re-applying the fix:
```
python3 -m pytest tests/test_gate_obligation_runner.py tests/test_gate_obligations.py tests/test_gate_obligation_runner_scope.py -q
58 passed in 0.68s
```

Standalone before/after measurement (real `fulfill_obligation()` call, status read back from disk):

| case | before: action / record.status | after: action / record.status |
|---|---|---|
| `not_executable`/`provider_not_installed` | `fulfilled` / `not_executable` | `pending` / `pending` |
| `not_executable`/`provider_not_configured` (control, still permanent) | `fulfilled` / `not_executable` | `not_executable` / `not_executable` |
| real `pass` (control) | `fulfilled` / `fulfilled` | `fulfilled` / `fulfilled` (unchanged) |

## Open Items

None.