### PR TITLE
feat(gate-obligations): retire un-gateable obligations honestly (OI-1388)

### DIFF
--- a/scripts/gate_obligation_retire_backlog.py
+++ b/scripts/gate_obligation_retire_backlog.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""gate_obligation_retire_backlog.py — one-time honest booking for the
+existing gate-obligation backlog (OI-1388).
+
+Measured 2026-08-23 against the central store: 337 non-terminal obligations
+(``pending``/``unresolvable``) — 58 already have a merged PR, 4 a closed
+(never-merged) PR, and 212 never produced a PR at all with their head branch
+already gone from origin. None of these can still be gated: the PR either
+already closed the review window, or the dispatch died before ever opening
+one. Yet nothing ever closed the obligation record — it just sits pending
+forever, indistinguishable from a dispatch that is still running.
+
+This script books the honest end-state for exactly those three shapes, using
+:data:`gate_obligations.STATUS_RETIRED` — never ``fulfilled``, which would
+falsely claim a review happened. Terminal, not re-run on a later pass
+(idempotent): an obligation already in
+``gate_obligations.TERMINAL_STATUSES`` is left untouched.
+
+Discriminator: PR STATE, never age (operator decision 2026-08-23 — an age
+threshold is not defensible in an audit: "why seven days and not five"). An
+obligation with an OPEN PR is never touched, regardless of how old it is —
+that PR can still gate it. Concretely, per dispatch_id/branch
+``dispatch/<id>``:
+
+  - open PR exists              -> left alone (still gateable)
+  - PR merged                   -> retired, reason=pr_merged
+  - PR closed without merge     -> retired, reason=pr_closed
+  - no PR at all, branch gone   -> retired, reason=no_pr_branch_gone
+  - no PR at all, branch exists -> left alone (class 3: cannot tell "still
+                                    running" from "dead, branch never
+                                    cleaned up" without an age threshold,
+                                    which OI-1388 forbids using here — see
+                                    the report this dispatch produced for the
+                                    diagnostic count of that class)
+
+No backdated gate results (OI-1259 hard boundary): ``resolved_at`` is stamped
+at the moment THIS script books the record, never backdated to the historical
+PR merge/close date — the ungated review window stays honestly ungated in the
+record. The historical date is preserved in ``reason_detail`` instead.
+
+Usage:
+    python3 scripts/gate_obligation_retire_backlog.py            # dry run
+    python3 scripts/gate_obligation_retire_backlog.py --write     # persist
+
+Dry run is the default on purpose — this walks the whole backlog and the
+operator reviews the counts before anything is written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+for _p in (SCRIPT_DIR / "lib", SCRIPT_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from gate_obligations import (  # noqa: E402
+    REASON_NO_PR_BRANCH_GONE,
+    REASON_PR_CLOSED,
+    REASON_PR_MERGED,
+    STATUS_RETIRED,
+    TERMINAL_STATUSES,
+    iter_obligations,
+    update_obligation,
+)
+from gate_obligation_runner import _gh_json, _resolve_github_owner_repo  # noqa: E402
+
+# A growing repo needs headroom; 2026-08-23 measured 1537 merged + 113
+# closed-without-merge + 3 open on this repo — 5000 leaves ample margin
+# without needing pagination.
+_GH_LIST_LIMIT = 5000
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Live data fetchers (IO — kept separate from the pure classification logic
+# below so tests exercise the logic against fixture data, never the real gh
+# CLI or the real store).
+# ---------------------------------------------------------------------------
+
+
+def fetch_prs(owner_repo: str, state: str, fields: str, limit: int = _GH_LIST_LIMIT) -> List[Dict[str, Any]]:
+    """Bulk ``gh pr list`` for one PR state; [] on any failure (never raises)."""
+    data = _gh_json(
+        ["pr", "list", "--state", state, "--json", fields, "--limit", str(limit)],
+        owner_repo=owner_repo,
+    )
+    return data if isinstance(data, list) else []
+
+
+def fetch_existing_branches(project_root: Path) -> Set[str]:
+    """``dispatch/<id>`` branch names that currently exist on origin."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(project_root), "ls-remote", "--heads", "origin"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return set()
+    if proc.returncode != 0:
+        return set()
+    names: Set[str] = set()
+    for line in proc.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        ref = parts[1].strip()
+        if ref.startswith("refs/heads/"):
+            names.add(ref[len("refs/heads/"):])
+    return names
+
+
+def build_pr_index(
+    merged_raw: List[Dict[str, Any]],
+    closed_raw: List[Dict[str, Any]],
+    open_raw: List[Dict[str, Any]],
+) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]], Set[str]]:
+    """Turn three raw ``gh pr list`` payloads into branch-keyed lookups.
+
+    ``gh pr list --state closed`` returns EVERY non-open PR, merged included
+    (measured 2026-08-23: 1650 closed-state PRs, 1537 of them with
+    ``mergedAt`` set) — so ``closed_by_branch`` is filtered to the genuine
+    closed-without-merge subset here, not left to the caller to get wrong.
+    """
+    merged_by_branch = {
+        p["headRefName"]: p for p in merged_raw if p.get("headRefName")
+    }
+    closed_by_branch = {
+        p["headRefName"]: p
+        for p in closed_raw
+        if p.get("headRefName") and not p.get("mergedAt")
+    }
+    open_branches = {p["headRefName"] for p in open_raw if p.get("headRefName")}
+    return merged_by_branch, closed_by_branch, open_branches
+
+
+# ---------------------------------------------------------------------------
+# Pure classification — no IO, fully testable against fixture data.
+# ---------------------------------------------------------------------------
+
+
+def classify_obligation(
+    dispatch_id: str,
+    *,
+    merged_by_branch: Dict[str, Dict[str, Any]],
+    closed_by_branch: Dict[str, Dict[str, Any]],
+    open_branches: Set[str],
+    existing_branches: Set[str],
+) -> Optional[Tuple[str, str, str]]:
+    """Return ``(new_status, reason, reason_detail)``, or None to leave alone.
+
+    An open PR always wins (never touched, regardless of any other signal):
+    it can still gate the obligation. Class 3 (no PR at all, branch still on
+    origin) also returns None — deliberately left for a human, per the
+    module's ``REASON_NO_PR_BRANCH_EXISTS`` docstring.
+    """
+    branch = f"dispatch/{dispatch_id}"
+    if branch in open_branches:
+        return None
+    if branch in merged_by_branch:
+        pr = merged_by_branch[branch]
+        number = pr.get("number")
+        merged_at = pr.get("mergedAt") or "an unrecorded date"
+        return (
+            STATUS_RETIRED,
+            REASON_PR_MERGED,
+            f"PR #{number} merged on {merged_at} — the review window this "
+            f"obligation declared is closed; nothing left to guard",
+        )
+    if branch in closed_by_branch:
+        pr = closed_by_branch[branch]
+        number = pr.get("number")
+        closed_at = pr.get("closedAt") or "an unrecorded date"
+        return (
+            STATUS_RETIRED,
+            REASON_PR_CLOSED,
+            f"PR #{number} closed without merge on {closed_at} — nothing "
+            f"left to guard",
+        )
+    if branch not in existing_branches:
+        return (
+            STATUS_RETIRED,
+            REASON_NO_PR_BRANCH_GONE,
+            f"dispatch {dispatch_id} never produced a PR and its head "
+            f"branch {branch} no longer exists on origin — nothing left "
+            f"to guard",
+        )
+    return None
+
+
+def run_backlog_retirement(
+    state_dir: Path,
+    *,
+    merged_by_branch: Dict[str, Dict[str, Any]],
+    closed_by_branch: Dict[str, Dict[str, Any]],
+    open_branches: Set[str],
+    existing_branches: Set[str],
+    write: bool = False,
+) -> Dict[str, Any]:
+    """Walk every obligation under ``state_dir`` and apply the classifier.
+
+    Idempotent: an obligation already in ``TERMINAL_STATUSES`` (including an
+    already-retired one from a prior run) is left untouched. Dry run
+    (``write=False``, the default) never calls :func:`update_obligation` —
+    it only reports what WOULD change.
+    """
+    obligations = list(iter_obligations(state_dir))
+
+    before_by_status: Dict[str, int] = {}
+    for _path, record in obligations:
+        status = str(record.get("status") or "pending")
+        before_by_status[status] = before_by_status.get(status, 0) + 1
+
+    after_by_status: Dict[str, int] = dict(before_by_status)
+    retired_by_reason: Dict[str, int] = {}
+    class3_dispatch_ids: List[str] = []
+    changes: List[Dict[str, Any]] = []
+
+    for path, record in obligations:
+        status = str(record.get("status") or "pending")
+        dispatch_id = str(record.get("dispatch_id") or path.stem)
+
+        if status in TERMINAL_STATUSES:
+            if status == STATUS_RETIRED:
+                reason = str(record.get("reason") or "")
+                retired_by_reason[reason] = retired_by_reason.get(reason, 0) + 1
+            continue
+
+        outcome = classify_obligation(
+            dispatch_id,
+            merged_by_branch=merged_by_branch,
+            closed_by_branch=closed_by_branch,
+            open_branches=open_branches,
+            existing_branches=existing_branches,
+        )
+        if outcome is None:
+            branch = f"dispatch/{dispatch_id}"
+            if branch in existing_branches:
+                class3_dispatch_ids.append(dispatch_id)
+            continue
+
+        new_status, reason, reason_detail = outcome
+        changes.append(
+            {
+                "dispatch_id": dispatch_id,
+                "path": str(path),
+                "from_status": status,
+                "status": new_status,
+                "reason": reason,
+                "reason_detail": reason_detail,
+            }
+        )
+        after_by_status[status] = after_by_status.get(status, 0) - 1
+        after_by_status[new_status] = after_by_status.get(new_status, 0) + 1
+        retired_by_reason[reason] = retired_by_reason.get(reason, 0) + 1
+
+        if write:
+            update_obligation(
+                path,
+                status=new_status,
+                resolved_at=_utc_now_iso(),
+                reason=reason,
+                reason_detail=reason_detail,
+            )
+
+    return {
+        "state_dir": str(state_dir),
+        "write": write,
+        "obligations_seen": len(obligations),
+        "before_by_status": before_by_status,
+        "after_by_status": after_by_status,
+        "retired_by_reason": retired_by_reason,
+        "class3_branch_exists_no_pr_count": len(class3_dispatch_ids),
+        "class3_branch_exists_no_pr_dispatch_ids": class3_dispatch_ids,
+        "changes": changes,
+        "changed_count": len(changes),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--state-dir", type=Path, default=None,
+        help="VNX state dir (default: resolved via vnx_paths ensure_env)",
+    )
+    parser.add_argument(
+        "--project-root", type=Path, default=SCRIPT_DIR.parent,
+        help="Checkout to run 'git ls-remote' against (default: this repo)",
+    )
+    parser.add_argument(
+        "--write", action="store_true",
+        help="Persist the retirements (default: dry run, changes nothing)",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=_GH_LIST_LIMIT,
+        help=f"gh pr list --limit per state query (default: {_GH_LIST_LIMIT})",
+    )
+    parser.add_argument("--json", action="store_true", help="Machine-readable output")
+    args = parser.parse_args(argv)
+
+    if args.state_dir is not None:
+        state_dir = args.state_dir
+    else:
+        import vnx_paths  # noqa: PLC0415
+
+        state_dir = Path(vnx_paths.ensure_env()["VNX_STATE_DIR"])
+    if not state_dir.is_dir():
+        print(f"ERROR: state dir not found: {state_dir}", file=sys.stderr)
+        return 20
+
+    owner_repo = _resolve_github_owner_repo(state_dir)
+    if not owner_repo:
+        print("ERROR: cannot resolve a GitHub owner/repo for this store", file=sys.stderr)
+        return 20
+
+    merged_raw = fetch_prs(owner_repo, "merged", "number,headRefName,mergedAt", args.limit)
+    closed_raw = fetch_prs(owner_repo, "closed", "number,headRefName,mergedAt,closedAt", args.limit)
+    open_raw = fetch_prs(owner_repo, "open", "number,headRefName", args.limit)
+    merged_by_branch, closed_by_branch, open_branches = build_pr_index(merged_raw, closed_raw, open_raw)
+    existing_branches = fetch_existing_branches(args.project_root)
+
+    summary = run_backlog_retirement(
+        state_dir,
+        merged_by_branch=merged_by_branch,
+        closed_by_branch=closed_by_branch,
+        open_branches=open_branches,
+        existing_branches=existing_branches,
+        write=args.write,
+    )
+    summary["owner_repo"] = owner_repo
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(f"owner_repo={owner_repo} write={args.write} obligations_seen={summary['obligations_seen']}")
+        print(f"before: {summary['before_by_status']}")
+        print(f"after:  {summary['after_by_status']}")
+        print(f"retired_by_reason (post-run total): {summary['retired_by_reason']}")
+        print(
+            "class 3 (no PR ever, branch still exists on origin — left "
+            f"untouched, report only): {summary['class3_branch_exists_no_pr_count']}"
+        )
+        if args.write:
+            print(f"{summary['changed_count']} obligation(s) retired this run")
+        else:
+            print(
+                f"DRY RUN — {summary['changed_count']} obligation(s) would be "
+                "retired; pass --write to persist"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -27,6 +27,16 @@ runner fulfils them:
      obligation is recorded in the distinct ``unresolvable`` status (a fault,
      NOT a wait). It stays retryable for a bounded term and then escalates to
      the loud terminal ``not_executable`` with ``reason=unresolvable_timeout``.
+  6. OI-1388: "no PR yet" (4) is only a genuine wait while the dispatch could
+     still produce one. If no PR ever showed up AND the dispatch's head branch
+     (``dispatch/<id>``) no longer exists on GitHub, the dispatch is dead —
+     nothing will ever gate this obligation. That is recorded in the terminal
+     ``retired`` status (``reason=no_pr_branch_gone``), distinct from
+     ``fulfilled`` (no gate ever actually reviewed it). The discriminator is
+     the branch's existence, never an age threshold: a branch that still
+     exists (or whose existence gh could not determine) leaves the obligation
+     ``pending`` exactly as before — a live dispatch must never be closed on
+     ambiguous evidence.
 
 Scheduling: launchd ``com.vnx.gate-obligation-runner.plist`` (StartInterval
 900s); also safe to run manually at any time — fulfilment is idempotent
@@ -56,9 +66,11 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 from gate_obligations import (  # noqa: E402
+    REASON_NO_PR_BRANCH_GONE,
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
+    STATUS_RETIRED,
     STATUS_UNRESOLVABLE,
     TERMINAL_STATUSES,
     iter_obligations,
@@ -136,12 +148,19 @@ RESOLUTION_UNRESOLVABLE = "unresolvable"
 
 @dataclass
 class PrResolution:
-    """Outcome of resolving an obligation's PR number."""
+    """Outcome of resolving an obligation's PR number.
+
+    ``branch_exists`` is only populated when ``status == RESOLUTION_AWAITING``:
+    ``True``/``False`` when GitHub was actually queried, ``None`` when it
+    could not be determined (or wasn't queried) — never treated as "gone"
+    (OI-1388: an obligation must never be retired on ambiguous evidence).
+    """
 
     status: str
     pr_number: Optional[int] = None
     owner_repo: Optional[str] = None
     reason: Optional[str] = None
+    branch_exists: Optional[bool] = None
 
 
 def utc_now_iso() -> str:
@@ -324,6 +343,39 @@ def _branch_from_github(pr_number: int, owner_repo: str) -> Optional[str]:
     return None
 
 
+def _branch_exists_on_github(dispatch_id: str, owner_repo: str) -> Optional[bool]:
+    """Whether ``dispatch/<dispatch_id>`` still exists as a head ref on GitHub.
+
+    Returns ``True``/``False`` on a definite answer, ``None`` when it cannot be
+    determined (gh missing, timeout, network error, or any non-404 failure).
+    OI-1388: a caller may only treat ``False`` as "the dispatch died without a
+    PR" — ``None`` must stay a wait, never a retirement, so a transient gh
+    hiccup can never close an obligation on ambiguous evidence.
+    """
+    if shutil.which("gh") is None:
+        return None
+    branch = f"dispatch/{dispatch_id}"
+    try:
+        proc = subprocess.run(
+            ["gh", "api", f"repos/{owner_repo}/branches/{branch}"],
+            capture_output=True, text=True, timeout=_GH_TIMEOUT_SECONDS, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        _LOG.debug("branch existence check failed for %s: %s", branch, exc)
+        return None
+    if proc.returncode == 0:
+        return True
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    if "404" in combined or "Not Found" in combined:
+        return False
+    _LOG.debug(
+        "branch existence check for %s returned an unrecognised failure "
+        "(rc=%s) — treating as unknown, not gone: %s",
+        branch, proc.returncode, combined.strip(),
+    )
+    return None
+
+
 def _owner_repo_from_remote_url(url: str) -> Optional[str]:
     """Derive ``owner/repo`` from a GitHub remote URL (https or ssh form).
 
@@ -469,9 +521,14 @@ def resolve_pr_number(state_dir: Path, record: Dict[str, Any]) -> PrResolution:
         return PrResolution(
             RESOLUTION_RESOLVED, pr_number=from_github, owner_repo=owner_repo,
         )
+    # OI-1388: no PR exists yet, but that reads as "not yet" forever unless we
+    # also ask whether the dispatch could still produce one. A dead branch is
+    # the one fact that answers that without a timer.
+    branch_exists = _branch_exists_on_github(dispatch_id, owner_repo)
     return PrResolution(
         RESOLUTION_AWAITING,
         owner_repo=owner_repo,
+        branch_exists=branch_exists,
         reason=f"no PR yet for head branch dispatch/{dispatch_id}",
     )
 
@@ -603,8 +660,33 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
         return outcome
 
     if resolution.status == RESOLUTION_AWAITING:
+        if resolution.branch_exists is False:
+            # OI-1388: the dispatch never produced a PR AND its head branch is
+            # gone from origin — nothing will ever gate this obligation.
+            # Terminal, distinct from `fulfilled` (no gate ever reviewed it).
+            branch_name = f"dispatch/{dispatch_id}"
+            update_obligation(
+                path,
+                status=STATUS_RETIRED,
+                branch=branch_name,
+                attempts=attempts,
+                last_attempt_at=now,
+                resolved_at=now,
+                reason=REASON_NO_PR_BRANCH_GONE,
+                reason_detail=(
+                    f"dispatch {dispatch_id} never produced a PR and its head "
+                    f"branch {branch_name} no longer exists on "
+                    f"{resolution.owner_repo or 'the resolved repo'} — nothing "
+                    f"left for {gate} to guard"
+                ),
+            )
+            outcome["action"] = STATUS_RETIRED
+            outcome["detail"] = "dispatch died without ever producing a PR; branch gone — retired"
+            return outcome
         # The repo resolves and gh works, but no PR exists yet for the head
-        # branch. A genuine wait: stays pending for the freshness monitor.
+        # branch, and the branch is still there (or its existence could not be
+        # determined) — a genuine wait: stays pending for the freshness
+        # monitor, never closed on ambiguous evidence.
         update_obligation(
             path,
             status=STATUS_PENDING,

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -26,6 +26,14 @@ This module is the registry half of the fix:
      declaration without evidence becomes a finding, per sleutel, never per
      directory.
 
+OI-1388 (2026-08-23): an obligation can also become permanently un-gateable —
+its PR merged or closed, or its dispatch died before ever opening one — and
+nothing closed the record. It sat ``pending`` forever, indistinguishable from
+a dispatch that is still running. :data:`STATUS_RETIRED` books that honestly
+(never ``fulfilled``): ``scripts/gate_obligation_runner.py`` closes it going
+forward when a dispatch dies without a PR, and the one-time
+``scripts/gate_obligation_retire_backlog.py`` books the existing backlog.
+
 Design notes:
   - Best-effort at the door: :func:`register_obligation` never raises; the
     door must never be blocked by bookkeeping (same contract as
@@ -63,8 +71,35 @@ STATUS_FAILED = "failed"
 # for a not-yet-opened PR) so a misconfigured obligation never reads as "not
 # yet" forever (OI-1253 fix-forward).
 STATUS_UNRESOLVABLE = "unresolvable"
+# OI-1388: an obligation whose PR/branch reality means NOTHING can ever gate
+# it any more — the PR merged/closed ungated, or the dispatch died without
+# ever producing one. Deliberately NOT "fulfilled": fulfilled means "a gate
+# actually reviewed this"; retired means "the window to review it is closed
+# and nothing did". Every consumer that counts "reviewed" work must key off
+# STATUS_FULFILLED specifically, never off TERMINAL_STATUSES membership, or a
+# retired obligation would silently inflate that count.
+STATUS_RETIRED = "retired"
 
-TERMINAL_STATUSES = frozenset({STATUS_FULFILLED, STATUS_NOT_EXECUTABLE, STATUS_FAILED})
+TERMINAL_STATUSES = frozenset(
+    {STATUS_FULFILLED, STATUS_NOT_EXECUTABLE, STATUS_FAILED, STATUS_RETIRED}
+)
+
+# The four distinct retirement reasons (OI-1388). The distinction is the
+# information this status exists to preserve — collapsing them into one
+# generic "retired" reason would throw away exactly what an audit needs.
+#
+# REASON_NO_PR_BRANCH_EXISTS is part of the vocabulary but is deliberately
+# NEVER emitted by this fleet's automation (scripts/gate_obligation_runner.py,
+# scripts/gate_obligation_retire_backlog.py): "the dispatch never produced a
+# PR, but its branch is still on origin" cannot be told apart from "the
+# dispatch is still running" without an age threshold, and OI-1388 forbids
+# using age as the discriminator. It stays defined for a human operator who
+# has out-of-band evidence the dispatch is dead (e.g. its tmux session is
+# gone) to book the same honest end-state by hand.
+REASON_PR_MERGED = "pr_merged"
+REASON_PR_CLOSED = "pr_closed"
+REASON_NO_PR_BRANCH_GONE = "no_pr_branch_gone"
+REASON_NO_PR_BRANCH_EXISTS = "no_pr_branch_exists"
 
 # Distinct sentinel gate key for explicit no-gate records (dispatch
 # 20260816-gate-never-skippable). Deliberately NOT a member of the Gate enum: a
@@ -298,6 +333,11 @@ __all__ = [
     "STATUS_NOT_EXECUTABLE",
     "STATUS_FAILED",
     "STATUS_UNRESOLVABLE",
+    "STATUS_RETIRED",
+    "REASON_PR_MERGED",
+    "REASON_PR_CLOSED",
+    "REASON_NO_PR_BRANCH_GONE",
+    "REASON_NO_PR_BRANCH_EXISTS",
     "TERMINAL_STATUSES",
     "NO_GATE_KEY",
     "obligations_dir",

--- a/tests/test_gate_obligation_retire_backlog.py
+++ b/tests/test_gate_obligation_retire_backlog.py
@@ -1,0 +1,425 @@
+"""tests/test_gate_obligation_retire_backlog.py — OI-1388: honest one-time
+booking of the pending-forever gate-obligation backlog.
+
+Every test here drives ``scripts/gate_obligation_retire_backlog.py`` against
+a throwaway store under ``tmp_path`` with hand-built PR/branch fixtures — the
+real ``gh`` CLI and the real store are never touched (the dispatch's own
+warning: never fire the obligation runner/backlog script against the live
+store from a test).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+for _p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import gate_obligation_retire_backlog as backlog  # noqa: E402
+from gate_obligations import (  # noqa: E402
+    REASON_NO_PR_BRANCH_GONE,
+    REASON_PR_CLOSED,
+    REASON_PR_MERGED,
+    STATUS_FULFILLED,
+    STATUS_PENDING,
+    STATUS_RETIRED,
+    STATUS_UNRESOLVABLE,
+    obligation_path,
+    register_obligation,
+    update_obligation,
+)
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "vnx-data" / "state"
+    (state_dir / "review_gates" / "obligations").mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _read_obligation(state_dir: Path, dispatch_id: str) -> dict:
+    return json.loads(obligation_path(state_dir, dispatch_id).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# 0. IO wrapper negative paths — a gh/git failure must degrade to an empty
+#    result, never raise and never silently fabricate data.
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_prs_returns_empty_list_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(backlog, "_gh_json", lambda *a, **k: None)
+    assert backlog.fetch_prs("Vinix24/vnx-orchestration", "merged", "number,headRefName") == []
+
+
+def test_fetch_prs_returns_empty_list_on_malformed_gh_output(monkeypatch):
+    """gh returning a JSON object instead of the expected array must not
+    crash the caller — an unexpected shape degrades to empty, same as a
+    hard failure."""
+    monkeypatch.setattr(backlog, "_gh_json", lambda *a, **k: {"unexpected": "shape"})
+    assert backlog.fetch_prs("Vinix24/vnx-orchestration", "merged", "number,headRefName") == []
+
+
+def test_fetch_existing_branches_returns_empty_set_on_git_failure(monkeypatch, tmp_path):
+    def fake_run(cmd, **kwargs):
+        return types.SimpleNamespace(returncode=128, stdout="", stderr="fatal: not a repo")
+
+    monkeypatch.setattr(backlog.subprocess, "run", fake_run)
+    assert backlog.fetch_existing_branches(tmp_path) == set()
+
+
+def test_fetch_existing_branches_parses_ls_remote_output(monkeypatch, tmp_path):
+    ls_remote_output = (
+        "abc123\trefs/heads/dispatch/20260801-foo\n"
+        "def456\trefs/heads/main\n"
+        "ghi789\trefs/heads/dispatch/20260802-bar\n"
+    )
+
+    def fake_run(cmd, **kwargs):
+        return types.SimpleNamespace(returncode=0, stdout=ls_remote_output, stderr="")
+
+    monkeypatch.setattr(backlog.subprocess, "run", fake_run)
+    branches = backlog.fetch_existing_branches(tmp_path)
+    assert branches == {"dispatch/20260801-foo", "main", "dispatch/20260802-bar"}
+
+
+# ---------------------------------------------------------------------------
+# 1. build_pr_index — the gh "closed includes merged" gotcha (measured
+#    2026-08-23: 1650 closed-state PRs, 1537 of them with mergedAt set).
+# ---------------------------------------------------------------------------
+
+
+def test_build_pr_index_separates_merged_from_closed_without_merge():
+    merged_raw = [{"number": 100, "headRefName": "dispatch/a", "mergedAt": "2026-08-01T00:00:00Z"}]
+    # gh's "closed" state query returns EVERY non-open PR, merged included.
+    closed_raw = [
+        {"number": 100, "headRefName": "dispatch/a", "mergedAt": "2026-08-01T00:00:00Z", "closedAt": "2026-08-01T00:00:00Z"},
+        {"number": 101, "headRefName": "dispatch/b", "mergedAt": None, "closedAt": "2026-08-02T00:00:00Z"},
+    ]
+    open_raw = [{"number": 102, "headRefName": "dispatch/c"}]
+
+    merged_by_branch, closed_by_branch, open_branches = backlog.build_pr_index(
+        merged_raw, closed_raw, open_raw,
+    )
+
+    assert set(merged_by_branch) == {"dispatch/a"}
+    assert set(closed_by_branch) == {"dispatch/b"}, (
+        "a merged PR must never leak into the closed-without-merge bucket, "
+        "even though gh's closed-state query includes it"
+    )
+    assert open_branches == {"dispatch/c"}
+
+
+# ---------------------------------------------------------------------------
+# 2. classify_obligation — pure, no IO.
+# ---------------------------------------------------------------------------
+
+
+def test_classify_pr_merged_returns_retired_with_number_and_date():
+    outcome = backlog.classify_obligation(
+        "d-merged",
+        merged_by_branch={"dispatch/d-merged": {"number": 1234, "mergedAt": "2026-08-01T12:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),
+    )
+    assert outcome is not None
+    status, reason, reason_detail = outcome
+    assert status == STATUS_RETIRED
+    assert reason == REASON_PR_MERGED
+    assert reason_detail
+    assert "1234" in reason_detail
+    assert "2026-08-01" in reason_detail
+
+
+def test_classify_pr_closed_without_merge_returns_retired():
+    outcome = backlog.classify_obligation(
+        "d-closed",
+        merged_by_branch={},
+        closed_by_branch={"dispatch/d-closed": {"number": 5678, "closedAt": "2026-08-05T09:00:00Z"}},
+        open_branches=set(),
+        existing_branches=set(),
+    )
+    assert outcome is not None
+    status, reason, reason_detail = outcome
+    assert status == STATUS_RETIRED
+    assert reason == REASON_PR_CLOSED
+    assert "5678" in reason_detail
+    assert "2026-08-05" in reason_detail
+    assert "without merge" in reason_detail
+
+
+def test_classify_no_pr_branch_gone_returns_retired():
+    outcome = backlog.classify_obligation(
+        "d-dead",
+        merged_by_branch={},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),  # branch not present anywhere
+    )
+    assert outcome is not None
+    status, reason, reason_detail = outcome
+    assert status == STATUS_RETIRED
+    assert reason == REASON_NO_PR_BRANCH_GONE
+    assert "d-dead" in reason_detail
+
+
+def test_classify_open_pr_returns_none_even_if_also_in_other_buckets():
+    """An open PR always wins — the obligation can still be gated."""
+    outcome = backlog.classify_obligation(
+        "d-open",
+        merged_by_branch={},
+        closed_by_branch={},
+        open_branches={"dispatch/d-open"},
+        existing_branches={"dispatch/d-open"},
+    )
+    assert outcome is None
+
+
+def test_classify_no_pr_branch_exists_returns_none():
+    """Class 3: no PR at all, branch still on origin — left for a human,
+    never auto-retired (cannot tell 'still running' from 'dead, uncleaned'
+    without an age threshold, which OI-1388 forbids)."""
+    outcome = backlog.classify_obligation(
+        "d-maybe-running",
+        merged_by_branch={},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches={"dispatch/d-maybe-running"},
+    )
+    assert outcome is None
+
+
+# ---------------------------------------------------------------------------
+# 3. run_backlog_retirement — integration against a real tmp_path store.
+#    RED test 1 (dispatch requirement): a PR-merged obligation is pending on
+#    unfixed main; after this script it must carry the new end-state with a
+#    non-empty reason naming the PR number.
+# ---------------------------------------------------------------------------
+
+
+def test_run_backlog_write_retires_pr_merged_obligation(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260801-merged-example", gate="codex_gate", project_id="vnx-dev",
+    )
+
+    summary = backlog.run_backlog_retirement(
+        state_dir,
+        merged_by_branch={"dispatch/20260801-merged-example": {"number": 1401, "mergedAt": "2026-08-10T10:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),
+        write=True,
+    )
+
+    record = _read_obligation(state_dir, "20260801-merged-example")
+    # State, reason-presence, and reason-content asserted separately — a
+    # composite check would silently pass on the wrong field.
+    assert record["status"] == STATUS_RETIRED
+    assert record["status"] != STATUS_FULFILLED
+    assert record["reason"], "the reason field is required, never empty"
+    assert record["reason"] == REASON_PR_MERGED
+    assert record["reason_detail"], "reason_detail is required, never empty"
+    assert "1401" in record["reason_detail"]
+    assert "2026-08-10" in record["reason_detail"]
+    assert summary["changed_count"] == 1
+    assert summary["retired_by_reason"][REASON_PR_MERGED] == 1
+
+
+def test_run_backlog_never_backdates_resolved_at(tmp_path):
+    """OI-1259 hard boundary: resolved_at is stamped at booking time, never
+    backdated to the historical PR merge date."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260801-no-backdate", gate="codex_gate", project_id="vnx-dev",
+    )
+    backlog.run_backlog_retirement(
+        state_dir,
+        merged_by_branch={"dispatch/20260801-no-backdate": {"number": 1, "mergedAt": "2020-01-01T00:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),
+        write=True,
+    )
+    record = _read_obligation(state_dir, "20260801-no-backdate")
+    assert record["resolved_at"] != "2020-01-01T00:00:00Z"
+    assert not str(record["resolved_at"]).startswith("2020")
+
+
+def test_run_backlog_dry_run_writes_nothing(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260801-dry-run", gate="codex_gate", project_id="vnx-dev",
+    )
+
+    summary = backlog.run_backlog_retirement(
+        state_dir,
+        merged_by_branch={"dispatch/20260801-dry-run": {"number": 1, "mergedAt": "2026-08-01T00:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),
+        write=False,
+    )
+
+    record = _read_obligation(state_dir, "20260801-dry-run")
+    assert record["status"] == STATUS_PENDING, "a dry run must never write to disk"
+    assert summary["changed_count"] == 1, "dry run still reports what WOULD change"
+    assert summary["after_by_status"].get(STATUS_RETIRED) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Control cases the dispatch requires to keep passing.
+# ---------------------------------------------------------------------------
+
+
+def test_control_open_pr_obligation_is_never_touched(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260801-open-pr", gate="codex_gate", project_id="vnx-dev",
+    )
+
+    summary = backlog.run_backlog_retirement(
+        state_dir,
+        merged_by_branch={},
+        closed_by_branch={},
+        open_branches={"dispatch/20260801-open-pr"},
+        existing_branches={"dispatch/20260801-open-pr"},
+        write=True,
+    )
+
+    record = _read_obligation(state_dir, "20260801-open-pr")
+    assert record["status"] == STATUS_PENDING
+    assert summary["changed_count"] == 0
+
+
+def test_control_fulfilled_obligation_is_never_rebooked(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="20260801-already-fulfilled", gate="codex_gate", project_id="vnx-dev",
+    )
+    update_obligation(path, status=STATUS_FULFILLED, resolved_at="2026-08-01T00:00:00Z")
+
+    summary = backlog.run_backlog_retirement(
+        state_dir,
+        # Even if the bulk PR fetch WOULD classify this as merged, an
+        # already-terminal obligation must never be touched.
+        merged_by_branch={"dispatch/20260801-already-fulfilled": {"number": 1, "mergedAt": "2026-08-01T00:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),
+        write=True,
+    )
+
+    record = _read_obligation(state_dir, "20260801-already-fulfilled")
+    assert record["status"] == STATUS_FULFILLED
+    assert record["resolved_at"] == "2026-08-01T00:00:00Z"
+    assert summary["changed_count"] == 0
+
+
+def test_control_retired_status_does_not_count_as_reviewed(tmp_path):
+    """The new end-state must never inflate a 'how much was actually
+    reviewed' count."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(state_dir, dispatch_id="d-1", gate="codex_gate", project_id="vnx-dev")
+    fulfilled_path = register_obligation(state_dir, dispatch_id="d-2", gate="codex_gate", project_id="vnx-dev")
+    update_obligation(fulfilled_path, status=STATUS_FULFILLED, resolved_at="2026-08-01T00:00:00Z")
+
+    summary = backlog.run_backlog_retirement(
+        state_dir,
+        merged_by_branch={"dispatch/d-1": {"number": 1, "mergedAt": "2026-08-01T00:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),
+        write=True,
+    )
+
+    reviewed = summary["after_by_status"].get(STATUS_FULFILLED, 0)
+    assert reviewed == 1, "only the genuinely fulfilled obligation counts as reviewed"
+    assert summary["after_by_status"].get(STATUS_RETIRED, 0) == 1
+
+
+def test_control_running_dispatch_stays_pending(tmp_path):
+    """A dispatch that is still running (no PR yet, branch still exists) must
+    stay pending — never auto-retired."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260823-still-running", gate="codex_gate", project_id="vnx-dev",
+    )
+
+    summary = backlog.run_backlog_retirement(
+        state_dir,
+        merged_by_branch={},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches={"dispatch/20260823-still-running"},
+        write=True,
+    )
+
+    record = _read_obligation(state_dir, "20260823-still-running")
+    assert record["status"] == STATUS_PENDING
+    assert summary["changed_count"] == 0
+    assert "20260823-still-running" in summary["class3_branch_exists_no_pr_dispatch_ids"]
+    assert summary["class3_branch_exists_no_pr_count"] == 1
+
+
+def test_control_unresolvable_obligation_is_still_in_scope(tmp_path):
+    """`unresolvable` is not in TERMINAL_STATUSES — the backlog script must
+    still classify it once the environment resolves (this script provides a
+    real owner_repo by construction, so it's the right place to close these
+    out too)."""
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="20260801-was-unresolvable", gate="codex_gate", project_id="vnx-dev",
+    )
+    update_obligation(path, status=STATUS_UNRESOLVABLE, reason="unresolvable_repo", reason_detail="env was wrong")
+
+    summary = backlog.run_backlog_retirement(
+        state_dir,
+        merged_by_branch={"dispatch/20260801-was-unresolvable": {"number": 42, "mergedAt": "2026-08-01T00:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches=set(),
+        write=True,
+    )
+
+    record = _read_obligation(state_dir, "20260801-was-unresolvable")
+    assert record["status"] == STATUS_RETIRED
+    assert summary["changed_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Idempotency: running twice must change nothing the second time.
+# ---------------------------------------------------------------------------
+
+
+def test_run_backlog_is_idempotent(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(state_dir, dispatch_id="d-merged", gate="codex_gate", project_id="vnx-dev")
+    register_obligation(state_dir, dispatch_id="d-dead", gate="codex_gate", project_id="vnx-dev")
+    register_obligation(state_dir, dispatch_id="d-still-running", gate="codex_gate", project_id="vnx-dev")
+
+    kwargs = dict(
+        merged_by_branch={"dispatch/d-merged": {"number": 1, "mergedAt": "2026-08-01T00:00:00Z"}},
+        closed_by_branch={},
+        open_branches=set(),
+        existing_branches={"dispatch/d-still-running"},
+        write=True,
+    )
+
+    first = backlog.run_backlog_retirement(state_dir, **kwargs)
+    assert first["changed_count"] == 2  # d-merged retired, d-dead retired; d-still-running left alone
+
+    second = backlog.run_backlog_retirement(state_dir, **kwargs)
+    assert second["changed_count"] == 0, "a second run must change nothing"
+
+    merged_record = _read_obligation(state_dir, "d-merged")
+    dead_record = _read_obligation(state_dir, "d-dead")
+    running_record = _read_obligation(state_dir, "d-still-running")
+    assert merged_record["status"] == STATUS_RETIRED
+    assert dead_record["status"] == STATUS_RETIRED
+    assert running_record["status"] == STATUS_PENDING

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -40,11 +40,14 @@ import producer_freshness
 from dispatch_cli import run_dispatch
 from gate_obligations import (
     NO_GATE_KEY,
+    REASON_NO_PR_BRANCH_GONE,
     STATUS_FAILED,
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
+    STATUS_RETIRED,
     STATUS_UNRESOLVABLE,
+    TERMINAL_STATUSES,
     obligation_path,
     pr_number_from_pr_id,
     register_obligation,
@@ -344,7 +347,11 @@ def test_runner_gate_failure_is_loud_and_registered(tmp_path, monkeypatch):
 def test_runner_leaves_pending_when_no_pr_yet(tmp_path, monkeypatch):
     """Repo resolves and gh works, but no PR exists yet — a genuine WAIT, not a
     fault. The obligation stays pending (OI-1253 fix-forward: this must not be
-    confused with the `unresolvable` env-wrong state)."""
+    confused with the `unresolvable` env-wrong state).
+
+    The dispatch's head branch still exists (a still-running dispatch), so
+    OI-1388's dead-branch retirement path must NOT fire here — control case
+    for that new behavior, exercised below in the retirement tests."""
     state_dir = _make_state_dir(tmp_path)
     register_obligation(
         state_dir, dispatch_id="20260731-oi876-no-pr", gate="codex_gate",
@@ -353,6 +360,7 @@ def test_runner_leaves_pending_when_no_pr_yet(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
     monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
+    monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: True)
 
     summary = runner.run(state_dir)
 
@@ -361,6 +369,128 @@ def test_runner_leaves_pending_when_no_pr_yet(tmp_path, monkeypatch):
     record = _read_obligation(state_dir, "20260731-oi876-no-pr")
     assert record["status"] == STATUS_PENDING
     assert record["attempts"] == 1
+
+
+def test_runner_leaves_pending_when_branch_existence_unknown(tmp_path, monkeypatch):
+    """gh could not determine whether the branch still exists (outage, rate
+    limit, timeout) — ambiguous evidence must never retire an obligation.
+    Stays pending, exactly like the "branch confirmed to exist" case."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260731-oi1388-branch-unknown", gate="codex_gate",
+        project_id="vnx-dev",
+    )
+    monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
+    monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
+    monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: None)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 1
+    record = _read_obligation(state_dir, "20260731-oi1388-branch-unknown")
+    assert record["status"] == STATUS_PENDING
+
+
+# ---------------------------------------------------------------------------
+# 2d. OI-1388: a dispatch that dies without ever producing a PR must not stay
+# pending forever — nothing closes that obligation today. RED on unfixed
+# main: with no dead-branch check, resolve_pr_number returns AWAITING and the
+# obligation lands STATUS_PENDING regardless of whether the branch is gone.
+# ---------------------------------------------------------------------------
+
+
+def test_runner_retires_obligation_when_dispatch_died_without_pr(tmp_path, monkeypatch):
+    """A dispatch that never produced a PR, whose head branch no longer
+    exists on origin, is DEAD — nothing will ever gate it. The obligation
+    must land in a terminal state, never stay pending forever."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260801-oi1388-dead-no-pr", gate="codex_gate",
+        project_id="vnx-dev",
+    )
+    monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
+    monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
+    monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: False)
+
+    summary = runner.run(state_dir)
+
+    # State assertion, split from the reason assertions below — a composite
+    # check would silently pass even if the wrong field carried the evidence.
+    record = _read_obligation(state_dir, "20260801-oi1388-dead-no-pr")
+    assert summary["pending_after"] == 0
+    assert record["status"] == STATUS_RETIRED
+    assert record["status"] != STATUS_FULFILLED, (
+        "a dead dispatch with no PR was never reviewed — it must never read as fulfilled"
+    )
+    assert record["status"] in TERMINAL_STATUSES, "the runner must never retry a dead-branch retirement"
+
+    assert record["reason"] == REASON_NO_PR_BRANCH_GONE
+    assert record["reason"], "the reason field is required, never empty"
+
+    assert record["reason_detail"], "the reason_detail field is required, never empty"
+    assert "20260801-oi1388-dead-no-pr" in record["reason_detail"]
+    assert "dispatch/20260801-oi1388-dead-no-pr" in record["reason_detail"]
+
+
+def test_runner_never_refires_a_retired_obligation(tmp_path, monkeypatch):
+    """A retired obligation is terminal: a later run must never touch it
+    again, exactly like an already-fulfilled one."""
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="20260801-oi1388-retired-stays", gate="codex_gate",
+        project_id="vnx-dev",
+    )
+    update_obligation(
+        path, status=STATUS_RETIRED, reason=REASON_NO_PR_BRANCH_GONE,
+        reason_detail="already retired", resolved_at="2026-08-01T00:00:00Z",
+    )
+    monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
+    monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: (_ for _ in ()).throw(
+        AssertionError("a terminal obligation must never be re-resolved")
+    ))
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260801-oi1388-retired-stays")
+    assert record["status"] == STATUS_RETIRED
+    assert record["reason_detail"] == "already retired", "a retired obligation must never be rewritten"
+
+
+def test_retired_status_never_counts_as_fulfilled_in_a_status_tally(tmp_path):
+    """Control case: any report that tallies obligations by status must be
+    able to tell `retired` apart from `fulfilled` — a naive status-count
+    (the shape any consumer report would take) must not conflate the two."""
+    state_dir = _make_state_dir(tmp_path)
+    fulfilled_path = register_obligation(
+        state_dir, dispatch_id="d-fulfilled", gate="codex_gate", project_id="vnx-dev",
+    )
+    update_obligation(fulfilled_path, status=STATUS_FULFILLED, resolved_at="2026-08-01T00:00:00Z")
+    retired_path = register_obligation(
+        state_dir, dispatch_id="d-retired", gate="codex_gate", project_id="vnx-dev",
+    )
+    update_obligation(
+        retired_path, status=STATUS_RETIRED, reason=REASON_NO_PR_BRANCH_GONE,
+        reason_detail="dead", resolved_at="2026-08-01T00:00:00Z",
+    )
+
+    import gate_obligations as go
+
+    tally = {}
+    for _path, record in go.iter_obligations(state_dir):
+        tally[record["status"]] = tally.get(record["status"], 0) + 1
+
+    assert tally.get(STATUS_FULFILLED) == 1, "the fulfilled obligation must count as reviewed"
+    assert tally.get(STATUS_RETIRED) == 1, "the retired obligation must count separately"
+    total_terminal = sum(tally.get(s, 0) for s in TERMINAL_STATUSES)
+    assert total_terminal == 2
+    assert tally[STATUS_FULFILLED] < total_terminal, (
+        "'reviewed' (fulfilled) must not be reported as the full terminal count "
+        "— a retired obligation inflating it would be exactly the OI-1400 shape"
+    )
 
 
 def test_runner_marks_unresolvable_when_repo_unattributable(tmp_path, monkeypatch):
@@ -743,6 +873,31 @@ def test_evaluate_unreadable_obligation_is_source_unreadable(tmp_path):
 
     assert section["status"] == "error"
     assert section["findings"][0]["kind"] == "source_unreadable"
+
+
+def test_scan_treats_retired_as_resolved_not_pending(tmp_path):
+    """OI-1388: a retired obligation must read as resolved evidence for
+    freshness — the same as fulfilled/not_executable/failed — never as a
+    still-open declaration that could trip a staleness finding."""
+    state_dir = _make_state_dir(tmp_path)
+    old_declared = "2026-07-01T00:00:00Z"  # would be stale if still counted pending
+    recent_resolved = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _write_obligation(
+        state_dir, "d-retired", "codex_gate",
+        declared_at=old_declared,
+        status=STATUS_RETIRED,
+        reason=REASON_NO_PR_BRANCH_GONE,
+        reason_detail="dead",
+        resolved_at=recent_resolved,
+    )
+
+    spec = {"path": str(state_dir / "review_gates" / "obligations")}
+    seen = producer_freshness.scan_gate_obligations(spec, now=time.time())
+
+    assert time.time() - seen["codex_gate"] < 3600, (
+        "a retired obligation's OLD declared_at must not drive staleness — "
+        "its recent resolved_at must be what freshness reads"
+    )
 
 
 def test_real_config_loads_with_obligations_producer():


### PR DESCRIPTION
## Summary

337 pending gate obligations never reach an end-state: their PR merged, their PR closed without merge, or their dispatch died without ever producing a PR. Nothing closes them — they sit `pending` forever, indistinguishable from a still-running dispatch, and the backlog keeps growing.

- Adds `STATUS_RETIRED` (`scripts/lib/gate_obligations.py`) with four reasons: `pr_merged`, `pr_closed`, `no_pr_branch_gone`, `no_pr_branch_exists` (last one reserved for manual/operator use — never auto-emitted). Deliberately **not** `fulfilled`: fulfilled means a gate actually reviewed the PR; retired means the review window is closed and nothing did.
- `scripts/gate_obligation_runner.py`: the ongoing runner now closes an obligation the moment it confirms the dispatch died without a PR — discriminator is **branch existence on GitHub**, never age (operator decision 2026-08-23: an age threshold is not defensible in an audit). A branch that still exists, or whose existence gh could not determine, leaves the obligation `pending` exactly as before.
- `scripts/gate_obligation_retire_backlog.py` (new): one-time script that books the existing backlog. Dry-run by default; `--write` persists. Idempotent (terminal obligations, including already-retired ones, are skipped). Never backdates `resolved_at` to the historical PR date (OI-1259 hard boundary) — the historical date lives in `reason_detail` instead.

## Changes

- `scripts/lib/gate_obligations.py` — `STATUS_RETIRED` + `TERMINAL_STATUSES` membership, four `REASON_*` constants, module docstring update.
- `scripts/gate_obligation_runner.py` — `_branch_exists_on_github()`, `PrResolution.branch_exists`, `resolve_pr_number()` populates it on the AWAITING path, `fulfill_obligation()` retires on confirmed-gone branch.
- `scripts/gate_obligation_retire_backlog.py` (new) — one-time backlog cleanup: `classify_obligation()` (pure), `build_pr_index()`, `fetch_prs()`/`fetch_existing_branches()` (IO), `run_backlog_retirement()` (orchestration), CLI with `--write`/`--json`/`--limit`.
- `tests/test_gate_obligations.py` — new/updated tests for the runner's dead-branch retirement path, freshness-scanner treatment of `retired`, and a "retired never counts as fulfilled" control test.
- `tests/test_gate_obligation_retire_backlog.py` (new) — 19 tests: classifier, PR-index dedup (gh's `--state closed` includes merged PRs), integration against a tmp_path store, idempotency, all required control cases.

## Verification

RED-before (stashed the runner.py change, kept the new `gate_obligations.py` constants + new tests):
```
python3 -m pytest tests/test_gate_obligations.py -k "retires_obligation_when_dispatch_died_without_pr or leaves_pending_when_no_pr_yet or branch_existence_unknown" -v
# 3 failed: AttributeError — runner has no attribute '_branch_exists_on_github'
```

GREEN after implementation:
```
python3 -m pytest tests/test_gate_obligations.py tests/test_gate_obligation_runner.py tests/test_gate_obligation_runner_scope.py tests/test_gate_obligation_retire_backlog.py tests/test_producer_freshness.py tests/test_pr_merge_review_gate.py -q
# 122 passed
```

`ruff check` clean on all touched/new files.

Real dry-run against the production store (`--state-dir ~/.vnx-data/vnx-dev/state`, no `--write`):
```
obligations_seen: 514
before_by_status: {pending: 340, not_executable: 113, fulfilled: 56, failed: 5}
after_by_status:  {pending: 29, not_executable: 113, fulfilled: 56, failed: 5, retired: 311}
retired_by_reason: {no_pr_branch_gone: 146, pr_merged: 133, pr_closed: 32}
class 3 (no PR, branch still exists — left untouched): 29
```
(Lower than the dispatch's morning class-3 figure of 63 because several hours passed between that measurement and this run — some in-flight dispatches completed in between, converting to either `pr_merged` or `no_pr_branch_gone`.)

**Dead inventory on the remote (report only, no action taken):** 29 branches with no PR at all still exist on origin as of this run. Left untouched per the dispatch instruction — a separate cleanup item.

## Open Items

None.