### PR TITLE
fix(merge-gate): scope CI check to the commit, not the branch (OI-1387)

### DIFF
--- a/scripts/lib/merge_preflight_ci_check.py
+++ b/scripts/lib/merge_preflight_ci_check.py
@@ -5,14 +5,29 @@ Determines whether the configured CI workflow has a *successful* run for the
 exact HEAD SHA being merged. The check toetst op het BESTAAN van een geslaagde
 run voor die head, niet op de afwezigheid van een gefaalde run:
 
-  - zero runs for the head            -> NO-GO ("niet toetsbaar")
-  - run with conclusion != "success"  -> NO-GO (in_progress is NO-GO too)
-  - success but for a DIFFERENT sha   -> NO-GO (an older commit does not count)
-  - success for the exact head        -> GO
+  - zero runs for the head sha          -> NO-GO ("niet toetsbaar")
+  - any run for the head sha is running -> NO-GO (in_progress/queued blocks)
+  - any run for the head sha != success -> NO-GO
+  - every run for the head sha succeeded -> GO
 
 Every unverifiable state (``gh`` missing, ``gh`` not authenticated, ``gh run
-list`` failing or unparseable, HEAD/branch unresolvable) is a NO-GO with its
-own message. A missing tool never passes as "no red found".
+list`` failing or unparseable, HEAD unresolvable) is a NO-GO with its own
+message. A missing tool never passes as "no red found".
+
+OI-1387: the query is scoped to the exact commit (``gh run list --commit``),
+NOT the branch. The tmux-spawn dispatch lane pushes a fix-forward commit to
+both the target branch and its own per-dispatch auto-branch, so one sha can
+have VNX CI runs on two branches at once. A branch-scoped query only sees the
+run on the branch it was given and can call GO while a run for the exact same
+sha is still in progress on the other branch — which is precisely the
+disagreement OI-1387 measured between this gate (was branch-scoped) and the
+review-gate's ``gh pr checks`` (always commit-scoped). Scoping both to the
+commit, and requiring EVERY run found on that commit to be conclusion=success,
+makes them agree. ``branch`` remains an accepted argument/CLI flag for callers
+that still resolve and pass it (e.g. ``pr_merge.py`` alongside head_sha), but
+it no longer participates in the CI query — there is no fallback to a
+branch-scoped query when head_sha is unresolvable, since that fallback would
+silently reintroduce the exact defect being fixed here.
 
 Escape hatch (OI-1216 merge-gate): an operator may override the gate by
 supplying a non-empty reason via ``override_reason`` /
@@ -23,9 +38,9 @@ visible in the output rather than hidden.
 
 This is the merge-preflight counterpart to ``pre_merge_gate.check_ci_workflow``
 (OI-931), which enforces the same invariant at gate time. The two share the
-same ``gh run list`` invocation shape and the same workflow-name resolution
-order (explicit arg > ``VNX_CI_WORKFLOW_NAME`` > "VNX CI"); they differ in
-verdict vocabulary (GO/NO-GO here) and messaging (merge-preflight terms).
+same workflow-name resolution order (explicit arg > ``VNX_CI_WORKFLOW_NAME``
+> "VNX CI"); they differ in verdict vocabulary (GO/NO-GO here) and messaging
+(merge-preflight terms).
 """
 
 from __future__ import annotations
@@ -49,9 +64,9 @@ CI_WORKFLOW_NAME_ENV_VAR = "VNX_CI_WORKFLOW_NAME"
 # means no override is attempted.
 OVERRIDE_ENV_VAR = "VNX_MERGE_OVERRIDE_REASON"
 
-# How many recent runs to pull per branch. Matching is by exact head SHA, so a
-# head older than the limit on a busy branch would read as "not run". The same
-# limit is used by pre_merge_gate.check_ci_workflow.
+# How many recent runs to pull for the commit. Matching is by exact head SHA,
+# so a head older than the limit would read as "not run". The same limit is
+# used by pre_merge_gate.check_ci_workflow.
 RUN_LIST_LIMIT = 10
 
 # Subprocess timeouts (seconds). Fail closed on expiry.
@@ -153,10 +168,15 @@ def check_ci_run_for_head(
     workflow_name: Optional[str] = None,
     override_reason: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Fail-closed check: a VNX CI run with conclusion=success must exist for head_sha.
+    """Fail-closed check: every VNX CI run for the exact head_sha must be conclusion=success.
 
     Returns {"verdict": "GO"|"NO-GO", "message": str, ...}. ``project_root`` is
     the directory whose HEAD is being merged (the worktree under preflight).
+
+    ``branch`` is accepted for callers that resolve and pass it alongside
+    ``head_sha`` (e.g. ``pr_merge.py``), but per OI-1387 it is NOT used to scope
+    the CI query — see the module docstring for why a branch-scoped query can
+    disagree with the review-gate's commit-scoped one on the same commit.
 
     ``override_reason`` is the escape hatch: a non-empty value skips the check
     with a visible GO (``overridden=True``), an empty/whitespace value is a
@@ -185,6 +205,8 @@ def check_ci_run_for_head(
         )
 
     # ── Resolve HEAD SHA ───────────────────────────────────────────────────
+    # No fallback to a branch-scoped query when this fails: that fallback is
+    # exactly the defect OI-1387 fixes (see module docstring).
     if head_sha is None:
         head_sha = _git(project_root, ["rev-parse", "HEAD"])
         if not head_sha:
@@ -193,15 +215,18 @@ def check_ci_run_for_head(
                 workflow_name=resolved_workflow,
             )
 
-    # ── Resolve branch ─────────────────────────────────────────────────────
-    if branch is None:
-        branch = _git(project_root, ["rev-parse", "--abbrev-ref", "HEAD"])
-        if not branch:
-            return _no_go(
-                "branch kon niet worden bepaald: deze merge is niet toetsbaar",
-                head_sha=head_sha,
-                workflow_name=resolved_workflow,
-            )
+    # `gh run list --commit` silently returns zero rows (exit 0, no error) for
+    # an abbreviated sha — measured 2026-08-23 on PR #1672, where that read as
+    # "no CI ran" instead of "wrong query". A short head_sha here would recreate
+    # that exact false-NO-GO, so it is refused explicitly rather than queried.
+    if len(head_sha) < 40:
+        return _no_go(
+            f"head_sha '{head_sha}' is afgekort ({len(head_sha)} tekens): "
+            "gh run list --commit vereist de volle 40-teken sha, anders komt er stil nul "
+            "rijen terug: deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
 
     # ── gh authentication ──────────────────────────────────────────────────
     auth, auth_err = _capture([gh_bin, "auth", "status"], timeout=GH_AUTH_TIMEOUT)
@@ -224,11 +249,11 @@ def check_ci_run_for_head(
             workflow_name=resolved_workflow,
         )
 
-    # ── Query workflow runs ────────────────────────────────────────────────
+    # ── Query workflow runs, scoped to the exact commit (OI-1387) ──────────
     run_list, run_err = _capture(
         [
             gh_bin, "run", "list",
-            "--branch", branch,
+            "--commit", head_sha,
             "--workflow", resolved_workflow,
             "--limit", str(RUN_LIST_LIMIT),
             "--json", "conclusion,headSha,status,databaseId",
@@ -266,40 +291,40 @@ def check_ci_run_for_head(
             workflow_name=resolved_workflow,
         )
 
-    # ── Match a run to the exact HEAD SHA ──────────────────────────────────
-    for run in runs:
-        if run.get("headSha") != head_sha:
-            continue
-        conclusion = run.get("conclusion") or ""
-        status = run.get("status") or ""
-        run_id = run.get("databaseId")
-        if conclusion == "success":
-            return {
-                "verdict": "GO",
-                "message": (
-                    f"{resolved_workflow} geslaagd op {head_sha[:12]} "
-                    f"(run {run_id})"
-                ),
-                "ci_conclusion": conclusion,
-                "ran_on_sha": True,
-                "head_sha": head_sha,
-                "ci_run_id": run_id,
-                "workflow_name": resolved_workflow,
-                "overridden": False,
-                "override_reason": None,
-            }
-        if status in ("in_progress", "queued"):
-            return _no_go(
-                f"{resolved_workflow} draait nog op {head_sha[:12]} (status: {status}): "
-                "deze merge is niet toetsbaar tot de run op 'success' eindigt",
-                ci_conclusion=None,
-                ran_on_sha=True,
-                head_sha=head_sha,
-                ci_run_id=run_id,
-                workflow_name=resolved_workflow,
-            )
+    # ── Every run for the exact HEAD SHA must be conclusion=success ────────
+    # ``--commit`` already scopes gh's response to head_sha; this filter is a
+    # defensive no-op against a gh quirk returning extra entries. Unlike the
+    # pre-OI-1387 code, which returned on the FIRST run matching head_sha,
+    # this collects ALL of them: a sha pushed to two branches (tmux-spawn
+    # fix-forward) can have more than one VNX CI run, and one done + one still
+    # running must NO-GO, not GO on the strength of whichever run sorted first.
+    matching = [run for run in runs if run.get("headSha") == head_sha]
+    if not matching:
         return _no_go(
-            f"{resolved_workflow} conclusion is '{conclusion or status}' op {head_sha[:12]}: "
+            f"Geen VNX CI-run gevonden voor {head_sha[:12]}: deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+
+    running = [run for run in matching if (run.get("status") or "") in ("in_progress", "queued")]
+    if running:
+        run_id = running[0].get("databaseId")
+        return _no_go(
+            f"{resolved_workflow} draait nog op {head_sha[:12]} (status: {running[0].get('status')}): "
+            "deze merge is niet toetsbaar tot alle runs op deze commit op 'success' eindigen",
+            ci_conclusion=None,
+            ran_on_sha=True,
+            head_sha=head_sha,
+            ci_run_id=run_id,
+            workflow_name=resolved_workflow,
+        )
+
+    failing = [run for run in matching if (run.get("conclusion") or "") != "success"]
+    if failing:
+        run_id = failing[0].get("databaseId")
+        conclusion = failing[0].get("conclusion") or ""
+        return _no_go(
+            f"{resolved_workflow} conclusion is '{conclusion}' op {head_sha[:12]}: "
             "deze merge is niet toetsbaar",
             ci_conclusion=conclusion or None,
             ran_on_sha=True,
@@ -308,23 +333,22 @@ def check_ci_run_for_head(
             workflow_name=resolved_workflow,
         )
 
-    # No run matched the HEAD SHA — distinguish "ran on a different SHA" from
-    # "never ran at all" so the two failure modes get distinct messages.
-    if runs:
-        latest_run = runs[0]
-        latest_sha = (latest_run.get("headSha") or "")[:12]
-        return _no_go(
-            f"{resolved_workflow} heeft niet gedraaid op HEAD {head_sha[:12]}; "
-            f"laatste run op '{branch}' was op {latest_sha}: "
-            "deze merge is niet toetsbaar (een run op een oudere commit telt niet)",
-            head_sha=head_sha,
-            workflow_name=resolved_workflow,
-        )
-    return _no_go(
-        f"Geen VNX CI-run gevonden voor {head_sha[:12]}: deze merge is niet toetsbaar",
-        head_sha=head_sha,
-        workflow_name=resolved_workflow,
-    )
+    run_ids = [run.get("databaseId") for run in matching]
+    run_word = "run" if len(run_ids) == 1 else "runs"
+    return {
+        "verdict": "GO",
+        "message": (
+            f"{resolved_workflow} geslaagd op {head_sha[:12]} "
+            f"({run_word} {', '.join(str(r) for r in run_ids)})"
+        ),
+        "ci_conclusion": "success",
+        "ran_on_sha": True,
+        "head_sha": head_sha,
+        "ci_run_id": run_ids[0] if len(run_ids) == 1 else run_ids,
+        "workflow_name": resolved_workflow,
+        "overridden": False,
+        "override_reason": None,
+    }
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -333,7 +357,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         description="Fail-closed check: does VNX CI have a successful run for the exact HEAD SHA?",
     )
     parser.add_argument("--project-root", required=True, help="Directory whose HEAD is being merged")
-    parser.add_argument("--branch", help="Branch name (defaults to git rev-parse --abbrev-ref HEAD)")
+    parser.add_argument(
+        "--branch",
+        help="Accepted for backward compat; NOT used to scope the CI query (OI-1387 — see module docstring)",
+    )
     parser.add_argument("--head-sha", help="Exact HEAD SHA (defaults to git rev-parse HEAD)")
     parser.add_argument("--workflow", help="CI workflow name (default: VNX_CI_WORKFLOW_NAME or 'VNX CI')")
     parser.add_argument("--gh-bin", default="gh", help="Path/name of the gh binary")

--- a/tests/test_merge_preflight_ci_check.py
+++ b/tests/test_merge_preflight_ci_check.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-"""Tests for the fail-closed VNX CI-run check (OI-1216).
+"""Tests for the fail-closed VNX CI-run check (OI-1216, OI-1387).
 
-Covers the four required states from the dispatch, each with a stubbed ``gh``
-outcome (no network):
+Covers the four required states from the original dispatch, each with a
+stubbed ``gh`` outcome (no network):
   (a) successful run for the exact head SHA            -> GO
   (b) zero runs                                        -> NO-GO
   (c) run with conclusion=failure for the exact head   -> NO-GO
-  (d) success but for a DIFFERENT sha on the branch    -> NO-GO
-
+  (d) success but for a run that (defensively) doesn't  -> NO-GO
+      match head_sha even though --commit was used
 plus the fail-closed edges the dispatch names: gh missing, gh not
 authenticated, and a still-running (in_progress) run.
+
+OI-1387 adds: the query must be scoped to the exact commit (``--commit``, not
+``--branch``), and the verdict must require EVERY run found for that commit to
+be conclusion=success, not just the first one encountered. See
+``TestCommitScopedQuery`` below.
 """
 
 import json
@@ -36,10 +41,6 @@ def _git_head_mock(sha: str) -> MagicMock:
     return MagicMock(returncode=0, stdout=sha + "\n", stderr="")
 
 
-def _git_branch_mock(branch: str = "feature-branch") -> MagicMock:
-    return MagicMock(returncode=0, stdout=branch + "\n", stderr="")
-
-
 def _gh_auth_ok() -> MagicMock:
     return MagicMock(returncode=0, stdout="", stderr="")
 
@@ -58,15 +59,20 @@ def _gh_run_output(conclusion, head_sha, status="completed", database_id=12345):
     return MagicMock(returncode=0, stdout=json.dumps(runs), stderr="")
 
 
+def _gh_multi_run_output(runs):
+    return MagicMock(returncode=0, stdout=json.dumps(runs), stderr="")
+
+
 def _gh_empty_output():
     return MagicMock(returncode=0, stdout=json.dumps([]), stderr="")
 
 
-def _subprocess_mocks(head_sha, branch="feature-branch"):
-    """git head -> git branch -> gh auth (ok) -> gh run list."""
+def _subprocess_mocks(head_sha):
+    """git head -> gh auth (ok) -> gh run list. No branch resolution (OI-1387):
+    the query is commit-scoped now, so branch is never resolved by the function
+    itself."""
     return [
         _git_head_mock(head_sha),
-        _git_branch_mock(branch),
         _gh_auth_ok(),
     ]
 
@@ -76,7 +82,8 @@ GH_PRESENT = "/usr/local/bin/gh"
 
 class TestCheckCIRunForHead:
     def test_ci_succeeded_for_exact_head(self, tmp_path):
-        """(a) successful run for the exact head SHA -> GO."""
+        """(a) successful run for the exact head SHA -> GO. Also the OI-1387
+        control case: exactly one run, conclusion=success, still GO."""
         sha = "a" * 40
         mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]
         with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
@@ -113,8 +120,10 @@ class TestCheckCIRunForHead:
         assert "conclusion is 'failure'" in result["message"]
         assert "niet toetsbaar" in result["message"]
 
-    def test_success_on_different_sha_is_no_go(self, tmp_path):
-        """(d) success but for a DIFFERENT sha on the branch -> NO-GO."""
+    def test_run_with_mismatched_sha_is_no_go(self, tmp_path):
+        """(d) defensive filter: a returned run whose headSha does not match
+        head_sha (a gh quirk despite --commit scoping) never counts -> NO-GO,
+        same message as zero runs."""
         sha = "d" * 40
         other = "e" * 40
         mocks = _subprocess_mocks(sha) + [_gh_run_output("success", other, database_id=99999)]
@@ -124,8 +133,7 @@ class TestCheckCIRunForHead:
         assert result["verdict"] == "NO-GO"
         assert result["ran_on_sha"] is False
         assert result["head_sha"] == sha
-        assert "heeft niet gedraaid op HEAD" in result["message"]
-        assert "oudere commit telt niet" in result["message"]
+        assert "Geen VNX CI-run gevonden" in result["message"]
         assert "niet toetsbaar" in result["message"]
 
     def test_in_progress_run_is_no_go(self, tmp_path):
@@ -155,7 +163,6 @@ class TestCheckCIRunForHead:
         sha = "g" * 40
         mocks = [
             _git_head_mock(sha),
-            _git_branch_mock(),
             _gh_auth_fail(),
         ]
         with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
@@ -199,6 +206,18 @@ class TestCheckCIRunForHead:
         assert "HEAD-SHA kon niet worden bepaald" in result["message"]
         assert "niet toetsbaar" in result["message"]
 
+    def test_abbreviated_head_sha_is_no_go(self, tmp_path):
+        """A short head_sha is refused before querying: `gh run list --commit`
+        silently returns zero rows for an abbreviated sha (measured 2026-08-23,
+        PR #1672) which would misread as 'no CI ran' rather than 'wrong query'."""
+        with patch("merge_preflight_ci_check.subprocess.run") as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path, head_sha="abc1234")
+        assert result["verdict"] == "NO-GO"
+        assert "afgekort" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+        mock_run.assert_not_called()
+
     def test_uses_default_workflow_name(self, tmp_path):
         """The gh run list call uses the default workflow name 'VNX CI'."""
         sha = "j" * 40
@@ -207,7 +226,7 @@ class TestCheckCIRunForHead:
              patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
             result = check_ci_run_for_head(tmp_path)
         assert result["verdict"] == "GO"
-        gh_call_args = mock_run.call_args_list[3].args[0]
+        gh_call_args = mock_run.call_args_list[2].args[0]
         workflow_idx = gh_call_args.index("--workflow")
         assert gh_call_args[workflow_idx + 1] == DEFAULT_CI_WORKFLOW_NAME
 
@@ -219,7 +238,7 @@ class TestCheckCIRunForHead:
              patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
             result = check_ci_run_for_head(tmp_path, workflow_name="CI/CD Pipeline")
         assert result["verdict"] == "GO"
-        gh_call_args = mock_run.call_args_list[3].args[0]
+        gh_call_args = mock_run.call_args_list[2].args[0]
         workflow_idx = gh_call_args.index("--workflow")
         assert gh_call_args[workflow_idx + 1] == "CI/CD Pipeline"
 
@@ -232,9 +251,88 @@ class TestCheckCIRunForHead:
              patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
             result = check_ci_run_for_head(tmp_path)
         assert result["verdict"] == "GO"
-        gh_call_args = mock_run.call_args_list[3].args[0]
+        gh_call_args = mock_run.call_args_list[2].args[0]
         workflow_idx = gh_call_args.index("--workflow")
         assert gh_call_args[workflow_idx + 1] == "CI/CD Pipeline"
+
+
+class TestCommitScopedQuery:
+    """OI-1387: the merge-gate and the review-gate (``gh pr checks``, always
+    commit-scoped) must agree on the same commit. Regression coverage for the
+    fix: query by ``--commit``, and require ALL runs on that commit to have
+    succeeded, not just the first one encountered.
+    """
+
+    def test_query_uses_commit_not_branch(self, tmp_path):
+        """The gh run list call is scoped by --commit <full_head_sha>, never
+        --branch, even when a branch is passed through for other callers."""
+        sha = "1" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks) as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path, branch="some-other-branch")
+        assert result["verdict"] == "GO"
+        gh_call_args = mock_run.call_args_list[2].args[0]
+        assert "--branch" not in gh_call_args
+        commit_idx = gh_call_args.index("--commit")
+        assert gh_call_args[commit_idx + 1] == sha
+
+    def test_running_run_on_other_branch_blocks_go(self, tmp_path):
+        """OI-1387 regression, red on main: a sha pushed to two branches (the
+        tmux-spawn fix-forward lane pushes the same commit to the target branch
+        AND its own per-dispatch auto-branch) has two VNX CI runs — one
+        success, one still running. Pre-fix ``check_ci_run_for_head`` returned
+        on the FIRST run matching head_sha and ignored the rest, so this exact
+        fixture gave GO on main (verdict='GO', measured against the pre-fix
+        snapshot before this dispatch's edit). Post-fix it must NO-GO: every
+        run for the commit must be conclusion=success, and none may still be
+        running.
+        """
+        sha = "2" * 40
+        runs = [
+            {"conclusion": "success", "headSha": sha, "status": "completed", "databaseId": 111},
+            {"conclusion": None, "headSha": sha, "status": "in_progress", "databaseId": 222},
+        ]
+        mocks = _subprocess_mocks(sha) + [_gh_multi_run_output(runs)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path, branch="feature-branch")
+        assert result["verdict"] == "NO-GO"
+        assert result["ran_on_sha"] is True
+        assert "draait nog" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_two_successful_runs_on_same_commit_is_go(self, tmp_path):
+        """Two runs for the same commit, both conclusion=success (e.g. one per
+        branch after a fix-forward push) -> GO. Every run succeeded and none is
+        running, which is exactly what the fixed comparison requires."""
+        sha = "3" * 40
+        runs = [
+            {"conclusion": "success", "headSha": sha, "status": "completed", "databaseId": 111},
+            {"conclusion": "success", "headSha": sha, "status": "completed", "databaseId": 222},
+        ]
+        mocks = _subprocess_mocks(sha) + [_gh_multi_run_output(runs)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "GO"
+        assert result["ci_conclusion"] == "success"
+        assert result["ci_run_id"] == [111, 222]
+
+    def test_one_success_one_failed_on_same_commit_is_no_go(self, tmp_path):
+        """Two runs for the same commit, one success and one failure -> NO-GO:
+        every run must succeed, not just one of them."""
+        sha = "4" * 40
+        runs = [
+            {"conclusion": "success", "headSha": sha, "status": "completed", "databaseId": 111},
+            {"conclusion": "failure", "headSha": sha, "status": "completed", "databaseId": 222},
+        ]
+        mocks = _subprocess_mocks(sha) + [_gh_multi_run_output(runs)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert "conclusion is 'failure'" in result["message"]
 
 
 class TestOverrideEscapeHatch:
@@ -346,3 +444,21 @@ class TestCLI:
         out = json.loads(capsys.readouterr().out)
         assert out["verdict"] == "NO-GO"
         assert "niet toetsbaar" in out["message"]
+
+    def test_cli_branch_flag_accepted_but_unused_in_query(self, tmp_path, capsys):
+        """--branch is still a valid CLI flag (backward compat for callers that
+        pass it) but must not appear in the gh run list invocation (OI-1387).
+        An explicit --head-sha skips git rev-parse HEAD entirely, so only the
+        gh auth + gh run list calls are mocked."""
+        sha = "o" * 40
+        mocks = [_gh_auth_ok(), _gh_run_output("success", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks) as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            rc = mpci.main([
+                "--project-root", str(tmp_path), "--json",
+                "--head-sha", sha, "--branch", "some-branch",
+            ])
+        assert rc == 0
+        gh_call_args = mock_run.call_args_list[-1].args[0]
+        assert "--branch" not in gh_call_args
+        assert "--commit" in gh_call_args


### PR DESCRIPTION
## Summary

`merge_preflight_ci_check.check_ci_run_for_head` (the merge-gate) queried
`gh run list --branch <branch>` while the review-gate's `_execute_ci_gate`
uses `gh pr checks <pr>`, which is always commit-scoped. The tmux-spawn
dispatch lane pushes a fix-forward commit to both the target branch and its
own per-dispatch auto-branch, so one sha can carry VNX CI runs on two
branches at once — the merge-gate only saw the branch it was given, the
review-gate saw all of them, and the two disagreed on the exact same commit
(measured 21-08 on PR #1630, reconfirmed 23-08 on `main`).

## Changes

- `scripts/lib/merge_preflight_ci_check.py`:
  - `check_ci_run_for_head` now queries `gh run list --commit <full_head_sha>`
    instead of `--branch <branch>`. `branch` remains an accepted
    argument/CLI flag (callers like `pr_merge.py` still resolve and pass it)
    but no longer participates in the CI query, and there is no fallback to
    a branch-scoped query when `head_sha` is unresolvable.
  - Verdict logic now requires **every** run found for the exact commit to
    be `conclusion=success`, with none still running — not just the first
    match in the list (the old loop returned on the first `headSha` match
    and ignored the rest).
  - Added a guard: an abbreviated `head_sha` (<40 chars) is refused before
    querying, since `gh run list --commit` silently returns zero rows for a
    short sha (measured 23-08 on PR #1672) — that would otherwise misread as
    "no CI ran" instead of "wrong query".
- `tests/test_merge_preflight_ci_check.py`: updated the mock call-sequence
  (branch is no longer git-resolved), and added `TestCommitScopedQuery` plus
  an abbreviated-sha test.

## Verification

- `python3 -m pytest tests/test_merge_preflight_ci_check.py tests/test_pr_merge_ci_gate.py tests/test_pr_merge_match_head.py -v` → **41 passed**.
- Regression test (`test_running_run_on_other_branch_blocks_go`) reproduces the
  measured bug: against the pre-fix module snapshot (`git show HEAD:...`,
  before this PR's edit) the fixture (one `success` run + one `in_progress`
  run for the same sha) returned `verdict=GO` — confirmed red by running it
  standalone against the pre-fix code. Against the fixed code it returns
  `NO-GO`.
- Control case (`test_ci_succeeded_for_exact_head`): a sha with exactly one
  `success` run still returns `GO`.
- Real-commit check: on PR #1671's head `ae11e43583f8ac8613793cbdfff8599b9d733ee0`,
  the fixed merge-gate (`gh run list --commit`) returns `GO` and `gh pr checks 1671`
  shows all 16 checks in the `pass` bucket — both sources now agree on the
  same real commit.

## Open Items

- `pre_merge_gate.check_ci_workflow` (OI-931, `scripts/pre_merge_gate.py:967`)
  has the same `--branch`-scoped `gh run list` pattern and is named in this
  file's module docstring as the sibling implementation. It was explicitly
  out of scope for this dispatch (which targets only
  `merge_preflight_ci_check.check_ci_run_for_head`) but carries the same
  latent disagreement risk and is a candidate for a follow-up OI.

Dispatch-ID: 20260823-beta2-b-oi1387-ci-bron
Model: sonnet
Provider: claude