### PR TITLE
fix(config-runtime): fall back to canonical state-dir resolver (OI-1461)

### DIFF
--- a/scripts/lib/config_runtime.py
+++ b/scripts/lib/config_runtime.py
@@ -9,10 +9,13 @@ the runtime, while an un-set flag resolves exactly as the env-only world did (be
 Single-tenant: one runtime process serves one project. ``autowire()`` binds the resolver to that
 project's state dir + sets it as config_registry's default project, so read-sites call ``get_bool``
 / ``get`` with no project_id. Idempotent (wires once) and fail-soft (any resolution error leaves the
-registry env-only — the runtime never breaks because the config DB is missing).
+registry env-only — the runtime never breaks because the config DB is missing) — but fail-soft is
+LOUD (a WARNING naming the reason), not silent: a store that cannot be found reads identically to a
+flag the operator explicitly turned off unless the miss is logged (OI-1461).
 """
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -24,16 +27,47 @@ if _LIB not in sys.path:
 
 import config_registry  # noqa: E402  (after the scripts/lib path guard above)
 
+logger = logging.getLogger(__name__)
+
 # Keyed by (state_dir_str, project_id) so a second project in the same process gets its own store.
 # Value is True when that (state_dir, project_id) pair is wired; False / absent otherwise.
 _wired_for: "dict[tuple[str, str], bool]" = {}
 
 
 def _resolve_state_dir(state_dir: "str | Path | None") -> Optional[Path]:
+    """Resolve the runtime state dir. Order: explicit arg > ``$VNX_STATE_DIR`` > the fabric's
+    canonical resolver (``vnx_paths.resolve_paths()["VNX_STATE_DIR"]``) — the same resolver
+    ``orphan_sweep.py`` and ``glm_gate.py``'s ``_resolve_data_dir`` chain fall back to.
+
+    Relying solely on the env var (OI-1461) left every process that starts without an explicit
+    ``VNX_STATE_DIR`` export unable to see an operator-set ``project_config`` value even though
+    ``vnx_paths.resolve_paths()`` finds the exact same store two lines later — a genuine
+    review-gate chain stall on a flag that was correctly set in the DB the whole time.
+    """
     if state_dir:
         return Path(state_dir)
     env_sd = os.environ.get("VNX_STATE_DIR")
-    return Path(env_sd) if env_sd else None
+    if env_sd:
+        return Path(env_sd)
+    try:
+        from vnx_paths import resolve_paths  # type: ignore[import]
+        resolved = resolve_paths().get("VNX_STATE_DIR")
+    except Exception as exc:
+        logger.warning(
+            "config_runtime: canonical state-dir resolver (vnx_paths.resolve_paths) failed (%s); "
+            "operator config in project_config will NOT be read this process — reads fall back to "
+            "env vars / registry defaults only",
+            exc,
+        )
+        return None
+    if not resolved:
+        logger.warning(
+            "config_runtime: canonical state-dir resolver returned no VNX_STATE_DIR; operator "
+            "config in project_config will NOT be read this process — reads fall back to env vars "
+            "/ registry defaults only"
+        )
+        return None
+    return Path(resolved)
 
 
 def _resolve_project_id(state_dir: Path, project_id: Optional[str]) -> Optional[str]:
@@ -59,14 +93,27 @@ def autowire(state_dir: "str | Path | None" = None, project_id: Optional[str] = 
     try:
         sd = _resolve_state_dir(state_dir)
         if sd is None:
+            # _resolve_state_dir already logged the reason (env-only miss vs. resolver failure).
             return False
         pid = _resolve_project_id(sd, project_id)
         if not pid:
+            logger.warning(
+                "config_runtime: could not resolve a project_id for state_dir=%s; operator config "
+                "in project_config will NOT be read this process — reads fall back to env vars / "
+                "registry defaults only",
+                sd,
+            )
             return False
         wire_key = (str(sd), pid)
         if not _wired_for.get(wire_key):
             # First time for this pair: confirm the DB exists before wiring.
             if not (sd / "runtime_coordination.db").exists():
+                logger.warning(
+                    "config_runtime: no runtime_coordination.db under state_dir=%s (project_id=%s); "
+                    "operator config in project_config will NOT be read this process — reads fall "
+                    "back to env vars / registry defaults only",
+                    sd, pid,
+                )
                 return False
         # Always (re)apply the global registry state for the requested pair, so a switch
         # back to a previously-wired project restores ITS resolver + default — a bare cache

--- a/tests/test_config_runtime.py
+++ b/tests/test_config_runtime.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 """Tests for config_runtime — the runtime-process façade that autowires config_registry (P0, PR 6).
 
-Dispatch-ID: 20260627-config-runtime
+Dispatch-ID: 20260627-config-runtime / 20260824-alpha-a5-config-reader-fallback (OI-1461)
 
 Covers: autowire binds the DB resolver + default project so a UI-set value is honoured; behaviour
 preservation (no DB value / no state → exactly env-or-default); idempotence + fail-soft; and
 config_registry's new default-project resolution.
+
+OI-1461: ``_resolve_state_dir`` used to rely SOLELY on ``$VNX_STATE_DIR`` and return None the
+moment it was unset — even though ``vnx_paths.resolve_paths()`` (the fabric's canonical resolver)
+finds the exact same store without it. Every test below mocks ``vnx_paths.resolve_paths`` to `{}`
+by default (via the autouse fixture) so the REAL environment's actual central store — which, on
+this repo's own dev machine, genuinely exists at ``~/.vnx-data/vnx-dev/state`` — never leaks into
+a "no state dir" test and silently flips its outcome.
 """
 
+import logging
 import sqlite3
 import sys
 from pathlib import Path
@@ -20,6 +28,7 @@ sys.path.insert(0, str(REPO / "scripts" / "lib"))
 import config_registry as cr  # noqa: E402
 import config_store_db as cs  # noqa: E402
 import config_runtime as crt  # noqa: E402
+import vnx_paths  # noqa: E402
 
 PID = "vnx-dev"
 
@@ -31,6 +40,11 @@ def _clean(monkeypatch):
         monkeypatch.delenv(f"VNX_OVERRIDE_{cr._bare(k)}", raising=False)
     monkeypatch.delenv("VNX_STATE_DIR", raising=False)
     monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    # Default: the canonical resolver finds nothing. This is what makes the OLD "no VNX_STATE_DIR
+    # -> False" tests still deterministic under the NEW fallback — without this, they would
+    # silently pick up this repo's own real ~/.vnx-data/vnx-dev/state store. Tests that want to
+    # exercise the fallback override this explicitly.
+    monkeypatch.setattr(vnx_paths, "resolve_paths", lambda: {})
     crt._wired_for.clear()
     cr.set_db_resolver(None)
     cr.set_default_project_id(None)
@@ -44,7 +58,9 @@ def _state_dir_with(tmp_path, key, value, project_id=PID):
     sd = tmp_path / "state"
     sd.mkdir()
     conn = sqlite3.connect(sd / "runtime_coordination.db")
-    cs.set_config(conn, project_id, key, value, actor="op")
+    entry = cr.CONFIG_REGISTRY[key]
+    approval_id = "test-approval" if entry.requires_approval else None
+    cs.set_config(conn, project_id, key, value, actor="op", approval_id=approval_id)
     conn.close()
     return sd
 
@@ -97,6 +113,54 @@ def test_autowire_is_idempotent(tmp_path):
     assert crt.autowire(state_dir=sd, project_id=PID) is True
     # A second call with the same (state_dir, project_id) is a fast no-op and still returns True.
     assert crt.autowire(state_dir=sd, project_id=PID) is True
+    assert crt.get_bool("VNX_SCOUT_PREPASS") is True
+
+
+# ---------------------------------------------------------------------------
+# OI-1461: canonical-resolver fallback when VNX_STATE_DIR is unset
+# ---------------------------------------------------------------------------
+
+def test_get_falls_back_to_canonical_resolver_without_env(tmp_path, monkeypatch):
+    """The bug: a real operator-set value (VNX_CI_GATE_REQUIRED=1 in project_config) was
+    invisible to config_runtime.get() whenever the process started without VNX_STATE_DIR
+    exported — even though vnx_paths.resolve_paths() finds the same store fine. Without the
+    fix this asserts "0" (the registry default) instead of the DB value "1"."""
+    sd = _state_dir_with(tmp_path, "VNX_CI_GATE_REQUIRED", "1")
+    monkeypatch.setattr(vnx_paths, "resolve_paths", lambda: {"VNX_STATE_DIR": str(sd)})
+    monkeypatch.setattr(vnx_paths, "project_id_from_state_dir", lambda _sd: PID)
+
+    assert crt.get("VNX_CI_GATE_REQUIRED") == "1"
+    assert crt.get_bool("VNX_CI_GATE_REQUIRED") is True
+
+
+def test_autowire_warns_loudly_when_store_unfindable(monkeypatch, caplog):
+    """Fail-loud requirement: a genuinely unfindable store (no env var, canonical resolver also
+    comes up empty) must be visibly DIFFERENT from a flag the operator turned off, or an
+    operator-set '1' and a missing store both read back as the same silent '0'. This must fail
+    on the absence of the WARNING, not on a missing symbol — autowire() already returned False
+    before this fix; what was missing is that it did so silently."""
+    monkeypatch.setattr(vnx_paths, "resolve_paths", lambda: {})  # canonical resolver: nothing found
+    with caplog.at_level(logging.WARNING, logger="config_runtime"):
+        result = crt.autowire(project_id=PID)
+    assert result is False
+    assert any(
+        "state-dir" in rec.message.lower() and "config_runtime" in rec.name
+        for rec in caplog.records
+    ), f"expected a loud WARNING naming the unresolved state-dir; got: {[r.message for r in caplog.records]}"
+
+
+def test_explicit_env_state_dir_still_wins(tmp_path, monkeypatch):
+    """Control: an explicit VNX_STATE_DIR must keep winning outright — the canonical resolver
+    must not even be consulted when it is set. Proven by making the mocked resolver raise."""
+    sd = _state_dir_with(tmp_path, "VNX_SCOUT_PREPASS", "1")
+    monkeypatch.setenv("VNX_STATE_DIR", str(sd))
+    monkeypatch.setenv("VNX_PROJECT_ID", PID)
+
+    def _must_not_be_called():
+        raise AssertionError("canonical resolver must not be consulted when VNX_STATE_DIR is set")
+
+    monkeypatch.setattr(vnx_paths, "resolve_paths", _must_not_be_called)
+
     assert crt.get_bool("VNX_SCOUT_PREPASS") is True
 
 


### PR DESCRIPTION
## Summary
- `config_runtime._resolve_state_dir` relied solely on `$VNX_STATE_DIR` and returned `None` the moment it was unset, even though `vnx_paths.resolve_paths()["VNX_STATE_DIR"]` finds the exact same central store two lines later.
- Result: every process that starts without an explicit `VNX_STATE_DIR` export cannot see any operator-set `project_config` value — measured as a 20-hour review-gate chain stall on `VNX_CI_GATE_REQUIRED=1`, which was correctly set in the DB the entire time.
- Fixes the reader only. No flag values, registry defaults, or the explicit-env-var override path were touched.

## Changes
- `scripts/lib/config_runtime.py`
  - `_resolve_state_dir`: order is now explicit arg > `$VNX_STATE_DIR` > `vnx_paths.resolve_paths()["VNX_STATE_DIR"]` (the same canonical resolver `orphan_sweep.py` and `glm_gate.py`'s `_resolve_data_dir` chain already fall back to).
  - `autowire()`: every failure path (unresolved state dir, unresolved project_id, missing `runtime_coordination.db`) now emits a `logger.warning(...)` naming the reason instead of returning `False` silently — a store that cannot be found must read differently from a flag the operator explicitly turned off.
- `tests/test_config_runtime.py`
  - Autouse fixture now mocks `vnx_paths.resolve_paths` to `{}` by default so the existing "no state dir" tests stay deterministic under the new fallback (this repo's own dev machine genuinely has a real `~/.vnx-data/vnx-dev/state` store, which would otherwise leak into those tests).
  - `test_get_falls_back_to_canonical_resolver_without_env` — proves `config_runtime.get()` reads a DB-set value via the canonical resolver with no `VNX_STATE_DIR` exported.
  - `test_autowire_warns_loudly_when_store_unfindable` — proves the fail-loud requirement: a genuinely unfindable store logs a WARNING naming the state-dir miss.
  - `test_explicit_env_state_dir_still_wins` — control: an explicit `VNX_STATE_DIR` still wins outright and the canonical resolver is never even consulted (proven by making the mock raise).
  - `_state_dir_with` helper now passes `approval_id` for registry keys that `requires_approval` (needed once the new tests exercised `VNX_CI_GATE_REQUIRED`, which is such a key).

## Verification

Targeted tests, run from the worktree root:

```
python3 -m pytest tests/test_config_runtime.py -v
# 11 passed
```

Red-before-fix (git-stashed the source fix, tests unchanged), confirming both new tests fail on BEHAVIOR not a missing symbol:
```
FAILED test_get_falls_back_to_canonical_resolver_without_env
  AssertionError: assert '0' == '1'
FAILED test_autowire_warns_loudly_when_store_unfindable
  AssertionError: expected a loud WARNING naming the unresolved state-dir; got: []
2 failed, 9 passed
```

Green-after-fix: all 11 pass (see command above).

Consumer regression check (direct neighbours that import `config_runtime`):
```
python3 -m pytest tests/test_plan_gate_enforcement.py tests/test_dispatch_serialization.py tests/test_dispatch_cli.py tests/test_audit_correctness_fixes.py tests/smart_router/test_staging.py -q
# 274 passed
```

Real-store before/after repro (empty environment, `env -i`), exactly as specified in the dispatch:
```
# before (git-stashed the fix):
False '0'
# after:
True '1'
```

## Open Items
None.

---

**Dispatch-ID**: 20260824-alpha-a5-config-reader-fallback
**Model**: sonnet
**Provider**: claude