### PR TITLE
fix(orphan-sweep): a worktree's life-sign must not be its tmux session (OI-1427)

### DIFF
--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -41,11 +41,14 @@ runtime objects persist forever:
    Recorded under ``tmux_completed_orphans_killed`` / ``_preserved``, each
    entry carrying the ground it was decided on.
 
-2. **git worktrees** ``<repo>/.vnx-data/worktrees/dispatch-<dispatch_id>`` — the
-   same lane's ephemeral trees. An orphan is a worktree whose tmux session is
+2. **git worktrees** ``<repo>/.vnx-data/worktrees/dispatch-<dispatch_id>`` — every
+   lane's ephemeral trees (tmux-spawn, headless ``claude -p``, and the provider
+   lanes all allocate through the same ``dispatch_worktree_isolation.
+   create_dispatch_worktree``). An orphan is a worktree whose tmux session is
    gone (the session is the worktree's lifecycle authority: only its teardown
    reaps the tree, so a surviving session means the wrapper may still be about
-   to reap it). Cleanup REUSES the exact in-process teardown path
+   to reap it) AND that is not otherwise known to be in flight (OI-1427,
+   below). Cleanup REUSES the exact in-process teardown path
    (``tmux_worktree.classify_path`` + ``reap``): a DIRTY worktree is MARKED
    (``git worktree lock`` with a reason) and NEVER deleted; clean/committed/
    pushed are removed exactly as teardown would, including process-group and
@@ -60,6 +63,39 @@ runtime objects persist forever:
    failure against a socket that DOES exist, or an unrecognized non-zero
    exit) is never read as "zero sessions" — it records an error and skips
    the worktree reap for this entire run instead of guessing.
+
+   **"No tmux session" is not "dead" (OI-1427).** A headless ``claude -p``
+   dispatch never opens a tmux session at all — kind-1's ``surviving_ids`` is
+   entirely tmux-derived, so a running headless worker fails that check from
+   the first second of its run, not just after a crash. Measured 21-08: a real
+   sweep run reaped the worktree of a headless dispatch that was still in its
+   reading phase, mid-run. A second, independent life-sign closes that gap:
+   the dispatch REGISTER (``dispatch_register.ndjson``, already loaded once
+   per run for kind 1b below) records a ``dispatch_created`` event at the
+   door's commit-to-fire moment for EVERY lane — tmux, headless, and provider
+   alike — strictly before ``create_dispatch_worktree`` ever runs. A worktree
+   whose dispatch id is KNOWN to the register and not yet provably terminal
+   (no ``dispatch_completed`` register event, no terminal receipt per
+   ``event_outcome_semantics.classify_event_outcome``) is preserved exactly
+   like a live tmux session — see ``_dispatch_known_inflight``.
+
+   Two other candidates were considered and rejected: (1) an account-wide
+   ``claude-tmux-slot-*.lock`` in ``~/.vnx-data/locks/`` DOES carry a live pid
+   for a running dispatch (measured 23-08: slot-1 held a live pid, slot-8 a
+   dead one from 10-08) but only when ``claude_serial_enabled`` is on AND only
+   for the two claude lanes — a provider-lane (kimi/glm/deepseek) dispatch
+   never acquires that lock at all (``serialization_class`` is ``None`` for
+   ``is_claude_lane=False`` — ``dispatch_plan.py`` D5), so lock-only liveness
+   would leave every in-flight provider-lane worktree with zero protection,
+   the same defect this fix closes, just for a different lane. (2) scanning
+   every process's cwd for a live worker in this worktree has no portable
+   answer on macOS (no ``/proc``; ``lsof`` per pid is expensive and permission
+   -gated for other users' processes) and was not pursued.
+
+   Register-unmeasurable (the register itself could not be read this run)
+   fails OPEN exactly like the tmux-listing case above: every worktree not
+   already proven alive by a tmux session is preserved this run rather than
+   guessed dead, and the failure is recorded in ``errors``.
 
 3. **``dispatches/active/<id>/manifest.json``** — the subprocess lane's active
    manifests. Delegated to :mod:`crash_recovery_sweep`, which already recovers
@@ -343,6 +379,56 @@ def _evaluate_completed_orphan(
         return False, f"pane_{pane_state.state}"
 
     return True, f"{evidence};pane={pane_state.state}"
+
+
+# ---------------------------------------------------------------------------
+# Kind 2 — register-derived liveness for the tmux-less lanes (OI-1427)
+# ---------------------------------------------------------------------------
+
+def _dispatch_known_inflight(
+    dispatch_id: str,
+    *,
+    register_known_ids: "set[str] | None",
+    register_completed_ids: "set[str] | None",
+    receipts_index: "dict[str, list] | None",
+) -> "bool | None":
+    """Could ``dispatch_id`` still be a live, tmux-less (headless/provider)
+    dispatch? A second, tmux-independent life-sign for kind 2 — see the
+    OI-1427 paragraph in the module docstring for why this exists and why the
+    lock-based and cwd-scanning alternatives were rejected.
+
+    True  -> the register KNOWS this dispatch id and nothing PROVES it has
+             reached a terminal outcome (no ``dispatch_completed`` register
+             event, no terminal receipt — including when the receipts index
+             itself could not be read: "can't prove it's dead" counts as "not
+             provably dead", the same fail-open direction as everywhere else
+             in this module).
+    False -> the register has never heard of this dispatch id (an ordinary,
+             pre-existing orphan — unaffected by this check), OR it has and a
+             terminal outcome IS proven.
+    None  -> unmeasurable: the register itself could not be read this run.
+
+    Deliberately a separate function from ``_evaluate_completed_orphan``
+    rather than a shared refactor of its (b)+(c) evidence lookup: that
+    function's conjunction must keep "receipts_unmeasurable" distinct from
+    "not_completed" for its per-session reason string (kind 1b), while this
+    caller (kind 2) only ever needs the two-way fold "not provably dead" —
+    forcing one shape onto both would either lose kind 1b's reason
+    granularity or make kind 2 carry reason strings it never uses.
+    """
+    if register_known_ids is None:
+        return None
+    if dispatch_id not in register_known_ids:
+        return False
+    if register_completed_ids is not None and dispatch_id in register_completed_ids:
+        return False
+    if receipts_index is None:
+        return True
+    for rec in receipts_index.get(dispatch_id) or []:
+        outcome = classify_event_outcome(rec.get("event_type"), rec.get("status"))
+        if outcome is not None:
+            return False
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -635,6 +721,25 @@ def sweep(
             result.worktrees_scanned.append(str(entry))
             if listing_unmeasurable or wid in surviving_ids:
                 result.worktrees_skipped_live.append(str(entry))
+                continue
+            # OI-1427: no tmux session is not "dead" — a headless/provider
+            # dispatch never has one. True (known, not provably terminal) or
+            # None (register unmeasurable) both mean "never reap on doubt";
+            # only a hard False (unknown to the register, or provably
+            # terminal) falls through to the classify/reap path below.
+            inflight = _dispatch_known_inflight(
+                wid,
+                register_known_ids=register_known_ids,
+                register_completed_ids=register_completed_ids,
+                receipts_index=receipts_index,
+            )
+            if inflight is not False:
+                result.worktrees_skipped_live.append(str(entry))
+                logger.info(
+                    "orphan_sweep: SKIP worktree %s — no tmux session but register %s",
+                    entry.name,
+                    "shows it in flight" if inflight else "was unmeasurable",
+                )
                 continue
             branch = f"dispatch/{wid}"
             try:

--- a/tests/test_orphan_sweep.py
+++ b/tests/test_orphan_sweep.py
@@ -301,6 +301,109 @@ def test_sweep_is_idempotent(env, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# OI-1427 — a headless dispatch's worktree must survive a sweep even though
+# it opens NO tmux session at all (the kind-1 "surviving_ids" signal is
+# entirely tmux-derived, so a headless dispatch fails that check from second
+# one). The register knows this dispatch (a dispatch_created event is written
+# by the door for EVERY lane -- tmux, headless, and provider -- before the
+# worktree is even created) and shows no terminal outcome yet: that is the
+# life-sign this class of worktree actually has. The control test proves the
+# tmux-session path is untouched -- without it, a broken probe that always
+# "protects" would pass the headless test for the wrong reason.
+# ---------------------------------------------------------------------------
+
+def test_headless_inflight_worktree_survives_sweep_without_tmux_session(env, tmp_path):
+    """On main (pre-fix) this fails on BEHAVIOR, not a missing symbol: sweep()
+    runs to completion with no tmux session and no register knowledge of the
+    worktree's liveness, classifies the freshly-allocated (clean) worktree as
+    an orphan, and reaps it -- exactly the OI-1427 incident (a live headless
+    dispatch's worktree deleted out from under it)."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "headless-1")
+    _write_register_event(env, "dispatch_created", "headless-1")  # known, in flight
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: [],  # headless dispatch opens NO tmux session, ever
+    )
+
+    assert str(handle.path) in res.worktrees_skipped_live
+    assert handle.path.is_dir()
+    assert res.worktrees_removed == []
+
+
+def test_headless_worktree_reaped_once_register_shows_terminal(env, tmp_path):
+    """The flip side: once the register proves the dispatch reached a terminal
+    outcome, the new criterion must NOT protect it forever -- otherwise a
+    genuinely orphaned headless worktree (crashed wrapper, but one that got as
+    far as writing dispatch_completed) could never be swept."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "headless-done-1")
+    _write_register_event(env, "dispatch_created", "headless-done-1")
+    _write_register_event(env, "dispatch_completed", "headless-done-1")
+
+    res = osweep.sweep(repo_root=local, data_dir=env, list_sessions=lambda: [])
+
+    assert str(handle.path) in res.worktrees_removed
+    assert not handle.path.exists()
+
+
+def test_headless_unknown_worktree_unaffected_by_new_criterion(env, tmp_path):
+    """A worktree whose dispatch id the register has never heard of (e.g. a
+    genuinely stale leftover) must still be reaped exactly as before -- the
+    new criterion only ever ADDS protection, never removes it, and must never
+    turn 'register says nothing' into a reason to preserve."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "never-registered-1")
+
+    res = osweep.sweep(repo_root=local, data_dir=env, list_sessions=lambda: [])
+
+    assert str(handle.path) in res.worktrees_removed
+    assert not handle.path.exists()
+
+
+def test_headless_register_unmeasurable_fails_open_on_worktree(env, tmp_path, monkeypatch):
+    """'Cannot measure the register' must never collapse into 'not in flight'
+    -- mirrors the existing listing_unmeasurable contract for kind 1/2."""
+    import dispatch_register
+
+    def _raise(*, state_dir=None):
+        raise RuntimeError("register read blew up")
+
+    monkeypatch.setattr(dispatch_register, "read_events", _raise)
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "unmeasurable-1")
+
+    res = osweep.sweep(repo_root=local, data_dir=env, list_sessions=lambda: [])
+
+    assert str(handle.path) in res.worktrees_skipped_live
+    assert handle.path.is_dir()
+    assert res.worktrees_removed == []
+    assert any(e.get("kind") == "completed_check" for e in res.errors)
+
+
+def test_headless_control_tmux_session_still_protects_worktree(env, tmp_path):
+    """Control for the tests above: a dispatch WITH a live tmux session must
+    still be protected via the pre-existing, unrelated tmux path -- proves
+    the measurement instrument still works and the headless tests above are
+    not passing because every worktree is now unconditionally preserved."""
+    local = _git_repo(tmp_path)
+    handle = _alloc(local, "tmux-ctrl-1")
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        list_sessions=lambda: ["vnx-tmux-ctrl-1"],
+        probe_liveness=lambda s: True,
+    )
+
+    assert str(handle.path) in res.worktrees_skipped_live
+    assert handle.path.is_dir()
+    assert res.worktrees_removed == []
+
+
+# ---------------------------------------------------------------------------
 # Kind 3 — active manifests (delegated to crash_recovery_sweep)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Kind 2 (worktree orphan detection) in `scripts/lib/orphan_sweep.py` only checked tmux-session liveness (`surviving_ids`). A headless `claude -p` dispatch never opens a tmux session, so it read as orphaned from second one of its run — not just after a crash. Measured 21-08: a real sweep run reaped the worktree of a live headless dispatch mid-run (~104s of lost work, no worse damage only because the worker was still in its reading phase).
- Adds a second, tmux-independent life-sign for kind 2: a worktree whose dispatch id is **known to the register** (`dispatch_created`, written by the door for every lane — tmux, headless, provider — before the worktree is even created) and **not yet provably terminal** (no `dispatch_completed` register event, no terminal receipt) is now preserved exactly like a live tmux session.
- Register-unmeasurable fails open, mirroring the module's existing `listing_unmeasurable` contract.

## Changes
- `scripts/lib/orphan_sweep.py`
  - New `_dispatch_known_inflight()` — tri-state (`True`/`False`/`None`) register-derived liveness check reused for kind 2, deliberately kept separate from kind 1b's `_evaluate_completed_orphan` (different reason-string granularity needs).
  - Kind-2 loop in `sweep()`: before classifying/reaping a worktree with no surviving tmux session, also checks `_dispatch_known_inflight`; only a hard `False` (unknown to register, or provably terminal) falls through to the existing classify/reap path.
  - Module docstring updated: records the OI-1427 defect, the fix, and the two rejected alternatives (lock-based — real but scoped to the two claude lanes only, leaves provider-lane worktrees unprotected; cwd-scanning — no portable answer on macOS).
- `tests/test_orphan_sweep.py`
  - 5 new tests: in-flight headless worktree survives without a tmux session (the red-on-main case), a control proving the tmux path still works, terminal-register worktree still gets reaped, unknown-to-register worktree still gets reaped (new criterion never removes protection), and register-unmeasurable fails open.

## Verification
Red baseline captured on pre-fix code (`git stash`-equivalent — ran before implementing the fix):
```
tests/test_orphan_sweep.py::test_headless_inflight_worktree_survives_sweep_without_tmux_session FAILED
tests/test_orphan_sweep.py::test_headless_register_unmeasurable_fails_open_on_worktree FAILED
```
Both failed on **behavior** (`res.worktrees_removed` showed the worktree wrongly reaped, `res.worktrees_skipped_live` stayed empty) — not on a missing symbol, since `sweep()` ran to completion using only pre-existing code paths.

Post-fix, full targeted suite:
```
python3 -m pytest tests/test_orphan_sweep.py tests/test_orphan_sweep_fail_open.py tests/test_pool_reaper.py tests/test_worker_permission_relay.py -q
79 + 108 passed (187 total), 0 failed
```

Real-repo before/after `--dry-run --json` (main-branch code vs. this fix, same `--repo-root`, mutates nothing):
```
worktrees_scanned:      before=15 after=15
worktrees_removed:      before=8  after=8
worktrees_preserved:    before=3  after=3
worktrees_skipped_live: before=4  after=4
errors:                 before=[] after=[]
```
No worktree changed classification in either direction — `worktrees_removed` neither grew nor shrank on today's snapshot (no worktree in the current fleet happens to be a clean, tmux-less, register-in-flight worktree at this exact instant; that scenario is exercised deterministically by the pytest suite via forced register state, per the dispatch's own note that "a momentopname is geen eindstand"). The 8 real worktrees still classified `removed` are old glm_gate/kimi_gate/panel-diverge ephemeral runs, spot-checked as genuinely stale.

## Open Items
None.

**Dispatch-ID**: 20260823-alpha-a3-worktree-levensteken
**Model**: sonnet
**Provider**: claude