### PR TITLE
fix(gate-status): has_complete_evidence refuses non-terminal records (OI-1435)

### DIFF
--- a/scripts/lib/gate_status.py
+++ b/scripts/lib/gate_status.py
@@ -114,23 +114,59 @@ def canonical_status(result: Dict[str, Any]) -> str:
     return status
 
 
-def has_complete_evidence(result: Dict[str, Any]) -> bool:
-    """True when a gate result carries a complete evidence trail (OI-1178).
+# OI-1435: sentinel placeholders a non-normalising writer can slip into a
+# string field instead of leaving it truly absent/empty. A bare non-empty
+# check lets these straight through; they must count as "no evidence" too.
+_EVIDENCE_SENTINEL_VALUES = frozenset({"unknown", "none", "null"})
 
-    A gate that actually ran and produced a verdict materializes BOTH a
-    non-empty ``contract_hash`` (the hashed contract it judged) and a
-    non-empty ``report_path`` (the on-disk report of its findings). An
-    infra failure booked by ``gate_recorder.record_failure`` carries
+
+def _is_populated_evidence_field(value: Any) -> bool:
+    """True when ``value`` is a real, populated evidence-field string.
+
+    Collapses three distinct non-values to False: the field is absent or
+    the wrong type, the field is present but blank/whitespace-only, and the
+    field carries a placeholder sentinel (``"unknown"``/``"none"``/``"null"``
+    as literal text) rather than a real value.
+    """
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    return stripped.lower() not in _EVIDENCE_SENTINEL_VALUES
+
+
+def has_complete_evidence(result: Dict[str, Any]) -> bool:
+    """True when a gate result is terminal AND carries a complete evidence
+    trail (OI-1178, hardened OI-1435).
+
+    Requires ALL of: (1) :func:`is_terminal` — a decided pass/fail/
+    not_executable outcome, never ``unavailable`` or an in-flight status;
+    (2) ``contract_hash`` is a real, populated value; (3) ``report_path`` is
+    a real, populated value. "Real, populated" (2 and 3) is
+    :func:`_is_populated_evidence_field` — absent, blank, and
+    sentinel-placeholder are three different non-values, all False here.
+
+    OI-1435: before this fix, an ``unavailable`` record carrying non-empty
+    ``contract_hash``/``report_path`` (e.g. stale values echoed forward from
+    a prior attempt) read as complete evidence — True on a record with no
+    decided verdict. That separation used to depend entirely on every
+    caller remembering to call :func:`is_terminal` before this function; the
+    terminality check now lives INSIDE the function so the invariant holds
+    regardless of call order — a caller that already checks ``is_terminal``
+    first is now redundant, not wrong.
+
+    An infra failure booked by ``gate_recorder.record_failure`` carries
     neither: ``report_path`` is always "" and ``contract_hash`` echoes
     whatever the never-executed request carried, typically "". Requiring
-    BOTH non-empty separates "a gate ran and decided" from "the gate never
-    ran" — the latter must never be summed up as a PASS.
+    BOTH non-empty (on top of terminality) separates "a gate ran and
+    decided" from "the gate never ran" — the latter must never be summed up
+    as a PASS.
     """
-    contract_hash = result.get("contract_hash")
-    report_path = result.get("report_path")
-    return (
-        isinstance(contract_hash, str) and bool(contract_hash.strip())
-        and isinstance(report_path, str) and bool(report_path.strip())
+    if not is_terminal(result):
+        return False
+    return _is_populated_evidence_field(result.get("contract_hash")) and _is_populated_evidence_field(
+        result.get("report_path")
     )
 
 

--- a/tests/test_gate_unavailable_rollup.py
+++ b/tests/test_gate_unavailable_rollup.py
@@ -43,15 +43,88 @@ from gate_status import has_complete_evidence, is_pass
 @pytest.mark.parametrize(
     "result,expected",
     [
-        ({"contract_hash": "abc", "report_path": "/tmp/r.md"}, True),
-        ({"contract_hash": "", "report_path": "/tmp/r.md"}, False),
-        ({"contract_hash": "abc", "report_path": ""}, False),
-        ({"contract_hash": "abc", "report_path": None}, False),
+        # OI-1435: has_complete_evidence now also requires is_terminal, so
+        # every case here carries a terminal status="pass" — the intent of
+        # this table is to pin the contract_hash/report_path requirement in
+        # isolation from terminality (covered separately below).
+        ({"status": "pass", "contract_hash": "abc", "report_path": "/tmp/r.md"}, True),
+        ({"status": "pass", "contract_hash": "", "report_path": "/tmp/r.md"}, False),
+        ({"status": "pass", "contract_hash": "abc", "report_path": ""}, False),
+        ({"status": "pass", "contract_hash": "abc", "report_path": None}, False),
+        ({"status": "pass"}, False),
         ({}, False),
     ],
 )
 def test_has_complete_evidence_requires_hash_and_path(result, expected):
     assert has_complete_evidence(result) is expected
+
+
+# ---------------------------------------------------------------------------
+# has_complete_evidence: terminality is enforced BY THE FUNCTION (OI-1435)
+# ---------------------------------------------------------------------------
+
+
+def test_has_complete_evidence_false_on_nonterminal_record_even_with_full_evidence():
+    """The invariant hangs off the function, not off caller call-order.
+
+    A caller that invokes has_complete_evidence WITHOUT ever calling
+    is_terminal first must still get the correct answer: an unavailable
+    (non-terminal) record with both evidence fields fully populated must
+    never read as complete evidence.
+    """
+    record = {"status": "unavailable", "contract_hash": "abc123", "report_path": "/tmp/r.md"}
+    assert has_complete_evidence(record) is False
+
+
+@pytest.mark.parametrize("status", ["pending", "running", "queued", "requested"])
+def test_has_complete_evidence_false_on_inflight_status_with_full_evidence(status):
+    record = {"status": status, "contract_hash": "abc123", "report_path": "/tmp/r.md"}
+    assert has_complete_evidence(record) is False
+
+
+@pytest.mark.parametrize("status", ["pass", "completed", "failed", "not_executable"])
+def test_has_complete_evidence_true_on_terminal_status_with_full_evidence(status):
+    record = {"status": status, "contract_hash": "abc123", "report_path": "/tmp/r.md"}
+    assert has_complete_evidence(record) is True
+
+
+# ---------------------------------------------------------------------------
+# has_complete_evidence: three buckets — absent, empty, sentinel (OI-1435)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        # bucket 1: field ABSENT entirely
+        {"status": "pass", "report_path": "/tmp/r.md"},
+        # bucket 2: field present but EMPTY/whitespace
+        {"status": "pass", "contract_hash": "   ", "report_path": "/tmp/r.md"},
+        # bucket 3: field carries a SENTINEL placeholder, not a real value
+        {"status": "pass", "contract_hash": "unknown", "report_path": "/tmp/r.md"},
+        {"status": "pass", "contract_hash": "None", "report_path": "/tmp/r.md"},
+        {"status": "pass", "contract_hash": "null", "report_path": "/tmp/r.md"},
+    ],
+)
+def test_has_complete_evidence_false_on_contract_hash_absent_empty_or_sentinel(result):
+    assert has_complete_evidence(result) is False
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        # bucket 1: field ABSENT entirely
+        {"status": "pass", "contract_hash": "abc123"},
+        # bucket 2: field present but EMPTY/whitespace
+        {"status": "pass", "contract_hash": "abc123", "report_path": " "},
+        # bucket 3: field carries a SENTINEL placeholder, not a real value
+        {"status": "pass", "contract_hash": "abc123", "report_path": "unknown"},
+        {"status": "pass", "contract_hash": "abc123", "report_path": "NONE"},
+        {"status": "pass", "contract_hash": "abc123", "report_path": "NULL"},
+    ],
+)
+def test_has_complete_evidence_false_on_report_path_absent_empty_or_sentinel(result):
+    assert has_complete_evidence(result) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`has_complete_evidence()` in `scripts/lib/gate_status.py` previously answered True purely on `contract_hash`/`report_path` non-emptiness, with the terminality guard (`is_terminal()`) living entirely in the caller. Every real production caller happened to already gate on `is_terminal` (explicitly, or implicitly via `is_pass`), so the bug never bit today — but the invariant hung off call ORDER, not off the function. This closes that trap: the terminality check now lives inside `has_complete_evidence` itself, and adds sentinel-placeholder rejection (`"unknown"`/`"none"`/`"null"` as literal text) on top of the existing absent/empty checks.

## Changes
- `scripts/lib/gate_status.py`
  - `has_complete_evidence()` now requires `is_terminal(result)` before ever checking the evidence fields.
  - New `_is_populated_evidence_field()` helper collapses three non-value buckets (absent, empty/whitespace, sentinel placeholder) to False.
  - New `_EVIDENCE_SENTINEL_VALUES = {"unknown", "none", "null"}`, mirroring the existing `_GHOST_SENTINEL_VALUES` convention in `ghost_receipt_filter.py`.
  - Docstring rewritten to state the new contract and why terminality lives inside the function.
- `tests/test_gate_unavailable_rollup.py`
  - Updated the pre-existing `test_has_complete_evidence_requires_hash_and_path` parametrize table to carry a terminal `status` (it previously tested hash/path emptiness on status-less records, which is now also gated by the new terminality requirement).
  - Added: invariant-hangs-off-the-function test (non-terminal record with both fields populated → False, no `is_terminal` pre-check needed by the caller).
  - Added: in-flight vs terminal status parametrized coverage.
  - Added: three-bucket sentinel tests (absent / empty / sentinel) for both `contract_hash` and `report_path`.

### Call sites audited (`grep -rn has_complete_evidence`)
- `scripts/closure_verifier.py:374` and `:759` — already call `gate_is_terminal()` immediately before `gate_has_complete_evidence()`. **Unchanged**: now a redundant double-check, not incorrect.
- `scripts/lib/gate_executor.py:373` — `decided_pass = bool(passed) and has_complete_evidence(exec_result)`. `passed` comes from `is_pass()`, which is only True for `PASS_STATES` — a status set that is always terminal. **Unchanged**: `passed=True` already implies terminal, so the `and` short-circuits identically before and after this fix.
- `scripts/commands/gate.sh:157` — `marker = 'PASS' if (passed and has_complete_evidence(d)) else ...`, reached only after `status` is explicitly checked against `unavailable`/`not_executable`/`not_configured`/`failed`/`fail`/`blocked` in prior branches, and gated by the same `is_pass()`-implies-terminal reasoning as above. **Unchanged**.

No call site relied on the old, weaker (order-dependent) contract, confirming this closes a latent trap rather than fixing an active misbehavior.

## Verification

**Before (on `scripts/lib/gate_status.py` prior to this PR):**
```
record                                                 is_terminal    has_complete_evidence
status=pass + contract_hash + report_path              True           True
status=pass, velden afwezig                            True           False
status=unavailable + contract_hash + report_path       False          True     <- bug
status=not_executable + beide velden                   True           True
```

**After:**
```
record                                                 is_terminal    has_complete_evidence
status=pass + contract_hash + report_path              True           True
status=pass, velden afwezig                            True           False
status=unavailable + contract_hash + report_path       False          False    <- fixed
status=not_executable + beide velden                   True           True
```

Row 3 flips to False; rows 1, 2, 4 are unchanged — exactly the required outcome.

```
python3 -m pytest tests/test_gate_status*.py tests/test_closure_verifier*.py tests/test_gate_unavailable_rollup.py tests/test_dlv45_gate_recognition.py tests/test_dlv1_glm_gate.py tests/test_dlv2_kimi_gate_evidence.py tests/test_glm_gate_data_dir_guard.py tests/test_kimi_gate_data_dir_guard.py -v
# 243 passed, 1 skipped, 1 failed
```

The 1 failure (`test_gate_status_schema.py::test_closure_verifier_reads_status_completed_as_pass`) is **pre-existing on unmodified `main`** — reproduced independently via `git stash` before applying any change (an unrelated `_find_gate_result` filename-slug matching issue, nothing to do with `has_complete_evidence`). Not introduced or touched by this PR.

## Open Items
None.

**Model**: sonnet
**Provider**: claude