### PR TITLE
feat(ledger-health): drive scripts/ledger_health.py via launchd (OI-1409)

### DIFF
--- a/scripts/launchd/com.vnx.ledger-health.plist
+++ b/scripts/launchd/com.vnx.ledger-health.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.vnx.ledger-health</string>
+  <!--
+    OI-1409: ledger_health.py exists, works, mutates nothing, and had no
+    driver — nobody ever ran it, so its receipt-coverage/pull-cursor/chain
+    findings only ever reflected whatever state existed the one time a human
+    happened to invoke it by hand. This job is the driver, nothing else: it
+    does not fix findings, does not touch dispatch_register.ndjson or
+    t0_receipts.ndjson, and does not move DEFAULT_CURSOR_STALE_HOURS. It only
+    makes sure `python3 scripts/ledger_health.py` actually runs on a cadence,
+    so `vnx doctor`'s ledger:health check (_check_ledger_health) reads a
+    beacon that reflects current reality instead of a stale or nonexistent
+    one.
+
+    Interval: every 6h (21600s). ledger_health.py writes its own beacon with
+    BEACON_EXPECTED_INTERVAL_SECONDS=86400 (health_beacon.py: a beacon whose
+    age exceeds its own expected_interval_seconds reads as "stale" per
+    all_beacons()) and check_pull_cursor()'s DEFAULT_CURSOR_STALE_HOURS is
+    24.0h = 86400s — both windows this job exists to stay inside. A
+    StartInterval at or above 86400 would make the beacon (or the cursor
+    check it reports on) stale by construction, which is exactly the
+    "mechanism with no drive" defect this dispatch fixes. 21600s gives 4
+    runs/day: even 3 consecutive missed runs (an 18h gap) still lands inside
+    the 86400s window with margin, instead of the interval and the threshold
+    racing each other on every single run.
+
+    Installed automatically by vnx init for the VNX orchestration repo.
+    Also installable manually via reload_plist.sh:
+      bash scripts/launchd/reload_plist.sh com.vnx.ledger-health
+
+    A non-zero exit (1 = findings, 2 = SKIPPED_UNVERIFIED/cannot-measure) is
+    expected and normal — ledger_health.py's job is to measure and record,
+    not to gate. Do not wire this job's exit code into anything that fails a
+    build; that is explicitly out of scope for this dispatch (30 dispatch-ids
+    of pre-existing receipt debt would turn every PR red on someone else's
+    backlog).
+
+    The store is NOT pinned by path. The job identifies its project via
+    VNX_PROJECT_ID (below), one instance per project; ledger_health.py's
+    ambient resolver (vnx_paths.resolve_paths(), which honors VNX_PROJECT_ID
+    before any other signal) then derives VNX_DATA_DIR/VNX_STATE_DIR from
+    that id. A consumer installing this template for their own project MUST
+    set VNX_PROJECT_ID to their project id: vnx init substitutes the
+    ${VNX_PROJECT_ID} placeholder with the project id argument, so manual
+    installs must edit it by hand. Hardcoding a store path here would make a
+    copied template run on the original project's ledger (OI-1253 fix-forward,
+    same failure mode gate-obligation-runner already fixed once).
+  -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/ledger_health.py</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>21600</integer>
+  <key>StandardOutPath</key><string>/tmp/vnx-ledger-health.log</string>
+  <key>StandardErrorPath</key><string>/tmp/vnx-ledger-health.err</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VNX_HOME</key>
+    <string>${VNX_HOME}</string>
+    <key>VNX_PROJECT_ID</key>
+    <string>${VNX_PROJECT_ID}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>

--- a/tests/test_ledger_health_launchd.py
+++ b/tests/test_ledger_health_launchd.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests for OI-1409 — the launchd drive behind scripts/ledger_health.py.
+
+``ledger_health.py`` existed, worked, mutated nothing, and had no driver:
+nothing ever invoked it, so its beacon (and the doctor check that reads it,
+``vnx_cli/commands/doctor.py::_check_ledger_health``) only ever reflected
+whatever state existed the one time a human ran it by hand. This file locks
+in the two behaviors the launchd drive (``scripts/launchd/com.vnx.ledger-
+health.plist`` + ``init_cmd._install_ledger_health_runner``) exists to
+guarantee — not "the plist file exists" and not "a constant equals X"
+(memory: a test on the constant's literal value or the file's mere presence
+expires the moment either is renamed):
+
+  1. The chosen launchd ``StartInterval`` is provably smaller than
+     ``ledger_health.BEACON_EXPECTED_INTERVAL_SECONDS`` — both values read
+     live (the interval from the plist actually produced by
+     ``_install_ledger_health_runner``, the same install path ``vnx init``
+     runs; the threshold straight from the ``ledger_health`` module), never
+     copied as a literal into this file.
+  2. When ``ledger_health.py`` reruns on that cadence,
+     ``health_beacon.all_beacons`` never classifies its beacon as stale;
+     when nothing reruns it at all, the same beacon goes stale exactly at
+     ``BEACON_EXPECTED_INTERVAL_SECONDS`` — the pre-dispatch failure mode,
+     reproduced here instead of just asserted away.
+
+Both timestamps are forced via ``monkeypatch`` on ``time.time`` in the
+``ledger_health`` and ``health_beacon`` modules — never read off wall-clock
+reality, which would only ever prove "worked once, on this machine, today".
+"""
+from __future__ import annotations
+
+import os as _os
+import plistlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(VNX_ROOT))
+
+import ledger_health as lh  # noqa: E402
+import health_beacon  # noqa: E402
+from vnx_cli.commands import init_cmd  # noqa: E402
+
+PLIST_NAME = "com.vnx.ledger-health"
+
+
+def _install_and_read_interval(tmp_path, monkeypatch) -> int:
+    """Run the REAL install path (``init_cmd._install_ledger_health_runner``)
+    against a fake engine root + fake home, then parse the ``StartInterval``
+    that actually lands on disk. Exercises the same code ``vnx init`` runs —
+    not a hand-copied number that could drift from what gets installed.
+
+    Fake engine root lives under ``tmp_path`` (never under
+    ``.vnx-data/worktrees/``, which this very test suite's real repo path
+    is) so the OI-1117 worktree guard in ``_install_launchd_agent`` does not
+    fire and silently skip the install.
+    """
+    real_engine = init_cmd._engine.engine_root()
+    fake_engine_root = tmp_path / "fake-vnx-engine"
+    fake_engine_root.mkdir()
+    _os.symlink(
+        real_engine / "scripts", fake_engine_root / "scripts", target_is_directory=True
+    )
+    monkeypatch.setattr(init_cmd._engine, "engine_root", lambda: fake_engine_root)
+
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    def fake_run(cmd, **kwargs):
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = ""
+        m.stdout = f"{PLIST_NAME}\n" if cmd == ["launchctl", "list"] else ""
+        return m
+
+    monkeypatch.setattr(init_cmd.subprocess, "run", fake_run)
+
+    installed = init_cmd._install_ledger_health_runner(
+        str(fake_engine_root), project_id="test-project"
+    )
+    assert installed is True, (
+        "_install_ledger_health_runner returned False — the plist template "
+        "or the install wiring is missing (OI-1409 not implemented)"
+    )
+
+    dest = fake_home / "Library" / "LaunchAgents" / f"{PLIST_NAME}.plist"
+    with dest.open("rb") as fh:
+        data = plistlib.load(fh)
+    return int(data["StartInterval"])
+
+
+class TestLedgerHealthLaunchdCadence:
+    def test_start_interval_is_below_beacon_staleness_threshold(self, tmp_path, monkeypatch):
+        """The interval the job actually installs with must stay under the
+        module's own staleness window, or the beacon this job writes goes
+        stale by construction between every pair of runs."""
+        interval = _install_and_read_interval(tmp_path, monkeypatch)
+        assert interval < lh.BEACON_EXPECTED_INTERVAL_SECONDS, (
+            f"StartInterval={interval}s must be below "
+            f"BEACON_EXPECTED_INTERVAL_SECONDS={lh.BEACON_EXPECTED_INTERVAL_SECONDS}s"
+        )
+
+    def test_beacon_stays_fresh_across_cadence_but_goes_stale_without_a_rerun(
+        self, tmp_path, monkeypatch
+    ):
+        interval = _install_and_read_interval(tmp_path, monkeypatch)
+
+        data_dir = tmp_path / "data"
+        state_dir = data_dir / "state"
+        state_dir.mkdir(parents=True)
+        # Minimal but real (parseable, empty) ledger/register — enough for
+        # compute_health to run every check to a real STATUS_OK/finding,
+        # never SKIPPED_UNVERIFIED, which would leave the beacon's status
+        # field ambiguous for this test's purpose (staleness, not findings).
+        (state_dir / lh.REGISTER_NAME).write_text("", encoding="utf-8")
+        (state_dir / lh.LEDGER_NAME).write_text("", encoding="utf-8")
+
+        t0 = 1_800_000_000.0
+        monkeypatch.setattr(lh.time, "time", lambda: t0)
+        result = lh.compute_health(data_dir, state_dir)
+        lh.write_health_surface(data_dir, result)
+
+        # One tick before the NEXT scheduled launchd run: if the job fires
+        # every `interval` seconds as installed, the beacon is at most
+        # `interval` seconds old at any point in the cycle.
+        t_within_cadence = t0 + interval - 1
+        monkeypatch.setattr(health_beacon.time, "time", lambda: t_within_cadence)
+        beacons = health_beacon.all_beacons(data_dir)
+        assert beacons["ledger_health"]["health"] != "stale", (
+            f"beacon read {interval - 1}s after its last write must not be stale — "
+            f"that is well inside the {interval}s launchd cadence this job installs"
+        )
+
+        # No rerun at all, all the way past the module's own staleness
+        # window — the pre-dispatch state: ledger_health.py existed, wrote a
+        # beacon once, and nothing ever invoked it again.
+        t_beyond_threshold = t0 + lh.BEACON_EXPECTED_INTERVAL_SECONDS + 1
+        monkeypatch.setattr(health_beacon.time, "time", lambda: t_beyond_threshold)
+        beacons_stale = health_beacon.all_beacons(data_dir)
+        assert beacons_stale["ledger_health"]["health"] == "stale", (
+            "a beacon nobody ever reruns must read stale once its age passes "
+            f"BEACON_EXPECTED_INTERVAL_SECONDS={lh.BEACON_EXPECTED_INTERVAL_SECONDS}s — "
+            "this is the exact 'mechanism built, never driven' defect OI-1409 fixes"
+        )

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -723,12 +723,12 @@ def vnx_init(args) -> int:
         return 1
 
 
-def _install_gate_obligation_runner(vnx_home: str, project_id: str = "") -> bool:
-    """Install the gate-obligation-runner launchd plist (OI-917).
+def _install_launchd_agent(vnx_home: str, plist_name: str, project_id: str = "") -> bool:
+    """Install a VNX launchd plist by name (OI-917, generalized for OI-1409).
 
     Reads the plist template from the engine root's scripts/launchd/ directory,
     substitutes ``${VNX_HOME}`` with the resolved VNX home path and
-    ``${VNX_PROJECT_ID}`` with the project's id (OI-1253 fix-forward: the job
+    ``${VNX_PROJECT_ID}`` with the project's id (OI-1253 fix-forward: a job
     identifies its project via VNX_PROJECT_ID, one instance per project, never
     via a hardcoded store path), writes atomically to ``~/Library/LaunchAgents/``,
     and loads via launchctl.
@@ -740,8 +740,6 @@ def _install_gate_obligation_runner(vnx_home: str, project_id: str = "") -> bool
     Raises RuntimeError if launchctl load fails (never silent).
     Raises OSError if the template exists but is unreadable.
     """
-    plist_name = "com.vnx.gate-obligation-runner"
-
     # --- OI-1117: refuse launchd agent install on an unstable root -----------
     # When vnx init runs from an ephemeral worktree (dispatch/PR isolation),
     # engine_root() resolves to a directory under .vnx-data/worktrees/. A
@@ -820,6 +818,31 @@ def _install_gate_obligation_runner(vnx_home: str, project_id: str = "") -> bool
         )
 
     return True
+
+
+def _install_gate_obligation_runner(vnx_home: str, project_id: str = "") -> bool:
+    """Install the gate-obligation-runner launchd plist (OI-917).
+
+    Thin wrapper over ``_install_launchd_agent`` — kept as its own name/
+    signature because tests and callers address it directly.
+    """
+    return _install_launchd_agent(
+        vnx_home, "com.vnx.gate-obligation-runner", project_id=project_id
+    )
+
+
+def _install_ledger_health_runner(vnx_home: str, project_id: str = "") -> bool:
+    """Install the ledger-health launchd plist (OI-1409).
+
+    ``scripts/ledger_health.py`` is read-only reconciliation tooling that
+    existed with nothing ever invoking it — this gives it the same launchd
+    drive OI-917 already gave gate-obligation-runner, on its own cadence
+    (see the plist's comment block for the interval rationale). Thin wrapper
+    over ``_install_launchd_agent``, mirroring ``_install_gate_obligation_runner``.
+    """
+    return _install_launchd_agent(
+        vnx_home, "com.vnx.ledger-health", project_id=project_id
+    )
 
 
 def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) -> int:
@@ -948,6 +971,16 @@ def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) ->
             print("  skipped gate-obligation-runner (plist template not found)")
     except (OSError, RuntimeError) as exc:
         print(f"  warning: gate-obligation-runner install failed: {exc}")
+
+    # --- OI-1409: install ledger-health launchd agent -------------------------
+    try:
+        installed = _install_ledger_health_runner(
+            str(_engine.engine_root()), project_id=project_id
+        )
+        if not installed:
+            print("  skipped ledger-health (plist template not found)")
+    except (OSError, RuntimeError) as exc:
+        print(f"  warning: ledger-health install failed: {exc}")
 
     print()
     print(f"Runtime state: {data_root}")


### PR DESCRIPTION
## Summary
- `scripts/ledger_health.py` existed, worked, mutated nothing, and had no driver — nobody ever ran it. Fourth recurrence of this pattern (`report_to_receipt_converter.py`, `gate_obligation_runner.py` preceded it).
- Adds `scripts/launchd/com.vnx.ledger-health.plist` on a 21600s (6h) cadence, comfortably under `BEACON_EXPECTED_INTERVAL_SECONDS=86400s` / `DEFAULT_CURSOR_STALE_HOURS=24h`.
- Wires the install into `vnx init` at the exact spot `gate-obligation-runner` installs, generalizing `_install_gate_obligation_runner` into `_install_launchd_agent(vnx_home, plist_name, project_id)` (kept as a thin wrapper — no existing call site or test needed to change).
- Manual install via the existing generic `bash scripts/launchd/reload_plist.sh com.vnx.ledger-health` — no second install mechanism invented.

## Out of scope (explicit, per dispatch)
- `DEFAULT_CURSOR_STALE_HOURS` unchanged (still 24.0h).
- The 30+ dispatch-ids missing receipts are not repaired.
- No CI gate on this job's exit code (30 dispatch-ids of pre-existing debt would redden every PR on someone else's backlog).

## Changes
- `scripts/launchd/com.vnx.ledger-health.plist` (new) — launchd job template, `${VNX_HOME}`/`${VNX_PROJECT_ID}` placeholders substituted at install, matching the gate-obligation-runner pattern (OI-1253 fix-forward: never a hardcoded store path).
- `vnx_cli/commands/init_cmd.py` — generalized `_install_gate_obligation_runner` into `_install_launchd_agent`; added `_install_ledger_health_runner` wrapper; wired into `_vnx_init_scaffold` right after the gate-obligation-runner install.
- `tests/test_ledger_health_launchd.py` (new) — behavior tests (not file-existence/constant-value tests): (1) the actually-installed `StartInterval` is provably below `ledger_health.BEACON_EXPECTED_INTERVAL_SECONDS`, both read live; (2) `health_beacon.all_beacons` reads the beacon as fresh within the installed cadence and stale once nothing reruns it past the threshold — both forced via monkeypatched `time.time()`.

## Verification

Targeted + neighbour tests, all green:
```
python3 -m pytest tests/test_ledger_health_launchd.py tests/test_cli_init.py tests/test_ledger_health.py tests/test_gate_obligation_runner.py tests/test_path_parity.py -q
........................................................................ [ 54%]
.............................................................            [100%]
133 passed in 4.48s
```

Red-before-green, two distinct failure classes (both captured in full in the report — see `## Verification` there):
- Full pre-dispatch state (plist absent + `_install_ledger_health_runner` absent): `AttributeError: module 'vnx_cli.commands.init_cmd' has no attribute '_install_ledger_health_runner'` — missing-symbol class.
- Wiring present but plist artifact removed: `AssertionError: _install_ledger_health_runner returned False` — behavior class (the install path runs but the observable outcome is wrong).

`plistlib.load()` on the new template also caught a real XML defect during test-writing: an em-dash-free comment describing `--project-id` substitution broke XML comment parsing (`--` is illegal inside XML comments) — fixed by rewording, verified via `plistlib` round-trip, not by eyeballing the file.

Receipt-coverage measurement (dispatch instruction — measure, don't fix): ran `python3 scripts/ledger_health.py --json --no-write` against production state. 32 dispatch-ids currently missing receipts (was 30 on 2026-08-23 morning per the dispatch text; +2 from two dispatches — this one and a concurrent sibling — still in flight). Classified via register-entry shape: real dispatch-door registrations carry `event=dispatch_created` + `gate` + `extra.{lane,provider,permit_fingerprint}`; fixture-shaped entries are bare `worker_exited`/`gate_passed`/sparse `dispatch_created`/`dispatch_started` events, several with `dispatch_moved` paths literally pointing into `pytest-of-<user>` tmp dirs. Split: **15 real work, 17 test fixture** (leaked into the production register by a pre-OI-1117-era test-isolation gap, not something this dispatch touches).

## Open Items
None — full scope delivered per dispatch. The receipt-coverage/pull-cursor findings themselves remain open (30+/17-fixture backlog, cursor staleness) — explicitly out of scope for this dispatch, flagged as material for a follow-up item.