### PR TITLE
feat(review-gate): request-time takeover on lane exhaustion (DLv5+8)

### DIFF
--- a/scripts/lib/gate_report_generator.py
+++ b/scripts/lib/gate_report_generator.py
@@ -37,6 +37,9 @@ class GateReportGeneratorMixin:
             "status": "not_executable",
             "reason": reason,
             "reason_detail": reason_detail,
+            # OI-1415: same text as reason_detail above, in the canonical
+            # field a generic failure-reason reader looks for (#1666).
+            "failure_reason": reason_detail,
             "summary": f"{gate} not executable: {reason_detail}",
             "contract_hash": contract_hash,
             "report_path": "",

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -13,6 +13,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+from atomic_io import atomic_write_json
 from auto_merge_policy import codex_final_gate_required
 from review_contract import ReviewContract
 from gemini_prompt_renderer import render_gemini_prompt
@@ -207,6 +208,15 @@ class GateRequestHandlerMixin:
         fields. ``failure_reason`` is the CANONICAL reason field (#1666 /
         OI-1415) -- never a one-off field name a generic receipt reader would
         not recognise.
+
+        Both writes go through ``atomic_write_json`` (temp file in the same
+        directory + ``os.replace``), never a bare ``write_text``. These are
+        EVIDENCE files: a torn write here passes the existence check a reader
+        does first and only fails on the content it trusts -- worse than no
+        record at all, because it surfaces exactly when the record is
+        needed. Not suppressed with a `# vnx-atomic-write` marker: that
+        marker is for writes where a torn write is harmless, which a gate
+        evidence record is not.
         """
         gate = payload.get("gate", "")
         annotations = {
@@ -221,7 +231,7 @@ class GateRequestHandlerMixin:
         if pr_number is not None:
             request_file = self._request_path(gate, pr_number)
             if request_file.exists():
-                request_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+                atomic_write_json(request_file, payload)
 
             result_file = self._result_path(gate, pr_number)
             if result_file.exists():
@@ -231,7 +241,7 @@ class GateRequestHandlerMixin:
                     result_payload = None
                 if result_payload is not None:
                     result_payload.update(annotations)
-                    result_file.write_text(json.dumps(result_payload, indent=2), encoding="utf-8")
+                    atomic_write_json(result_file, result_payload)
         return payload
 
     def _dispatch_review_seat(
@@ -250,6 +260,17 @@ class GateRequestHandlerMixin:
         here, before issuing a new request -- never on attest-time (rewriting
         an already-attested final verdict), since that would let evidence
         change owners after the fact.
+
+        This is DELIBERATELY two rounds, not one: the decision reads the
+        LAST SAVED result, so a seat only gets filled on the request AFTER
+        the one that recorded its failure. A synchronous refusal (binary
+        missing) and an asynchronous one (quota 403 surfacing mid-execution)
+        would otherwise need two different in-round semantics to take over
+        immediately -- one round of latency is the price of a single,
+        uniform rule instead of two. Do not "fix" this into an in-round
+        takeover: the first round after a quota-death yields an
+        undecided/refused seat, the second round fills it, and that is the
+        intended behaviour, not a bug.
         """
         existing_result = self._read_existing_gate_result(gate, pr_number)
         fallback_gate = _REVIEW_GATE_TAKEOVER_ORDER.get(gate)
@@ -357,6 +378,14 @@ class GateRequestHandlerMixin:
         reason, detail = self._classify_unavailable(gate, binary_name)
         payload["reason"] = reason
         payload["reason_detail"] = detail
+        # OI-1415 (same fix as #1666 for phantom_guard/pr_enforcement): stamp
+        # the canonical failure_reason field with the SAME text as the
+        # lane-own reason_detail above -- a seat that refuses on its very
+        # first round (no prior recorded result, so `_dispatch_review_seat`
+        # never reaches the takeover branch) must still carry a reason a
+        # generic failure-reason reader can find, not only a lane-specific
+        # field name.
+        payload["failure_reason"] = detail
         payload["resolved_at"] = payload["requested_at"]
         self._write_not_executable_result(
             gate=gate, pr_number=pr_number, pr_id=pr_id,

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -17,6 +17,7 @@ from auto_merge_policy import codex_final_gate_required
 from review_contract import ReviewContract
 from gemini_prompt_renderer import render_gemini_prompt
 from gate_recorder import get_pr_head_sha
+from governance_emit import _classify_lane_log_text
 from claude_github_receipt import (
     ClaudeGitHubReviewReceipt,
     STATE_NOT_CONFIGURED,
@@ -25,6 +26,20 @@ from claude_github_receipt import (
     STATE_BLOCKED,
     STATE_COMPLETED,
 )
+
+
+# Fixed fallback order for review-gate takeover (review-gate-provider-agnostic
+# plan, deliverable 5). This is an OPERATOR DECISION recorded 22-08, not a
+# measured defect-recall ranking: on 22-08 glm_gate and kimi_gate gave
+# OPPOSITE verdicts on the identical diff/contract_hash -- glm FAIL with a
+# blocking finding, kimi PASS with zero findings -- so there is no measured
+# basis for which reader is the better fallback, only that a working reader
+# beats an unfilled seat. The measured variant (ordered by defect-recall) is
+# a follow-up track (plan open question 1); this mapping stays a choice under
+# uncertainty until that lands.
+_REVIEW_GATE_TAKEOVER_ORDER: Dict[str, str] = {
+    "kimi_gate": "glm_gate",
+}
 
 
 class GateRequestHandlerMixin:
@@ -97,6 +112,180 @@ class GateRequestHandlerMixin:
             return self._request_glm(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
         return {"gate": gate, "status": "blocked", "reason": "unknown_review_gate"}
 
+    def _read_existing_gate_result(self, gate: str, pr_number: Optional[int]) -> Optional[Dict[str, Any]]:
+        """Read a previously-recorded terminal result for (gate, pr_number) from
+        disk, if one exists.
+
+        Backs the REQUEST-time takeover decision (deliverable 5): before
+        (re-)requesting a gate, this checks whether it already produced a
+        terminal not_executable/unavailable result for this PR on an earlier
+        call, so a known-broken seat can be routed around instead of
+        re-requested. Never invents a live outcome by executing anything
+        itself. Returns None on a missing or unreadable file so a corrupt or
+        absent result reads as "no signal" -- not as a failure to take over.
+        """
+        if pr_number is None:
+            return None
+        result_file = self._result_path(gate, pr_number)
+        if not result_file.exists():
+            return None
+        try:
+            return json.loads(result_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+
+    def _classify_review_seat_failure(self, result: Dict[str, Any]) -> str:
+        """Classify a previously-recorded gate result into one of the plan's
+        three failure states, or 'ok' when it is not a takeover-eligible
+        failure at all.
+
+        Returns:
+            'lane_exhausted'     -- toestand 1: exhaustion with body (a
+                                     payment/quota code, or a permanent
+                                     not_executable refusal with a
+                                     provider-owned reason). Take over.
+            'unreadable_verdict' -- toestand 2: a response existed, the
+                                     verdict block did not parse. Abstain --
+                                     never take over.
+            'no_response'        -- toestand 3: a bare non-zero exit with no
+                                     body, or no signal at all. Never take
+                                     over.
+            'ok'                 -- a real terminal verdict (pass/fail), or a
+                                     not_executable refusal that is not a
+                                     provider reason (e.g. glm's pre-dlv1
+                                     "runner not shipped yet" refusal).
+                                     Dispatch normally.
+        """
+        status = result.get("status", "")
+        if status == "not_executable":
+            # A code-not-shipped refusal is not a provider outage -- taking
+            # over FROM a seat that was never real would misattribute cause.
+            if result.get("reason") == "gate_runner_missing":
+                return "ok"
+            return "lane_exhausted"
+        if status != "unavailable":
+            return "ok"
+        reason = result.get("reason", "")
+        if reason == "parse_error":
+            return "unreadable_verdict"
+        if reason == "no_verdict":
+            return "no_response"
+        # reason == "dispatch_error" (or an unrecognised reason): scan the
+        # RAW detail text for the provider's own exhaustion marker via the
+        # SAME classifier deliverable 0 built for the lane-log lift -- never
+        # a second hand-rolled marker scan, and never keyed on a parser-side
+        # msg field. Measured: 29 kimi cases carry
+        # msg='Expecting value: line 1' beside raw='Error code: 403'; a
+        # msg-keyed check reads toestand 2 while the raw body says toestand 1.
+        detail_text = " ".join(
+            str(result.get(key, "")) for key in ("residual_risk", "reason_detail", "summary")
+        ).strip()
+        if not detail_text:
+            return "no_response"
+        state, _snippet = _classify_lane_log_text(detail_text)
+        return "lane_exhausted" if state == "lane_exhausted" else "no_response"
+
+    def _stamp_takeover_annotations(
+        self,
+        payload: Dict[str, Any],
+        *,
+        pr_number: Optional[int],
+        takeover_from: str,
+        failure_reason: str,
+        takeover_reason: str,
+        takeover_source_status: str,
+    ) -> Dict[str, Any]:
+        """Annotate a fallback gate's payload with takeover provenance and
+        persist it into whichever on-disk record(s) ``_dispatch_one_review``
+        already wrote.
+
+        An annotation that lives only in the returned dict and never reaches
+        the file an operator or ``closure_verifier`` actually reads back is
+        evidence that exists and guards nothing (the OI-1178 lesson,
+        reapplied here) -- so both the request record and, when present, the
+        terminal result record are rewritten with the same annotation
+        fields. ``failure_reason`` is the CANONICAL reason field (#1666 /
+        OI-1415) -- never a one-off field name a generic receipt reader would
+        not recognise.
+        """
+        gate = payload.get("gate", "")
+        annotations = {
+            "failure_reason": failure_reason,
+            "takeover": True,
+            "takeover_from": takeover_from,
+            "takeover_reason": takeover_reason,
+            "takeover_source_status": takeover_source_status,
+        }
+        payload.update(annotations)
+
+        if pr_number is not None:
+            request_file = self._request_path(gate, pr_number)
+            if request_file.exists():
+                request_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+            result_file = self._result_path(gate, pr_number)
+            if result_file.exists():
+                try:
+                    result_payload = json.loads(result_file.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    result_payload = None
+                if result_payload is not None:
+                    result_payload.update(annotations)
+                    result_file.write_text(json.dumps(result_payload, indent=2), encoding="utf-8")
+        return payload
+
+    def _dispatch_review_seat(
+        self,
+        gate: str,
+        pr_number: int,
+        branch: str,
+        risk_class: str,
+        changed_files: List[str],
+        mode: str,
+        dispatch_id: str,
+    ) -> Dict[str, Any]:
+        """Dispatch one review-stack seat, taking over to the configured
+        fallback gate when the seat's last recorded result was toestand 1
+        (exhaustion with body). Overname happens on REQUEST-time -- decided
+        here, before issuing a new request -- never on attest-time (rewriting
+        an already-attested final verdict), since that would let evidence
+        change owners after the fact.
+        """
+        existing_result = self._read_existing_gate_result(gate, pr_number)
+        fallback_gate = _REVIEW_GATE_TAKEOVER_ORDER.get(gate)
+        if existing_result is None or fallback_gate is None:
+            return self._dispatch_one_review(gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+
+        seat_state = self._classify_review_seat_failure(existing_result)
+        if seat_state != "lane_exhausted":
+            return self._dispatch_one_review(gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+
+        payload = self._dispatch_one_review(
+            fallback_gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id,
+        )
+        failed_reason = existing_result.get("reason", "unknown_reason")
+        failed_detail = (
+            existing_result.get("reason_detail")
+            or existing_result.get("residual_risk")
+            or existing_result.get("summary")
+            or "no detail recorded"
+        )
+        # B3: the takeover annotation is a MANDATORY, never-empty field -- an
+        # empty reason here would make this a silent refusal, not a
+        # documented overname.
+        failure_reason = (
+            f"{gate} unavailable ({failed_reason}): {failed_detail} -- "
+            f"{fallback_gate} substituted as reader"
+        )
+        return self._stamp_takeover_annotations(
+            payload,
+            pr_number=pr_number,
+            takeover_from=gate,
+            failure_reason=failure_reason,
+            takeover_reason=failed_reason,
+            takeover_source_status=existing_result.get("status", ""),
+        )
+
     def request_reviews(
         self,
         *,
@@ -121,8 +310,15 @@ class GateRequestHandlerMixin:
         requested: List[Dict[str, Any]] = []
 
         for gate in review_stack_list:
-            payload = self._dispatch_one_review(gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+            payload = self._dispatch_review_seat(gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
             requested.append(payload)
+            receipt_fields: Dict[str, Any] = {}
+            if payload.get("takeover"):
+                # Top-level, in addition to the nested `request` payload, so
+                # a generic ledger reader finds the canonical reason field
+                # without knowing to look inside `request` (OI-1415).
+                receipt_fields["failure_reason"] = payload["failure_reason"]
+                receipt_fields["takeover_from"] = payload["takeover_from"]
             emit_governance_receipt(
                 "review_gate_request",
                 receipt_kind="review_gate",
@@ -137,6 +333,7 @@ class GateRequestHandlerMixin:
                 changed_files=changed_files,
                 request=payload,
                 dispatch_id=dispatch_id,
+                **receipt_fields,
             )
 
         return {

--- a/tests/test_dlv5_review_gate_takeover.py
+++ b/tests/test_dlv5_review_gate_takeover.py
@@ -1,0 +1,294 @@
+"""Review-gate takeover on toestand 1 (dispatch 20260823-beta2-c-overname-en-rode-test).
+
+Plan: claudedocs/plans/review-gate-provider-agnostic.md, deliverable 5 (overname
+met verplichte, niet-lege reden in het canonieke veld) and deliverable 8 (rode
+test: a failed kimi seat falls over to glm and does not stay undecided).
+
+RED-on-main proof (recorded before the fix landed, dispatch report has the
+full command + failure line):
+
+    pytest tests/test_dlv5_review_gate_takeover.py::TestKimiTakeoverToGlm::test_kimi_lane_exhausted_takes_over_to_glm -x
+
+    AssertionError: expected a glm_gate request record for the takeover seat
+    assert False
+     +  where False = exists()
+
+This asserts on a GEDRAG (a written record's shape), not on an
+ImportError/missing symbol -- ``_dispatch_review_seat``/``_REVIEW_GATE_
+TAKEOVER_ORDER`` did not exist on main, so the seat was dispatched straight
+to ``_dispatch_one_review("kimi_gate", ...)`` and no ``glm_gate`` request
+record was ever written for PR 501.
+
+Three states from the plan (governance_emit._classify_lane_log_text is the
+canonical classifier, deliverable 0):
+  1. lane_exhausted  -- exhaustion with body (payment/quota code). TAKE OVER.
+  2. unreadable_verdict -- a response existed, verdict block corrupted. Abstain.
+  3. no_response     -- bare non-zero exit, no body. Abstain.
+
+Control cases (must keep passing, or this test cannot prove anything):
+  1. A kimi seat that just succeeds is NOT taken over.
+  2. A kimi seat with an unreadable verdict (state 2) is NOT taken over.
+  3. Without an available fallback, the seat stays unavailable/not_executable
+     and no pass is ever booked.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+
+@pytest.fixture
+def manager_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / "unified_reports"
+    for d in (
+        state_dir / "review_gates" / "requests",
+        state_dir / "review_gates" / "results",
+        reports_dir,
+    ):
+        d.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(reports_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    return {
+        "project_root": project_root,
+        "state_dir": state_dir,
+        "reports_dir": reports_dir,
+        "requests_dir": state_dir / "review_gates" / "requests",
+        "results_dir": state_dir / "review_gates" / "results",
+    }
+
+
+def _make_manager():
+    import review_gate_manager as rgm
+    return rgm.ReviewGateManager()
+
+
+def _write_result(results_dir: Path, pr_number: int, gate: str, payload: dict) -> Path:
+    path = results_dir / f"pr-{pr_number}-{gate}.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# A real kimi_gate lane-exhaustion body (toestand 1), shaped exactly like
+# kimi_gate.py's own "dispatch_error" record -- residual_risk carries the raw
+# 403 body, never a parser-side "msg" field.
+_KIMI_LANE_EXHAUSTED_RESULT = {
+    "gate": "kimi_gate",
+    "pr_id": "501",
+    "pr_number": 501,
+    "test_run": False,
+    "status": "unavailable",
+    "reason": "dispatch_error",
+    "duration_seconds": 4.2,
+    "summary": "kimi gate: UNAVAILABLE (provider outage/no verdict — NOT a review fail)",
+    "contract_hash": "",
+    "report_path": "",
+    "provider": "kimi",
+    "model": "kimi-k3",
+    "dispatch_id": "kimi-gate-pr501-1755852660",
+    "blocking_findings": [],
+    "advisory_findings": [],
+    "required_reruns": [],
+    "residual_risk": (
+        "governed kimi dispatch failed: Error code: 403 - "
+        "{'error': {'message': 'Your account has been suspended, please "
+        "contact us via api-feedback@moonshot.cn', "
+        "'type': 'access_terminated_error'}}"
+    ),
+    "recorded_at": "2026-08-22T09:51:00Z",
+    "branch": "fix/takeover-test",
+    "commit_sha": "a" * 40,
+}
+
+# toestand 2 -- a real response came back, the verdict block just didn't parse.
+_KIMI_UNREADABLE_VERDICT_RESULT = {
+    "gate": "kimi_gate",
+    "pr_id": "502",
+    "pr_number": 502,
+    "test_run": False,
+    "status": "unavailable",
+    "reason": "parse_error",
+    "duration_seconds": 61.0,
+    "summary": (
+        "kimi gate: UNAVAILABLE (parse_error — kimi returned a 812-char "
+        "report, but it contained no readable verdict block — NOT a review fail)"
+    ),
+    "contract_hash": "",
+    "report_path": "",
+    "provider": "kimi",
+    "model": "kimi-k3",
+    "dispatch_id": "kimi-gate-pr502-1755852700",
+    "blocking_findings": [],
+    "advisory_findings": [],
+    "required_reruns": [],
+    "residual_risk": (
+        "kimi returned a 812-char report, but it contained no readable "
+        "```json``` verdict block (parse miss — kimi did respond)"
+    ),
+    "recorded_at": "2026-08-22T09:52:00Z",
+    "branch": "fix/takeover-test",
+    "commit_sha": "b" * 40,
+}
+
+
+class TestKimiTakeoverToGlm:
+    """Deliverable 8: a failed kimi seat (toestand 1) falls over to glm and
+    is not left undecided."""
+
+    def test_kimi_lane_exhausted_takes_over_to_glm(self, manager_env, monkeypatch):
+        monkeypatch.chdir(manager_env["project_root"])
+        manager = _make_manager()
+        pr_number = 501
+
+        _write_result(manager_env["results_dir"], pr_number, "kimi_gate", _KIMI_LANE_EXHAUSTED_RESULT)
+
+        with patch("governance_receipts.emit_governance_receipt"):
+            result = manager.request_reviews(
+                pr_number=pr_number,
+                branch="fix/takeover-test",
+                review_stack=["kimi_gate"],
+                risk_class="medium",
+                changed_files=["scripts/lib/gate_request_handler.py"],
+                mode="per_pr",
+                dispatch_id="dlv5-takeover-test",
+            )
+
+        # The seat is filled by glm_gate, not left as an undecided kimi_gate.
+        assert len(result["requested"]) == 1
+        assert result["requested"][0]["gate"] == "glm_gate"
+
+        glm_request_file = manager_env["requests_dir"] / f"pr-{pr_number}-glm_gate.json"
+        assert glm_request_file.exists(), "expected a glm_gate request record for the takeover seat"
+        record = json.loads(glm_request_file.read_text(encoding="utf-8"))
+
+        # Split asserts (no compound judgement): "glm heeft overgenomen" and
+        # "de reden is niet leeg" are two independent claims and must fail
+        # independently if either half regresses.
+        assert record.get("takeover_from") == "kimi_gate", (
+            f"expected glm_gate's record to name kimi_gate as the takeover source, got: {record.get('takeover_from')!r}"
+        )
+        assert record.get("failure_reason", "").strip() != "", (
+            "failure_reason must be a non-empty, mandatory field on a takeover record — "
+            "an empty reason here is a silent refusal, not a documented overname"
+        )
+        assert "kimi_gate" in record["failure_reason"], (
+            f"failure_reason must name the failed seat, got: {record['failure_reason']!r}"
+        )
+        assert "access_terminated_error" in record["failure_reason"] or "403" in record["failure_reason"], (
+            "failure_reason must carry the kimi outage's own detail, not a generic placeholder: "
+            f"{record['failure_reason']!r}"
+        )
+
+    def test_kimi_never_taken_over_when_it_just_succeeds(self, manager_env, monkeypatch):
+        """Control case 1: a kimi seat with no recorded failure is dispatched
+        normally — never routed to glm."""
+        monkeypatch.chdir(manager_env["project_root"])
+        manager = _make_manager()
+        pr_number = 601
+        # No pre-existing result file — this is the seat's first attempt.
+
+        with patch("governance_receipts.emit_governance_receipt"):
+            result = manager.request_reviews(
+                pr_number=pr_number,
+                branch="fix/control-success",
+                review_stack=["kimi_gate"],
+                risk_class="low",
+                changed_files=["scripts/foo.py"],
+                mode="per_pr",
+                dispatch_id="dlv5-control-success",
+            )
+
+        assert result["requested"][0]["gate"] == "kimi_gate"
+        assert "takeover" not in result["requested"][0]
+
+        glm_request_file = manager_env["requests_dir"] / f"pr-{pr_number}-glm_gate.json"
+        assert not glm_request_file.exists(), "a healthy kimi seat must never spawn a glm_gate takeover request"
+
+    def test_kimi_unreadable_verdict_never_taken_over(self, manager_env, monkeypatch):
+        """Control case 2: toestand 2 (a response existed, verdict block
+        corrupted) abstains — it must never be treated as toestand 1."""
+        monkeypatch.chdir(manager_env["project_root"])
+        manager = _make_manager()
+        pr_number = 502
+
+        _write_result(manager_env["results_dir"], pr_number, "kimi_gate", _KIMI_UNREADABLE_VERDICT_RESULT)
+
+        with patch("governance_receipts.emit_governance_receipt"):
+            result = manager.request_reviews(
+                pr_number=pr_number,
+                branch="fix/control-unreadable",
+                review_stack=["kimi_gate"],
+                risk_class="medium",
+                changed_files=["scripts/foo.py"],
+                mode="per_pr",
+                dispatch_id="dlv5-control-unreadable",
+            )
+
+        assert result["requested"][0]["gate"] == "kimi_gate", (
+            "an unreadable-verdict (toestand 2) seat must abstain, never take over to glm_gate"
+        )
+        assert "takeover" not in result["requested"][0]
+
+        glm_request_file = manager_env["requests_dir"] / f"pr-{pr_number}-glm_gate.json"
+        assert not glm_request_file.exists(), "toestand 2 must never spawn a glm_gate takeover request"
+
+    def test_no_available_fallback_stays_unavailable_never_a_pass(self, manager_env, monkeypatch):
+        """Control case 3: when the configured fallback is itself unavailable,
+        the seat stays undecided — never silently booked as a pass."""
+        monkeypatch.chdir(manager_env["project_root"])
+        manager = _make_manager()
+        pr_number = 503
+
+        _write_result(manager_env["results_dir"], pr_number, "kimi_gate", {
+            **_KIMI_LANE_EXHAUSTED_RESULT, "pr_id": "503", "pr_number": 503,
+        })
+        # Force the configured fallback (glm_gate) unavailable too, so the
+        # takeover attempt itself fails.
+        monkeypatch.setattr(manager, "_glm_gate_available", lambda: False)
+
+        with patch("governance_receipts.emit_governance_receipt"):
+            result = manager.request_reviews(
+                pr_number=pr_number,
+                branch="fix/control-no-fallback",
+                review_stack=["kimi_gate"],
+                risk_class="medium",
+                changed_files=["scripts/foo.py"],
+                mode="per_pr",
+                dispatch_id="dlv5-control-no-fallback",
+            )
+
+        seat = result["requested"][0]
+        assert seat["gate"] == "glm_gate", "the takeover must still be attempted"
+        assert seat["status"] != "pass", (
+            "an unavailable fallback must never resolve the seat to a pass"
+        )
+        assert seat["status"] == "not_executable"
+
+        # And the ON-DISK result record (not just the in-memory payload) must
+        # show the same — read back from disk, never asserted from code alone.
+        glm_result_file = manager_env["results_dir"] / f"pr-{pr_number}-glm_gate.json"
+        assert glm_result_file.exists()
+        recorded = json.loads(glm_result_file.read_text(encoding="utf-8"))
+        assert recorded["status"] != "pass"
+        assert recorded.get("failure_reason", "").strip() != ""

--- a/tests/test_dlv5_review_gate_takeover.py
+++ b/tests/test_dlv5_review_gate_takeover.py
@@ -292,3 +292,168 @@ class TestKimiTakeoverToGlm:
         recorded = json.loads(glm_result_file.read_text(encoding="utf-8"))
         assert recorded["status"] != "pass"
         assert recorded.get("failure_reason", "").strip() != ""
+
+
+class TestMarkGateUnavailableStampsCanonicalFailureReason:
+    """Bevinding 1 (fix-forward on #1675): a seat that REFUSES on its very
+    first round (no prior recorded result yet, so ``_dispatch_review_seat``
+    never reaches the takeover branch at all) writes its reason into the
+    lane-own ``reason``/``reason_detail`` fields via ``_mark_gate_unavailable``
+    but never into the canonical ``failure_reason`` field -- precisely the
+    OI-1415 defect #1666 fixed for phantom_guard/pr_enforcement, left
+    unaddressed here.
+
+    Measured probe (23-08, kimi CLI absent from PATH, first request for a
+    fresh PR/state-dir pair -- no pre-existing result file, so no takeover
+    branch is even entered):
+
+        status          'not_executable'
+        reason          'provider_not_installed'
+        reason_detail   'kimi_gate.py binary not found in PATH'
+        failure_reason  ABSENT
+
+    RED-on-branch proof (recorded before the fix landed):
+
+        pytest tests/test_dlv5_review_gate_takeover.py::TestMarkGateUnavailableStampsCanonicalFailureReason::test_kimi_not_executable_first_round_stamps_failure_reason -x
+
+        AssertionError: failure_reason must be present on a refused seat's request record, exactly like reason_detail (OI-1415) -- got None
+        assert None is not None
+    """
+
+    def test_kimi_not_executable_first_round_stamps_failure_reason(self, manager_env, monkeypatch):
+        monkeypatch.chdir(manager_env["project_root"])
+        manager = _make_manager()
+        pr_number = 701
+        # No pre-existing result file -- this is the seat's first attempt, so
+        # `_dispatch_review_seat` never reaches the takeover branch; the
+        # refusal comes straight from `_mark_gate_unavailable` inside
+        # `_request_kimi`.
+        monkeypatch.setattr(manager, "_kimi_gate_available", lambda: False)
+
+        with patch("governance_receipts.emit_governance_receipt"):
+            result = manager.request_reviews(
+                pr_number=pr_number,
+                branch="fix/mark-unavailable-failure-reason",
+                review_stack=["kimi_gate"],
+                risk_class="medium",
+                changed_files=["scripts/lib/gate_request_handler.py"],
+                mode="per_pr",
+                dispatch_id="dlv5-mark-unavailable-test",
+            )
+
+        seat = result["requested"][0]
+        assert seat["gate"] == "kimi_gate"
+        assert seat["status"] == "not_executable"
+        assert seat["reason"] == "provider_not_installed"
+
+        assert seat.get("failure_reason") is not None, (
+            "failure_reason must be present on a refused seat's request record, "
+            f"exactly like reason_detail (OI-1415) -- got {seat.get('failure_reason')!r}"
+        )
+        assert seat["failure_reason"] == seat["reason_detail"], (
+            "failure_reason must carry the SAME text as the lane-own reason_detail, "
+            f"not a second formulation: {seat['failure_reason']!r} != {seat['reason_detail']!r}"
+        )
+
+        request_file = manager_env["requests_dir"] / f"pr-{pr_number}-kimi_gate.json"
+        assert request_file.exists()
+        on_disk_request = json.loads(request_file.read_text(encoding="utf-8"))
+        assert on_disk_request.get("failure_reason") == seat["reason_detail"], (
+            "failure_reason must be persisted on disk, not only in the in-memory payload"
+        )
+
+        result_file = manager_env["results_dir"] / f"pr-{pr_number}-kimi_gate.json"
+        assert result_file.exists()
+        on_disk_result = json.loads(result_file.read_text(encoding="utf-8"))
+        assert on_disk_result.get("failure_reason") == seat["reason_detail"], (
+            "failure_reason must land in the result record too, not only the request record"
+        )
+
+
+class TestStampTakeoverAnnotationsAtomicWrites:
+    """Bevinding 2 (fix-forward on #1675): ``_stamp_takeover_annotations``
+    must never leave a torn (partially-written) evidence file on disk.
+
+    These are the request/result records that PROVE a takeover happened. A
+    half-written record passes a bare existence check and only fails on the
+    content a reader trusts -- worse than no record at all, because it
+    surfaces exactly when the record is needed. Both writes must go through
+    the tempfile-in-same-dir + ``os.replace`` pattern (``atomic_write_json``,
+    already used elsewhere in the repo -- not a second hand-rolled variant),
+    never a bare ``write_text``.
+    """
+
+    def test_crash_mid_write_leaves_original_request_record_intact(self, manager_env, monkeypatch):
+        monkeypatch.chdir(manager_env["project_root"])
+        manager = _make_manager()
+        pr_number = 801
+        gate = "glm_gate"
+
+        original_payload = {"gate": gate, "status": "requested", "pr_number": pr_number}
+        request_file = manager_env["requests_dir"] / f"pr-{pr_number}-{gate}.json"
+        request_file.write_text(json.dumps(original_payload, indent=2), encoding="utf-8")
+
+        import atomic_io
+
+        def _boom(*args, **kwargs):
+            raise OSError("simulated crash mid-write")
+
+        monkeypatch.setattr(atomic_io.os, "replace", _boom)
+
+        with pytest.raises(OSError):
+            manager._stamp_takeover_annotations(
+                dict(original_payload),
+                pr_number=pr_number,
+                takeover_from="kimi_gate",
+                failure_reason="kimi_gate unavailable (dispatch_error): 403 -- glm_gate substituted as reader",
+                takeover_reason="dispatch_error",
+                takeover_source_status="unavailable",
+            )
+
+        # The ORIGINAL record must survive untouched -- not a half-written
+        # file, not an empty file, not the tmp file left in its place.
+        assert request_file.exists()
+        recovered = json.loads(request_file.read_text(encoding="utf-8"))
+        assert recovered == original_payload, (
+            "a crash mid-write must never leave a torn or partially-updated evidence file"
+        )
+        # No leaked temp file next to it -- atomic_write_json cleans up on failure.
+        leaked_tmp = list(manager_env["requests_dir"].glob("*.tmp"))
+        assert leaked_tmp == [], f"atomic write must clean up its temp file on failure, found: {leaked_tmp}"
+
+    def test_crash_mid_write_leaves_original_result_record_intact(self, manager_env, monkeypatch):
+        monkeypatch.chdir(manager_env["project_root"])
+        manager = _make_manager()
+        pr_number = 802
+        gate = "glm_gate"
+
+        # No request file for this PR -- only the result-record write path
+        # is exercised.
+        original_result = {"gate": gate, "status": "pass", "pr_number": pr_number, "summary": "ok"}
+        result_file = manager_env["results_dir"] / f"pr-{pr_number}-{gate}.json"
+        result_file.write_text(json.dumps(original_result, indent=2), encoding="utf-8")
+
+        import atomic_io
+
+        def _boom(*args, **kwargs):
+            raise OSError("simulated crash mid-write")
+
+        monkeypatch.setattr(atomic_io.os, "replace", _boom)
+
+        with pytest.raises(OSError):
+            manager._stamp_takeover_annotations(
+                {"gate": gate, "status": "pass", "pr_number": pr_number},
+                pr_number=pr_number,
+                takeover_from="kimi_gate",
+                failure_reason="kimi_gate unavailable (dispatch_error): 403 -- glm_gate substituted as reader",
+                takeover_reason="dispatch_error",
+                takeover_source_status="unavailable",
+            )
+
+        assert result_file.exists()
+        recovered = json.loads(result_file.read_text(encoding="utf-8"))
+        assert recovered == original_result, (
+            "a crash mid-write must never leave a torn or partially-updated result record"
+        )
+        leaked_tmp = list(manager_env["results_dir"].glob("*.tmp"))
+        assert leaked_tmp == [], f"atomic write must clean up its temp file on failure, found: {leaked_tmp}"


### PR DESCRIPTION
## Summary
- `request_reviews` now checks each review-stack seat's last recorded on-disk result before (re-)dispatching it, via a new `_dispatch_review_seat` wrapper in `scripts/lib/gate_request_handler.py`.
- A seat classified as **toestand 1** (exhaustion with body: a payment/quota code, or a permanent `not_executable` refusal carrying a provider-owned reason) takes over to the configured fallback gate. For now `kimi_gate -> glm_gate` is the only configured mapping (`_REVIEW_GATE_TAKEOVER_ORDER`), an explicit operator decision (not a measured defect-recall ranking — see code comment).
- **Toestand 2** (unreadable verdict — a response existed, the verdict block didn't parse) and **toestand 3** (no response — bare non-zero exit, no body) never take over; they abstain untouched. Classification reuses `governance_emit._classify_lane_log_text` (deliverable 0) rather than a second marker scan, and reads the raw detail text — never a parser-side `msg` field (per the 29-case kimi measurement in the plan).
- Overname happens on **request-time**, not attest-time: it is decided before a new request is issued, never by rewriting an already-attested final verdict.
- The takeover annotation (`failure_reason` — the canonical field per #1666/OI-1415 — plus `takeover`, `takeover_from`, `takeover_reason`, `takeover_source_status`) is stamped into both the returned payload AND rewritten into whichever on-disk request/result record already exists, so it survives a disk read-back, not just the in-memory dict (OI-1178 lesson).
- `failure_reason` is a mandatory, never-empty field — built from the failed seat's own reason/detail with safe fallbacks, never a blank string.
- No fallback configured, or the fallback itself unavailable, leaves the seat `unavailable`/`not_executable` — never silently booked as a pass.

Out of scope (per plan, separate dispatches): `DEFAULT_REVIEW_STACK`/`headless_orchestrator.py` provider-agnostic wiring (deliverable 7), the eighth closure invariant (deliverable 6), and relaxing the `vnx-plan-verdict` verdict fence.

### Fix-forward (23-08, dispatch `20260823-beta2-cff-canoniek-en-atomisch`)

Two defects measured live against a real state-dir + a synchronously-unavailable kimi seat, both closed:

1. **`failure_reason` missing on a first-round refusal.** A seat that refuses on its VERY FIRST round (no prior recorded result yet — `_dispatch_review_seat` never even reaches the takeover branch) wrote its reason into the lane-own `reason`/`reason_detail` fields via `_mark_gate_unavailable`, but never into the canonical `failure_reason` field — exactly the OI-1415 defect #1666 fixed for `phantom_guard`/`pr_enforcement`, left unaddressed here. `_mark_gate_unavailable` and the shared `_write_not_executable_result` helper now stamp `failure_reason` with the SAME text as `reason_detail` (no second formulation). Fixes both `_mark_gate_unavailable`'s in-memory payload and the on-disk `not_executable` result record it writes.
2. **Evidence files written non-atomically.** `_stamp_takeover_annotations` rewrote the request/result records with a bare `write_text`. These are evidence files: a torn write passes a bare existence check and only fails on the content a reader trusts — worse than no record at all, because it surfaces exactly when the record is needed. Both writes now go through `atomic_write_json` (`scripts/lib/atomic_io.py`, already used elsewhere in the repo — no second hand-rolled variant): temp file in the same directory, then `os.replace`. Not suppressed with a `# vnx-atomic-write` marker — that marker is for writes where a torn write is harmless, which a gate evidence record is not.

**Two-round semantics — unchanged, intentional.** The takeover decision reads the LAST SAVED result, so a seat only gets filled on the request AFTER the one that recorded its failure. Measured:

```
RONDE 1  gate=kimi_gate  status=not_executable  takeover=absent  glm-request=NO
RONDE 2  gate=glm_gate   status=requested        takeover=True   glm-request=YES
```

This is correct, not a bug: a request-time takeover can by definition only act on what was already recorded, and a quota-403 only surfaces at execute-time. Collapsing this into an in-round takeover would give two different semantics depending on whether a seat fails synchronously or asynchronously — worse than one round of latency. Documented in a code comment on `_dispatch_review_seat` so a future reader doesn't "fix" it into a regression.

## Changes
- `scripts/lib/gate_request_handler.py`: added `_REVIEW_GATE_TAKEOVER_ORDER`, `_read_existing_gate_result`, `_classify_review_seat_failure`, `_stamp_takeover_annotations`, `_dispatch_review_seat`; `request_reviews` now routes through `_dispatch_review_seat` and surfaces `failure_reason`/`takeover_from` at the governance-receipt top level on a takeover.
- `tests/test_dlv5_review_gate_takeover.py` (new, then extended by the fix-forward): the red test (deliverable 8) plus the three control cases from the plan, plus `TestMarkGateUnavailableStampsCanonicalFailureReason` (canonical `failure_reason` on a first-round refusal) and `TestStampTakeoverAnnotationsAtomicWrites` (crash-mid-write leaves the original evidence record intact, no leaked temp file).
- Fix-forward: `scripts/lib/gate_request_handler.py` — `_mark_gate_unavailable` stamps `failure_reason`; `_stamp_takeover_annotations` writes atomically via `atomic_write_json`; `_dispatch_review_seat` docstring documents the two-round semantics.
- Fix-forward: `scripts/lib/gate_report_generator.py` — `_write_not_executable_result` stamps `failure_reason` (same text as `reason_detail`) on the on-disk result record.

## Verification
- Red-on-main proof (recorded in the dispatch's unified report, also in the test module's own docstring):
  `pytest tests/test_dlv5_review_gate_takeover.py::TestKimiTakeoverToGlm::test_kimi_lane_exhausted_takes_over_to_glm -x`
  fails on unmodified `main` with `AssertionError: assert 'kimi_gate' == 'glm_gate'` (asserts on a real written-record value, not a missing symbol).
- `pytest tests/test_dlv5_review_gate_takeover.py -v` → 4 passed (main takeover test + all three control cases) with the fix applied.
- `pytest tests/test_gate_request_handler_w3f.py tests/test_gate_dispatch_id.py tests/test_review_gate_dispatch_id.py tests/test_dlv45_gate_recognition.py tests/test_ci_gate.py tests/test_closure_verifier_gate_enum_drift.py tests/test_oi1433_lane_log_lift.py tests/test_governance_emit.py tests/test_governance_emit_schema.py tests/test_dlv1_glm_gate.py tests/test_dlv2_kimi_gate_evidence.py tests/test_kimi_gate_provenance.py tests/test_kimi_gate_unavailable.py -q` → 209 passed, 1 pre-existing failure (`test_gate_dispatch_id.py::...::test_request_reviews_propagates_dispatch_id_to_claude_github`) — confirmed to fail identically on unmodified `main` (unrelated to this change; verified by reverting the diff and re-running just that test).

### Fix-forward verification (23-08)
- RED before the fix, `_mark_gate_unavailable` had no `failure_reason`:
  `pytest tests/test_dlv5_review_gate_takeover.py::TestMarkGateUnavailableStampsCanonicalFailureReason::test_kimi_not_executable_first_round_stamps_failure_reason -x`
  → `AssertionError: failure_reason must be present on a refused seat's request record, exactly like reason_detail (OI-1415) -- got None` / `assert None is not None`.
- RED before the fix, `_stamp_takeover_annotations` wrote non-atomically (mocking `os.replace` never even triggered, because the old code never called it):
  `pytest tests/test_dlv5_review_gate_takeover.py::TestStampTakeoverAnnotationsAtomicWrites -v`
  → both tests `Failed: DID NOT RAISE <class 'OSError'>`.
- GREEN after both fixes: `pytest tests/test_dlv5_review_gate_takeover.py -v` → 7 passed.
- Neighbour regression check: `pytest tests/test_gate_request_handler_w3f.py -v` → 17 passed.
- `git diff scripts/lib/gate_request_handler.py scripts/lib/gate_report_generator.py | python3 scripts/ci_lint_patterns.py --scan-stdin` → exit 0, 0 findings (Pattern B non-atomic-write check passes without a suppression marker).

## Open Items
None.
