### PR TITLE
fix(review-gate): lift the real outage reason off the lane log (OI-1452)

### DIFF
--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -98,6 +98,7 @@ from gate_recorder import (
     stamp_request_identity,
 )
 from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
+from governance_emit import _classify_lane_log_text, _read_lane_log_text  # OI-1452: lift the real reason off the raw lane log — same classifier OI-1433 built, never a second marker scan
 from unified_report_schema import SchemaViolation, parse_frontmatter
 from gate_report_recovery import (
     AmbiguousRecoveryCandidates,
@@ -367,6 +368,34 @@ _UNAVAILABLE_SUMMARIES = {
 }
 
 
+def _lift_lane_log_reason(dispatch_id: str, data_dir: "Path | None") -> "str | None":
+    """OI-1452: when ``_frontmatter_run_outcome`` says the run failed but the
+    frontmatter itself carries no WHY (just ``exit_code``/``token_usage``),
+    read the per-dispatch raw lane log (``logs/conversations/<dispatch_id>.log``)
+    and classify it with governance_emit's shared classifier — the SAME
+    function OI-1433 built for this exact purpose and kimi_gate.py reuses
+    identically. Never a second hand-rolled marker scan.
+
+    The glm lane does not always write a per-dispatch log (a run can die
+    before the tee starts). Returns the bounded reason snippet only when the
+    log carries a real billing/quota exhaustion marker
+    (``_classify_lane_log_text`` -> ``lane_exhausted``). Returns None —
+    never invents a reason — when the log is missing/empty
+    (``_read_lane_log_text`` already collapses every read failure to None)
+    or when the log has content but no exhaustion marker
+    (``unreadable_verdict``): the frontmatter-only detail stays exactly as
+    informative as it already was, and the gate does not fail on a missing
+    log.
+    """
+    if data_dir is None:
+        return None
+    text = _read_lane_log_text(dispatch_id, data_dir)
+    if not text:
+        return None
+    state, reason = _classify_lane_log_text(text)
+    return reason if state == "lane_exhausted" else None
+
+
 def _status_summary(status: str, blocking: list, reason: str = "") -> str:
     """Summary line for the result record — outage vs recovery vs verdict must be unmistakable."""
     if status == "unavailable":
@@ -529,6 +558,17 @@ def main(argv: "list[str] | None" = None) -> int:
                         f"(exit_code={exit_code!r}, token_usage.output={output_tokens!r}) — "
                         "provider-side outage, not a review outcome"
                     )
+                    # OI-1452: the frontmatter above tells us the run failed, not
+                    # WHY. Lift the real reason off the raw lane log so the
+                    # request-time takeover classifier (which scans this same
+                    # provider_failed_detail once it lands in residual_risk) can
+                    # actually see a billing/quota exhaustion marker instead of a
+                    # generic exit_code/token_usage summary. The glm lane does
+                    # not always write this log — a missing file degrades to the
+                    # frontmatter-only detail above, never a crash or a guess.
+                    lane_log_reason = _lift_lane_log_reason(dispatch_id, base_data_dir)
+                    if lane_log_reason:
+                        provider_failed_detail += f" — lane log: {lane_log_reason}"
                     status, blocking, residual = _verdict_to_status(
                         {}, report_text or "", provider_failed_detail=provider_failed_detail
                     )

--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -523,6 +523,10 @@ def main(argv: "list[str] | None" = None) -> int:
 
     recovered_path: "Path | None" = None
 
+    # OI-1452 fix-forward: tracked across both branches below so the record
+    # build can stamp the canonical failure_reason field (see there) — only
+    # ever set by the lane-log lift in the run_failed branch, never guessed.
+    lane_log_reason: "str | None" = None
     if dispatch_error:
         verdict: dict = {}
         status, blocking = "unavailable", []
@@ -706,6 +710,21 @@ def main(argv: "list[str] | None" = None) -> int:
         ],
         "required_reruns": [],
         "residual_risk": residual,
+        # OI-1452 fix-forward (OI-1453 tracks the other four gates): also
+        # stamp the canonical failure_reason field (established OI-1415,
+        # scripts/lib/phantom_guard.py) with the SAME text placed above in
+        # residual_risk, but ONLY the lifted lane-log reason — never a
+        # placeholder or a summary of the frontmatter fields when the lift
+        # found nothing. Three ways to be wrong here, in ascending order of
+        # danger: an EMPTY field fails visibly (a reader can tell the cause
+        # is unknown); a PLACEHOLDER ("unknown", "n/a") passes every
+        # presence check and fails silently; a SUMMARY that merely looks
+        # like a cause is worst of all, because it cannot be told apart from
+        # a real one. Filling this field with anything but the real lifted
+        # reason would make every existing record look complete while
+        # explaining nothing — a regression hidden BEHIND the fix meant to
+        # surface it.
+        "failure_reason": lane_log_reason or "",
         "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         # dispatch-20260823-beta2-j: audit marker distinguishing a record
         # produced by a live model call from one formalized by --reprocess

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -490,6 +490,10 @@ def main(argv: "list[str] | None" = None) -> int:
 
     recovered_path: "Path | None" = None
 
+    # OI-1452 fix-forward: tracked across both branches below so the record
+    # build can stamp the canonical failure_reason field (see there) — only
+    # ever set by the lane-log lift in the run_failed branch, never guessed.
+    lane_log_reason: "str | None" = None
     if dispatch_error:
         verdict: dict = {}
         status, blocking = "unavailable", []
@@ -668,6 +672,21 @@ def main(argv: "list[str] | None" = None) -> int:
         ],
         "required_reruns": [],
         "residual_risk": residual,
+        # OI-1452 fix-forward (OI-1453 tracks the other four gates): also
+        # stamp the canonical failure_reason field (established OI-1415,
+        # scripts/lib/phantom_guard.py) with the SAME text placed above in
+        # residual_risk, but ONLY the lifted lane-log reason — never a
+        # placeholder or a summary of the frontmatter fields when the lift
+        # found nothing. Three ways to be wrong here, in ascending order of
+        # danger: an EMPTY field fails visibly (a reader can tell the cause
+        # is unknown); a PLACEHOLDER ("unknown", "n/a") passes every
+        # presence check and fails silently; a SUMMARY that merely looks
+        # like a cause is worst of all, because it cannot be told apart from
+        # a real one. Filling this field with anything but the real lifted
+        # reason would make every existing record look complete while
+        # explaining nothing — a regression hidden BEHIND the fix meant to
+        # surface it.
+        "failure_reason": lane_log_reason or "",
         "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         # dispatch-20260823-beta2-j: audit marker distinguishing a record
         # produced by a live model call from one formalized by --reprocess

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -108,6 +108,7 @@ from gate_recorder import (
     stamp_request_identity,
 )
 from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
+from governance_emit import _classify_lane_log_text, _read_lane_log_text  # OI-1452: lift the real reason off the raw lane log — same classifier OI-1433 built, never a second marker scan
 from unified_report_schema import SchemaViolation, parse_frontmatter
 from gate_report_recovery import (
     AmbiguousRecoveryCandidates,
@@ -358,6 +359,32 @@ _UNAVAILABLE_SUMMARIES = {
 }
 
 
+def _lift_lane_log_reason(dispatch_id: str, data_dir: "Path | None") -> "str | None":
+    """OI-1452: when ``_frontmatter_run_outcome`` says the run failed but the
+    frontmatter itself carries no WHY (just ``exit_code``/``token_usage``),
+    read the per-dispatch raw lane log (``logs/conversations/<dispatch_id>.log``)
+    and classify it with governance_emit's shared classifier — the SAME
+    function OI-1433 built for this exact purpose. Never a second hand-rolled
+    marker scan: two independent scanners drift (that is the OI-1452 bug in
+    the takeover classifier, one layer up).
+
+    Returns the bounded reason snippet only when the log carries a real
+    billing/quota exhaustion marker (``_classify_lane_log_text`` ->
+    ``lane_exhausted``). Returns None — never invents a reason — when the log
+    is missing/empty (``_read_lane_log_text`` already collapses every read
+    failure to None) or when the log has content but no exhaustion marker
+    (``unreadable_verdict``): the frontmatter-only detail from the caller
+    stays exactly as informative as it already was.
+    """
+    if data_dir is None:
+        return None
+    text = _read_lane_log_text(dispatch_id, data_dir)
+    if not text:
+        return None
+    state, reason = _classify_lane_log_text(text)
+    return reason if state == "lane_exhausted" else None
+
+
 def _status_summary(status: str, blocking: list, reason: str = "") -> str:
     """Summary line for the result record — outage vs recovery vs verdict must be unmistakable."""
     if status == "unavailable":
@@ -498,6 +525,15 @@ def main(argv: "list[str] | None" = None) -> int:
                         f"(exit_code={exit_code!r}, token_usage.output={output_tokens!r}) — "
                         "provider-side outage, not a review outcome"
                     )
+                    # OI-1452: the frontmatter above tells us the run failed, not
+                    # WHY. Lift the real reason off the raw lane log so the
+                    # request-time takeover classifier (which scans this same
+                    # provider_failed_detail once it lands in residual_risk) can
+                    # actually see a billing/quota exhaustion marker instead of a
+                    # generic exit_code/token_usage summary.
+                    lane_log_reason = _lift_lane_log_reason(dispatch_id, base_data_dir)
+                    if lane_log_reason:
+                        provider_failed_detail += f" — lane log: {lane_log_reason}"
                     status, blocking, residual = _verdict_to_status(
                         {}, report_text or "", provider_failed_detail=provider_failed_detail
                     )

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -491,10 +491,25 @@ def _read_lane_log_text(dispatch_id: str, data_dir: Path) -> Optional[str]:
     return text if text.strip() else None
 
 
-def _bounded_snippet(text: str, max_len: int = 300) -> str:
+def _bounded_snippet(text: str, max_len: int = 300, anchor: "int | None" = None) -> str:
     """Collapse whitespace and cap length — same shape as failure_classification.py's
-    _extract_detail, so a lifted reason never carries a multi-KB blob."""
-    snippet = " ".join(text.split())
+    _extract_detail, so a lifted reason never carries a multi-KB blob.
+
+    ``anchor`` (OI-1452): a character offset into the RAW (uncollapsed)
+    ``text`` to window the snippet around, instead of always starting at
+    position 0. A short single-shot error body (the original OI-1433 case)
+    has the marker right at the start, so a prefix snippet already captures
+    it. A long multi-turn lane log (measured: a real 52KB kimi conversation
+    log with the 403 body ~2KB in, past tool-call preamble) does not — a
+    prefix-only snippet silently drops the very marker phrase that decided
+    the classification, which breaks the one thing a lifted reason must do:
+    survive a later re-classification of the text it was lifted into.
+    ``anchor=None`` keeps the exact original prefix behavior.
+    """
+    window = text
+    if anchor is not None:
+        window = text[max(0, anchor - 80):]
+    snippet = " ".join(window.split())
     if len(snippet) > max_len:
         snippet = snippet[:max_len].rstrip() + "…"
     return snippet
@@ -507,12 +522,24 @@ def _classify_lane_log_text(text: str) -> Tuple[str, Optional[str]]:
     on a narrow provider-owned label, see _LANE_EXHAUSTED_MARKERS) or
     'unreadable_verdict' (the lane produced content but no recognizable
     billing/quota signal — the model may have answered, but no verdict could
-    be read out of it). reason is only populated for lane_exhausted.
+    be read out of it). reason is only populated for lane_exhausted, and is
+    windowed around the EARLIEST-occurring marker's position in the text
+    (OI-1452), not the start of the text or the first tuple-order marker —
+    see ``_bounded_snippet``'s ``anchor`` parameter. Position, not tuple
+    order, decides the anchor: a real 403 body can trip more than one marker
+    (e.g. both "reached your usage limit" and "access_terminated_error" in
+    the same message), and the tuple-order marker is not necessarily the one
+    closest to the start — anchoring on whichever happened to be listed
+    first would arbitrarily drop earlier, equally-real context.
     """
     lowered = text.lower()
+    earliest_idx: Optional[int] = None
     for marker in _LANE_EXHAUSTED_MARKERS:
-        if marker in lowered:
-            return "lane_exhausted", _bounded_snippet(text)
+        idx = lowered.find(marker)
+        if idx != -1 and (earliest_idx is None or idx < earliest_idx):
+            earliest_idx = idx
+    if earliest_idx is not None:
+        return "lane_exhausted", _bounded_snippet(text, anchor=earliest_idx)
     return "unreadable_verdict", None
 
 

--- a/tests/test_oi1452_canonical_failure_reason.py
+++ b/tests/test_oi1452_canonical_failure_reason.py
@@ -1,0 +1,223 @@
+"""tests/test_oi1452_canonical_failure_reason.py — kimi_gate.py/glm_gate.py's
+OI-1452 lift lands the real outage reason in ``residual_risk``, but never in
+``failure_reason`` — the CANONICAL field OI-1415 (#1666,
+scripts/lib/phantom_guard.py) established for generic failure readers.
+
+Measured 23-08 over ALL 405 review-gate result records on the central store,
+across all six gates and the entire history: 0 of 405 carry a filled
+``failure_reason``. 328 carry the reason in ``residual_risk`` instead — the
+request-time takeover classifier finds it there, but a generic reader that
+only knows to look at the canonical field sees nothing.
+
+This fix stamps ``failure_reason`` with the SAME text placed in
+``residual_risk`` — but ONLY the text the OI-1452 lift itself computed (the
+lane-log-derived reason), never a placeholder and never a summary of the
+frontmatter fields when the lift found nothing. Three ways to be wrong here,
+in ascending order of danger: an EMPTY field fails visibly (a reader can tell
+the cause is unknown); a PLACEHOLDER passes every presence check and fails
+silently; a SUMMARY that merely looks like a cause is worst of all, because
+it cannot be told apart from a real one. That is why every test below
+asserts EQUALITY against the exact lifted text, never mere non-emptiness — a
+``assert record["failure_reason"]`` check would go green the moment someone
+"helpfully" fills the field with anything at all.
+
+Covers all four states from the dispatch:
+  1. lane-log WITH exhaustion marker -> failure_reason == the lifted text,
+     and that same text is a substring of residual_risk
+  2. lane-log ABSENT -> failure_reason empty, current behavior unchanged
+  3. lane-log present but WITHOUT a marker -> failure_reason empty
+  4. a SUCCESSFUL run -> failure_reason empty, no lane log ever read
+
+Plus one verification against the REAL production record/lane-log pair
+(``kimi-gate-pr1677-1787477677``, the same outage
+``test_oi1452_lane_log_lift_provider_failed_detail.py`` documents) — read
+from the live central store (read-only) and round-tripped through the real
+gate code on a copy in ``tmp_path``; nothing is ever written back to the
+live store. Skips cleanly on a machine without that local store.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+for _p in (str(SCRIPTS_DIR), str(SCRIPTS_DIR / "lib")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import kimi_gate
+import glm_gate
+from governance_emit import _classify_lane_log_text
+
+from test_oi1452_lane_log_lift_provider_failed_detail import (
+    _FIXTURES,
+    _GLM_REAL_SHAPE_REPORT,
+    _KIMI_REAL_SHAPE_REPORT,
+    _REAL_PASS_REPORT,
+    _run_gate_for_real_pr,
+)
+
+_KIMI_MARKER_LOG = (_FIXTURES / "kimi_403_quota.log").read_text(encoding="utf-8")
+_NO_MARKER_LOG = (_FIXTURES / "content_no_verdict.log").read_text(encoding="utf-8")
+
+# The exact text the lift computes for the marker fixture — derived from the
+# SAME classifier the gates call, never a separately hand-typed string that
+# could silently drift from what the code actually produces.
+_EXPECTED_LIFTED_REASON = _classify_lane_log_text(_KIMI_MARKER_LOG)[1]
+assert _EXPECTED_LIFTED_REASON, "fixture must carry a real exhaustion marker"
+
+
+# ---------------------------------------------------------------------------
+# 1. lane-log WITH exhaustion marker -> failure_reason == the lifted text
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_lane_log_with_marker_stamps_failure_reason_equal_to_lifted_text(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _KIMI_REAL_SHAPE_REPORT, _KIMI_MARKER_LOG,
+    )
+    assert rc == 1
+    assert record["failure_reason"] == _EXPECTED_LIFTED_REASON
+    assert _EXPECTED_LIFTED_REASON in record["residual_risk"]
+    # residual_risk keeps its own additional prefix — the two fields are not
+    # simply duplicates of each other.
+    assert record["residual_risk"] != record["failure_reason"]
+
+
+def test_glm_lane_log_with_marker_stamps_failure_reason_equal_to_lifted_text(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _GLM_REAL_SHAPE_REPORT, _KIMI_MARKER_LOG,
+    )
+    assert rc == 1
+    assert record["failure_reason"] == _EXPECTED_LIFTED_REASON
+    assert _EXPECTED_LIFTED_REASON in record["residual_risk"]
+    assert record["residual_risk"] != record["failure_reason"]
+
+
+# ---------------------------------------------------------------------------
+# 2. lane-log ABSENT -> failure_reason empty, current behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_no_lane_log_leaves_failure_reason_empty(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _KIMI_REAL_SHAPE_REPORT, lane_log_text=None,
+    )
+    assert rc == 1
+    assert record["failure_reason"] == ""
+    assert record["residual_risk"] == (
+        "kimi's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=0) — provider-side outage, not a "
+        "review outcome"
+    )
+
+
+def test_glm_no_lane_log_leaves_failure_reason_empty(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _GLM_REAL_SHAPE_REPORT, lane_log_text=None,
+    )
+    assert rc == 1
+    assert record["failure_reason"] == ""
+    assert record["residual_risk"] == (
+        "glm's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=0) — provider-side outage, not a "
+        "review outcome"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. lane-log present but WITHOUT a marker -> failure_reason empty
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_lane_log_without_marker_leaves_failure_reason_empty(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _KIMI_REAL_SHAPE_REPORT, _NO_MARKER_LOG,
+    )
+    assert rc == 1
+    assert record["failure_reason"] == ""
+    assert "lane log" not in record["residual_risk"]
+
+
+def test_glm_lane_log_without_marker_leaves_failure_reason_empty(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _GLM_REAL_SHAPE_REPORT, _NO_MARKER_LOG,
+    )
+    assert rc == 1
+    assert record["failure_reason"] == ""
+    assert "lane log" not in record["residual_risk"]
+
+
+# ---------------------------------------------------------------------------
+# 4. a SUCCESSFUL run -> failure_reason empty, no lane log ever read
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_successful_run_leaves_failure_reason_empty(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _REAL_PASS_REPORT, _KIMI_MARKER_LOG,
+    )
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["failure_reason"] == ""
+
+
+def test_glm_successful_run_leaves_failure_reason_empty(tmp_path, monkeypatch):
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _REAL_PASS_REPORT, _KIMI_MARKER_LOG,
+    )
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["failure_reason"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 5. Verification against the REAL production record/lane-log pair — read
+#    from the live central store (read-only), round-tripped through the
+#    real gate on a COPY in tmp_path. Never writes back to the live store.
+# ---------------------------------------------------------------------------
+
+
+def _real_store_dir() -> Path:
+    """The operator's real central store — deliberately NOT read from
+    ``VNX_DATA_DIR``: ``tests/conftest.py`` pins that env var to an isolated
+    tmp dir fleet-wide (module-level, before any test module is collected)
+    so tests never touch production by accident. This lookup wants the
+    opposite — a real, read-only look at the live store — so it goes
+    straight at the well-known local path instead of the isolated env var.
+    """
+    return Path.home() / ".vnx-data" / "vnx-dev"
+
+
+def test_kimi_real_pr1677_record_and_lane_log_stamp_failure_reason_on_copy(tmp_path, monkeypatch):
+    store = _real_store_dir()
+    real_report = store / "unified_reports" / "kimi-gate-pr1677-1787477677.md"
+    real_log = store / "logs" / "conversations" / "kimi-gate-pr1677-1787477677.log"
+    if not (real_report.is_file() and real_log.is_file()):
+        pytest.skip(
+            f"real PR #1677 kimi_gate report/lane-log not present under {store} — "
+            "this verification only runs on the operator's own local central store"
+        )
+
+    real_report_text = real_report.read_text(encoding="utf-8")
+    real_log_text = real_log.read_text(encoding="utf-8")
+    expected_reason = _classify_lane_log_text(real_log_text)[1]
+    assert expected_reason, "real PR #1677 lane log must classify as lane_exhausted"
+
+    rc, record, data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, real_report_text, real_log_text, pr="1677",
+    )
+
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["failure_reason"] == expected_reason
+    assert expected_reason in record["residual_risk"]
+    # only the tmp_path copy was ever touched — the live store's files are
+    # unchanged (read-only reads above), and the result record landed under
+    # data_dir, not under the live store.
+    assert str(data_dir).startswith(str(tmp_path))
+    assert real_report.read_text(encoding="utf-8") == real_report_text
+    assert real_log.read_text(encoding="utf-8") == real_log_text

--- a/tests/test_oi1452_lane_log_lift_provider_failed_detail.py
+++ b/tests/test_oi1452_lane_log_lift_provider_failed_detail.py
@@ -1,0 +1,345 @@
+"""tests/test_oi1452_lane_log_lift_provider_failed_detail.py — the request-time
+review-gate takeover (DLv5+8, PR #1675/OI-1436) never fires on a REAL
+production kimi_gate/glm_gate outage, because the reason never reaches the
+result record (OI-1452).
+
+Measured 23-08 on a COPY of the central store against the real kimi-gate
+outage on PR #1677 (``pr-1677-kimi_gate.json`` /
+``logs/conversations/kimi-gate-pr1677-1787477677.log``, see the dispatch
+report for the full before/after transcript):
+
+    _classify_review_seat_failure(real record)  -> 'no_response'
+    takeover only fires on                       -> 'lane_exhausted'
+
+The real record's ``residual_risk`` carries only the frontmatter-derived
+detail (``kimi's own report frontmatter stamps this run as failed
+(exit_code=1, token_usage.output=0) ...``) — never the raw 403/quota body,
+which sits in the per-dispatch raw lane log instead. The takeover
+classifier (``gate_request_handler._classify_review_seat_failure``, PR
+#1675, not yet merged onto this branch) scans ``residual_risk`` /
+``reason_detail`` / ``summary`` with ``governance_emit._classify_lane_log_text``
+for a billing/quota exhaustion marker; with nothing but the generic
+exit_code/token_usage sentence to scan, it can never see one.
+
+kimi_gate.py / glm_gate.py now lift the real reason off the raw lane log
+(``logs/conversations/<dispatch_id>.log``) into ``provider_failed_detail``
+(and therefore ``residual_risk``) using the SAME classifier OI-1433 built
+for exactly this purpose (``governance_emit._classify_lane_log_text``) —
+never a second hand-rolled marker scan.
+
+RED-on-main proof (recorded before the fix landed — see the dispatch report
+for the exact command + failure line):
+
+    pytest tests/test_oi1452_lane_log_lift_provider_failed_detail.py::test_kimi_real_record_format_lifts_lane_log_reason_into_residual_risk -x
+
+    AssertionError: expected the lifted lane-log reason to land in residual_risk
+    assert False
+
+Companion fix (also in this dispatch, in ``governance_emit.py``): the
+existing ``_classify_lane_log_text``/``_bounded_snippet`` always windowed the
+lifted reason from the START of the raw text. That is fine for a short
+single-shot error body (the original OI-1433 fixture), but the real PR #1677
+lane log is a 52KB multi-turn conversation transcript with ~2KB of tool-call
+chatter BEFORE the 403 body — a prefix-only snippet silently dropped the
+exhaustion marker it was supposed to carry, which broke the round-trip
+through the takeover classifier even with kimi_gate.py's lift wired up. The
+snippet now windows around the earliest-occurring marker's actual position
+in the text instead of always starting at offset 0 — see
+``tests/test_oi1433_lane_log_lift.py`` for the pre-existing suite this must
+not regress (verified green after this change).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+for _p in (str(SCRIPTS_DIR), str(SCRIPTS_DIR / "lib")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import kimi_gate
+import glm_gate
+from governance_emit import _classify_lane_log_text
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "lane_logs"
+_FAKE_DIFF = "diff --git a/x b/x\n+ok\n"
+
+# Sanity check on the shared fixtures this file leans on (also used by
+# tests/test_oi1433_lane_log_lift.py): one carries a real billing/quota
+# exhaustion marker, the other carries content with no such marker at all.
+assert _classify_lane_log_text((_FIXTURES / "kimi_403_quota.log").read_text())[0] == "lane_exhausted"
+assert _classify_lane_log_text((_FIXTURES / "content_no_verdict.log").read_text())[0] == "unreadable_verdict"
+
+
+def _report_with_frontmatter(
+    provider: str,
+    model: str,
+    body: str,
+    *,
+    exit_code: int,
+    output_tokens: int = 0,
+    token_usage_measured: bool = False,
+) -> str:
+    """The ECHTE recordformaat (OI-1452): a governed report whose OWN
+    frontmatter stamps the underlying run as failed (exit_code != 0), but
+    whose body is ordinary — possibly truncated — prose with NO verdict
+    block and NO 403/quota text at all. This is the exact shape measured on
+    the real PR #1677 kimi_gate report on disk: 36 lines of real model
+    output ("The dispatch prompt doesn't inline the exact report path...."),
+    zero mention of the outage that actually killed the run. A fixture that
+    embeds the 403 directly in the report body (the pre-existing takeover
+    test's fixture) proves the takeover logic, not this coupling.
+    """
+    return (
+        "---\n"
+        "schema_version: 1\n"
+        f"provider: {provider}\n"
+        f"model: {model}\n"
+        "duration_seconds: 258.33\n"
+        f"exit_code: {exit_code}\n"
+        "token_usage:\n"
+        "  input: 0\n"
+        f"  output: {output_tokens}\n"
+        "  cache_read: 0\n"
+        f"token_usage_measured: {'true' if token_usage_measured else 'false'}\n"
+        "---\n"
+        "\n"
+        f"{body}"
+    )
+
+
+# Real body text, same shape as the actual PR #1677 kimi_gate report on
+# disk: genuine (truncated) model prose, no verdict fence, no outage text.
+_REAL_SHAPE_BODY = (
+    "The dispatch prompt doesn't inline the exact report path, but the panel "
+    "convention (`plan_gate_panel.py:976`) is `$VNX_DATA_DIR/unified_reports/"
+    "{dispatch_id}.md`. Now let me verify the diff against the actual "
+    "worktree files and check consumers for regressions.\n"
+)
+
+_KIMI_REAL_SHAPE_REPORT = _report_with_frontmatter(
+    "kimi", "kimi-k3", _REAL_SHAPE_BODY, exit_code=1, output_tokens=0,
+)
+_GLM_REAL_SHAPE_REPORT = _report_with_frontmatter(
+    "glm-harness", "glm-5.2", _REAL_SHAPE_BODY, exit_code=1, output_tokens=0,
+)
+
+_REAL_PASS_REPORT = (
+    "Reviewed the diff, no issues.\n\n"
+    "```json\n"
+    '{"verdict": "pass", "findings": [], "residual_risk": null}\n'
+    "```\n"
+)
+
+
+def _fake_dispatcher_factory(data_dir: Path, report_text: str, lane_log_text: "str | None"):
+    """Build a ``_make_default_dispatcher``-shaped double that writes the
+    unified report AND (when given) the per-dispatch raw lane log, keyed on
+    the actual ``dispatch_id`` the caller passes in — exactly like the real
+    governed lane: ``provider_dispatch`` tees the raw lane log to
+    ``logs/conversations/<dispatch_id>.log`` as a side effect of the run,
+    and the report is already on disk by the time the dispatcher call
+    returns the text kimi_gate.py/glm_gate.py go on to read.
+    """
+    def _make(*_a, **_k):
+        def _dispatch(provider, model_arg, instruction, dispatch_id):
+            reports_dir = data_dir / "unified_reports"
+            reports_dir.mkdir(parents=True, exist_ok=True)
+            (reports_dir / f"{dispatch_id}.md").write_text(report_text, encoding="utf-8")
+            if lane_log_text is not None:
+                log_dir = data_dir / "logs" / "conversations"
+                log_dir.mkdir(parents=True, exist_ok=True)
+                (log_dir / f"{dispatch_id}.log").write_text(lane_log_text, encoding="utf-8")
+            return report_text
+        return _dispatch
+    return _make
+
+
+def _run_gate_for_real_pr(gate_module, tmp_path, monkeypatch, report_text, lane_log_text, *, pr="4242"):
+    """Run ``gate_module.main()`` against a non-offline PR (no --diff-file,
+    so ``test_run`` stays False, matching a real governed run): a stubbed
+    diff source, a dispatcher double that writes the report + lane log like
+    the real lane does, and stubbed gh-identity lookups (no real ``gh``
+    subprocess calls). Same convention as
+    tests/test_dlv2_kimi_gate_evidence.py / tests/test_dlv1_glm_gate.py.
+    """
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(gate_module, "_get_diff", lambda pr_arg, diff_file: _FAKE_DIFF)
+    monkeypatch.setattr(
+        gate_module, "_make_default_dispatcher",
+        _fake_dispatcher_factory(data_dir, report_text, lane_log_text),
+    )
+    monkeypatch.setattr(gate_module, "get_pr_head_branch", lambda pr_number: "feature/oi1452-test")
+    monkeypatch.setattr(gate_module, "get_pr_head_sha", lambda pr_number: "cafedeadbeef")
+
+    rc = gate_module.main(["--pr", pr, "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / f"pr-{pr}-{gate_module.__name__}.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    return rc, record, data_dir
+
+
+# ---------------------------------------------------------------------------
+# 1. The lift: ECHTE recordformaat (frontmatter reason, no 403 in the
+#    report) + a lane log carrying the real exhaustion marker -> the
+#    reason must land in residual_risk. RED on pre-fix kimi_gate.py/
+#    glm_gate.py, GREEN after (see dispatch report for the recorded
+#    before/after pytest run).
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_real_record_format_lifts_lane_log_reason_into_residual_risk(tmp_path, monkeypatch):
+    lane_log_text = (_FIXTURES / "kimi_403_quota.log").read_text(encoding="utf-8")
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _KIMI_REAL_SHAPE_REPORT, lane_log_text,
+    )
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "dispatch_error"
+    # the frontmatter-derived detail must stay — this fix ADDS the reason,
+    # it does not replace the existing (correct) exit_code/token_usage detail
+    assert "exit_code=1" in record["residual_risk"]
+    assert "access_terminated_error" in record["residual_risk"], (
+        "expected the lifted lane-log reason to land in residual_risk"
+    )
+
+
+def test_glm_real_record_format_lifts_lane_log_reason_into_residual_risk(tmp_path, monkeypatch):
+    lane_log_text = (_FIXTURES / "kimi_403_quota.log").read_text(encoding="utf-8")
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _GLM_REAL_SHAPE_REPORT, lane_log_text,
+    )
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "dispatch_error"
+    assert "exit_code=1" in record["residual_risk"]
+    assert "access_terminated_error" in record["residual_risk"], (
+        "expected the lifted lane-log reason to land in residual_risk"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. The coupling: the SAME lift, re-classified by the request-time takeover
+#    (PR #1675/OI-1436, gate_request_handler._classify_review_seat_failure)
+#    flips from 'no_response' to 'lane_exhausted'. Split out from test 1 —
+#    asserts on the classifier's own returned value, not on residual_risk
+#    text. Skips gracefully until PR #1675 merges onto this branch (its
+#    classifier does not exist here yet); it activates automatically once it
+#    does. See the dispatch report's "Meet het op het ECHTE record" section
+#    for a real (ad hoc, uncommitted) run of this exact coupling against the
+#    actual PR #1677 production record.
+# ---------------------------------------------------------------------------
+
+
+def test_lifted_reason_flips_takeover_classification_to_lane_exhausted(tmp_path, monkeypatch):
+    gate_request_handler = pytest.importorskip(
+        "gate_request_handler",
+        reason="review-gate takeover classifier lands in PR #1675 (OI-1436); "
+        "not yet merged onto this branch",
+    )
+    classify = getattr(gate_request_handler.GateRequestHandlerMixin, "_classify_review_seat_failure", None)
+    if classify is None:
+        pytest.skip(
+            "_classify_review_seat_failure not yet on GateRequestHandlerMixin (PR #1675 pending)"
+        )
+
+    lane_log_text = (_FIXTURES / "kimi_403_quota.log").read_text(encoding="utf-8")
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _KIMI_REAL_SHAPE_REPORT, lane_log_text,
+    )
+    assert record["status"] == "unavailable" and record["reason"] == "dispatch_error"
+
+    # BEFORE: the frontmatter-only detail, exactly as kimi_gate.py produced
+    # it before this dispatch's fix (no lane-log lift at all).
+    before_record = dict(record)
+    before_record["residual_risk"] = (
+        "kimi's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=0) — provider-side outage, not a "
+        "review outcome"
+    )
+    # _classify_review_seat_failure never touches self — safe to call unbound.
+    assert classify(None, before_record) == "no_response"
+
+    # AFTER: the actual record this dispatch's fix produced.
+    assert classify(None, record) == "lane_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# 3. Control cases — must keep passing, or the fix proves nothing.
+# ---------------------------------------------------------------------------
+
+
+def test_kimi_no_lane_log_present_keeps_current_behavior_no_invented_reason(tmp_path, monkeypatch):
+    """The frontmatter says the run failed; no lane log exists at all
+    (``_read_lane_log_text`` -> None). The gate must not crash and must not
+    invent a reason — residual_risk stays exactly the frontmatter-only
+    detail from before this fix."""
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _KIMI_REAL_SHAPE_REPORT, lane_log_text=None,
+    )
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "dispatch_error"
+    assert record["residual_risk"] == (
+        "kimi's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=0) — provider-side outage, not a "
+        "review outcome"
+    )
+    assert "lane log" not in record["residual_risk"]
+
+
+def test_glm_no_lane_log_present_keeps_current_behavior_no_invented_reason(tmp_path, monkeypatch):
+    """Mirrors the kimi case, but is also the real production shape: the
+    glm lane does not always write a per-dispatch log (measured: no log
+    exists for the PR #1681 glm_gate outage either)."""
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _GLM_REAL_SHAPE_REPORT, lane_log_text=None,
+    )
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "dispatch_error"
+    assert record["residual_risk"] == (
+        "glm's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=0) — provider-side outage, not a "
+        "review outcome"
+    )
+    assert "lane log" not in record["residual_risk"]
+
+
+def test_kimi_lane_log_without_exhaustion_marker_stays_unavailable_not_lane_exhausted(tmp_path, monkeypatch):
+    """A lane log exists and has content, but no billing/quota exhaustion
+    marker (``_classify_lane_log_text`` -> ``unreadable_verdict``). This
+    must NOT be lifted into residual_risk — toestand 2/3 behavior stays
+    unchanged, never upgraded to lane_exhausted on a log that says nothing
+    about the cause."""
+    lane_log_text = (_FIXTURES / "content_no_verdict.log").read_text(encoding="utf-8")
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _KIMI_REAL_SHAPE_REPORT, lane_log_text,
+    )
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "dispatch_error"
+    assert record["residual_risk"] == (
+        "kimi's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=0) — provider-side outage, not a "
+        "review outcome"
+    )
+    assert "lane log" not in record["residual_risk"]
+
+
+def test_kimi_successful_run_never_reads_lane_log(tmp_path, monkeypatch):
+    """A real parsed verdict (pass) must never trigger a lane-log read, even
+    when a quota-shaped log happens to exist for the same dispatch_id — the
+    frontmatter/lane-log path is only ever consulted once verdict
+    extraction has already failed."""
+    lane_log_text = (_FIXTURES / "kimi_403_quota.log").read_text(encoding="utf-8")
+    rc, record, _data_dir = _run_gate_for_real_pr(
+        kimi_gate, tmp_path, monkeypatch, _REAL_PASS_REPORT, lane_log_text,
+    )
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert "access_terminated_error" not in json.dumps(record)


### PR DESCRIPTION
## Summary
- kimi_gate.py/glm_gate.py's `provider_failed_detail` only echoed the report's own `exit_code`/`token_usage` frontmatter on a provider-side run failure, never the actual WHY. The request-time review-gate takeover (PR #1675/OI-1436, not yet merged) scans `residual_risk`/`reason_detail`/`summary` for a billing/quota exhaustion marker before deciding to take over a failed seat — with nothing but a generic exit_code sentence to scan, it can never see one and stays stuck on `no_response` instead of `lane_exhausted`.
- Measured on a COPY of the central store against the real kimi_gate outage on PR #1677: before this fix, `_classify_review_seat_failure` returns `no_response`; after, `lane_exhausted`.
- Companion fix in `governance_emit.py`: `_classify_lane_log_text`'s reason snippet always windowed from the start of the text, which silently dropped the marker on a long multi-turn lane log (the real PR #1677 log is 52KB with the 403 body ~2KB in, past the previous 300-char prefix window) — breaking the round-trip through the takeover classifier even with the lift wired up. The snippet now windows around the earliest-occurring marker's actual position instead of the start of the text.

## Fix-forward addition (this update): fill the canonical `failure_reason` field too
Measured over ALL 405 review-gate result records on the central store, across all six gates and the entire history: **0 of 405 carry a filled `failure_reason`** (codex_gate 0/250, ci_gate 0/102, gemini_review 0/19, claude_github_optional 0/16, kimi_gate 0/13, glm_gate 0/5). Where the reason DOES land: `residual_risk` 328, `reason` 162, `reason_detail` 128.

`failure_reason` is the canonical field OI-1415 (#1666) established — the place a generic reader looks for the cause. The OI-1452 lift above writes into `residual_risk`, which the request-time takeover classifier scans, but a generic `failure_reason` reader still sees nothing: the machine works, the human doesn't.

**We fill the canonical field on the two gates where we now compute the cause — `kimi_gate` and `glm_gate`. The other four gates (`codex_gate`, `ci_gate`, `gemini_review`, `claude_github_optional`) still don't populate `failure_reason` at all — tracked separately as OI-1453.** This PR does not close that gap fleet-wide, only where the OI-1452 lift already exists.

`failure_reason` gets set to exactly the same text `_lift_lane_log_reason()` computed (verified with an equality assert, not a non-empty check) — never a placeholder, never a summary of the frontmatter fields, when the lift found nothing. `residual_risk` is untouched; this is additive, mirroring the OI-1415 pattern in `scripts/lib/phantom_guard.py`.

## Changes
- `scripts/kimi_gate.py` — new `_lift_lane_log_reason()`; wired into the `run_failed is True` branch to append the classified lane-log reason to `provider_failed_detail`. Record now also stamps `failure_reason` with the lifted text only (empty otherwise).
- `scripts/glm_gate.py` — same fix, mirrored (degrades gracefully when the glm lane wrote no per-dispatch log, e.g. the PR #1681 case). Same `failure_reason` stamp.
- `scripts/lib/governance_emit.py` — `_bounded_snippet()` gained an `anchor` parameter; `_classify_lane_log_text()` now anchors the snippet on the earliest-occurring exhaustion marker's position instead of always the start of the text (backward compatible: `anchor=None` for any other caller).
- `tests/test_oi1452_lane_log_lift_provider_failed_detail.py` — original lift suite (see Verification).
- `tests/test_oi1452_canonical_failure_reason.py` — new suite for the `failure_reason` addition: equality asserts (never non-empty checks) across all four states (marker present / lane-log absent / lane-log present without marker / successful run, for both gates), plus one verification run against the REAL `kimi-gate-pr1677-1787477677` record and lane log, read from the live central store (read-only) and round-tripped through the real gate on a `tmp_path` copy — never writes back to the live store, skips cleanly on a machine without that local store.

## Verification
Targeted tests only (dispatch rule — not the full suite):
```
pytest tests/test_oi1452_lane_log_lift_provider_failed_detail.py tests/test_oi1433_lane_log_lift.py tests/test_oi1452_canonical_failure_reason.py tests/test_kimi_gate_unavailable.py tests/test_dlv1_glm_gate.py tests/test_dlv2_kimi_gate_evidence.py tests/test_kimi_gate_provenance.py tests/test_gate_recorder_provenance.py tests/test_dlv45_gate_recognition.py
```
`90 passed, 1 skipped` (skip: `test_lifted_reason_flips_takeover_classification_to_lane_exhausted`, `importorskip`-guarded on PR #1675 not yet merged onto this branch — activates automatically once it lands).

RED-before-fix (original lift) was captured with a scoped `git stash` of just the 3 fix files: both `test_*_real_record_format_lifts_lane_log_reason_into_residual_risk` tests failed with `AssertionError: expected the lifted lane-log reason to land in residual_risk`, all others (the control cases) already passed.

Real-record measurement (ad hoc, on a temp copy of the store + a read-only, uncommitted fetch of PR #1675's classifier for verification only — never committed here):
```
classificatie VOOR (echt record, ongewijzigd): no_response
classificatie NA   (met OI-1452 lift toegepast): lane_exhausted
```

`failure_reason` verified on the same real PR #1677 record/lane-log pair, on a `tmp_path` copy of the store (`tests/test_oi1452_canonical_failure_reason.py::test_kimi_real_pr1677_record_and_lane_log_stamp_failure_reason_on_copy`): `failure_reason` equals the exact text `_classify_lane_log_text()` returns for the real 52KB lane log, and that text is a substring of `residual_risk`.

## Open Items
- `test_lifted_reason_flips_takeover_classification_to_lane_exhausted` is currently SKIPPED on this branch — `gate_request_handler._classify_review_seat_failure` (PR #1675/OI-1436) isn't merged yet. It will activate automatically once that PR lands; no action needed on this PR's side.
- This PR is scoped to `kimi_gate.py`/`glm_gate.py`/`governance_emit.py` only — it does not touch `gate_request_handler.py` (out of scope, owned by PR #1675).
- **`failure_reason` is only filled on `kimi_gate`/`glm_gate` — the other four review gates (`codex_gate`, `ci_gate`, `gemini_review`, `claude_github_optional`) still never populate the canonical field at all. Tracked as OI-1453, not addressed here.**

## Rebase note (2026-08-25)
Rebased onto current `main` (was conflicting against #1681, `cf27f3c9`, which restructured the same
verdict-resolution flow in both `glm_gate.py`/`kimi_gate.py` and retired the `parse_error` bucket).
Two semantic conflicts per file, resolved identically in both:

1. **`_status_summary` had two definitions after the merge.** Kept main's signature
   (`reason=""`, no `report_len` — `report_len` was already dead weight per #1681) and its
   `_UNAVAILABLE_SUMMARIES` dict, and kept this branch's `_lift_lane_log_reason()` alongside it.
   Exactly one `def _status_summary` remains per file.
2. **`provider_failed_detail` handling.** #1681 replaced the old single-path
   `provider_failed_detail`/`_verdict_to_status` call with a `verdict → no_verdict →
   relabeled_verdict → frontmatter(run_failed) → recovery-search` chain, and dropped the old
   unconditional pre-chain block this branch's `368c0c42` had patched. Rather than keep the
   now-dead pre-chain block, the lane-log lift (`_lift_lane_log_reason()` call +
   `provider_failed_detail += " — lane log: ..."`) was threaded into main's own
   `if run_failed is True:` branch, immediately after `provider_failed_detail` is built and
   before the single `_verdict_to_status(..., provider_failed_detail=...)` call in that branch —
   the same place the old code called it, just inside main's restructured chain instead of
   before it. No duplicate `_verdict_to_status` call; a real parsed verdict still always wins
   (the chain checks `verdict` first, before ever reaching this branch); `gate_report_recovery`
   /`--reprocess` are untouched (I did not modify that code); a missing/markerless lane log still
   degrades to the frontmatter-only detail, never a crash or an invented reason
   (`_lift_lane_log_reason` returns `None` on both).

The second commit (`failure_reason` canonical-field stamp) applied cleanly on top with no
further conflicts — it only reads the `lane_log_reason` variable this resolution already wires
through the same `run_failed is True` branch.

Verified post-rebase: `grep -c 'def _status_summary'` → 1 in both files. `grep -c 'parse_error'`
→ 1 in both files, but that one hit in each is main's own pre-existing explanatory comment
(`# ... "parse_error" (a single bucket for "no readable verdict on a clean run") is retired ...`,
already on `origin/main` before this rebase touched anything, verified via `git show
origin/main:scripts/glm_gate.py`/`kimi_gate.py`) — not a reintroduction of the retired bucket.
Targeted tests (`test_oi1452_lane_log_lift_provider_failed_detail.py`,
`test_gate_report_recovery.py`, `test_gate_recovery_wiring.py`, `test_kimi_gate_unavailable.py`)
plus neighbours (`test_oi1452_canonical_failure_reason.py`, `test_kimi_gate_provenance.py`,
`test_dlv2_kimi_gate_evidence.py`, `test_dlv1_glm_gate.py`): all green, 0 failures.

Dispatch-ID: 20260823-beta2-k-oi1452-lane-log-lift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

