### PR TITLE
fix(kimi-glm-gate): poortrun zonder --data-dir schreef stil niets (OI-1435 residu)

### DIFF
--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -94,6 +94,7 @@ from plan_gate_panel import _make_default_dispatcher, _resolve_data_dir  # gover
 from gate_recorder import (
     get_pr_head_branch,
     get_pr_head_sha,
+    persist_request,
     record_terminal_result,
     stamp_request_identity,
 )
@@ -440,6 +441,54 @@ def main(argv: "list[str] | None" = None) -> int:
     data_dir = args.data_dir or None
     base_data_dir = _resolve_data_dir(data_dir)
 
+    pr_number = int(args.pr) if str(args.pr).isdigit() else None
+    # dispatch_id must exist before the request record below AND before the
+    # if/else that follows (both --reprocess and a live run need the SAME
+    # dispatch_id their downstream code uses — see the (now-redundant)
+    # reassignments removed from both arms below this block).
+    dispatch_id = args.reprocess if args.reprocess else f"glm-gate-pr{args.pr}-{int(time.time())}"
+    # Offline runs read the diff from a file (--diff-file) and are NOT tied to
+    # a live GitHub PR — branch/commit_sha are computed once, here, and reused
+    # for both the request record below and the result record's identity
+    # stamp further down, so a real ``gh pr view`` lookup never runs twice for
+    # the same run.
+    test_run = bool(args.diff_file)
+    branch = "" if test_run else get_pr_head_branch(pr_number)
+    commit_sha = "" if test_run else get_pr_head_sha(pr_number)
+    # Informative only (OI-1435 follow-up): points a human at the governed
+    # dispatch's own unified report even on a non-terminal ``unavailable``
+    # result, where ``report_path`` is deliberately left empty so
+    # has_complete_evidence/is_terminal are never fooled into treating an
+    # outage as a decided verdict. This field is never read by either check.
+    report_path_informational = str(base_data_dir / "unified_reports" / f"{dispatch_id}.md")
+
+    requests_dir = base_data_dir / "state" / "review_gates" / "requests"
+    request_payload = {
+        "gate": "glm_gate",
+        "status": "requested",
+        "provider": "glm-harness",
+        "branch": branch,
+        "pr_number": pr_number,
+        "commit_sha": commit_sha,
+        "report_path": report_path_informational,
+        "requested_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "dispatch_id": dispatch_id,
+        "test_run": test_run,
+    }
+    # OI-1435 residu (defect 4): a request record must exist BEFORE the gate
+    # ever dispatches — a record written only after the run proves nothing
+    # was "requested" first. Same on-disk shape (pr-<N>-<gate>.json under
+    # state/review_gates/requests/) as ci_gate/codex_gate's own request
+    # writers (gate_request_handler._request_ci_gate/_request_codex via
+    # gate_recorder.persist_request) so a generic reader of the requests dir
+    # sees no difference between this and any other gate's request.
+    try:
+        requests_dir.mkdir(parents=True, exist_ok=True)
+        persist_request(requests_dir, "glm_gate", request_payload, pr_number=pr_number, pr_id="")
+    except OSError as exc:
+        print(f"glm_gate: FAILED to write request record: {exc}", file=sys.stderr)
+        return 1
+
     if args.reprocess:
         # Deel 3 (dispatch-20260823-beta2-j): re-run the SAME parse/recover/
         # record pipeline below against a dispatch that already ran, without a
@@ -449,7 +498,7 @@ def main(argv: "list[str] | None" = None) -> int:
         # record) is unchanged code, so a recovered verdict here was produced
         # by the gate itself, on the run's own commit, in the run's own
         # contract shape — not prose-to-verdict promotion of a new source.
-        dispatch_id = args.reprocess
+        # dispatch_id is already resolved above (shared with the request record).
         report_path_obj = base_data_dir / "unified_reports" / f"{dispatch_id}.md"
         if not report_path_obj.is_file():
             print(
@@ -477,7 +526,7 @@ def main(argv: "list[str] | None" = None) -> int:
             print(f"glm_gate: no diff for PR {args.pr}", file=sys.stderr)
             return 1
 
-        dispatch_id = f"glm-gate-pr{args.pr}-{int(time.time())}"
+        # dispatch_id is already resolved above (shared with the request record).
         # role="review-gate" (dispatch-20260823-beta2-j): the default role of
         # _make_default_dispatcher is "plan-reviewer", which carries
         # agents/plan-reviewer/CLAUDE.md — a role written for a PLAN-GATE
@@ -690,17 +739,23 @@ def main(argv: "list[str] | None" = None) -> int:
     record = {
         "gate": "glm_gate",
         "pr_id": str(args.pr),
-        "pr_number": int(args.pr) if str(args.pr).isdigit() else None,
+        "pr_number": pr_number,
         # Offline runs read the diff from a file (--diff-file) and are NOT tied
         # to a live GitHub PR; they must never count as gate evidence. The
         # closure verifier refuses records with test_run: true.
-        "test_run": bool(args.diff_file),
+        "test_run": test_run,
         "status": status,
         "reason": reason,
         "duration_seconds": round(duration, 3),
         "summary": _status_summary(status, blocking, reason),
         "contract_hash": contract_hash,
         "report_path": report_path,
+        # Informative only — NEVER read by has_complete_evidence/is_terminal.
+        # Always the governed dispatch's own unified report path, even when
+        # ``report_path`` above is deliberately left empty on a non-terminal
+        # ``unavailable`` status, so a human can still find the real review
+        # text (OI-1435 follow-up).
+        "report_path_informational": report_path_informational,
         "provider": "glm-harness",
         "model": args.model,
         "dispatch_id": dispatch_id,
@@ -735,24 +790,37 @@ def main(argv: "list[str] | None" = None) -> int:
     # Stamp branch + commit_sha through the shared writer so the merge door
     # can join a glm_gate result on the PR head (GitHub), not the local
     # checkout HEAD. Offline runs (--diff-file) are not tied to a live PR and
-    # legitimately carry neither.
+    # legitimately carry neither. Reuses the SAME branch/commit_sha resolved
+    # once above (for the request record) instead of a second gh lookup.
     stamp_request_identity(
         record,
         {
             "gate": record["gate"],
             "pr_id": record["pr_id"],
-            "branch": "" if record["test_run"] else get_pr_head_branch(record["pr_number"]),
-            "commit_sha": "" if record["test_run"] else get_pr_head_sha(record["pr_number"]),
+            "branch": branch,
+            "commit_sha": commit_sha,
         },
     )
 
-    if data_dir:
-        results_dir = Path(data_dir) / "state" / "review_gates" / "results"
-        out = results_dir / f"pr-{args.pr}-glm_gate.json"
+    # Unconditional, and resolved from the SAME base_data_dir the report path
+    # above is built from (never the raw, possibly-empty ``data_dir`` CLI
+    # value) — a poort run with no explicit --data-dir must still land its
+    # result where the merge door and closure verifier can find it (residu of
+    # OI-1178/OI-1435: this guard used to check the raw arg, so an omitted
+    # --data-dir silently skipped this entire block on a fully successful,
+    # fully-billed run).
+    results_dir = base_data_dir / "state" / "review_gates" / "results"
+    out = results_dir / f"pr-{args.pr}-glm_gate.json"
+    try:
         record_terminal_result(
             gate="glm_gate", pr_id=record["pr_id"], result_path=out, payload=record,
         )
-        print(f"glm_gate: wrote {out}", file=sys.stderr)
+    except (OSError, ValueError) as exc:
+        # A poort that cannot persist its own evidence must fail LOUDLY, not
+        # burn the dispatch cost and exit 0 with nothing on disk.
+        print(f"glm_gate: FAILED to write result record to {out}: {exc}", file=sys.stderr)
+        return 1
+    print(f"glm_gate: wrote {out}", file=sys.stderr)
 
     if args.json:
         print(json.dumps(record, indent=2))

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -104,6 +104,7 @@ from plan_gate_panel import _make_default_dispatcher, _resolve_data_dir  # gover
 from gate_recorder import (
     get_pr_head_branch,
     get_pr_head_sha,
+    persist_request,
     record_terminal_result,
     stamp_request_identity,
 )
@@ -418,6 +419,55 @@ def main(argv: "list[str] | None" = None) -> int:
     data_dir = args.data_dir or None
     base_data_dir = _resolve_data_dir(data_dir)
 
+    pr_number = int(args.pr) if str(args.pr).isdigit() else None
+    # dispatch_id must exist before the request record below AND before the
+    # if/else that follows (both --reprocess and a live run need the SAME
+    # dispatch_id their downstream code uses — see the (now-redundant)
+    # reassignments removed from both arms below this block).
+    dispatch_id = args.reprocess if args.reprocess else f"kimi-gate-pr{args.pr}-{int(time.time())}"
+    # Offline runs read the diff from a file (--diff-file) and are NOT tied to
+    # a live GitHub PR — branch/commit_sha are computed once, here, and reused
+    # for both the request record below and the result record's identity
+    # stamp further down, so a real ``gh pr view`` lookup never runs twice for
+    # the same run.
+    test_run = bool(args.diff_file)
+    branch = "" if test_run else get_pr_head_branch(pr_number)
+    commit_sha = "" if test_run else get_pr_head_sha(pr_number)
+    # Informative only (OI-1178 follow-up): points a human at the governed
+    # dispatch's own unified report even on a non-terminal ``unavailable``
+    # result, where ``report_path`` is deliberately left empty so
+    # has_complete_evidence/is_terminal are never fooled into treating an
+    # outage as a decided verdict. This field is never read by either check.
+    report_path_informational = str(base_data_dir / "unified_reports" / f"{dispatch_id}.md")
+
+    requests_dir = base_data_dir / "state" / "review_gates" / "requests"
+    request_payload = {
+        "gate": "kimi_gate",
+        "status": "requested",
+        "provider": "kimi",
+        "branch": branch,
+        "pr_number": pr_number,
+        "commit_sha": commit_sha,
+        "report_path": report_path_informational,
+        "requested_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "dispatch_id": dispatch_id,
+        "test_run": test_run,
+    }
+    # Defect 4 (23-08 poort-schrijft-stil-niets dispatch): a request record
+    # must exist BEFORE the gate ever dispatches — a record written only
+    # after the run proves nothing was "requested" first. Same on-disk shape
+    # (pr-<N>-<gate>.json under state/review_gates/requests/) as
+    # ci_gate/codex_gate's own request writers
+    # (gate_request_handler._request_ci_gate/_request_codex via
+    # gate_recorder.persist_request) so a generic reader of the requests dir
+    # sees no difference between this and any other gate's request.
+    try:
+        requests_dir.mkdir(parents=True, exist_ok=True)
+        persist_request(requests_dir, "kimi_gate", request_payload, pr_number=pr_number, pr_id="")
+    except OSError as exc:
+        print(f"kimi_gate: FAILED to write request record: {exc}", file=sys.stderr)
+        return 1
+
     if args.reprocess:
         # Deel 3 (dispatch-20260823-beta2-j): re-run the SAME parse/recover/
         # record pipeline below against a dispatch that already ran, without a
@@ -427,7 +477,7 @@ def main(argv: "list[str] | None" = None) -> int:
         # record) is unchanged code, so a recovered verdict here was produced
         # by the gate itself, on the run's own commit, in the run's own
         # contract shape — not prose-to-verdict promotion of a new source.
-        dispatch_id = args.reprocess
+        # dispatch_id is already resolved above (shared with the request record).
         report_path_obj = base_data_dir / "unified_reports" / f"{dispatch_id}.md"
         if not report_path_obj.is_file():
             print(
@@ -455,7 +505,7 @@ def main(argv: "list[str] | None" = None) -> int:
             print(f"kimi_gate: no diff for PR {args.pr}", file=sys.stderr)
             return 1
 
-        dispatch_id = f"kimi-gate-pr{args.pr}-{int(time.time())}"
+        # dispatch_id is already resolved above (shared with the request record).
         # role="review-gate" (dispatch-20260823-beta2-j): see glm_gate.py's
         # own comment at the identical call site. The default role
         # "plan-reviewer" carries agents/plan-reviewer/CLAUDE.md, written for
@@ -652,17 +702,23 @@ def main(argv: "list[str] | None" = None) -> int:
     record = {
         "gate": "kimi_gate",
         "pr_id": str(args.pr),
-        "pr_number": int(args.pr) if str(args.pr).isdigit() else None,
+        "pr_number": pr_number,
         # Offline runs read the diff from a file (--diff-file) and are NOT tied
         # to a live GitHub PR; they must never count as gate evidence. The
         # closure verifier refuses records with test_run: true.
-        "test_run": bool(args.diff_file),
+        "test_run": test_run,
         "status": status,
         "reason": reason,
         "duration_seconds": round(duration, 3),
         "summary": _status_summary(status, blocking, reason),
         "contract_hash": contract_hash,
         "report_path": report_path,
+        # Informative only — NEVER read by has_complete_evidence/is_terminal.
+        # Always the governed dispatch's own unified report path, even when
+        # ``report_path`` above is deliberately left empty on a non-terminal
+        # ``unavailable`` status, so a human can still find the real review
+        # text.
+        "report_path_informational": report_path_informational,
         "provider": "kimi",
         "model": args.model,
         "dispatch_id": dispatch_id,
@@ -697,24 +753,36 @@ def main(argv: "list[str] | None" = None) -> int:
     # A4: stamp branch + commit_sha through the shared writer so the merge
     # door can join a kimi_gate result on the PR head (GitHub), not the local
     # checkout HEAD. Offline runs (--diff-file) are not tied to a live PR and
-    # legitimately carry neither.
+    # legitimately carry neither. Reuses the SAME branch/commit_sha resolved
+    # once above (for the request record) instead of a second gh lookup.
     stamp_request_identity(
         record,
         {
             "gate": record["gate"],
             "pr_id": record["pr_id"],
-            "branch": "" if record["test_run"] else get_pr_head_branch(record["pr_number"]),
-            "commit_sha": "" if record["test_run"] else get_pr_head_sha(record["pr_number"]),
+            "branch": branch,
+            "commit_sha": commit_sha,
         },
     )
 
-    if data_dir:
-        results_dir = Path(data_dir) / "state" / "review_gates" / "results"
-        out = results_dir / f"pr-{args.pr}-kimi_gate.json"
+    # Unconditional, and resolved from the SAME base_data_dir the report path
+    # above is built from (never the raw, possibly-empty ``data_dir`` CLI
+    # value) — a poort run with no explicit --data-dir must still land its
+    # result where the merge door and closure verifier can find it (this
+    # guard used to check the raw arg, so an omitted --data-dir silently
+    # skipped this entire block on a fully successful, fully-billed run).
+    results_dir = base_data_dir / "state" / "review_gates" / "results"
+    out = results_dir / f"pr-{args.pr}-kimi_gate.json"
+    try:
         record_terminal_result(
             gate="kimi_gate", pr_id=record["pr_id"], result_path=out, payload=record,
         )
-        print(f"kimi_gate: wrote {out}", file=sys.stderr)
+    except (OSError, ValueError) as exc:
+        # A poort that cannot persist its own evidence must fail LOUDLY, not
+        # burn the dispatch cost and exit 0 with nothing on disk.
+        print(f"kimi_gate: FAILED to write result record to {out}: {exc}", file=sys.stderr)
+        return 1
+    print(f"kimi_gate: wrote {out}", file=sys.stderr)
 
     if args.json:
         print(json.dumps(record, indent=2))

--- a/tests/test_glm_gate_data_dir_guard.py
+++ b/tests/test_glm_gate_data_dir_guard.py
@@ -1,0 +1,389 @@
+"""glm_gate.py write-without---data-dir tests (dispatch beta2-h-poort-schrijft-stil-niets).
+
+Measured 23-08, live, on PR #1672: ``python3 scripts/glm_gate.py --pr 1672
+--json`` ran the full governed review (six minutes, a real 2476-char report on
+disk), but NOTHING landed in ``state/review_gates/results/`` — the merge door,
+closure verifier, and obligation runner could not see the run at all.
+
+Root cause: ``glm_gate.py``/``kimi_gate.py`` both resolve a correct,
+always-populated ``base_data_dir`` via ``_resolve_data_dir(data_dir)``, but the
+write guard checked the RAW ``data_dir`` (``args.data_dir or None``) instead —
+so an invocation with no explicit ``--data-dir`` and no ``VNX_DATA_DIR`` in the
+environment skipped the entire write block, silently, on exit 0, after a fully
+billed dispatch. The report path (built from ``base_data_dir``) was correct
+all along; only the result-record write guarded on the wrong variable.
+
+These tests never touch the real central store: ``_resolve_data_dir`` is
+monkeypatched on the glm_gate module namespace (not on plan_gate_panel, its
+source module — ``from X import Y`` binds at import time) to return a
+tmp_path-rooted directory regardless of what raw ``data_dir`` the CLI parsed,
+so the "no --data-dir, no VNX_DATA_DIR" scenario can be reproduced hermetically
+without ever falling through to ``~/.vnx-data/<project_id>``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import glm_gate
+import gate_artifacts
+from gate_status import has_complete_evidence, is_terminal
+
+_REAL_PASS_REPORT = (
+    "Reviewed the diff, no issues.\n\n"
+    "```json\n"
+    '{"verdict": "pass", "findings": [], "residual_risk": null}\n'
+    "```\n"
+)
+
+_FAKE_DIFF = "diff --git a/x b/x\n+ok\n"
+
+
+def _write_unified_report(data_dir: Path, dispatch_id: str, text: str) -> Path:
+    reports_dir = data_dir / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = reports_dir / f"{dispatch_id}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _fake_dispatcher_factory(data_dir: Path, text: str, *, seen: "list | None" = None, requests_dir: "Path | None" = None, pr: str = ""):
+    """Same shape as the other gate test files' dispatcher double, plus an
+    optional ``seen`` list that records whether the request record already
+    existed on disk at dispatch time — used to prove ordering (defect 4)."""
+    def _make(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            if seen is not None and requests_dir is not None:
+                seen.append((requests_dir / f"pr-{pr}-glm_gate.json").exists())
+            _write_unified_report(data_dir, dispatch_id, text)
+            return text
+        return _dispatch
+    return _make
+
+
+def _force_resolved_base(monkeypatch, base_data_dir: Path) -> None:
+    """Force glm_gate's resolved base to a tmp_path-rooted dir, independent of
+    whatever raw ``data_dir`` argparse produced — this is what
+    ``_resolve_data_dir(None)`` does for real (falls through to the central
+    store for the active project); redirecting it here keeps the test
+    hermetic while reproducing the exact "guard checks the wrong variable"
+    defect."""
+    monkeypatch.setattr(glm_gate, "_resolve_data_dir", lambda _data_dir: base_data_dir)
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 (RED on unfixed main): omitting --data-dir must not skip the write.
+# ---------------------------------------------------------------------------
+
+
+def test_no_data_dir_flag_and_no_env_still_writes_result_record(tmp_path, monkeypatch):
+    """The reproduction from the dispatch: no --data-dir, VNX_DATA_DIR absent
+    from the environment entirely (not just empty — genuinely unset), a real
+    (non-offline) PR run. On unfixed main this assertion fails on the MEASURED
+    filesystem state (the file does not exist), not on a missing symbol."""
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    base_data_dir = tmp_path / "central-store"
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    rc = glm_gate.main(["--pr", "9001"])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-9001-glm_gate.json"
+    # Split asserts, as the dispatch requires: existence, then readability,
+    # then field correctness — each is its own measured fact.
+    assert out.exists(), "glm_gate must write its result record even without --data-dir"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["gate"] == "glm_gate"
+    assert record["pr_id"] == "9001"
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Control case 1: WITH --data-dir, behaviour is unchanged — lands exactly at
+# that path.
+# ---------------------------------------------------------------------------
+
+
+def test_with_explicit_data_dir_flag_lands_at_exactly_that_path(tmp_path, monkeypatch):
+    data_dir = tmp_path / "explicit"
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    rc = glm_gate.main(["--pr", "9002", "--data-dir", str(data_dir)])
+
+    out = data_dir / "state" / "review_gates" / "results" / "pr-9002-glm_gate.json"
+    assert rc == 0
+    assert out.exists()
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["status"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Control case 2: an unavailable record still keeps empty contract_hash and
+# report_path (the OI-1435 separation is untouched by this fix).
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_still_keeps_evidence_fields_empty(tmp_path, monkeypatch):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_make_default_dispatcher", lambda *a, **k: (lambda *a2, **k2: ""))
+
+    rc = glm_gate.main(["--pr", "0", "--diff-file", str(diff_file)])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-0-glm_gate.json"
+    assert out.exists()
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["status"] == "unavailable"
+    assert record["contract_hash"] == ""
+    assert record["report_path"] == ""
+    assert has_complete_evidence(record) is False
+    assert is_terminal(record) is False
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Control case 3: report path and result path resolve under the same store.
+# ---------------------------------------------------------------------------
+
+
+def test_report_path_and_result_path_share_the_same_resolved_base(tmp_path, monkeypatch):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    rc = glm_gate.main(["--pr", "9003"])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-9003-glm_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert rc == 0
+    report_path = Path(record["report_path"])
+    assert report_path.is_file()
+    assert str(base_data_dir) in str(report_path)
+    assert str(base_data_dir) in str(out)
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: an informational report-path field points a human at the real
+# report even on ``unavailable``, without ever counting as evidence.
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_carries_informational_report_path_but_not_as_evidence(tmp_path, monkeypatch):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    prose_report = "## Review notes\n\nLooks fine, no structured verdict emitted.\n"
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, prose_report),
+    )
+
+    rc = glm_gate.main(["--pr", "0", "--diff-file", str(diff_file)])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-0-glm_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    # The bug this closes: a full report existed on disk while report_path
+    # was empty and no field pointed a human at it.
+    assert record["report_path"] == ""
+    assert record["report_path_informational"], "informational field must point at the real report"
+    assert Path(record["report_path_informational"]).is_file()
+    # Never counted as evidence — has_complete_evidence only reads
+    # contract_hash/report_path, never the informational field.
+    assert has_complete_evidence(record) is False
+    assert is_terminal(record) is False
+
+
+# ---------------------------------------------------------------------------
+# Defect 4: a request record must exist BEFORE the dispatch is ever attempted.
+# ---------------------------------------------------------------------------
+
+
+def test_request_record_exists_before_dispatch_is_attempted(tmp_path, monkeypatch):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    requests_dir = base_data_dir / "state" / "review_gates" / "requests"
+    seen_at_dispatch_time = []
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher",
+        _fake_dispatcher_factory(
+            base_data_dir, _REAL_PASS_REPORT,
+            seen=seen_at_dispatch_time, requests_dir=requests_dir, pr="9004",
+        ),
+    )
+
+    rc = glm_gate.main(["--pr", "9004"])  # NO --data-dir
+
+    assert rc == 0
+    assert seen_at_dispatch_time == [True], (
+        "the request record must already be on disk by the time the dispatcher is invoked"
+    )
+    req_out = requests_dir / "pr-9004-glm_gate.json"
+    assert req_out.exists()
+    request_record = json.loads(req_out.read_text(encoding="utf-8"))
+    assert request_record["gate"] == "glm_gate"
+    assert request_record["pr_number"] == 9004
+    assert request_record["dispatch_id"]
+    assert request_record["branch"] == "feature/x"
+    assert request_record["commit_sha"] == "deadbeef"
+
+
+def test_request_record_written_even_when_dispatch_raises(tmp_path, monkeypatch):
+    """A request record proves "this was requested" independent of whether
+    the dispatch itself later blows up — it must not vanish on failure."""
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    def _boom(*a, **k):
+        raise RuntimeError("glm-harness dispatch exploded")
+
+    monkeypatch.setattr(glm_gate, "_make_default_dispatcher", lambda *a, **k: _boom)
+
+    rc = glm_gate.main(["--pr", "9005"])  # NO --data-dir
+
+    assert rc == 1
+    req_out = base_data_dir / "state" / "review_gates" / "requests" / "pr-9005-glm_gate.json"
+    assert req_out.exists()
+
+
+def test_request_record_field_shape_matches_ci_gate_convention(tmp_path, monkeypatch):
+    """A generic reader must see no difference between this request record
+    and an existing ci_gate/codex_gate one: same core identity fields
+    (gate/status/provider/branch/pr_number/commit_sha/report_path/
+    requested_at/dispatch_id), all populated."""
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = glm_gate.main(["--pr", "9006"])  # NO --data-dir
+    assert rc == 0
+
+    req_out = base_data_dir / "state" / "review_gates" / "requests" / "pr-9006-glm_gate.json"
+    request_record = json.loads(req_out.read_text(encoding="utf-8"))
+
+    # Same core identity field set an existing ci_gate/codex_gate request
+    # record carries (gate_request_handler._request_ci_gate/_request_codex),
+    # each non-empty/non-null for a live (non-offline) run.
+    existing_route_fields = {
+        "gate": "ci_gate", "status": "requested", "provider": "gh_cli",
+        "branch": "main", "pr_number": 42, "commit_sha": "abc123",
+        "report_path": "/tmp/x.md", "requested_at": "2026-08-23T00:00:00Z",
+        "dispatch_id": "ci-gate-pr42-1",
+    }
+    for field in existing_route_fields:
+        assert field in request_record, f"missing field {field!r} present on ci_gate's own request shape"
+        value = request_record[field]
+        assert value not in (None, ""), f"field {field!r} must be populated, got {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# Loud-failure requirement: a write failure must not exit 0.
+# ---------------------------------------------------------------------------
+
+
+def test_result_write_failure_exits_nonzero_with_explicit_stderr_reason(tmp_path, monkeypatch, capsys):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    def _raise_disk_full(**_kwargs):
+        raise OSError("disk full (simulated)")
+
+    monkeypatch.setattr(glm_gate, "record_terminal_result", _raise_disk_full)
+
+    rc = glm_gate.main(["--pr", "9007"])  # NO --data-dir
+    captured = capsys.readouterr()
+
+    assert rc == 1, "a poort that cannot persist its own evidence must never exit 0"
+    assert "FAILED" in captured.err
+    assert "disk full" in captured.err
+
+
+def test_request_write_failure_exits_nonzero_before_any_dispatch(tmp_path, monkeypatch, capsys):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(glm_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(glm_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(glm_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    dispatched = []
+
+    def _spy_dispatcher_factory(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            dispatched.append(True)
+            return _REAL_PASS_REPORT
+        return _dispatch
+
+    monkeypatch.setattr(glm_gate, "_make_default_dispatcher", _spy_dispatcher_factory)
+
+    def _raise_disk_full(*_a, **_k):
+        raise OSError("disk full (simulated)")
+
+    monkeypatch.setattr(glm_gate, "persist_request", _raise_disk_full)
+
+    rc = glm_gate.main(["--pr", "9008"])  # NO --data-dir
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "FAILED" in captured.err
+    assert dispatched == [], "a request-record write failure must not still burn a dispatch"
+
+
+# ---------------------------------------------------------------------------
+# Identity check: never a second hasher, sanity re-check after the refactor.
+# ---------------------------------------------------------------------------
+
+
+def test_glm_gate_still_reuses_the_canonical_hasher():
+    assert glm_gate._compute_contract_hash is gate_artifacts._compute_contract_hash

--- a/tests/test_kimi_gate_data_dir_guard.py
+++ b/tests/test_kimi_gate_data_dir_guard.py
@@ -1,0 +1,352 @@
+"""kimi_gate.py write-without---data-dir tests (dispatch beta2-h-poort-schrijft-stil-niets).
+
+Same defect, same fix, as ``test_glm_gate_data_dir_guard.py`` — see that file's
+module docstring for the full measured reproduction (PR #1672, 23-08).
+kimi_gate.py carried the identical bug: the write guard checked the raw
+``data_dir`` CLI value instead of the resolved ``base_data_dir``, so an
+invocation with no explicit ``--data-dir`` and no ``VNX_DATA_DIR`` in the
+environment silently skipped the entire result-record write after a fully
+billed dispatch.
+
+``_resolve_data_dir`` is monkeypatched on the kimi_gate module namespace (not
+on plan_gate_panel, its source module) to keep these tests hermetic — they
+never fall through to the real ``~/.vnx-data/<project_id>`` central store.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import kimi_gate
+import gate_artifacts
+from gate_status import has_complete_evidence, is_terminal
+
+_REAL_PASS_REPORT = (
+    "Reviewed the diff, no issues.\n\n"
+    "```json\n"
+    '{"verdict": "pass", "findings": [], "residual_risk": null}\n'
+    "```\n"
+)
+
+_FAKE_DIFF = "diff --git a/x b/x\n+ok\n"
+
+
+def _write_unified_report(data_dir: Path, dispatch_id: str, text: str) -> Path:
+    reports_dir = data_dir / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = reports_dir / f"{dispatch_id}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _fake_dispatcher_factory(data_dir: Path, text: str, *, seen: "list | None" = None, requests_dir: "Path | None" = None, pr: str = ""):
+    def _make(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            if seen is not None and requests_dir is not None:
+                seen.append((requests_dir / f"pr-{pr}-kimi_gate.json").exists())
+            _write_unified_report(data_dir, dispatch_id, text)
+            return text
+        return _dispatch
+    return _make
+
+
+def _force_resolved_base(monkeypatch, base_data_dir: Path) -> None:
+    monkeypatch.setattr(kimi_gate, "_resolve_data_dir", lambda _data_dir: base_data_dir)
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 (RED on unfixed main): omitting --data-dir must not skip the write.
+# ---------------------------------------------------------------------------
+
+
+def test_no_data_dir_flag_and_no_env_still_writes_result_record(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    base_data_dir = tmp_path / "central-store"
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    rc = kimi_gate.main(["--pr", "9001"])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-9001-kimi_gate.json"
+    assert out.exists(), "kimi_gate must write its result record even without --data-dir"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["gate"] == "kimi_gate"
+    assert record["pr_id"] == "9001"
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Control case 1: WITH --data-dir, behaviour is unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_with_explicit_data_dir_flag_lands_at_exactly_that_path(tmp_path, monkeypatch):
+    data_dir = tmp_path / "explicit"
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    rc = kimi_gate.main(["--pr", "9002", "--data-dir", str(data_dir)])
+
+    out = data_dir / "state" / "review_gates" / "results" / "pr-9002-kimi_gate.json"
+    assert rc == 0
+    assert out.exists()
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["status"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Control case 2: an unavailable record still keeps empty contract_hash and
+# report_path.
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_still_keeps_evidence_fields_empty(tmp_path, monkeypatch):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_make_default_dispatcher", lambda *a, **k: (lambda *a2, **k2: ""))
+
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file)])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    assert out.exists()
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["status"] == "unavailable"
+    assert record["contract_hash"] == ""
+    assert record["report_path"] == ""
+    assert has_complete_evidence(record) is False
+    assert is_terminal(record) is False
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Control case 3: report path and result path resolve under the same store.
+# ---------------------------------------------------------------------------
+
+
+def test_report_path_and_result_path_share_the_same_resolved_base(tmp_path, monkeypatch):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    rc = kimi_gate.main(["--pr", "9003"])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-9003-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert rc == 0
+    report_path = Path(record["report_path"])
+    assert report_path.is_file()
+    assert str(base_data_dir) in str(report_path)
+    assert str(base_data_dir) in str(out)
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: an informational report-path field points a human at the real
+# report even on ``unavailable``, without ever counting as evidence.
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_carries_informational_report_path_but_not_as_evidence(tmp_path, monkeypatch):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    prose_report = "## Review notes\n\nLooks fine, no structured verdict emitted.\n"
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, prose_report),
+    )
+
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file)])  # NO --data-dir
+
+    out = base_data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["report_path"] == ""
+    assert record["report_path_informational"], "informational field must point at the real report"
+    assert Path(record["report_path_informational"]).is_file()
+    assert has_complete_evidence(record) is False
+    assert is_terminal(record) is False
+
+
+# ---------------------------------------------------------------------------
+# Defect 4: a request record must exist BEFORE the dispatch is ever attempted.
+# ---------------------------------------------------------------------------
+
+
+def test_request_record_exists_before_dispatch_is_attempted(tmp_path, monkeypatch):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    requests_dir = base_data_dir / "state" / "review_gates" / "requests"
+    seen_at_dispatch_time = []
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher",
+        _fake_dispatcher_factory(
+            base_data_dir, _REAL_PASS_REPORT,
+            seen=seen_at_dispatch_time, requests_dir=requests_dir, pr="9004",
+        ),
+    )
+
+    rc = kimi_gate.main(["--pr", "9004"])  # NO --data-dir
+
+    assert rc == 0
+    assert seen_at_dispatch_time == [True], (
+        "the request record must already be on disk by the time the dispatcher is invoked"
+    )
+    req_out = requests_dir / "pr-9004-kimi_gate.json"
+    assert req_out.exists()
+    request_record = json.loads(req_out.read_text(encoding="utf-8"))
+    assert request_record["gate"] == "kimi_gate"
+    assert request_record["pr_number"] == 9004
+    assert request_record["dispatch_id"]
+    assert request_record["branch"] == "feature/x"
+    assert request_record["commit_sha"] == "deadbeef"
+
+
+def test_request_record_written_even_when_dispatch_raises(tmp_path, monkeypatch):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    def _boom(*a, **k):
+        raise RuntimeError("kimi dispatch exploded")
+
+    monkeypatch.setattr(kimi_gate, "_make_default_dispatcher", lambda *a, **k: _boom)
+
+    rc = kimi_gate.main(["--pr", "9005"])  # NO --data-dir
+
+    assert rc == 1
+    req_out = base_data_dir / "state" / "review_gates" / "requests" / "pr-9005-kimi_gate.json"
+    assert req_out.exists()
+
+
+def test_request_record_field_shape_matches_ci_gate_convention(tmp_path, monkeypatch):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = kimi_gate.main(["--pr", "9006"])  # NO --data-dir
+    assert rc == 0
+
+    req_out = base_data_dir / "state" / "review_gates" / "requests" / "pr-9006-kimi_gate.json"
+    request_record = json.loads(req_out.read_text(encoding="utf-8"))
+
+    existing_route_fields = {
+        "gate": "ci_gate", "status": "requested", "provider": "gh_cli",
+        "branch": "main", "pr_number": 42, "commit_sha": "abc123",
+        "report_path": "/tmp/x.md", "requested_at": "2026-08-23T00:00:00Z",
+        "dispatch_id": "ci-gate-pr42-1",
+    }
+    for field in existing_route_fields:
+        assert field in request_record, f"missing field {field!r} present on ci_gate's own request shape"
+        value = request_record[field]
+        assert value not in (None, ""), f"field {field!r} must be populated, got {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# Loud-failure requirement: a write failure must not exit 0.
+# ---------------------------------------------------------------------------
+
+
+def test_result_write_failure_exits_nonzero_with_explicit_stderr_reason(tmp_path, monkeypatch, capsys):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(base_data_dir, _REAL_PASS_REPORT),
+    )
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    def _raise_disk_full(**_kwargs):
+        raise OSError("disk full (simulated)")
+
+    monkeypatch.setattr(kimi_gate, "record_terminal_result", _raise_disk_full)
+
+    rc = kimi_gate.main(["--pr", "9007"])  # NO --data-dir
+    captured = capsys.readouterr()
+
+    assert rc == 1, "a poort that cannot persist its own evidence must never exit 0"
+    assert "FAILED" in captured.err
+    assert "disk full" in captured.err
+
+
+def test_request_write_failure_exits_nonzero_before_any_dispatch(tmp_path, monkeypatch, capsys):
+    base_data_dir = tmp_path / "central-store"
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    _force_resolved_base(monkeypatch, base_data_dir)
+    monkeypatch.setattr(kimi_gate, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(kimi_gate, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(kimi_gate, "get_pr_head_sha", lambda pr_number: "deadbeef")
+
+    dispatched = []
+
+    def _spy_dispatcher_factory(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            dispatched.append(True)
+            return _REAL_PASS_REPORT
+        return _dispatch
+
+    monkeypatch.setattr(kimi_gate, "_make_default_dispatcher", _spy_dispatcher_factory)
+
+    def _raise_disk_full(*_a, **_k):
+        raise OSError("disk full (simulated)")
+
+    monkeypatch.setattr(kimi_gate, "persist_request", _raise_disk_full)
+
+    rc = kimi_gate.main(["--pr", "9008"])  # NO --data-dir
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "FAILED" in captured.err
+    assert dispatched == [], "a request-record write failure must not still burn a dispatch"
+
+
+# ---------------------------------------------------------------------------
+# Identity check: never a second hasher, sanity re-check after the refactor.
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_gate_still_reuses_the_canonical_hasher():
+    assert kimi_gate._compute_contract_hash is gate_artifacts._compute_contract_hash


### PR DESCRIPTION
## Summary

`kimi_gate.py` en `glm_gate.py` guardden het wegschrijven van hun resultaatrecord op de RAUWE `--data-dir`-waarde (`args.data_dir or None`), in plaats van op de al-opgeloste `base_data_dir` (`_resolve_data_dir(data_dir)`, twee regels erboven). Zonder `--data-dir` én zonder `VNX_DATA_DIR` in de omgeving sloeg het hele schrijfblok stil over — gemeten live op PR #1672: zes minuten, $0,072, een echt rapport van 2476 tekens op schijf, en NUL records in `state/review_gates/results/`.

Beide poorten schreven bovendien NOOIT een aanvraagrecord (0 over de hele centrale store), waardoor sluitingsinvariant 1 ("Request record exists") structureel onhaalbaar was voor elke PR die door kimi of glm gereviewd werd.

De keten van gisteren (#1669/#1671) bewees dus alleen dat emitteren werkt WANNEER de vlag toevallig werd meegegeven — niet dat het gegarandeerd is.

## Changes

- **`scripts/glm_gate.py`, `scripts/kimi_gate.py`**:
  - Resultaatrecord wordt nu **onvoorwaardelijk** weggeschreven, resolved vanuit `base_data_dir` (nooit meer de rauwe `data_dir`).
  - Een schrijffout (disk full, permissies) faalt nu **LUID**: expliciete reden op stderr, non-zero exit — nooit meer stil exit 0.
  - Er wordt nu een **aanvraagrecord** gepersist (`gate_recorder.persist_request`, zelfde vorm/pad-conventie als `ci_gate`/`codex_gate`: `state/review_gates/requests/pr-<N>-<gate>.json`) **VOOR** de dispatch start — bewezen met een test die aantoont dat het bestand al bestaat op het moment dat de dispatcher wordt aangeroepen. Een schrijffout hier faalt ook luid, vóór er dispatch-kosten gemaakt worden.
  - Een `unavailable`-resultaat houdt `contract_hash`/`report_path` leeg (OI-1435-scheiding ongewijzigd), maar draagt nu een **informatief** `report_path_informational`-veld dat naar het echte rapport op schijf wijst — nooit gelezen door `has_complete_evidence`/`is_terminal`.
  - `branch`/`commit_sha` worden één keer opgelost en hergebruikt voor zowel het aanvraag- als het resultaatrecord (voorheen een dubbele `gh pr view`-lookup).

## Verification

Nieuwe tests, elk eerst bewezen ROOD op de ongewijzigde `HEAD` (via `git show HEAD:scripts/{glm,kimi}_gate.py`, tijdelijk teruggezet, getest, dan hersteld) en GROEN na de fix:

```
python3 -m pytest tests/test_glm_gate_data_dir_guard.py tests/test_kimi_gate_data_dir_guard.py -q
22 passed
```

Op de ongewijzigde `HEAD`: 9 van de 11 nieuwe tests per bestand faalden (18 van 22 totaal), de 2 "control case met expliciete `--data-dir`"-tests per bestand slaagden al (bewijst dat dat pad ongewijzigd blijft).

Volledige regressie op alle geraakte/aanpalende bestanden:

```
python3 -m pytest tests/test_glm_gate_data_dir_guard.py tests/test_kimi_gate_data_dir_guard.py \
  tests/test_dlv1_glm_gate.py tests/test_dlv2_kimi_gate_evidence.py \
  tests/test_kimi_gate_unavailable.py tests/test_kimi_gate_provenance.py \
  tests/test_oi1394_gate_indicator_scope.py tests/test_dlv45_gate_recognition.py -q
84 passed
```

`python3 -m py_compile scripts/glm_gate.py scripts/kimi_gate.py` — OK.

## Open Items

- **Buiten scope, apart benoemd (uit de dispatch-instructie zelf)**: `closure_verifier` toetst sluitingsinvariant 1 ("Request record exists") alleen generiek voor `claude_github_optional`-contracten (regel ~451-492); `pr_merge._run_review_gate` toetst het resultaat, niet de aanvraag. Deze PR zorgt dat het aanvraagrecord nu WEL bestaat, maar de CODE toetst die aanwezigheid nog niet generiek af voor kimi_gate/glm_gate. Dat is een apart item, niet meegenomen hier.
- De verdict-fence (`vnx-plan-verdict`) is bewust ongewijzigd gelaten — dat is een beveiligingsbesluit tegen verdict-spoofing, geen onderdeel van dit defect (eigen item, OI-1434).
- De request-record-vorm draagt geen `review_mode`/`risk_class`/`changed_files` — die context bestaat niet bij een kale `--pr N`-CLI-aanroep (in tegenstelling tot de manager-route in `gate_request_handler._request_kimi`/`_request_glm`, die wél via T0's PR-classificatie loopt). De kernvelden (gate/status/provider/branch/pr_number/commit_sha/report_path/requested_at/dispatch_id) zijn wel identiek aan ci_gate/codex_gate.

Model: sonnet
Provider: claude