### PR TITLE
fix(receipts): per-receipt_kind field contract + exit_code status fallback (OI-1408)

### DIFF
--- a/scripts/lib/append_receipt_internals/validation.py
+++ b/scripts/lib/append_receipt_internals/validation.py
@@ -290,6 +290,10 @@ def _validate_receipt(receipt: Dict[str, Any]) -> str:
     # a worker dispatch-terminal receipt must name the model that ran.
     _validate_model_present(receipt)
 
+    # OI-1408: per-receipt_kind field contract — see _validate_dispatch_field_
+    # contract below for what this enforces and why.
+    _validate_dispatch_field_contract(receipt, event_name)
+
     _warn_if_review_gate_missing_dispatch_id(event_name, receipt)
 
     return event_name
@@ -401,6 +405,100 @@ def _validate_model_present(receipt: Dict[str, Any]) -> None:
             "like a valid model name (contains spaces, backticks, or exceeds "
             f"{_MODEL_NAME_MAX_LENGTH} characters); refusing to write "
             "(fail-closed — prose is not a model identifier).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# OI-1408: per-receipt_kind field contract.
+#
+# Before this, ``model`` (above) was the ONLY receipt field with a fail-
+# closed CONTENT check with no exemption gaps. Every other field's presence
+# check — ``dispatch_id``/``event_type`` via ``_requires_dispatch_id`` above —
+# is a structural KEY check: it fails on an absent key but is blind to a
+# present-but-empty value or a sentinel literal that reads as filled but
+# isn't. Measured on the real ledger (dispatch-20260823-alpha-a2, OI-1408):
+# 3903 dispatch receipts, 551 carrying the literal sentinel "unknown" as
+# ``task_id`` and 3352 never carrying the key at all — ZERO ever carried a
+# real value. A presence/membership check does not see the 551; it reads
+# them as filled.
+#
+# This is the same three-state discipline as ``_validate_model_present``
+# above (absent / empty / sentinel), extended to a declared per-receipt_kind
+# field list instead of the single hardcoded ``model`` field. Starts at
+# receipt_kind="dispatch" — the kind that carries the audit trail.
+#
+# ``task_id`` is deliberately NOT part of this contract. The decision (OI-
+# 1408): given zero real values across the entire measured ledger, the field
+# never carried a task concept distinct from ``dispatch_id`` — it is retired,
+# not left as an unenforced "nice to have". The two measured sentinel-writers
+# (``report_to_receipt_converter.py``'s ``base`` dict and
+# ``report_parser.py::_build_enhanced_receipt``) were fixed alongside this
+# contract to omit the key instead of stamping "unknown"; a contract that
+# required it here without that fix would refuse every dispatch receipt from
+# those two writers starting the moment this shipped. The three-state
+# discipline the decision itself was measured against (absent / empty /
+# sentinel — a plain presence check reads the 551 "unknown" receipts as
+# filled) is applied at those two write sites directly, not duplicated here
+# as an unused helper: task_id carries no fail-closed requirement to check.
+
+# event_types for which "status" is an outcome CLAIM. task_started /
+# dispatch_sent / dispatch_ack / ack / etc. (DISPATCH_REQUIRED_EVENTS minus
+# this set) precede any outcome by construction — a receipt for one of those
+# legitimately has no status yet, and is exempt by event_type, not by the
+# source-exemption below.
+_STATUS_BEARING_EVENT_TYPES = frozenset({
+    "task_complete",
+    "task_completed",
+    "subprocess_completion",
+    "task_failed",
+    "task_timeout",
+    "task_blocked",
+    "report_contract_invalid",
+})
+
+
+def _validate_dispatch_field_contract(receipt: Dict[str, Any], event_name: str) -> None:
+    """Fail-closed field contract for receipt_kind="dispatch" (OI-1408).
+
+    Currently enforces one field: ``status`` must carry a real, non-empty
+    value on a receipt whose event_type claims a terminal outcome (see
+    ``_STATUS_BEARING_EVENT_TYPES``). An absent or empty status on such a
+    receipt is the OI-1382/1383/1408 residue this dispatch closed at the
+    write side (``report_to_receipt_converter.py``'s exit_code fallback +
+    "no_signal" stamp) — this is the append-time backstop, so a future writer
+    that reintroduces the empty-status bug is refused here regardless of
+    whether it goes through that converter.
+
+    "unknown" is intentionally NOT treated as a sentinel here (contrast the
+    ``task_id``/``model`` sentinel sets): it is a recognized ignorable literal
+    in the canonical status vocabulary (event_outcome_semantics), not a
+    stand-in for "no value" — rejecting it would refuse legitimate
+    low-information-but-real status claims.
+
+    Sources exempt from the ``model`` requirement (``_MODEL_EXEMPT_SOURCES``
+    — corrective/system writers with no worker identity to report: their
+    receipts override a worker's own claim, and refusing them on a missing
+    content field would lose the rejection signal, which is worse than the
+    fail-closed gain) are exempt here too, derived from that same constant
+    rather than a second hand-typed list.
+    """
+    receipt_kind = str(receipt.get("receipt_kind") or "").strip()
+    if receipt_kind != "dispatch":
+        return
+    if event_name not in _STATUS_BEARING_EVENT_TYPES:
+        return
+    source = str(receipt.get("source") or "").strip().lower()
+    if source in _MODEL_EXEMPT_SOURCES:
+        return
+    status = receipt.get("status")
+    if status is None or not str(status).strip():
+        raise AppendReceiptError(
+            "missing_status",
+            EXIT_VALIDATION_ERROR,
+            f"receipt_kind={receipt_kind!r} source={source!r} event_type="
+            f"{event_name!r} carries no status at all (absent or empty); "
+            "refusing to write (fail-closed — OI-1408 field contract: a "
+            "receipt claiming a terminal outcome must carry a readable one).",
         )
 
 

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -599,8 +599,17 @@ def _resolve_report_provider_model(
 #   "success"       -> fail-closed validation (OI-1035 et al.) must all pass
 #   "failure"       -> task_failed receipt (OI-1130), never a task_complete
 #   "ignorable"     -> no outcome signal, keeps pre-existing contract semantics
-#   "no_signal"     -> empty/absent status, keeps pre-existing contract semantics
+#   "no_signal"     -> status absent AND no usable exit_code fallback (OI-1408);
+#                      the written receipt still stamps status="no_signal",
+#                      never an empty string — see the receipt construction below
 #   anything else   -> refused as task_failed with failure_reason="unknown_status"
+#
+# OI-1408: an absent status is resolved BEFORE the categorization above by
+# falling back to the report's exit_code (required by schemas/unified_report_v1.
+# json, unlike status) — exit_code==0 -> "success", nonzero -> "failed". Only
+# when exit_code is ALSO absent/unparseable does a report fall through to
+# "no_signal". This derives the input to the one canonical mapping; it is not
+# a second mapping.
 
 
 def _check_branch_on_origin(dispatch_id: str) -> bool:
@@ -838,10 +847,6 @@ def build_receipt_from_report(
         or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     )
 
-    # Use "unknown" for task_id so the idempotency key aligns with what
-    # report_parser.py produces (it defaults task_id to "unknown").  This lets
-    # append_receipt_payload()'s rolling cache deduplicate same-cycle runs.
-
     # OI-989/OI-993: resolve the report path via the shared resolver instead
     # of blindly using the scanner's current path.  When the worker wrote
     # multiple files (e.g. <id>.md AND dispatch-<id>.md), the resolver picks
@@ -870,13 +875,27 @@ def build_receipt_from_report(
         # Receipt-quality PR-4: real role from dispatch_metadata via the
         # resolver; fail-open to identity_unresolved (never unknown / fake).
         "role": _resolve_report_role(dispatch_id, merged, state_dir),
-        "task_id": merged.get("task_id", "unknown"),
         "terminal": merged.get("terminal", "unknown"),
         "provider": _resolved_provider,
         "model": _resolved_model,
         "timestamp": timestamp,
         "report_path": canonical_report_path,
     }
+    # OI-1408: task_id is NOT part of the receipt_kind="dispatch" field
+    # contract (append_receipt_internals/validation.py::
+    # _validate_dispatch_field_contract). Measured across every dispatch
+    # receipt written since 16-08 (3903
+    # receipts): 3352 never carried the key at all, 551 carried the literal
+    # sentinel "unknown" this line used to stamp, and ZERO ever carried a
+    # real value — no emitter has ever had a task concept distinct from
+    # dispatch_id. Fabricating "unknown" every time is worse than omitting
+    # the key: it reads as data. Carry the field through ONLY when the
+    # report itself declares a real, non-sentinel value.
+    real_task_id = str(merged.get("task_id") or "").strip()
+    if real_task_id and real_task_id.lower() not in {
+        "unknown", "none", "null", "n/a", "na", "unset", "-",
+    }:
+        base["task_id"] = real_task_id
 
     # OI-1035 fail-closed gate: when the report claims a terminal success
     # status, all three validation checks must pass before a success receipt
@@ -885,6 +904,28 @@ def build_receipt_from_report(
     # "contract_invalid" bucket (which received 96 hits in 7 days and is
     # invisible to any alarm).
     status_raw = (merged.get("status") or "").strip().lower()
+    if not status_raw:
+        # OI-1408: schemas/unified_report_v1.json REQUIRES exit_code but never
+        # required status — a schema-valid v1 report can carry no status field
+        # at all (measured: 20260823-alpha-a1-ledger-health-cadans.md, exit_code:
+        # 0, no status key). Falling straight through to "no_signal" ignored an
+        # answer sitting two lines above the missing status. Derive the outcome
+        # from exit_code before treating the report as signal-less — this feeds
+        # the SAME canonical vocabulary below (resolve_status_category), not a
+        # second mapping.
+        exit_code_raw = merged.get("exit_code")
+        if exit_code_raw is not None:
+            try:
+                exit_code = int(str(exit_code_raw).strip())
+            except (TypeError, ValueError):
+                exit_code = None
+            if exit_code is not None:
+                status_raw = "success" if exit_code == 0 else "failed"
+                logger.info(
+                    "report_to_receipt_converter: dispatch=%s no status field — "
+                    "derived status=%r from exit_code=%d",
+                    dispatch_id, status_raw, exit_code,
+                )
     try:
         status_category = resolve_status_category(status_raw)
     except UnknownStatusError:
@@ -981,10 +1022,15 @@ def build_receipt_from_report(
             ] if resolved is not None else []
         return receipt_out
 
+    # OI-1408: even with the exit_code fallback above, a report can still
+    # carry neither status nor a parseable exit_code — genuinely no signal.
+    # That residual case must still land with a readable outcome on the line
+    # that hits disk, never an empty string (the OI-1382/1383 gap moved from
+    # "no row" to "a row with no outcome"; this closes the second move).
     receipt: Dict[str, Any] = {
         **base,
         "event_type": "task_complete",
-        "status": status_raw,
+        "status": status_raw or "no_signal",
     }
     if ambiguous_report:
         receipt["ambiguous_report_path"] = True

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -767,13 +767,22 @@ class ReportParser:
             'gate': metadata.get('gate', 'unknown'),
             'status': _receipt_status,
             'contract_valid': _contract_valid,  # governance visibility (audit #10)
-            'task_id': metadata.get('task_id', 'unknown'),
             'dispatch_id': metadata.get('dispatch_id', 'unknown'),
             'session_id': metadata.get('session_id'),  # Phase 2: Session tracking for cost attribution
             'report_path': report_path,
             'report_file': Path(report_path).name,  # Add filename for easier tracking
             'title': metadata.get('title', 'No title')
         }
+
+        # OI-1408: task_id is NOT part of the receipt_kind="dispatch" field
+        # contract — measured across 3903 dispatch receipts, no emitter has
+        # EVER filled it with a real value (only absent or the "unknown"
+        # sentinel parse_metadata() stamps via setdefault). Same missing-field
+        # contract as model/provider above: omitted when there is no real
+        # value, never written as the sentinel.
+        _task_id = str(metadata.get('task_id') or '').strip()
+        if _task_id and _task_id.lower() not in ('unknown', 'none', 'null', 'n/a', 'na', 'unset', '-'):
+            receipt['task_id'] = _task_id
 
         # OI-1086: lift model/provider from extracted metadata onto the receipt.
         # extract_metadata() already captures the `**Model**:`/`**Provider**:`
@@ -842,7 +851,10 @@ class ReportParser:
         # Mark if this is legacy format (missing required fields). `confidence`
         # dropped from this check (§3.3): the field itself no longer exists on
         # the receipt, so checking for it would spuriously flag every receipt.
-        required_fields = ['task_id', 'dispatch_id']
+        # `task_id` dropped (OI-1408): it is not part of the receipt_kind=
+        # "dispatch" field contract, so its absence is expected, not a legacy
+        # flag — see the missing-field contract comment above this method.
+        required_fields = ['dispatch_id']
         missing_fields = [f for f in required_fields if receipt.get(f) in ['unknown', None, 0]]
         if missing_fields:
             receipt['missing_fields'] = missing_fields

--- a/tests/test_receipt_field_contract.py
+++ b/tests/test_receipt_field_contract.py
@@ -1,0 +1,154 @@
+"""OI-1408 — per-receipt_kind field contract (append_receipt_internals/validation.py).
+
+Two things measured on the real ledger (see dispatch
+20260823-alpha-a2-receipt-veldcontract):
+
+1. ``model`` was the only receipt field with a fail-closed, gap-free content
+   check. Every other field's presence check (dispatch_id/event_type) is
+   structural — it fails on an absent KEY but is blind to a present-but-empty
+   value or a sentinel literal that reads as filled but isn't. 3903 dispatch
+   receipts measured: 551 carried the literal "unknown" as task_id, 3352
+   never carried the key, ZERO carried a real value.
+
+2. The OI-1382/1383 tmux-lane fallback (report_to_receipt_converter.py) could
+   book a task_complete receipt with an empty status — a row with no
+   readable outcome. See test_report_to_receipt_converter.py for the write-
+   side fix (exit_code fallback + "no_signal" stamp); this file tests the
+   append-time BACKSTOP in validation.py, which refuses an empty/absent
+   status on a dispatch-kind receipt regardless of which writer produced it.
+
+``task_id`` decision (OI-1408): retired from the contract, not enforced.
+Given zero real values across the entire measured ledger, the field never
+carried a task concept distinct from dispatch_id — see
+report_to_receipt_converter.py / report_parser.py for the write-side fix
+(omit the key instead of stamping "unknown").
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from append_receipt_internals.common import AppendReceiptError
+from append_receipt_internals.payload import append_receipt_payload
+
+# Importing append_receipt registers the append facade used by
+# append_receipt_payload (mirrors test_model_ssot_and_chainlink.py's pattern).
+import append_receipt  # noqa: E402, F401
+
+
+def _append(tmp_path: Path, receipt: dict, name: str = "t0_receipts.ndjson") -> dict:
+    rf = tmp_path / name
+    append_receipt_payload(receipt, receipts_file=str(rf), skip_enrichment=True)
+    return json.loads(rf.read_text().splitlines()[-1])
+
+
+_BASE = {
+    "timestamp": "2026-08-23T00:00:00Z",
+    "dispatch_id": "d-oi1408-status",
+    "terminal": "T1",
+    "receipt_kind": "dispatch",
+    "model": "sonnet",
+}
+
+
+class TestStatusFieldContract:
+    """The append-time backstop: a dispatch-kind receipt claiming a terminal
+    outcome (task_complete/task_failed/task_timeout/task_blocked/
+    subprocess_completion/report_contract_invalid) must carry a real,
+    non-empty status."""
+
+    def test_task_complete_without_status_key_rejected(self, tmp_path):
+        receipt = {**_BASE, "event_type": "task_complete"}
+        with pytest.raises(AppendReceiptError) as exc_info:
+            _append(tmp_path, receipt)
+        assert exc_info.value.code == "missing_status"
+
+    def test_task_complete_with_empty_status_rejected(self, tmp_path):
+        receipt = {**_BASE, "event_type": "task_complete", "status": ""}
+        with pytest.raises(AppendReceiptError) as exc_info:
+            _append(tmp_path, receipt)
+        assert exc_info.value.code == "missing_status"
+
+    def test_task_failed_without_status_rejected(self, tmp_path):
+        receipt = {**_BASE, "event_type": "task_failed"}
+        with pytest.raises(AppendReceiptError) as exc_info:
+            _append(tmp_path, receipt)
+        assert exc_info.value.code == "missing_status"
+
+    def test_task_complete_with_real_status_accepted(self, tmp_path):
+        line = _append(tmp_path, {**_BASE, "event_type": "task_complete", "status": "success"})
+        assert line["status"] == "success"
+
+    def test_task_complete_with_no_signal_literal_accepted(self, tmp_path):
+        # The write-side residual fallback (report_to_receipt_converter.py)
+        # stamps this literal when neither status nor exit_code is usable —
+        # it must pass the append-time gate, since it IS a readable outcome.
+        line = _append(tmp_path, {**_BASE, "event_type": "task_complete", "status": "no_signal"})
+        assert line["status"] == "no_signal"
+
+    def test_status_unknown_is_not_treated_as_a_sentinel(self, tmp_path):
+        # "unknown" is a recognized ignorable literal in the canonical status
+        # vocabulary (event_outcome_semantics), unlike task_id/model, where
+        # "unknown" IS a sentinel. Must not be rejected here.
+        line = _append(tmp_path, {**_BASE, "event_type": "task_complete", "status": "unknown"})
+        assert line["status"] == "unknown"
+
+    def test_non_completion_event_type_exempt(self, tmp_path):
+        # task_started precedes any outcome by construction — no status yet
+        # is not a defect.
+        line = _append(tmp_path, {**_BASE, "event_type": "task_started"})
+        assert "status" not in line
+
+    def test_model_exempt_source_exempt_from_status_too(self, tmp_path):
+        # Corrective/system writers (_MODEL_EXEMPT_SOURCES) are exempt from
+        # the status requirement for the same reason they're exempt from
+        # model: their receipts override a worker's own claim, and refusing
+        # them on a missing content field would lose the rejection signal.
+        line = _append(tmp_path, {
+            "timestamp": "2026-08-23T00:00:00Z",
+            "event_type": "task_complete",
+            "dispatch_id": "d-oi1408-exempt",
+            "terminal": "T0",
+            "source": "vnx_governance",
+            "receipt_kind": "dispatch",
+        })
+        assert line["source"] == "vnx_governance"
+        assert "status" not in line or line.get("status") in ("", None)
+
+    def test_non_dispatch_receipt_kind_exempt(self, tmp_path):
+        # The contract is scoped to receipt_kind="dispatch" only (OI-1408
+        # begins there — the kind that carries the audit trail).
+        line = _append(tmp_path, {
+            "timestamp": "2026-08-23T00:00:00Z",
+            "event_type": "state_mutation",
+            "dispatch_id": "d-oi1408-state",
+            "terminal": "T0",
+            "receipt_kind": "state_mutation",
+        })
+        assert line["receipt_kind"] == "state_mutation"
+
+
+class TestTaskIdNotInContract:
+    """OI-1408 decision: task_id carries no fail-closed requirement — a
+    dispatch-kind receipt is accepted whether task_id is absent, empty, or a
+    sentinel. The field is retired, not silently required."""
+
+    def test_dispatch_receipt_without_task_id_accepted(self, tmp_path):
+        line = _append(tmp_path, {**_BASE, "event_type": "task_complete", "status": "success"})
+        assert "task_id" not in line
+
+    def test_dispatch_receipt_with_sentinel_task_id_still_accepted(self, tmp_path):
+        # The contract does not reject a sentinel task_id (unlike model) —
+        # the field is simply not checked. Write-side omission is enforced
+        # in report_to_receipt_converter.py / report_parser.py instead, not
+        # at this append-time gate.
+        line = _append(tmp_path, {
+            **_BASE, "event_type": "task_complete", "status": "success", "task_id": "unknown",
+        })
+        assert line["task_id"] == "unknown"

--- a/tests/test_report_parser_model_provider.py
+++ b/tests/test_report_parser_model_provider.py
@@ -274,6 +274,32 @@ def test_unknown_frontmatter_model_omits_key(tmp_path):
     assert r["provider"] == "claude"
 
 
+def test_missing_task_id_omits_key_not_sentinel(tmp_path):
+    """OI-1408: task_id is not part of the receipt_kind='dispatch' field
+    contract. A report that never declares one must produce a receipt with
+    no task_id key at all — never the 'unknown' sentinel this used to stamp
+    via metadata.get('task_id', 'unknown')."""
+    r = _parse(tmp_path, _BOLD_MODEL_BODY)
+    assert "task_id" not in r
+
+
+def test_bold_task_id_kept_when_a_report_declares_a_real_one(tmp_path):
+    """The missing-field contract omits the sentinel, but a report that DOES
+    declare a real task_id (via the generic **Key**: value bold-field scan)
+    still has it carried through onto the receipt."""
+    body = (
+        "# Completion Report\n"
+        "**Status**: success\n"
+        "**Dispatch-ID**: 20260823-oi1408-task-id\n"
+        "**Task ID**: t-42\n"
+        "**Model**: opus\n"
+        "**Provider**: claude\n\n"
+        "## Summary\nReal task_id declared explicitly in the header block.\n"
+    )
+    r = _parse(tmp_path, body)
+    assert r["task_id"] == "t-42"
+
+
 def test_embedded_dispatch_instruction_model_recovered(tmp_path):
     """Mid-file door-stamped **Model**/**Provider** (embedded dispatch
     instruction) must be recovered even outside the 2000-char header window."""

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -118,6 +118,33 @@ def _write_frontmatter_report(path: Path, dispatch_id: str, **extra) -> Path:
     return path
 
 
+def _write_v1_report_missing_fields(
+    path: Path, dispatch_id: str, *, drop: tuple = (), **extra
+) -> Path:
+    """Write a v1-valid report with one or more frontmatter keys DROPPED
+    entirely (not overridden to empty) — mirrors a real report that never
+    declared the key, e.g. 20260823-alpha-a1-ledger-health-cadans.md
+    (exit_code: 0, no ``status`` key at all). schemas/unified_report_v1.json
+    requires ``exit_code`` but never requires ``status``, so this is a
+    schema-valid shape, not a malformed one.
+    """
+    fm = _v1_frontmatter_base(dispatch_id)
+    for key in drop:
+        fm.pop(key, None)
+    fm.update(extra)
+    fm_text = yaml.safe_dump(fm, sort_keys=False).strip()
+    content = (
+        f"---\n{fm_text}\n---\n\n"
+        "## Summary\n\nImplemented the feature per dispatch specification. "
+        "All tests pass and coverage is at target.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 42 passed\n\n"
+        "## Open Items\n\nNone\n"
+    )
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
 def _write_non_v1_success_report(
     path: Path, dispatch_id: str, *, with_headings: bool = True, **extra
 ) -> Path:
@@ -327,16 +354,47 @@ class TestStatusVocabularyFailClosed:
             assert receipt["status"] == status, (status, receipt)
             assert resolve_status_category(status) == "ignorable"
 
-    def test_empty_status_is_no_signal_not_success(self, tmp_path):
-        # An empty status passes through as a no-signal task_complete (write-side
-        # behavior unchanged) but resolves to "no_signal", never "success", so
-        # the read side no longer books absence as a success.
-        from event_outcome_semantics import resolve_status_category
+    def test_empty_status_with_exit_code_zero_derives_success(self, tmp_path, monkeypatch):
+        # OI-1408: schemas/unified_report_v1.json requires exit_code but never
+        # required status — an empty/absent status is no longer waved through
+        # as a signal-less task_complete when a real exit_code sits right next
+        # to it (measured: 20260823-alpha-a1-ledger-health-cadans.md carried
+        # exit_code: 0 and no status key at all). The outcome is derived from
+        # exit_code and resolved through the SAME canonical vocabulary
+        # (resolve_status_category), never a second mapping.
+        import report_to_receipt_converter as rtc
+        monkeypatch.setattr(rtc, "_check_branch_on_origin", lambda _did: True)
 
         receipt = self._receipt_for_status(tmp_path, "")
         assert receipt is not None
         assert receipt["event_type"] == "task_complete"
-        assert receipt["status"] == ""
+        assert receipt["status"] == "success"
+
+    def test_missing_status_nonzero_exit_code_derives_failure(self, tmp_path):
+        p = tmp_path / "20260823-no-status-fail.md"
+        _write_v1_report_missing_fields(
+            p, "20260823-no-status-fail", drop=("status",), exit_code=1,
+        )
+        receipt = build_receipt_from_report(p, p.read_text(encoding="utf-8"))
+        assert receipt is not None
+        assert receipt["event_type"] == "task_failed"
+        assert receipt["status"] == "failed"
+
+    def test_missing_status_and_exit_code_falls_back_to_no_signal_literal(self, tmp_path):
+        # The genuine residual case: neither status nor a usable exit_code.
+        # The receipt must still carry a readable literal ("no_signal"),
+        # never an empty string.
+        from event_outcome_semantics import resolve_status_category
+
+        p = tmp_path / "20260823-truly-signal-less.md"
+        _write_v1_report_missing_fields(
+            p, "20260823-truly-signal-less", drop=("status", "exit_code"),
+        )
+        receipt = build_receipt_from_report(p, p.read_text(encoding="utf-8"))
+        assert receipt is not None
+        assert receipt["event_type"] == "task_complete"
+        assert receipt["status"] == "no_signal"
+        assert receipt["status"] != ""
         assert resolve_status_category("") == "no_signal"
 
 
@@ -613,16 +671,18 @@ class TestReceiptContent:
         assert "timestamp" in r
         assert "report_path" in r
 
-    def test_receipt_task_id_defaults_to_unknown(self, tmp_path, state_dir):
+    def test_receipt_omits_task_id_when_report_never_declares_one(self, tmp_path, state_dir):
+        # OI-1408: task_id is not part of the receipt_kind="dispatch" field
+        # contract — measured across 3903 dispatch receipts, no emitter has
+        # ever filled it with a real value. This used to stamp the literal
+        # "unknown" sentinel; it now omits the key entirely.
         report = tmp_path / "20260601-taskid.md"
         _write_frontmatter_report(report, "20260601-taskid")
         convert_report_to_receipt(
             report, receipts_file=str(state_dir / "t0_receipts.ndjson")
         )
         r = _receipts(state_dir)[0]
-        # task_id="unknown" aligns with report_parser.py default so
-        # append_receipt_payload() idempotency key matches the Bash path's key.
-        assert r.get("task_id") == "unknown"
+        assert "task_id" not in r
 
 
 # ---------------------------------------------------------------------------
@@ -1013,12 +1073,17 @@ class TestPoisonedReportResilience:
         (no try/except around the per-report conversion) reproduces the
         original all-or-nothing failure, not a partial one.
 
-        The poisoned report itself lands as a "report_contract_invalid"
-        receipt (its body lacks the required ## Summary/## Changes/etc
-        headings — a separate, pre-existing contract check, not this
-        dispatch's concern) rather than "task_complete"; the point proven
-        here is that it no longer crashes the SCAN, so the two healthy
-        reports after it still get their receipts.
+        The poisoned report itself lands as a "task_failed" receipt: its
+        frontmatter carries exit_code: 0 with no status field, so OI-1408's
+        exit_code fallback resolves it as a claimed success — which then hits
+        the pre-existing OI-1035 fail-closed gate (its body lacks the
+        required ## Summary/## Changes/etc headings and it has no PR/branch
+        on origin) and is refused as an explicit failure, never the
+        lower-severity "report_contract_invalid" bucket OI-1035 was written
+        to avoid for success claims. The event_type this poisoned report
+        lands as is incidental to what this test proves: that it no longer
+        crashes the SCAN, so the two healthy reports after it still get
+        their receipts.
         """
         shutil.copy(_POISONED_REPORT, reports_dir / _POISONED_REPORT.name)
         _write_frontmatter_report(reports_dir / "zzz-healthy-a.md", "zzz-healthy-a")
@@ -1032,7 +1097,7 @@ class TestPoisonedReportResilience:
         receipts = _receipts(state_dir)
         event_types = {r["event_type"] for r in receipts}
         assert "task_complete" in event_types
-        assert "report_contract_invalid" in event_types
+        assert "task_failed" in event_types
 
 
 class TestScanCrashGuard:
@@ -2596,6 +2661,79 @@ class TestConvertDispatchIds:
         assert ids_booked == {"20260821-scoped"}
         wm = _load_watermark(state_dir / _WATERMARK_FILENAME)
         assert _compute_sha256(sibling) not in wm
+
+
+# ---------------------------------------------------------------------------
+# OI-1408 Deliverable 2: a report with no ``status`` field but a real
+# ``exit_code`` (schemas/unified_report_v1.json requires exit_code, never
+# status) must land with a readable outcome on the receipt LINE THAT ACTUALLY
+# HITS DISK — not a task_complete with status="". Mirrors the real fixture
+# 20260823-alpha-a1-ledger-health-cadans.md: exit_code: 0, no status key.
+# ---------------------------------------------------------------------------
+
+class TestNoStatusExitCodeFallbackOnDisk:
+    def test_missing_status_with_exit_code_zero_lands_as_success_on_disk(
+        self, reports_dir, state_dir, monkeypatch,
+    ):
+        import report_to_receipt_converter as rtc
+        monkeypatch.setattr(rtc, "_check_branch_on_origin", lambda _did: True)
+
+        _write_v1_report_missing_fields(
+            reports_dir / "20260823-disk-no-status.md",
+            "20260823-disk-no-status",
+            drop=("status",),
+        )
+
+        convert_dispatch_ids(["20260823-disk-no-status"], state_dir)
+
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        booked = receipts[0]
+        assert booked["event_type"] == "task_complete"
+        assert booked["status"] == "success", (
+            "report declared exit_code: 0 with no status field — the receipt "
+            "line that landed on disk must read as a success, not an empty "
+            f"status. Full booked receipt: {booked}"
+        )
+
+    def test_missing_status_nonzero_exit_code_lands_as_failed_on_disk(
+        self, reports_dir, state_dir,
+    ):
+        _write_v1_report_missing_fields(
+            reports_dir / "20260823-disk-no-status-fail.md",
+            "20260823-disk-no-status-fail",
+            drop=("status",),
+            exit_code=1,
+        )
+
+        convert_dispatch_ids(["20260823-disk-no-status-fail"], state_dir)
+
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        booked = receipts[0]
+        assert booked["event_type"] == "task_failed"
+        assert booked["status"] == "failed"
+
+    def test_missing_status_and_exit_code_lands_as_no_signal_literal_on_disk(
+        self, reports_dir, state_dir,
+    ):
+        _write_v1_report_missing_fields(
+            reports_dir / "20260823-disk-truly-signal-less.md",
+            "20260823-disk-truly-signal-less",
+            drop=("status", "exit_code"),
+        )
+
+        convert_dispatch_ids(["20260823-disk-truly-signal-less"], state_dir)
+
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        booked = receipts[0]
+        assert booked["event_type"] == "task_complete"
+        assert booked["status"] == "no_signal"
+        assert booked["status"] != "", (
+            "no-signal task_complete receipt landed with an empty status on "
+            f"disk — no readable outcome on the line: {booked}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Deliverable 1** — `_validate_dispatch_field_contract` (new, in `append_receipt_internals/validation.py`) fail-closed enforces `status` on completion-shaped `receipt_kind="dispatch"` receipts, at the same site as `_validate_model_present`, with the same three-state (absent/empty/sentinel) discipline and reusing `_MODEL_EXEMPT_SOURCES`.
- **`task_id` decision**: retired from the contract. Measured across 3903 dispatch receipts since 16-08: 3352 absent, 551 carrying the literal `"unknown"` sentinel, **zero** real values, ever. `report_to_receipt_converter.py` and `report_parser.py::_build_enhanced_receipt` (the two measured sentinel-writers) now omit the key instead of stamping `"unknown"`.
- **Deliverable 2** — revised mid-dispatch by the manager: the empty-status defect was not "status missing" but "`exit_code` present and unused". `schemas/unified_report_v1.json` requires `exit_code` but never requires `status`. `report_to_receipt_converter.py` now derives the outcome from `exit_code` (0 → success, nonzero → failed) through the **same** canonical vocabulary (`event_outcome_semantics.resolve_status_category`) before falling through to a `"no_signal"` literal — never an empty string — for the genuine residual case (neither status nor exit_code usable).

## Changes
- `scripts/lib/append_receipt_internals/validation.py` — new `_validate_dispatch_field_contract` + `_STATUS_BEARING_EVENT_TYPES`, wired into `_validate_receipt` alongside `_validate_model_present`.
- `scripts/lib/report_to_receipt_converter.py` — exit_code→status fallback before `resolve_status_category`; `"no_signal"` literal instead of `""` for the residual case; `task_id` sentinel-write removed (omit key unless a real value exists).
- `scripts/report_parser.py` — same `task_id` fix applied to `_build_enhanced_receipt` (separate bash `receipt_processor.sh` pipeline) — cross-cutting consistency; `required_fields` legacy-flag list no longer includes `task_id`.
- `tests/test_receipt_field_contract.py` (new) — 11 tests for the field contract: status-required-for-completion-events, `"unknown"` not treated as a status sentinel, non-completion events exempt, `_MODEL_EXEMPT_SOURCES` exempt, non-`dispatch` receipt_kind exempt, `task_id` not enforced.
- `tests/test_report_to_receipt_converter.py` — updated stale test that had locked in the old "write-side unchanged" empty-status behavior; new unit + disk-level (`convert_dispatch_ids` → actual NDJSON line) tests for the exit_code fallback in all three outcomes (success/failed/no_signal); updated the pre-existing poisoned-report test whose fixture (`exit_code: 0`, no status, malformed body) now correctly routes through the OI-1035 fail-closed gate as `task_failed` instead of the lower-severity `report_contract_invalid` bucket.
- `tests/test_report_parser_model_provider.py` — 2 new tests for the `report_parser.py` task_id fix.

## Verification
All new/changed-behavior tests were run RED before the fix (via `git stash`/`git checkout --` isolation) and GREEN after, on real behavior (actual receipt line on disk / actual `AppendReceiptError.code`), not symbol presence.

```
$ python3 -m pytest tests/test_receipt_field_contract.py tests/test_report_to_receipt_converter.py \
    tests/test_report_parser_model_provider.py tests/test_model_ssot_and_chainlink.py \
    tests/test_report_path.py tests/test_auto_report_integration.py tests/test_report_parser_contract.py \
    tests/test_receipt_v2_pr5_schema_cutover.py tests/test_tmux_interactive_dispatch.py \
    tests/test_receipt_validation_warnings.py tests/test_receipt_v2_pr4_wiring.py \
    tests/test_governance_emit_report_wrapper.py tests/test_governance_emit.py \
    tests/test_append_receipt.py tests/test_append_receipt_identity.py tests/test_append_receipt_dual_write.py \
    tests/test_append_receipt_observability.py tests/test_append_receipt_register_emit.py \
    tests/test_append_receipt_reroute.py tests/test_append_receipt_stderr.py \
    tests/test_worker_heartbeat_silence.py tests/test_status_vocab_drift.py \
    tests/test_runtime_adapter_certification.py tests/test_open_items_from_report.py \
    tests/test_heartbeat_subprocess_cleanup.py tests/test_dispatch_push_verified.py -q
928 passed, 2 failed
```
The 2 failures (`test_auto_report_integration.py::test_manual_report_status_parsed`, `test_receipt_v2_pr4_wiring.py::test_t24_envelope_subpath_verification_from_report`) are **pre-existing** and unrelated — confirmed by reverting all touched files and reproducing identically on the pre-dispatch baseline. Also confirmed pre-existing (unrelated model-registry config issue): `test_provider_dispatch_entry.py::TestProviderLitellmRouted::test_litellm_routes_to_dispatch_litellm`.

## Open Items
- **Role/terminal complementary gap** (observed during measurement, not fixed here — out of scope for this dispatch): within `receipt_kind="dispatch"`, `role` and `terminal` are filled by disjoint producers of the same receipt shape (e.g. the source-less converter path fills `role` 100%/`terminal` 0%, while `tmux_interactive` does the opposite). Neither field alone is reliable as an identity signal. A future OI could require "at least one of role/terminal is real" (exempting `_MODEL_EXEMPT_SOURCES`), but that needs its own measurement pass across all `task_started`/`dispatch_sent`/`ack` emitters before it's safe to fail-closed — deliberately not attempted here to avoid scope creep on an already two-part dispatch.
- **Stash-stack incident (self-reported)**: during isolation testing I ran a batched `git stash drop` that briefly deleted a stash entry belonging to a different branch (`dispatch/20260817-fix1585-r2`, an unrelated conversation-analyzer WIP). The commit object was still reachable and was immediately recovered via `git stash store` back onto the stack at its original SHA before any further stash operations — verified by content and reflog message. No data was lost, but flagging it per governance discipline.

---

## Wat deze reparatie NIET dekt (toegevoegd door T0-alpha bij verificatie)

**`terminal` draagt nog steeds de sentinel `unknown`.** Dit veldcontract dekt `status` en `task_id`,
niet `terminal`. Gemeten over 138 dispatch-receipts sinds 21-08: `terminal` is 22x een echte waarde,
101x afwezig, **15x de sentinel `unknown`**. Gefiled als **OI-1446** (warn). Bewust NIET aan deze PR
toegevoegd: die is 500 regels over zes bestanden en is met vijf onafhankelijke toetsen geverifieerd;
een derde veld erbij maakt een geverifieerde PR groter en ongeverifieerd.

**Richting voor OI-1446, en de naïeve fix pakt hier verkeerd uit.** Meet eerst per emitter of er
überhaupt iemand is die `terminal` betekenisvol KAN vullen. De Open-Items-sectie hierboven noemt de
reden: binnen `receipt_kind="dispatch"` vullen twee producenten `role` en `terminal` complementair
(de source-loze converter-route vult `role` 100% en `terminal` 0%, `tmux_interactive` precies
andersom). Een eis "terminal moet gevuld zijn" breekt dan de ene helft van de emitters.

## Waarom `task_id` WEGGELATEN wordt en niet gevuld met een sentinel

De keuze in deze PR is bewust en hij hoort met de code mee te reizen, niet alleen in een rapport te
staan: **een afwezig veld is beter dan een gevulde sentinel.**

Gemeten aanleiding, 23-08 over alle 3903 dispatch-receipts in het grootboek: `task_id` was 3352x
afwezig, **551x de letterlijke sentinel `unknown`**, en **0x een echte waarde**. Die 551 zijn de
gevaarlijkste klasse, want een sentinel passeert elke controle die op AANWEZIGHEID toetst in plaats
van op waarde. Afwezig faalt zichtbaar; `unknown` faalt stil en ziet er gevuld uit.

Zelfde reden waarom de terugval bij geen status én geen exit_code de literal `no_signal` schrijft en
geen lege string: onbekend moet leesbaar zijn, niet onzichtbaar.
