### PR TITLE
fix(cockpit): governance-enforcement-stack row reads real yaml, not a dead bool (OI-1385)

### DIFF
--- a/dashboard/api_subsystems.py
+++ b/dashboard/api_subsystems.py
@@ -7,10 +7,20 @@ reads the registry directly rather than shelling out to the CLI):
 
   (a) ``config_registry.CONFIG_REGISTRY`` — flag-backed subsystems. Several flags can share one
       subsystem (e.g. every intelligence-tuning flag maps to ``intelligence-self-learning-loop``);
-      the LAST-inserted flag per subsystem is shown as that row's canonical ``flag`` (PR-2's net-new
-      master-switch flags are appended after the pre-existing tuning flags they group).
+      the row's canonical ``flag`` is picked by ``config_registry.canonical_flags()`` (OI-1385) —
+      an EXPLICIT, order-independent rule (a flag with no production read-site can never win; a
+      multi-candidate subsystem needs exactly one flag marked ``cockpit_canonical=True``), not
+      "whichever entry CONFIG_REGISTRY iterates last".
   (b) ``config_registry.CONFIG_REGISTRY_SUBSYSTEMS`` — flag-less kernel subsystems (``phantom_guard``,
       ``dispatch-plan``, ...). Disjoint from (a) by construction (config_registry.py docstring).
+
+``governance-enforcement-stack``'s row is a further exception (OI-1385): its ``effective_value``
+is read directly from ``.vnx/governance_enforcement.yaml`` (via
+``governance_enforcement_effective_value()``), not from its canonical flag's registry value — that
+subsystem is governed by multi-level YAML checks, and the flag that used to be canonical here had
+zero production read-sites (see its ``read_site_wired`` entry in config_registry.py); showing its
+static default read as "parked" while the YAML ran hard-mandatory checks
+(``docs/core/framework-status-audit-and-cockpit_PRD.md:89``).
 
 HEALTH is read-only from ``health_beacon.all_beacons(data_dir)`` — the beacon root is
 ``VNX_DATA_DIR`` (health_beacon writes/reads under ``VNX_DATA_DIR/health``), NOT ``VNX_STATE_DIR``.
@@ -37,6 +47,10 @@ _SUB_SCRIPTS_LIB = str(VNX_DIR / "scripts" / "lib")
 if _SUB_SCRIPTS_LIB not in sys.path:
     sys.path.insert(0, _SUB_SCRIPTS_LIB)
 
+# The real governance-enforcement-stack afdwingniveau source (OI-1385) — read-only, never
+# written by this module. Matches governance_enforcer.DEFAULT_CONFIG_PATH's own derivation.
+_GOVERNANCE_ENFORCEMENT_YAML = VNX_DIR / ".vnx" / "governance_enforcement.yaml"
+
 try:
     import config_registry as _cr  # type: ignore[import]
     _REGISTRY_AVAILABLE = True
@@ -55,14 +69,44 @@ def _now() -> str:
 def _canonical_flags(cr) -> Dict[str, str]:
     """subsystem -> the one flag key shown as the row's canonical ``flag``.
 
-    CONFIG_REGISTRY is insertion-ordered; when several flags share a subsystem the LAST-inserted
-    one wins, matching ``vnx_cli/commands/subsystems.py``'s row-building convention.
+    Delegates to ``config_registry.canonical_flags()`` (OI-1385) — the explicit,
+    order-independent selection rule now lives there as the single source of truth so it can be
+    reused by other consumers of ``CONFIG_REGISTRY`` (e.g. ``vnx_cli/commands/subsystems.py``)
+    instead of re-deriving it. ``cr`` stays a parameter (rather than a bare module-level call)
+    so tests can inject a substitute registry module.
     """
-    canonical: Dict[str, str] = {}
-    for key, entry in cr.CONFIG_REGISTRY.items():
-        if entry.subsystem:
-            canonical[entry.subsystem] = key
-    return canonical
+    return cr.canonical_flags()
+
+
+# The one subsystem whose row's effective_value must NOT come from a CONFIG_REGISTRY bool at
+# all (OI-1385): governance-enforcement-stack is governed by multi-level checks in
+# .vnx/governance_enforcement.yaml, not a single on/off flag, and the flag that used to win
+# canonical selection here has zero production read-sites (config_registry.py:
+# read_site_wired=False). Showing its static default -- '0' -- read as "enforcement is parked"
+# while the yaml ran hard-mandatory checks (framework-status-audit-and-cockpit_PRD.md:89
+# predicted exactly this drift).
+_YAML_SOURCED_SUBSYSTEMS = frozenset({"governance-enforcement-stack"})
+
+
+def governance_enforcement_effective_value(config_path: Path) -> str:
+    """Read-only ``"<mode>:<max_check_level>"`` summary of governance_enforcement.yaml.
+
+    Never returns the registry's stale static bool. Returns the explicit sentinel "unknown" —
+    never a silent "0" -- when the file is missing, unreadable, or malformed: an unknown
+    enforcement level must never read as "off".
+    """
+    try:
+        import governance_enforcer as _ge
+        enforcer = _ge.GovernanceEnforcer()
+        enforcer.load_config(config_path)
+        summary = enforcer.effective_summary()
+        return f"{summary['mode']}:{summary['max_level']}"
+    except Exception:
+        _logger.warning(
+            "governance_enforcement.yaml at %s unreadable; reporting unknown effective value",
+            config_path, exc_info=True,
+        )
+        return "unknown"
 
 
 def build_rows(cr, project_id: Optional[str]) -> List[Dict[str, Any]]:
@@ -82,12 +126,16 @@ def build_rows(cr, project_id: Optional[str]) -> List[Dict[str, Any]]:
 
     for subsystem, flag_key in _canonical_flags(cr).items():
         entry = cr.CONFIG_REGISTRY[flag_key]
+        if subsystem in _YAML_SOURCED_SUBSYSTEMS:
+            effective_value = governance_enforcement_effective_value(_GOVERNANCE_ENFORCEMENT_YAML)
+        else:
+            effective_value = cr.get(flag_key, project_id)
         rows.append({
             "subsystem": subsystem,
             "what": entry.description,
             "flag": flag_key,
             "status": entry.status or "COCKPIT",
-            "effective_value": cr.get(flag_key, project_id),
+            "effective_value": effective_value,
         })
 
     rows.sort(key=lambda r: r["subsystem"])
@@ -127,4 +175,4 @@ def operator_get_subsystems(params: dict, *, project_id: "str | None" = None) ->
     return {"project_id": pid, "subsystems": rows, "queried_at": _now()}, 200
 
 
-__all__ = ["operator_get_subsystems", "build_rows"]
+__all__ = ["operator_get_subsystems", "build_rows", "governance_enforcement_effective_value"]

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -10,8 +10,12 @@ pins (VNX_CODEX_MODEL…), timeouts, internal plumbing, and the `VNX_OVERRIDE_*`
 are deliberately OUT: they stay env-only and are never UI-settable.
 
 DEFAULTS MIRROR THE CURRENT CODE. Every default here is the literal fallback the read-site uses
-today (e.g. `VNX_CI_GATE_REQUIRED` defaults to "0" — off — exactly as `review_gate_manager.py`
-reads it). Changing a default here must never change runtime behaviour vs the env-only world.
+today. Most feature toggles below default "0" (off); `VNX_CI_GATE_REQUIRED` is the exception,
+activated "0" -> "1" on 23-08 (OI-1385) once its 5-read-site enforcement chain was proven live
+(PR #1628) and the obligation-runner's bounded-pending handling for a temporarily-unavailable
+gate was confirmed on main. Changing a default here changes runtime behaviour for any read-site
+consulting it with no env/DB override set — that is the intended mechanism for a deliberate
+activation like this one, not an accident to guard against.
 
 Precedence (highest first), implemented by `get()`:
   1. ``VNX_OVERRIDE_<BARE>`` env var — the operator emergency brake (e.g. VNX_OVERRIDE_SCOUT_PREPASS).
@@ -51,12 +55,22 @@ class ConfigEntry:
     planned: bool = False  # exists in the registry/UI but not yet a live runtime flag
     subsystem: Optional[str] = None  # cockpit MAP grouping — display metadata only
     status: Optional[str] = None  # one of ALLOWED_STATUSES — display metadata only
+    # OI-1385: the cockpit's canonical-flag-per-subsystem selection (canonical_flags()
+    # below) must be an EXPLICIT decision, not "whichever entry is last in this dict".
+    # read_site_wired=False means NO production code consults this flag (a fact, not a
+    # display opinion) — such an entry can never be its subsystem's canonical flag,
+    # structurally, so a flag that later gains a real read-site becomes eligible again
+    # without touching any selection logic. cockpit_canonical=True is the tie-breaker
+    # when a subsystem has more than one read_site_wired entry; exactly one must be set,
+    # or canonical_flags() raises rather than silently picking by dict order.
+    read_site_wired: bool = True
+    cockpit_canonical: bool = False
 
 
 def _e(key, type_, default, category, description, *, writable=True, approval=False, planned=False,
-       subsystem=None, status=None):
+       subsystem=None, status=None, read_site_wired=True, cockpit_canonical=False):
     return ConfigEntry(key, type_, default, category, description, writable, approval, planned,
-                        subsystem, status)
+                        subsystem, status, read_site_wired, cockpit_canonical)
 
 
 # The inventory. Defaults verified against the read-sites (codex review finding: defaults must
@@ -107,12 +121,20 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "separately when VNX_CI_GATE_REQUIRED is on; do not include it here.", approval=True,
         subsystem="governance-enforcement-stack", status="LIVE"),
     "VNX_CI_GATE_REQUIRED": _e(
-        "VNX_CI_GATE_REQUIRED", "bool", "0", "gate",
+        "VNX_CI_GATE_REQUIRED", "bool", "1", "gate",
         "Require the CI gate before merge.", approval=True,
-        subsystem="governance-enforcement-stack", status="PARK"),
+        subsystem="governance-enforcement-stack", status="ACTIVATE",
+        cockpit_canonical=True),
     "VNX_WIRING_GATE_REQUIRED": _e(
         "VNX_WIRING_GATE_REQUIRED", "bool", "0", "gate",
-        "Require the wiring gate.", approval=True,
+        "Require the wiring gate. Shadow mode (0) is a deliberate decision, not an "
+        "oversight (OI-1385): wiring_gate sits on "
+        "closure_verifier._GATES_NOT_IMPLEMENTED_BY_CLOSURE, so the closure verifier "
+        "cannot honestly attest its evidence yet -- promoting to required would let a "
+        "gate produce blocking findings that no sluitingscontrole can verify. Revisit "
+        "when wiring_gate is promoted off that list (pinned by "
+        "test_wiring_gate_shadow_mode_decision_tied_to_closure_verifier_exclusion).",
+        approval=True,
         subsystem="governance-enforcement-stack", status="PARK"),
     "VNX_EVIDENCE_BOUND_GATE": _e(
         "VNX_EVIDENCE_BOUND_GATE", "enum", "advisory", "gate",
@@ -145,13 +167,23 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
     # already existed before this PR (backfilled with subsystem/status in PR-1) and are NOT re-added.
     "VNX_GOVERNANCE_ENFORCED": _e(
         "VNX_GOVERNANCE_ENFORCED", "bool", "0", "gate",
-        "Governance-enforcement-stack master switch (display metadata only; no read-site wired).",
+        "Governance-enforcement-stack master switch (display metadata only; no read-site "
+        "wired -- measured 23-08, OI-1385: sweep of the repo outside .git/.vnx-data finds "
+        "only the definition below, test files, and docs). read_site_wired=False so this "
+        "entry can never win canonical_flags() for its subsystem no matter where it sits "
+        "in this dict; VNX_CI_GATE_REQUIRED is the real, wired flag for "
+        "governance-enforcement-stack.",
         approval=True,
-        subsystem="governance-enforcement-stack", status="PARK"),
+        subsystem="governance-enforcement-stack", status="PARK",
+        read_site_wired=False),
     "VNX_LEARNING_LOOP_ENABLED": _e(
         "VNX_LEARNING_LOOP_ENABLED", "bool", "0", "intelligence",
         "Daily pattern learning / skill refinement / confidence-update loop.",
-        subsystem="intelligence-self-learning-loop", status="ACTIVATE"),
+        subsystem="intelligence-self-learning-loop", status="ACTIVATE",
+        # Explicit canonical pick among this subsystem's 6 flags (OI-1385): preserves the
+        # pre-existing last-wins winner now that canonical_flags() no longer picks by dict
+        # order. Not re-audited by this dispatch — out of scope.
+        cockpit_canonical=True),
     "VNX_DREAM_SCHEDULER_ENABLED": _e(
         "VNX_DREAM_SCHEDULER_ENABLED", "bool", "0", "intelligence",
         "Nightly memory consolidation + pending review dispatch.",
@@ -167,7 +199,10 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "the current filename-only record_adoption_from_receipt behavior (no new reads/writes). "
         "Prerequisite instrumentation for the reason-aware evaluator (PR-B); does not itself "
         "activate the learning loop.",
-        subsystem="injection-effectiveness-eval-loop", status="ACTIVATE"),
+        subsystem="injection-effectiveness-eval-loop", status="ACTIVATE",
+        # Explicit canonical pick (OI-1385): preserves the pre-existing last-wins winner for
+        # this subsystem's 2 flags. Not re-audited by this dispatch — out of scope.
+        cockpit_canonical=True),
     "VNX_PLAN_GATE_COMPLEX_ONLY": _e(
         "VNX_PLAN_GATE_COMPLEX_ONLY", "bool", "0", "gate",
         "Restrict the plan-gate panel to complex features: a LIGHT-scope plan "
@@ -220,7 +255,10 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "VNX_SMART_ROUTER_CANARY_PCT", "string", "0", "dispatch",
         "Canary fraction (0-100) of an enabled tier's traffic routed via the smart "
         "router; the rest follows the legacy path. Deterministic per dispatch.",
-        subsystem="smart-router-staging", status="LIVE"),
+        subsystem="smart-router-staging", status="LIVE",
+        # Explicit canonical pick (OI-1385): preserves the pre-existing last-wins winner for
+        # this subsystem's 5 flags. Not re-audited by this dispatch — out of scope.
+        cockpit_canonical=True),
 
     # Operator directive 2026-08-21 (dispatch-20260821-t0-tmux-concurrency-10): the
     # claude-tmux N-slot lock's concurrency cap, raised from 5 to 10 and made
@@ -376,3 +414,53 @@ def all_effective(project_id: Optional[str] = None) -> List[dict]:
             "status": entry.status,
         })
     return out
+
+
+def canonical_flags(registry: Optional[Dict[str, ConfigEntry]] = None) -> Dict[str, str]:
+    """subsystem -> the one CONFIG_REGISTRY key shown as the cockpit row's canonical ``flag``.
+
+    OI-1385: selection is EXPLICIT, not "whichever entry CONFIG_REGISTRY happens to iterate
+    last" — that insertion-order rule let a flag with zero production read-sites
+    (VNX_GOVERNANCE_ENFORCED) win over real, wired flags purely by dict placement, and the
+    cockpit showed its static "0" as the entire governance-enforcement-stack's afdwingniveau
+    while the real enforcement source (.vnx/governance_enforcement.yaml) ran mandatory checks.
+
+    Per subsystem:
+      - entries with ``read_site_wired=False`` are never eligible (a structural exclusion via
+        the entry's own property, not a name check in this function — a flag that later gains
+        a real read-site becomes eligible again automatically).
+      - exactly one eligible entry -> that entry wins, regardless of dict order.
+      - more than one eligible entry -> exactly one of them must carry
+        ``cockpit_canonical=True`` as the explicit tie-breaker; zero or more than one raises
+        ValueError rather than silently picking one (order-independent: reversing the dict's
+        insertion order never changes the winner).
+
+    ``registry`` defaults to this module's CONFIG_REGISTRY; a caller may pass a substitute dict
+    of ConfigEntry for testing the selection rule in isolation.
+    """
+    reg = CONFIG_REGISTRY if registry is None else registry
+    by_subsystem: Dict[str, List[str]] = {}
+    for key, entry in reg.items():
+        if entry.subsystem:
+            by_subsystem.setdefault(entry.subsystem, []).append(key)
+
+    canonical: Dict[str, str] = {}
+    for subsystem, keys in by_subsystem.items():
+        eligible = [k for k in keys if reg[k].read_site_wired]
+        if not eligible:
+            raise ValueError(
+                f"subsystem {subsystem!r} has no read_site_wired CONFIG_REGISTRY entry among "
+                f"{keys} -- the cockpit cannot show a canonical flag for it"
+            )
+        if len(eligible) == 1:
+            canonical[subsystem] = eligible[0]
+            continue
+        marked = [k for k in eligible if reg[k].cockpit_canonical]
+        if len(marked) != 1:
+            raise ValueError(
+                f"subsystem {subsystem!r} has {len(eligible)} read_site_wired candidates "
+                f"{eligible} but {len(marked)} marked cockpit_canonical=True -- exactly one "
+                "must be explicit"
+            )
+        canonical[subsystem] = marked[0]
+    return canonical

--- a/scripts/lib/governance_enforcer.py
+++ b/scripts/lib/governance_enforcer.py
@@ -280,6 +280,18 @@ class GovernanceEnforcer:
             for r in results
         )
 
+    def effective_summary(self) -> Dict[str, Any]:
+        """Public read-only summary: active mode + highest configured check level.
+
+        Used by the cockpit (dashboard/api_subsystems.py, OI-1385) to report the REAL
+        governance-enforcement-stack afdwingniveau read from this loaded config, instead of a
+        static registry bool that has no read-site of its own
+        (docs/core/framework-status-audit-and-cockpit_PRD.md:89). ``max_level`` is 0 when no
+        checks are configured (an empty/degenerate config) so callers never see None.
+        """
+        max_level = max((c.level for c in self._checks.values()), default=0)
+        return {"mode": self._mode, "max_level": max_level}
+
     def has_soft_failures(self, results: List[EnforcementResult]) -> bool:
         """Return True if any soft-mandatory check failed (unoverridden)."""
         return any(

--- a/tests/dashboard/test_api_subsystems.py
+++ b/tests/dashboard/test_api_subsystems.py
@@ -36,11 +36,19 @@ def test_build_rows_no_duplicate_subsystems():
 
 
 def test_build_rows_flag_backed_row_has_effective_value():
+    # OI-1385: VNX_CI_GATE_REQUIRED (5 production read-sites) is now canonical for
+    # governance-enforcement-stack, not VNX_GOVERNANCE_ENFORCED (0 read-sites, see
+    # config_registry.py's read_site_wired=False). effective_value no longer comes from the
+    # canonical flag's own registry value either -- it reads .vnx/governance_enforcement.yaml
+    # directly (see test_governance_row_effective_value_reads_real_yaml_source for the isolated,
+    # non-live-file version of this assertion).
     rows = api_sub.build_rows(cr, PID)
     governance = next(r for r in rows if r["subsystem"] == "governance-enforcement-stack")
-    assert governance["flag"] == "VNX_GOVERNANCE_ENFORCED"
-    assert governance["status"] == "PARK"
-    assert governance["effective_value"] == "0"  # default off
+    assert governance["flag"] == "VNX_CI_GATE_REQUIRED"
+    assert governance["status"] == "ACTIVATE"
+    assert governance["effective_value"] != "0", (
+        "must not read the static registry bool -- see governance_enforcement_effective_value()"
+    )
 
 
 def test_build_rows_flag_less_row_has_no_flag():
@@ -97,3 +105,135 @@ def test_operator_get_subsystems_unavailable_returns_503(monkeypatch):
     assert status == 503
     assert body["subsystems"] == []
     assert "error" in body
+
+
+# ---------------------------------------------------------------------------
+# OI-1385: governance_enforcement_effective_value() — yaml-sourced, never the static bool
+# ---------------------------------------------------------------------------
+
+
+def test_governance_enforcement_effective_value_reads_mode_and_max_level(tmp_path):
+    yaml_path = tmp_path / "governance_enforcement.yaml"
+    yaml_path.write_text(
+        "mode: standard\n"
+        "checks:\n"
+        "  a:\n"
+        "    level: 1\n"
+        "  b:\n"
+        "    level: 3\n",
+        encoding="utf-8",
+    )
+    assert api_sub.governance_enforcement_effective_value(yaml_path) == "standard:3"
+
+
+def test_governance_enforcement_effective_value_off_mode(tmp_path):
+    yaml_path = tmp_path / "governance_enforcement.yaml"
+    yaml_path.write_text("mode: off\nchecks:\n  a:\n    level: 0\n", encoding="utf-8")
+    assert api_sub.governance_enforcement_effective_value(yaml_path) == "off:0"
+
+
+def test_governance_enforcement_effective_value_missing_file_is_unknown_not_zero(tmp_path):
+    # PRD requirement (framework-status-audit-and-cockpit_PRD.md:89): an unreadable source must
+    # never silently read as "off" -- that is the exact drift class this dispatch fixes.
+    missing = tmp_path / "does-not-exist.yaml"
+    assert api_sub.governance_enforcement_effective_value(missing) == "unknown"
+
+
+def test_governance_enforcement_effective_value_malformed_file_is_unknown_not_zero(tmp_path):
+    bad = tmp_path / "governance_enforcement.yaml"
+    bad.write_text(":::not valid yaml:::\n  - [unterminated", encoding="utf-8")
+    assert api_sub.governance_enforcement_effective_value(bad) == "unknown"
+
+
+def test_build_rows_governance_row_uses_the_wired_yaml_path_constant(monkeypatch, tmp_path):
+    """Integration: build_rows() reads through the module-level path constant, not a hardcoded
+    path -- monkeypatching it changes the row's effective_value, proving the wiring is live."""
+    yaml_path = tmp_path / "governance_enforcement.yaml"
+    yaml_path.write_text("mode: strict\nchecks:\n  a:\n    level: 2\n", encoding="utf-8")
+    monkeypatch.setattr(api_sub, "_GOVERNANCE_ENFORCEMENT_YAML", yaml_path)
+
+    rows = api_sub.build_rows(cr, PID)
+
+    governance = next(r for r in rows if r["subsystem"] == "governance-enforcement-stack")
+    assert governance["effective_value"] == "strict:2"
+
+
+def test_real_governance_enforcement_yaml_is_currently_standard_hard_mandatory():
+    """Pins the OI-1385 dispatch's own measured ground truth (23-08): the committed
+    .vnx/governance_enforcement.yaml is mode: standard with gate_before_next_feature and
+    ci_green_required both at level 3 (hard_mandatory). If this ever drifts, re-verify the
+    dispatch report's blast-radius claims before trusting them."""
+    real_yaml = api_sub._GOVERNANCE_ENFORCEMENT_YAML
+    assert real_yaml.exists(), f"expected {real_yaml} to exist"
+    import yaml as _yaml
+    raw = _yaml.safe_load(real_yaml.read_text(encoding="utf-8"))
+    assert raw.get("mode") == "standard"
+    checks = raw.get("checks", {})
+    assert checks["gate_before_next_feature"]["level"] == 3
+    assert checks["ci_green_required"]["level"] == 3
+
+
+# ---------------------------------------------------------------------------
+# OI-1385: the cockpit-vs-reality contradiction control
+# ---------------------------------------------------------------------------
+#
+# "Bouw een controle die ROOD geeft wanneer de cockpit een subsysteem als geparkeerd of uit
+# toont terwijl de echte afdwinging mandatory is." The control composes two independent reads
+# (the real enforcement source, the cockpit row) and flags the case where they disagree.
+
+
+def _yaml_is_blocking(config_path) -> bool:
+    """True when a governance_enforcement.yaml-shaped config has at least one check at
+    level>=2 (soft_mandatory or hard_mandatory)."""
+    import governance_enforcer as ge
+    enforcer = ge.GovernanceEnforcer()
+    enforcer.load_config(config_path)
+    return enforcer.effective_summary()["max_level"] >= 2
+
+
+def _cockpit_shows_off(row) -> bool:
+    """True when a cockpit row reads as parked/off to an operator glancing at it."""
+    return row.get("effective_value") in (None, "", "0", "off")
+
+
+def _contradicts(source_blocking: bool, cockpit_shows_off: bool) -> bool:
+    return source_blocking and cockpit_shows_off
+
+
+def test_contradiction_control_flags_the_pre_fix_shape():
+    """Pin the exact OI-1385 shape: the real enforcement source is blocking (mode=standard,
+    hard-mandatory checks) while the cockpit shows the pre-fix stale '0' -- this is the
+    misreading a 23-08 morning measurement reported to the operator as 'enforcement is off'.
+    The control must flag it as a contradiction; run against the REAL live yaml (not a fixture)
+    so this documents the actual measured state, not a hypothetical."""
+    source_blocking = _yaml_is_blocking(api_sub._GOVERNANCE_ENFORCEMENT_YAML)
+    assert source_blocking is True, "expected the real committed yaml to currently be blocking"
+    stale_row = {"subsystem": "governance-enforcement-stack", "effective_value": "0"}
+    assert _contradicts(source_blocking, _cockpit_shows_off(stale_row)) is True
+
+
+def test_contradiction_control_clears_when_source_and_cockpit_both_off(tmp_path):
+    """Inverse case (required by the dispatch): a source that is genuinely off, with a cockpit
+    that also shows off, is NOT a contradiction -- without this case the control could not be
+    distinguished from one that is simply always red."""
+    off_yaml = tmp_path / "governance_enforcement.yaml"
+    off_yaml.write_text("mode: off\nchecks:\n  a:\n    level: 0\n", encoding="utf-8")
+    source_blocking = _yaml_is_blocking(off_yaml)
+    assert source_blocking is False
+    off_row = {"subsystem": "some-other-subsystem", "effective_value": "0"}
+    assert _contradicts(source_blocking, _cockpit_shows_off(off_row)) is False
+
+
+def test_real_cockpit_row_no_longer_contradicts_real_yaml_source():
+    """The regression pin for the fix itself (dispatch requirement: 'een test die op de HUIDIGE
+    main ROOD is op GEDRAG'). build_rows()'s REAL governance-enforcement-stack row must not
+    contradict the REAL governance_enforcement.yaml: RED before this dispatch's fix
+    (effective_value was the static '0' bool while the yaml was blocking, confirmed by running
+    this exact assertion against the unmodified files -- see the dispatch report); GREEN after
+    (effective_value now reads the yaml directly via governance_enforcement_effective_value())."""
+    source_blocking = _yaml_is_blocking(api_sub._GOVERNANCE_ENFORCEMENT_YAML)
+    rows = api_sub.build_rows(cr, PID)
+    row = next(r for r in rows if r["subsystem"] == "governance-enforcement-stack")
+    assert not _contradicts(source_blocking, _cockpit_shows_off(row)), (
+        f"cockpit row {row!r} contradicts the real enforcement source (blocking={source_blocking})"
+    )

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -674,8 +674,15 @@ def test_default_review_stack_includes_ci_gate_when_required(monkeypatch):
 def test_default_review_stack_control_case_gemini_codex_combo_unchanged(monkeypatch):
     """Control case (dispatch 20260823-beta2-e): with no config override, the
     existing gemini_review + codex_gate + claude_github_optional combination
-    must come back byte-for-byte unchanged."""
-    monkeypatch.delenv("VNX_CI_GATE_REQUIRED", raising=False)
+    must come back byte-for-byte unchanged.
+
+    VNX_CI_GATE_REQUIRED is pinned to "0" (not delenv'd) since OI-1385 flipped its
+    registry default to "1": this test measures the BASE stack composition, not
+    ci_gate's own default, so it must isolate that axis explicitly or it starts
+    asserting a gemini/codex/claude_github_optional-only stack that no longer
+    matches the wired default.
+    """
+    monkeypatch.setenv("VNX_CI_GATE_REQUIRED", "0")
     monkeypatch.delenv("VNX_DEFAULT_REVIEW_STACK", raising=False)
     import review_gate_manager as rgm
     stack = rgm._build_default_review_stack()
@@ -685,9 +692,15 @@ def test_default_review_stack_control_case_gemini_codex_combo_unchanged(monkeypa
 def test_default_review_stack_is_config_driven_not_hardcoded(monkeypatch):
     """OPERATOR-BESLUIT 23-08: kimi_gate/glm_gate must be reachable as the
     default review stack via config alone — no edit to
-    _build_default_review_stack() required."""
+    _build_default_review_stack() required.
+
+    VNX_CI_GATE_REQUIRED is pinned to "0" (not delenv'd) since OI-1385 flipped its
+    registry default to "1": this test measures whether VNX_DEFAULT_REVIEW_STACK
+    is honored verbatim, so ci_gate's independent default-on append must be
+    isolated out or it would silently ride along on every stack this test builds.
+    """
     monkeypatch.setenv("VNX_DEFAULT_REVIEW_STACK", "kimi_gate,glm_gate")
-    monkeypatch.delenv("VNX_CI_GATE_REQUIRED", raising=False)
+    monkeypatch.setenv("VNX_CI_GATE_REQUIRED", "0")
     import review_gate_manager as rgm
     stack = rgm._build_default_review_stack()
     assert stack == ["kimi_gate", "glm_gate"]

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -640,15 +640,27 @@ def test_contract_hash_determinism(gate_env):
 # ---------------------------------------------------------------------------
 
 
-def test_default_review_stack_excludes_ci_gate_by_default(monkeypatch):
-    """ci_gate is NOT in DEFAULT_REVIEW_STACK unless VNX_CI_GATE_REQUIRED=1."""
-    monkeypatch.delenv("VNX_CI_GATE_REQUIRED", raising=False)
-    # Force re-evaluation by importing the builder directly
-    import importlib
+def test_default_review_stack_excludes_ci_gate_when_explicitly_disabled(monkeypatch):
+    """ci_gate is excluded from DEFAULT_REVIEW_STACK when VNX_CI_GATE_REQUIRED=0.
+
+    OI-1385: VNX_CI_GATE_REQUIRED's registry default flipped "0" -> "1" (its 5-read-site chain
+    proved live on PR #1628, and the obligation-runner's bounded-pending handling for a
+    temporarily-unavailable gate is confirmed on main). This pins the explicit-off path,
+    replacing the old default-off pin below.
+    """
+    monkeypatch.setenv("VNX_CI_GATE_REQUIRED", "0")
     import review_gate_manager as rgm
-    # Temporarily patch the env and call the builder
     stack = rgm._build_default_review_stack()
     assert "ci_gate" not in stack
+
+
+def test_default_review_stack_includes_ci_gate_by_default(monkeypatch):
+    """OI-1385: VNX_CI_GATE_REQUIRED now defaults to "1" (registry default, config_registry.py)
+    -- ci_gate is in DEFAULT_REVIEW_STACK even with no env var set at all."""
+    monkeypatch.delenv("VNX_CI_GATE_REQUIRED", raising=False)
+    import review_gate_manager as rgm
+    stack = rgm._build_default_review_stack()
+    assert "ci_gate" in stack
 
 
 def test_default_review_stack_includes_ci_gate_when_required(monkeypatch):

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -34,10 +34,19 @@ def _clean(monkeypatch):
 # Inventory: defaults mirror the current code (codex finding #2)
 # ---------------------------------------------------------------------------
 
-def test_gate_flags_default_off_matching_code():
-    # The read-sites read these as `get("VNX_CI_GATE_REQUIRED", "0")` — off. Registry must match.
-    assert cr.CONFIG_REGISTRY["VNX_CI_GATE_REQUIRED"].default == "0"
+def test_ci_gate_activated_wiring_gate_stays_parked():
+    # OI-1385: VNX_CI_GATE_REQUIRED activated (default "0" -> "1", status PARK -> ACTIVATE).
+    # Its 5-read-site chain was already proven live on PR #1628 (ci_gate ran, status=pass,
+    # contract_hash+report_path present, commit_sha matched the PR head), and the
+    # obligation-runner's bounded-pending handling for a temporarily-unavailable gate
+    # (OI-1384 #1633, OI-1400 #1641/#1672) is confirmed on main before this flip.
+    assert cr.CONFIG_REGISTRY["VNX_CI_GATE_REQUIRED"].default == "1"
+    assert cr.CONFIG_REGISTRY["VNX_CI_GATE_REQUIRED"].status == "ACTIVATE"
+    # VNX_WIRING_GATE_REQUIRED stays PARKed -- a deliberate decision (closure_verifier cannot
+    # attest wiring_gate's evidence yet), pinned by
+    # test_wiring_gate_shadow_mode_decision_tied_to_closure_verifier_exclusion below.
     assert cr.CONFIG_REGISTRY["VNX_WIRING_GATE_REQUIRED"].default == "0"
+    assert cr.CONFIG_REGISTRY["VNX_WIRING_GATE_REQUIRED"].status == "PARK"
 
 
 def test_evidence_bound_gate_default_advisory_and_requires_approval():
@@ -253,6 +262,253 @@ def test_pr2_registering_flags_does_not_change_effective_value_when_unset():
     for key in PR2_NEW_FLAGS:
         entry = cr.CONFIG_REGISTRY[key]
         assert cr.get(key) == entry.default
+
+
+# ---------------------------------------------------------------------------
+# OI-1385: canonical_flags() — explicit, order-independent canonical selection
+# ---------------------------------------------------------------------------
+#
+# Before this dispatch, the cockpit picked a subsystem's canonical flag by
+# taking whichever CONFIG_REGISTRY entry a dict iteration happened to visit
+# LAST. That let VNX_GOVERNANCE_ENFORCED (zero production read-sites) win
+# over VNX_CI_GATE_REQUIRED (5 read-sites, hard-blocking) purely because it
+# was appended later in the file. These tests pin the replacement rule
+# against synthetic registries so the mechanism is tested in isolation from
+# the 17+ real subsystems.
+
+
+def _entry(key, *, subsystem, read_site_wired=True, cockpit_canonical=False, default="0"):
+    return cr.ConfigEntry(
+        key=key, type="bool", default=default, category="gate", description=key,
+        writable_from_ui=True, requires_approval=False,
+        subsystem=subsystem, status="PARK",
+        read_site_wired=read_site_wired, cockpit_canonical=cockpit_canonical,
+    )
+
+
+def test_canonical_flags_single_wired_candidate_wins_automatically():
+    """A subsystem with exactly one read_site_wired entry needs no explicit
+    cockpit_canonical marker -- it wins by construction, matching every
+    single-flag subsystem in the real registry today."""
+    registry = {"A": _entry("A", subsystem="sub")}
+    assert cr.canonical_flags(registry) == {"sub": "A"}
+
+
+def test_canonical_flags_raises_on_two_marked_candidates():
+    """Two entries in the same subsystem both marked cockpit_canonical=True
+    is an unresolved ambiguity -- must fail loud, not silently pick one."""
+    registry = {
+        "A": _entry("A", subsystem="sub", cockpit_canonical=True),
+        "B": _entry("B", subsystem="sub", cockpit_canonical=True),
+    }
+    with pytest.raises(ValueError, match="2 read_site_wired candidates"):
+        cr.canonical_flags(registry)
+
+
+def test_canonical_flags_raises_on_zero_marked_candidates():
+    """Two wired entries in the same subsystem, NEITHER marked
+    cockpit_canonical=True, is equally unresolved -- must fail loud rather
+    than default to dict order."""
+    registry = {
+        "A": _entry("A", subsystem="sub"),
+        "B": _entry("B", subsystem="sub"),
+    }
+    with pytest.raises(ValueError, match="0 marked cockpit_canonical"):
+        cr.canonical_flags(registry)
+
+
+def test_canonical_flags_raises_when_all_candidates_unwired():
+    """A subsystem where every entry has read_site_wired=False has no
+    eligible candidate at all -- must fail loud, not fall back to showing an
+    unwired flag's static value."""
+    registry = {
+        "A": _entry("A", subsystem="sub", read_site_wired=False),
+        "B": _entry("B", subsystem="sub", read_site_wired=False),
+    }
+    with pytest.raises(ValueError, match="no read_site_wired"):
+        cr.canonical_flags(registry)
+
+
+def test_canonical_flags_excludes_unwired_entry_structurally():
+    """read_site_wired=False excludes a candidate via its own property, not
+    a name check -- with one wired + one unwired entry, the wired one wins
+    with no cockpit_canonical marker needed at all (the unwired entry is
+    simply not in the running)."""
+    registry = {
+        "WIRED": _entry("WIRED", subsystem="sub", read_site_wired=True),
+        "UNWIRED": _entry("UNWIRED", subsystem="sub", read_site_wired=False),
+    }
+    assert cr.canonical_flags(registry) == {"sub": "WIRED"}
+
+
+def test_canonical_flags_result_is_independent_of_dict_insertion_order():
+    """T0 follow-up (23-08): the SAME two candidate entries in reversed
+    insertion order must resolve to the SAME canonical flag. Before OI-1385,
+    _canonical_flags picked "whichever entry is last in CONFIG_REGISTRY's
+    dict order" -- reversing the order silently flipped the winner. This is
+    exactly what nearly happened for real: a parallel PR adding
+    VNX_DEFAULT_REVIEW_STACK to governance-enforcement-stack landed it BEFORE
+    the other three entries, so VNX_GOVERNANCE_ENFORCED stayed canonical only
+    because of where the new line was pasted -- had it landed after, the
+    cockpit would have shown a comma-separated stack string as the whole
+    afdwinglaag's "effective value".
+    """
+    forward = {
+        "A": _entry("A", subsystem="sub", cockpit_canonical=True),
+        "B": _entry("B", subsystem="sub"),
+    }
+    reversed_order = {
+        "B": _entry("B", subsystem="sub"),
+        "A": _entry("A", subsystem="sub", cockpit_canonical=True),
+    }
+    assert list(reversed_order.keys()) == ["B", "A"], "fixture must actually differ in order"
+    winner_forward = cr.canonical_flags(forward)["sub"]
+    winner_reversed = cr.canonical_flags(reversed_order)["sub"]
+    assert winner_forward == winner_reversed == "A", (
+        "canonical selection must not depend on CONFIG_REGISTRY iteration order"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OI-1385: canonical_flags() against the REAL registry
+# ---------------------------------------------------------------------------
+
+
+def test_real_registry_canonical_flags_does_not_raise():
+    """The real CONFIG_REGISTRY must satisfy canonical_flags()'s invariant
+    (every subsystem has exactly one eligible winner) -- this is what keeps
+    dashboard/api_subsystems.py's build_rows() from 500ing in production."""
+    result = cr.canonical_flags()
+    assert result, "canonical_flags() returned nothing for the real registry"
+
+
+def test_real_registry_governance_stack_canonical_is_ci_gate_not_governance_enforced():
+    """The fix's actual behaviour change: VNX_CI_GATE_REQUIRED (5 read-sites,
+    hard-blocking) is now canonical for governance-enforcement-stack, not
+    VNX_GOVERNANCE_ENFORCED (0 read-sites)."""
+    result = cr.canonical_flags()
+    assert result["governance-enforcement-stack"] == "VNX_CI_GATE_REQUIRED"
+
+
+def test_real_registry_other_multi_flag_subsystems_unchanged():
+    """Bewijs item 3: 'de bestaande rijen voor andere subsystemen veranderen
+    niet'. These are the OTHER multi-flag subsystems in the real registry
+    (intelligence-self-learning-loop: 6 flags, injection-effectiveness-eval-
+    loop: 2, smart-router-staging: 5) -- their canonical winner must match
+    what docs/core/SUBSYSTEMS.md already has committed (the pre-OI-1385
+    last-wins outcome), unaffected by this fix."""
+    result = cr.canonical_flags()
+    assert result["intelligence-self-learning-loop"] == "VNX_LEARNING_LOOP_ENABLED"
+    assert result["injection-effectiveness-eval-loop"] == "VNX_INJECTION_WHY_ENABLED"
+    assert result["smart-router-staging"] == "VNX_SMART_ROUTER_CANARY_PCT"
+
+
+def test_real_registry_governance_enforced_can_never_be_canonical():
+    entry = cr.CONFIG_REGISTRY["VNX_GOVERNANCE_ENFORCED"]
+    assert entry.read_site_wired is False
+    result = cr.canonical_flags()
+    assert result["governance-enforcement-stack"] != "VNX_GOVERNANCE_ENFORCED"
+
+
+# ---------------------------------------------------------------------------
+# OI-1385: read_site_wired must track MEASURED production usage, not a claim
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXCLUDED_PARTS = frozenset({"tests", "__tests__", ".git", ".vnx-data", "docs", "node_modules"})
+_SWEPT_SUFFIXES = frozenset({".py", ".sh", ".ts", ".tsx", ".js"})
+
+
+def _production_read_sites(flag_name: str) -> list:
+    """Repo-wide sweep for `flag_name`, excluding test dirs, docs, and
+    config_registry.py's own definition -- mirrors the manual sweep the
+    OI-1385 dispatch measured by hand (23-08), so it can be re-run as a live
+    drift guard instead of trusting a one-time claim."""
+    hits = []
+    for path in _REPO_ROOT.rglob("*"):
+        if not path.is_file() or path.suffix not in _SWEPT_SUFFIXES:
+            continue
+        rel = path.relative_to(_REPO_ROOT)
+        # Exclude on the path RELATIVE to the repo root, not the absolute path — this worktree
+        # itself lives under a ".vnx-data/worktrees/..." directory in the outer repo, so an
+        # absolute-path check would match ".vnx-data" on every single file and sweep nothing.
+        if any(part in _EXCLUDED_PARTS for part in rel.parts):
+            continue
+        if path.name == "config_registry.py":
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if flag_name in text:
+            hits.append(str(rel))
+    return sorted(hits)
+
+
+def test_read_site_sweep_instrument_finds_known_hits_for_ci_gate_required():
+    """Sanity-check the sweep itself (OI-1385 dispatch requirement): a sweep
+    that returns zero for a flag with KNOWN production read-sites means the
+    instrument is broken, not that the flag is unwired. A nul-telling is
+    first a meetfout."""
+    hits = _production_read_sites("VNX_CI_GATE_REQUIRED")
+    assert hits, "sweep instrument broken: VNX_CI_GATE_REQUIRED has known production read-sites"
+    # the 5 read-sites the dispatch cited by name
+    for expected in (
+        "scripts/review_gate_manager.py",
+        "scripts/lib/gate_request_handler.py",
+        "scripts/lib/gate_report_generator.py",
+        "scripts/lib/gate_recorder.py",
+        "scripts/lib/gate_result_parser.py",
+    ):
+        assert expected in hits, f"sweep missed known read-site {expected}"
+
+
+def test_governance_enforced_read_site_wired_matches_measured_usage():
+    """Drift guard, symmetric in both directions (OI-1385 item 3): if
+    VNX_GOVERNANCE_ENFORCED ever gains a real production read-site,
+    read_site_wired must flip to True (else the cockpit stays blind to a
+    flag that now matters); if it stays at zero, read_site_wired must stay
+    False (else it could silently win canonical_flags() again)."""
+    hits = _production_read_sites("VNX_GOVERNANCE_ENFORCED")
+    entry = cr.CONFIG_REGISTRY["VNX_GOVERNANCE_ENFORCED"]
+    if hits:
+        assert entry.read_site_wired is True, (
+            f"VNX_GOVERNANCE_ENFORCED now has production read-site(s) {hits} -- flip "
+            "read_site_wired to True so it can become canonical again"
+        )
+    else:
+        assert entry.read_site_wired is False, (
+            "VNX_GOVERNANCE_ENFORCED has zero production read-sites but read_site_wired=True "
+            "-- it would wrongly become eligible as the subsystem's canonical cockpit flag"
+        )
+
+
+# ---------------------------------------------------------------------------
+# OI-1385 item 4: VNX_WIRING_GATE_REQUIRED shadow mode is a decision, tied to
+# closure_verifier's own exclusion list — not an independently-drifting flag.
+# ---------------------------------------------------------------------------
+
+
+def test_wiring_gate_shadow_mode_decision_tied_to_closure_verifier_exclusion():
+    """VNX_WIRING_GATE_REQUIRED stays PARK/'0' ONLY because wiring_gate sits
+    on closure_verifier._GATES_NOT_IMPLEMENTED_BY_CLOSURE -- the closure
+    verifier cannot honestly attest its evidence yet, so promoting the flag
+    to required would let a gate block merges with findings nothing verifies.
+    If wiring_gate is ever promoted off that list, this decision needs a
+    fresh review -- fail loud instead of leaving the flag stale forever."""
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    import closure_verifier as cv
+
+    assert "wiring_gate" in cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE, (
+        "wiring_gate's closure-verifier exclusion changed -- re-review "
+        "VNX_WIRING_GATE_REQUIRED's shadow-mode decision in config_registry.py and promote "
+        "it out of PARK if the closure verifier can now attest wiring_gate evidence"
+    )
+    entry = cr.CONFIG_REGISTRY["VNX_WIRING_GATE_REQUIRED"]
+    assert entry.default == "0"
+    assert entry.status == "PARK"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

OI-1385 claimed all three `governance-enforcement-stack` flags being `'0'` meant the whole
enforcement layer was parked. Re-measured 23-08 on `main@3cdadba4`: that conclusion was wrong for
2 of the 3 flags.

- `VNX_CI_GATE_REQUIRED` — a real switch, 5 production read-sites, already proven live on PR #1628.
- `VNX_WIRING_GATE_REQUIRED` — real, 2 read-sites, but deliberately in shadow mode (its own
  closure-verifier limitation, documented below).
- `VNX_GOVERNANCE_ENFORCED` — **zero** production read-sites. `dashboard/api_subsystems.py`'s
  canonical-flag selection picked whichever `CONFIG_REGISTRY` entry a dict iteration visited last,
  and this flag happened to be last — so the cockpit showed its dead `'0'` as the entire
  enforcement layer's status, while the real enforcer (`.vnx/governance_enforcement.yaml`,
  `mode: standard`, two hard-mandatory checks) was actually running.

## Changes

- **`scripts/lib/config_registry.py`**: `VNX_CI_GATE_REQUIRED` activated (default `"0"→"1"`,
  status `PARK→ACTIVATE`). New `canonical_flags()` — explicit, order-independent selection
  (`read_site_wired` + `cockpit_canonical`) replacing "last entry in dict order wins"; raises
  loudly on an unresolved subsystem instead of guessing. `VNX_GOVERNANCE_ENFORCED` marked
  `read_site_wired=False` so it can never win again, structurally. `VNX_WIRING_GATE_REQUIRED`'s
  description now documents *why* it stays parked.
- **`dashboard/api_subsystems.py`**: the `governance-enforcement-stack` row's `effective_value`
  now reads `.vnx/governance_enforcement.yaml` directly (mode + max check level), never the
  static flag. Missing/unreadable yaml → explicit `"unknown"`, never a silent `"0"`.
- **`scripts/lib/governance_enforcer.py`**: new public `GovernanceEnforcer.effective_summary()`.
- Test updates for the flipped default/canonical flag, plus new coverage (see Verification).

vnx_cli/commands/subsystems.py has an **identical duplicate** canonical-flag selector (renders
`docs/core/SUBSYSTEMS.md`) — outside this dispatch's write scope; flagged as an Open Item.

## Verification

Re-ran the dispatch's own measurement methodology as a test (`_production_read_sites`, repo sweep
excluding tests/docs): `VNX_CI_GATE_REQUIRED` → 7 production hits; `VNX_GOVERNANCE_ENFORCED` → 0.
Both pinned as live drift guards, not one-time claims.

`246 passed` across the touched files + direct neighbours:
```
python3 -m pytest tests/test_config_registry.py tests/dashboard/test_api_subsystems.py \
  tests/test_ci_gate.py tests/test_api_config.py tests/test_config_store_dao.py \
  tests/test_gate_obligations.py tests/test_gate_request_handler_w3f.py \
  tests/test_governance_enforcer.py tests/test_closure_verifier_gate_enum_drift.py \
  tests/test_wiring_gate_shadow_mode.py tests/test_closure_verifier.py \
  tests/vnx_cli/test_subsystems.py tests/test_subsystems_md_exists.py -q
```

Confirmed RED-before-fix by temporarily reverting the 3 source files (test files kept), showing
3 genuine assertion failures on measured behavior (not missing symbols), then restored and
re-confirmed green.

## Test plan

- [x] `canonical_flags()`: 2-candidate / 0-candidate / all-unwired raise; single-candidate
      auto-wins; order-independence (T0 follow-up requirement) pinned
- [x] Real registry: governance-enforcement-stack canonical = `VNX_CI_GATE_REQUIRED`; other
      multi-flag subsystems (intelligence-self-learning-loop, injection-effectiveness-eval-loop,
      smart-router-staging) unchanged
- [x] `governance_enforcement_effective_value()`: mode+level, off-mode, missing→unknown,
      malformed→unknown
- [x] Contradiction control: RED case (blocking source + stale `'0'` cockpit) and GREEN case
      (source off + cockpit off)
- [x] `wiring_gate` shadow-mode decision tied to `closure_verifier._GATES_NOT_IMPLEMENTED_BY_CLOSURE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

## Merge-ordering constraint (T0)

**This PR must be merged LAST in its batch.** Not for tidiness — for correctness of the
batch's own evidence.

Activating `VNX_CI_GATE_REQUIRED` adds `ci_gate` to `DEFAULT_REVIEW_STACK`:

```
before: ['gemini_review', 'codex_gate', 'claude_github_optional']
after:  ['gemini_review', 'codex_gate', 'claude_github_optional', 'ci_gate']
```

And `gate_request_handler.py:120` reads that stack with `list(DEFAULT_REVIEW_STACK)` **at
request time, not at merge time**. So every PR whose gates are requested *after* this merge
inherits an extra REQUIRED gate that the PRs merged before it never had. Mid-batch, that
leaves the remaining PRs needing `ci_gate` evidence that does not exist for them, and half the
batch stops satisfying the standard it was reviewed under.

Merged last, the flip is a clean boundary in the audit trail: everything before ran under one
stack, everything after under the next.

**Generalisation for whoever changes a review stack next:** the read happens at request time.
A stack change is therefore not retroactive and not inert — it silently re-scopes every gate
request that follows it.
