### PR TITLE
feat(review-gate): DEFAULT_REVIEW_STACK + headless_orchestrator provider-agnostic (OI-1435)

### DIFF
--- a/scripts/headless_orchestrator.py
+++ b/scripts/headless_orchestrator.py
@@ -417,7 +417,15 @@ class HeadlessOrchestrator:
             )
 
     def _check_all_gates_passed(self, event: LoopEvent) -> None:
-        """When a gate event arrives, check if all required gates have passed."""
+        """When a gate event arrives, check if all gates ACTUALLY REQUESTED for
+        this PR have passed — provider-agnostic (dispatch 20260823-beta2-e,
+        OI-1435). The required set is read from review_gates/requests/, not a
+        hardcoded {codex_gate, gemini_review}: whatever stack was requested
+        (codex+gemini, kimi_gate+glm_gate, or any future gate) unblocks the
+        feature the same way once its gates pass. A required gate that never
+        got requested therefore can never silently sit unmet — it is simply
+        not in the set being checked.
+        """
         ctx = _flatten_context(event.context)
         latest_event = ctx.get("latest_event", "")
         if "gate" not in latest_event.lower():
@@ -430,21 +438,21 @@ class HeadlessOrchestrator:
             return
         feature_id = f"F{m.group(1)}"
 
-        # Check gate results directory for evidence that required gates passed
-        gate_results_dir = self.state_dir / "review_gates" / "results"
-        if not gate_results_dir.exists():
+        # Check gate requests directory for what was actually requested for this PR
+        gate_requests_dir = self.state_dir / "review_gates" / "requests"
+        if not gate_requests_dir.exists():
             return
 
-        result_files = list(gate_results_dir.glob("pr-*.json"))
-        if not result_files:
+        request_files = list(gate_requests_dir.glob("pr-*.json"))
+        if not request_files:
             return
 
-        # Determine highest PR number from results.
+        # Determine highest PR number from requests.
         # The event context does not carry a GitHub PR number, so we fall back
-        # to max(pr_numbers) across all result files.  This may match a PR from
+        # to max(pr_numbers) across all request files.  This may match a PR from
         # a different feature if artifacts are not cleaned between features.
         pr_numbers: List[int] = []
-        for f in result_files:
+        for f in request_files:
             m2 = re.match(r"pr-(\d+)-", f.name)
             if m2:
                 pr_numbers.append(int(m2.group(1)))
@@ -452,30 +460,77 @@ class HeadlessOrchestrator:
             return
 
         latest_pr = max(pr_numbers)
-        pr_files = [f for f in result_files if f.name.startswith(f"pr-{latest_pr}-")]
-        gate_names_present = {f.name.split(f"pr-{latest_pr}-")[1].replace(".json", "") for f in pr_files}
+        prefix = f"pr-{latest_pr}-"
+        pr_request_files = [f for f in request_files if f.name.startswith(prefix)]
 
-        required = {"codex_gate", "gemini_review"}
-        if not required.issubset(gate_names_present):
+        # claude_github_optional never gates the merge (matches gate_executor's
+        # own has_required_failure rule); any other requested gate can opt out
+        # via an explicit required=false in its own request payload (e.g.
+        # codex_gate when the diff doesn't force it) — default True when the
+        # field is absent, since kimi_gate/glm_gate/gemini_review/ci_gate/
+        # wiring_gate requests never carry that field and are required by
+        # default.
+        required_gates: List[str] = []
+        for f in pr_request_files:
+            gate_name = f.name[len(prefix):-len(".json")]
+            if gate_name == "claude_github_optional":
+                continue
+            try:
+                request_data = json.loads(f.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.warning("Could not read gate request %s: %s", f, exc)
+                return
+            if not request_data.get("required", True):
+                continue
+            required_gates.append(gate_name)
+
+        if not required_gates:
+            logger.warning(
+                "No required gates found among requests for %s PR #%d — feature NOT unblocked",
+                feature_id, latest_pr,
+            )
             return
 
         # Verify each required gate's result JSON reports a passing status.
         # File presence alone is insufficient — a failed gate still produces a
         # result file with status "failed", which must block feature unblocking.
         # is_pass() also enforces blocking_findings and blocking_count (OI-1139).
+        gate_results_dir = self.state_dir / "review_gates" / "results"
         from gate_status import is_pass  # noqa: PLC0415
+
+        # UNION across gates, not majority: ANY missing-evidence or failed
+        # required gate blocks — no averaging or vote-counting anywhere below.
+        # Ground (measured 22-08): glm_gate and kimi_gate returned OPPOSITE
+        # verdicts on the identical diff with the identical contract_hash (glm
+        # FAIL with a blocking finding, kimi PASS with none) — neither reader
+        # outranks the other, so one blocking verdict is enough to block.
+        missing_gates: List[str] = []
         failed_gates: List[str] = []
-        for gate_name in required:
-            result_file = gate_results_dir / f"pr-{latest_pr}-{gate_name}.json"
+        for gate_name in required_gates:
+            result_file = gate_results_dir / f"{prefix}{gate_name}.json"
+            if not result_file.exists():
+                missing_gates.append(gate_name)
+                continue
             try:
                 result_data = json.loads(result_file.read_text(encoding="utf-8"))
             except Exception as exc:
                 logger.warning("Could not read gate result %s: %s", result_file, exc)
-                return
+                missing_gates.append(gate_name)
+                continue
             passed, reason = is_pass(result_data)
             if not passed:
                 failed_gates.append(f"{gate_name}({reason})")
 
+        # The stille-return bug this replaces: on main, an unrequested-but-
+        # hardcoded gate silently aborted the whole check with no log line —
+        # a deblocking that doesn't happen must be exactly as visible as one
+        # that does.
+        if missing_gates:
+            logger.warning(
+                "Required gate(s) missing evidence for %s PR #%d: %s — feature NOT unblocked",
+                feature_id, latest_pr, ", ".join(missing_gates),
+            )
+            return
         if failed_gates:
             logger.warning(
                 "Required gate(s) did not pass for %s PR #%d: %s — feature NOT unblocked",
@@ -488,7 +543,7 @@ class HeadlessOrchestrator:
             "event_type": "feature_gates_complete",
             "feature_id": feature_id,
             "pr_number": latest_pr,
-            "gate_names": sorted(gate_names_present),
+            "gate_names": sorted(required_gates),
         })
         logger.info(
             "All required gates passed for %s PR #%d — next feature dispatch unblocked",

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -99,6 +99,13 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "VNX_HEADLESS_ROUTING", "string", "0", "dispatch",
         "Headless dispatch routing mode.",
         subsystem="headless-dispatch-routing", status="LIVE"),
+    "VNX_DEFAULT_REVIEW_STACK": _e(
+        "VNX_DEFAULT_REVIEW_STACK", "string", "gemini_review,codex_gate,claude_github_optional", "gate",
+        "Comma-separated default review-gate stack (dispatch 20260823-beta2-e, OI-1435). "
+        "Lets an operator route review gates to any registered gate name — e.g. "
+        "kimi_gate,glm_gate — without editing review_gate_manager.py. ci_gate is appended "
+        "separately when VNX_CI_GATE_REQUIRED is on; do not include it here.", approval=True,
+        subsystem="governance-enforcement-stack", status="LIVE"),
     "VNX_CI_GATE_REQUIRED": _e(
         "VNX_CI_GATE_REQUIRED", "bool", "0", "gate",
         "Require the CI gate before merge.", approval=True,

--- a/scripts/lib/gate_executor.py
+++ b/scripts/lib/gate_executor.py
@@ -341,6 +341,14 @@ class GateExecutorMixin:
         """Execute all requested gates and classify results.
 
         Returns (gates_list, has_required_failure) tuple.
+
+        has_required_failure is a UNION across gates, not a majority: it flips
+        True the moment ANY required gate is not decided_pass — there is no
+        averaging or vote-counting here. Ground (measured 22-08): glm_gate and
+        kimi_gate returned OPPOSITE verdicts on the identical diff with the
+        identical contract_hash (glm FAIL with a blocking finding, kimi PASS
+        with none) — neither reader outranks the other, so one blocking
+        verdict is enough to block.
         """
         gates: List[Dict[str, Any]] = []
         has_required_failure = False

--- a/scripts/review_gate_manager.py
+++ b/scripts/review_gate_manager.py
@@ -32,8 +32,18 @@ from gate_report_generator import GateReportGeneratorMixin
 
 
 def _build_default_review_stack() -> List[str]:
-    stack = ["gemini_review", "codex_gate", "claude_github_optional"]
+    """The default review-gate stack, resolved from config instead of a
+    hardcoded name list (dispatch 20260823-beta2-e, OI-1435).
+
+    ``VNX_DEFAULT_REVIEW_STACK`` (config_registry, default
+    "gemini_review,codex_gate,claude_github_optional") is the single source
+    an operator edits to route the stack at any registered gate — e.g.
+    kimi_gate,glm_gate — without touching this function. ci_gate stays a
+    separate append gated by VNX_CI_GATE_REQUIRED, matching prior behavior.
+    """
     import config_runtime
+    raw = config_runtime.get("VNX_DEFAULT_REVIEW_STACK") or ""
+    stack = [item.strip() for item in raw.split(",") if item.strip()]
     if config_runtime.get_bool("VNX_CI_GATE_REQUIRED"):
         stack.append("ci_gate")
     return stack

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -659,6 +659,38 @@ def test_default_review_stack_includes_ci_gate_when_required(monkeypatch):
     assert "ci_gate" in stack
 
 
+def test_default_review_stack_control_case_gemini_codex_combo_unchanged(monkeypatch):
+    """Control case (dispatch 20260823-beta2-e): with no config override, the
+    existing gemini_review + codex_gate + claude_github_optional combination
+    must come back byte-for-byte unchanged."""
+    monkeypatch.delenv("VNX_CI_GATE_REQUIRED", raising=False)
+    monkeypatch.delenv("VNX_DEFAULT_REVIEW_STACK", raising=False)
+    import review_gate_manager as rgm
+    stack = rgm._build_default_review_stack()
+    assert stack == ["gemini_review", "codex_gate", "claude_github_optional"]
+
+
+def test_default_review_stack_is_config_driven_not_hardcoded(monkeypatch):
+    """OPERATOR-BESLUIT 23-08: kimi_gate/glm_gate must be reachable as the
+    default review stack via config alone — no edit to
+    _build_default_review_stack() required."""
+    monkeypatch.setenv("VNX_DEFAULT_REVIEW_STACK", "kimi_gate,glm_gate")
+    monkeypatch.delenv("VNX_CI_GATE_REQUIRED", raising=False)
+    import review_gate_manager as rgm
+    stack = rgm._build_default_review_stack()
+    assert stack == ["kimi_gate", "glm_gate"]
+
+
+def test_default_review_stack_config_override_still_appends_ci_gate(monkeypatch):
+    """ci_gate stays a separate, always-last append gated by
+    VNX_CI_GATE_REQUIRED regardless of what VNX_DEFAULT_REVIEW_STACK carries."""
+    monkeypatch.setenv("VNX_DEFAULT_REVIEW_STACK", "kimi_gate,glm_gate")
+    monkeypatch.setenv("VNX_CI_GATE_REQUIRED", "1")
+    import review_gate_manager as rgm
+    stack = rgm._build_default_review_stack()
+    assert stack == ["kimi_gate", "glm_gate", "ci_gate"]
+
+
 # ---------------------------------------------------------------------------
 # gh not available → not_executable
 # ---------------------------------------------------------------------------

--- a/tests/test_gate_status_check.py
+++ b/tests/test_gate_status_check.py
@@ -29,6 +29,18 @@ def _write_gate_result(results_dir: Path, pr_number: int, gate: str, status: str
     return f
 
 
+def _write_gate_request(state_dir: Path, pr_number: int, gate: str) -> Path:
+    """Write the request-side companion for a gate result (dispatch
+    20260823-beta2-e, OI-1435): _check_all_gates_passed now derives its
+    required set from review_gates/requests/, not from result-file presence
+    alone, so these tests must model both sides of the real writer flow."""
+    reqs_dir = state_dir / "review_gates" / "requests"
+    reqs_dir.mkdir(parents=True, exist_ok=True)
+    f = reqs_dir / f"pr-{pr_number}-{gate}.json"
+    f.write_text(json.dumps({"gate": gate, "pr_number": pr_number, "status": "requested"}), encoding="utf-8")
+    return f
+
+
 def _write_gate_result_extra(
     results_dir: Path,
     pr_number: int,
@@ -80,6 +92,8 @@ class TestCheckAllGatesPassed:
         """Gate file exists but status=failed — must NOT emit feature_gates_complete."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 57, "codex_gate")
+        _write_gate_request(orch.state_dir, 57, "gemini_review")
         _write_gate_result(results_dir, 57, "codex_gate", "failed")
         _write_gate_result(results_dir, 57, "gemini_review", "completed")
 
@@ -95,6 +109,8 @@ class TestCheckAllGatesPassed:
         """Both required gates have status=completed — must emit feature_gates_complete."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 57, "codex_gate")
+        _write_gate_request(orch.state_dir, 57, "gemini_review")
         _write_gate_result(results_dir, 57, "codex_gate", "completed")
         _write_gate_result(results_dir, 57, "gemini_review", "completed")
 
@@ -110,6 +126,8 @@ class TestCheckAllGatesPassed:
         """Both gates have status=pass (gate_result_parser path) — must emit complete."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 99, "codex_gate")
+        _write_gate_request(orch.state_dir, 99, "gemini_review")
         _write_gate_result(results_dir, 99, "codex_gate", "pass")
         _write_gate_result(results_dir, 99, "gemini_review", "pass")
 
@@ -120,11 +138,15 @@ class TestCheckAllGatesPassed:
         assert any(r.get("event_type") == "feature_gates_complete" for r in logged)
 
     def test_does_not_fire_when_gate_file_missing(self, tmp_path: Path) -> None:
-        """Only one required gate present — must not fire."""
+        """Both gates were requested, but gemini_review has no result yet —
+        must not fire, and (OI-1435) must log which requested gate is
+        missing evidence rather than silently returning."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 57, "codex_gate")
+        _write_gate_request(orch.state_dir, 57, "gemini_review")
         _write_gate_result(results_dir, 57, "codex_gate", "completed")
-        # gemini_review intentionally absent
+        # gemini_review requested but its result is intentionally absent
 
         logged: list[dict] = []
         with patch("headless_orchestrator._log_loop_event", side_effect=lambda _d, rec: logged.append(rec)):
@@ -136,6 +158,8 @@ class TestCheckAllGatesPassed:
         """status=pass but blocking_findings non-empty — is_pass() must block unblocking (OI-1139)."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 60, "codex_gate")
+        _write_gate_request(orch.state_dir, 60, "gemini_review")
         _write_gate_result_extra(
             results_dir, 60, "codex_gate", "pass",
             blocking_findings=["critical: hardcoded secret detected"],
@@ -154,6 +178,8 @@ class TestCheckAllGatesPassed:
         """status=completed but blocking_count=2 — is_pass() must block unblocking (OI-1139)."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 61, "codex_gate")
+        _write_gate_request(orch.state_dir, 61, "gemini_review")
         _write_gate_result(results_dir, 61, "codex_gate", "completed")
         _write_gate_result_extra(
             results_dir, 61, "gemini_review", "completed",
@@ -172,6 +198,8 @@ class TestCheckAllGatesPassed:
         """status=approve is in gate_status.PASS_STATES — must emit feature_gates_complete (OI-1139)."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 62, "codex_gate")
+        _write_gate_request(orch.state_dir, 62, "gemini_review")
         _write_gate_result(results_dir, 62, "codex_gate", "approve")
         _write_gate_result(results_dir, 62, "gemini_review", "approve")
 
@@ -189,6 +217,10 @@ class TestLatestPrScopedToCurrentFeature:
         """With gate results for PR #5 (failed) and PR #10 (completed), picks PR #10."""
         orch = _make_orchestrator(tmp_path)
         results_dir = orch.state_dir / "review_gates" / "results"
+        _write_gate_request(orch.state_dir, 5, "codex_gate")
+        _write_gate_request(orch.state_dir, 5, "gemini_review")
+        _write_gate_request(orch.state_dir, 10, "codex_gate")
+        _write_gate_request(orch.state_dir, 10, "gemini_review")
         _write_gate_result(results_dir, 5, "codex_gate", "failed")
         _write_gate_result(results_dir, 5, "gemini_review", "failed")
         _write_gate_result(results_dir, 10, "codex_gate", "completed")

--- a/tests/test_headless_orchestrator.py
+++ b/tests/test_headless_orchestrator.py
@@ -258,3 +258,137 @@ def test_health_file_updated(tmp_path: Path) -> None:
             finally:
                 headless_orchestrator._HEALTH_INTERVAL = original_interval
                 orch.stop()
+
+
+# ---------------------------------------------------------------------------
+# _check_all_gates_passed — provider-agnostic required-gate derivation
+# (dispatch 20260823-beta2-e, OI-1435): the required set comes from what was
+# actually REQUESTED for the PR (review_gates/requests/), not a hardcoded
+# {codex_gate, gemini_review}.
+# ---------------------------------------------------------------------------
+
+def _write_gate_request(state_dir: Path, pr_number: int, gate: str, *, required=None) -> None:
+    reqs_dir = state_dir / "review_gates" / "requests"
+    reqs_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"gate": gate, "status": "requested", "pr_number": pr_number}
+    if required is not None:
+        payload["required"] = required
+    (reqs_dir / f"pr-{pr_number}-{gate}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_gate_result(
+    state_dir: Path, pr_number: int, gate: str, *, status: str,
+    blocking_findings=None, blocking_count=None,
+) -> None:
+    results_dir = state_dir / "review_gates" / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"gate": gate, "pr_number": pr_number, "status": status}
+    if blocking_findings is not None:
+        payload["blocking_findings"] = blocking_findings
+    if blocking_count is not None:
+        payload["blocking_count"] = blocking_count
+    (results_dir / f"pr-{pr_number}-{gate}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _gate_event(dispatch_id: str):
+    import headless_orchestrator as ho
+    return ho.LoopEvent(
+        reason="review_gate_result",
+        context={"latest_event": "review_gate_result", "latest_dispatch_id": dispatch_id},
+    )
+
+
+def _read_loop_events(data_dir: Path) -> list:
+    path = data_dir / "events" / "autonomous_loop.ndjson"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_check_all_gates_passed_kimi_glm_stack_unblocks(tmp_path: Path) -> None:
+    """Provider-agnostic: a stack of kimi_gate+glm_gate ONLY (no codex_gate,
+    no gemini_review at all) must unblock the feature once both requested
+    gates pass. On the pre-fix hardcoded {codex_gate, gemini_review} check
+    this silently returns and no feature_gates_complete event is ever
+    logged — this test is RED on that code and GREEN after the fix."""
+    data_dir, state_dir = _make_state_dir(tmp_path)
+    import headless_orchestrator
+    orch = headless_orchestrator.HeadlessOrchestrator(data_dir=data_dir, state_dir=state_dir, dry_run=True)
+
+    _write_gate_request(state_dir, 501, "kimi_gate")
+    _write_gate_request(state_dir, 501, "glm_gate")
+    _write_gate_result(state_dir, 501, "kimi_gate", status="pass", blocking_findings=[], blocking_count=0)
+    _write_gate_result(state_dir, 501, "glm_gate", status="pass", blocking_findings=[], blocking_count=0)
+
+    orch._check_all_gates_passed(_gate_event("f88-pr1-kimi-glm-stack"))
+
+    events = _read_loop_events(data_dir)
+    complete = [e for e in events if e.get("event_type") == "feature_gates_complete"]
+    assert complete, f"expected feature_gates_complete to be logged, got: {events}"
+    assert complete[0]["pr_number"] == 501
+    assert sorted(complete[0]["gate_names"]) == ["glm_gate", "kimi_gate"]
+
+
+def test_check_all_gates_passed_codex_gemini_combo_unchanged(tmp_path: Path) -> None:
+    """Control case: the existing codex_gate + gemini_review combination
+    still unblocks exactly as before the provider-agnostic rewrite."""
+    data_dir, state_dir = _make_state_dir(tmp_path)
+    import headless_orchestrator
+    orch = headless_orchestrator.HeadlessOrchestrator(data_dir=data_dir, state_dir=state_dir, dry_run=True)
+
+    _write_gate_request(state_dir, 502, "gemini_review")
+    _write_gate_request(state_dir, 502, "codex_gate", required=True)
+    _write_gate_result(state_dir, 502, "gemini_review", status="pass", blocking_findings=[], blocking_count=0)
+    _write_gate_result(state_dir, 502, "codex_gate", status="pass", blocking_findings=[], blocking_count=0)
+
+    orch._check_all_gates_passed(_gate_event("f89-pr1-codex-gemini"))
+
+    events = _read_loop_events(data_dir)
+    complete = [e for e in events if e.get("event_type") == "feature_gates_complete"]
+    assert complete, f"expected feature_gates_complete to be logged, got: {events}"
+    assert complete[0]["pr_number"] == 502
+    assert sorted(complete[0]["gate_names"]) == ["codex_gate", "gemini_review"]
+
+
+def test_check_all_gates_passed_required_gate_fails_does_not_unblock(tmp_path: Path) -> None:
+    """Control case 1: a requested gate that FAILS must not unblock."""
+    data_dir, state_dir = _make_state_dir(tmp_path)
+    import headless_orchestrator
+    orch = headless_orchestrator.HeadlessOrchestrator(data_dir=data_dir, state_dir=state_dir, dry_run=True)
+
+    _write_gate_request(state_dir, 503, "kimi_gate")
+    _write_gate_request(state_dir, 503, "glm_gate")
+    _write_gate_result(state_dir, 503, "kimi_gate", status="pass", blocking_findings=[], blocking_count=0)
+    _write_gate_result(
+        state_dir, 503, "glm_gate", status="fail",
+        blocking_findings=[{"severity": "blocking", "title": "x", "description": "y"}],
+        blocking_count=1,
+    )
+
+    orch._check_all_gates_passed(_gate_event("f90-pr1-one-fails"))
+
+    events = _read_loop_events(data_dir)
+    assert not [e for e in events if e.get("event_type") == "feature_gates_complete"]
+
+
+def test_check_all_gates_passed_required_gate_missing_result_does_not_unblock_and_logs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Control case 2: a requested gate with NO result yet must not unblock,
+    and the reason plus the missing gate name must be logged — replacing the
+    silent return that shipped on main."""
+    data_dir, state_dir = _make_state_dir(tmp_path)
+    import headless_orchestrator
+    orch = headless_orchestrator.HeadlessOrchestrator(data_dir=data_dir, state_dir=state_dir, dry_run=True)
+
+    _write_gate_request(state_dir, 504, "kimi_gate")
+    _write_gate_request(state_dir, 504, "glm_gate")
+    _write_gate_result(state_dir, 504, "kimi_gate", status="pass", blocking_findings=[], blocking_count=0)
+    # glm_gate was requested but never produced a result file.
+
+    with caplog.at_level("WARNING", logger="headless_orchestrator"):
+        orch._check_all_gates_passed(_gate_event("f91-pr1-missing-result"))
+
+    events = _read_loop_events(data_dir)
+    assert not [e for e in events if e.get("event_type") == "feature_gates_complete"]
+    assert "missing evidence" in caplog.text and "glm_gate" in caplog.text, caplog.text


### PR DESCRIPTION
## Summary

Deliverable 7 of `claudedocs/plans/review-gate-provider-agnostic.md`.

- `DEFAULT_REVIEW_STACK` (`scripts/review_gate_manager.py::_build_default_review_stack`) is now resolved from config (`VNX_DEFAULT_REVIEW_STACK`, registered in `scripts/lib/config_registry.py`) instead of a hardcoded name list. Default is byte-identical to before: `gemini_review,codex_gate,claude_github_optional`. An operator can now route the stack to `kimi_gate,glm_gate` (or any other registered gate) without editing this function. `ci_gate` stays a separate append gated by `VNX_CI_GATE_REQUIRED`, unchanged.
- `headless_orchestrator._check_all_gates_passed` no longer hardcodes `required = {"codex_gate", "gemini_review"}`. The required set is now derived from what was actually **requested** for the PR (`review_gates/requests/`), excluding `claude_github_optional` and any gate whose request payload explicitly carries `required: false` (mirrors `gate_executor`'s own rule).
- The silent return is gone: a requested-but-missing-result gate, or a requested-but-failed gate, is now logged (`logger.warning`) with the gate name(s) and the reason before returning.
- Both places that summarize multiple gate outcomes into one decision (`gate_executor._execute_requested_gates`'s `has_required_failure`, and the orchestrator's own missing/failed check) got an explicit grounding comment: the summarization is a **union**, not a majority — one blocking verdict from any reader blocks. Ground: `glm_gate` and `kimi_gate` returned opposite verdicts on the identical diff with the identical `contract_hash` on 22-08.

## Changes

- `scripts/review_gate_manager.py` — `_build_default_review_stack()` reads `VNX_DEFAULT_REVIEW_STACK` via `config_runtime.get()` instead of a hardcoded list.
- `scripts/lib/config_registry.py` — new `VNX_DEFAULT_REVIEW_STACK` registry entry (string, default `gemini_review,codex_gate,claude_github_optional`, category `gate`, `approval=True`).
- `scripts/headless_orchestrator.py` — `_check_all_gates_passed` rewritten to derive the required-gate set from `review_gates/requests/` instead of a hardcoded `{codex_gate, gemini_review}`; logs missing/failed required gates instead of returning silently.
- `scripts/lib/gate_executor.py` — comment-only: documents the union-not-majority rule on `_execute_requested_gates`.
- `tests/test_ci_gate.py` — new tests for the config-driven default stack (unchanged default, operator override to `kimi_gate,glm_gate`, `ci_gate` still appended last).
- `tests/test_headless_orchestrator.py` — new tests: kimi_gate+glm_gate-only stack unblocks (RED on pre-fix code, GREEN after), codex+gemini combo unchanged, a failing required gate blocks, a missing-result required gate blocks and logs.
- `tests/test_gate_status_check.py` — existing OI-1139/1140 tests updated to also write the request-side companion file (the new required-set source), preserving their original intent under the new derivation.

## Verification

Targeted run (touched files + direct neighbours), all green post-fix:

```
python3 -m pytest tests/test_headless_orchestrator.py tests/test_gate_status_check.py \
  tests/test_ci_gate.py tests/test_closure_verifier.py tests/test_governance_profile_selector.py \
  tests/test_config_registry.py tests/test_config_runtime.py tests/test_audit_correctness_fixes.py \
  tests/test_subsystem_health.py -q
# 233 passed, 7 warnings (pre-existing deprecation warnings, unrelated)
```

RED-before-fix demonstrated by temporarily stashing only the source changes (keeping the new tests) and re-running:

```
tests/test_headless_orchestrator.py::test_check_all_gates_passed_kimi_glm_stack_unblocks
  AssertionError: expected feature_gates_complete to be logged, got: []

tests/test_ci_gate.py::test_default_review_stack_is_config_driven_not_hardcoded
tests/test_ci_gate.py::test_default_review_stack_config_override_still_appends_ci_gate
  AssertionError: assert ['gemini_review', 'codex_gate', 'claude_github_optional'] == ['kimi_gate', 'glm_gate']
```

Runtime measurement of `DEFAULT_REVIEW_STACK`, before/after (identical — control case 3):

```
$ python3 -c "import review_gate_manager; print(review_gate_manager.DEFAULT_REVIEW_STACK)"
['gemini_review', 'codex_gate', 'claude_github_optional']

$ VNX_DEFAULT_REVIEW_STACK="kimi_gate,glm_gate" python3 -c "import review_gate_manager; print(review_gate_manager.DEFAULT_REVIEW_STACK)"
['kimi_gate', 'glm_gate']
```

One pre-existing, unrelated failure noted and left untouched (confirmed present on unmodified `main` too, before any of this dispatch's changes): `tests/test_cli_flag_forwarding.py::test_rgm_request_auto_computes_changed_files_when_blank` — a test fixture lambda missing the `strict` kwarg that `_compute_changed_files` already required before this PR.

Also confirmed: `ruff check` on all four changed source files shows zero new findings — every flagged issue (unused imports, E402, f-string-without-placeholder) is pre-existing and on lines this PR did not touch.

## Open Items

None.

Dispatch-ID: 20260823-beta2-e-stack-provider-agnostisch
**Model**: sonnet
**Provider**: claude

---

## Deliverable 10 is hiermee HALF af (T0-annotatie, 23-08 17:15)

Deze PR levert het MECHANISME: de review-stack wordt instelbaar via
`VNX_DEFAULT_REVIEW_STACK` en de hardcodering `required = {"codex_gate",
"gemini_review"}` in `headless_orchestrator.py:458` verdwijnt.

Hij levert niet de UITKOMST. De default blijft `gemini_review, codex_gate,
claude_github_optional`, en de eigen test pint dat expliciet vast bij een lege
env. Beide providers zijn dood. Instelbaar met een dode default is mechanisch
provider-agnostisch en praktisch onveranderd.

De tweede helft is geen PR maar een operator-handeling: de projectwaarde
`VNX_DEFAULT_REVIEW_STACK` op `kimi_gate,glm_gate` zetten via de per-project DB,
met de operator als audit-actor. Die staat open bij Vincent.

Deliverable 10 is pas af als deze PR op main staat EN die waarde is gezet.
Zonder die tweede stap leest een groene merge hier als afgerond terwijl de
poort nog steeds twee dode lezers verklaart.
