### PR TITLE
fix(tmux-lane): wire skip_pr and target_remote_head into enforce_pr_exists (A3, OI-1115/OI-1113)

### DIFF
--- a/scripts/lib/pr_enforcement.py
+++ b/scripts/lib/pr_enforcement.py
@@ -109,6 +109,25 @@ class PrEnforcementResult:
     reason: Optional[str] = None
 
 
+def is_dispatch_branch_ref(base_ref: "Optional[str]") -> bool:
+    """Return True when *base_ref* names an existing dispatch branch on origin.
+
+    A dispatch branch has the form ``origin/dispatch/<id>``. When a dispatch's
+    base_ref is a dispatch branch, the dispatch is building ON TOP OF an
+    existing dispatch branch (e.g. a rebase/fix-forward) — the PR for that
+    branch already exists, and creating a second one is a duplicate
+    destination (OI-1115).
+
+    This is the single shared predicate ``skip_pr`` is derived from. It was
+    previously reimplemented per-lane as ``dispatch_envelope._is_dispatch_branch_ref``
+    (envelope lanes only); the A3 fix wires the tmux-spawn lane to the same
+    rule via this function so the two can never independently drift the way
+    OI-1115 itself did (dispatch_envelope wired it, tmux never did — three
+    duplicate PRs on 26-08 were the measured result).
+    """
+    return (base_ref or "").startswith("origin/dispatch/")
+
+
 def _normalize_work_ref(work_ref: "Optional[str]") -> "Optional[str]":
     """Strip common ref prefixes from a work_ref so it names a bare branch.
 

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1381,6 +1381,8 @@ class TmuxInteractiveDispatch:
         label: str,
         worktree_handle: "WorktreeHandle",
         worktree_state: str,
+        skip_pr: bool = False,
+        target_remote_head: "str | None" = None,
     ) -> "PrEnforcementResult":
         """Lane-context adapter over pr_enforcement.enforce_pr_exists (lane-fix B).
 
@@ -1393,6 +1395,21 @@ class TmuxInteractiveDispatch:
         one via gh_pr_ensure when it does not. Emits an audit event either way; a
         creation failure is ALSO recorded as a receipt-visible corrective receipt by
         pr_enforcement itself.
+
+        ``skip_pr`` (OI-1115, A3 parity fix): the caller derives this from
+        ``pr_enforcement.is_dispatch_branch_ref(base_ref)`` — the SAME predicate
+        the envelope lanes already used via ``dispatch_envelope._is_dispatch_branch_ref``.
+        Before A3 this lane never computed or passed ``skip_pr`` at all, so
+        ``enforce_pr_exists``'s default (``False``) always won: a dispatch built
+        on an existing ``origin/dispatch/<id>`` branch got a duplicate second PR
+        every time (measured 26-08: #1685/#1686/#1687, all three closed by hand).
+
+        ``target_remote_head`` (OI-1113, A3 parity fix): the remote HEAD of the
+        branch captured by the caller BEFORE the worker ran. Passed through so
+        ``enforce_pr_exists`` can verify containment after push — a force-push
+        that dropped commits is refused loudly instead of silently accepted.
+        This lane previously never passed it, so the OI-1113 containment check
+        never ran here even though the envelope lanes always had it.
 
         Never raises: mirrors the fail-open contract of the phantom-guard hook —
         an internal error here must not crash a real, successful dispatch.
@@ -1453,6 +1470,10 @@ class TmuxInteractiveDispatch:
                 # and ignores branch/worktree_state entirely — see its
                 # docstring and _enforce_pr_exists_for_work_ref.
                 work_ref=os.environ.get("VNX_WORK_REF") or None,
+                # OI-1115 / OI-1113 (A3 parity fix): both derived by the caller
+                # and simply threaded through here — see this method's docstring.
+                skip_pr=skip_pr,
+                target_remote_head=target_remote_head,
             )
         except Exception as exc:  # noqa: BLE001 — never block a real completion on this guard
             logger.error(
@@ -2915,6 +2936,31 @@ class TmuxInteractiveDispatch:
                         exc,
                     )
 
+        # ── OI-1115 (A3 parity fix): skip_pr derived from base_ref, exactly like
+        # dispatch_envelope._is_dispatch_branch_ref/_skip_pr — the shared predicate
+        # lives in pr_enforcement.is_dispatch_branch_ref so both lanes read the
+        # same rule. Computed unconditionally (base_ref is always known, worktree
+        # or not) so it is ready for the _enforce_pr_exists call further down.
+        from pr_enforcement import is_dispatch_branch_ref  # noqa: PLC0415
+        _skip_pr = is_dispatch_branch_ref(base_ref)
+
+        # ── OI-1113 parity fix: capture the remote HEAD of the target branch
+        # BEFORE the worker runs, mirroring dispatch_envelope._enforce_push_pr's
+        # pre-measurement — so a force-push during the run is detectable via
+        # enforce_pr_exists's containment check. For a new branch (first
+        # dispatch), there is no remote HEAD yet — stays None and the
+        # containment check is skipped downstream, same as the envelope lanes.
+        # Best-effort: a lookup failure degrades to None, never blocks dispatch.
+        _target_remote_head: "str | None" = None
+        if worktree_handle is not None:
+            try:
+                from pr_enforcement import _get_remote_head  # noqa: PLC0415
+                _target_remote_head = _get_remote_head(
+                    branch=worktree_handle.branch, repo_root=self._project_root,
+                )
+            except Exception:  # noqa: BLE001 — best-effort; None -> containment skipped
+                _target_remote_head = None
+
         # Per-dispatch hook signal dir: the SessionStart / UserPromptSubmit / Stop
         # hooks (guarded by VNX_TMUX_SIGNAL_DIR + VNX_DISPATCH_ID) drop sentinels
         # here. Best-effort: if mkdtemp fails the lane silently degrades to the
@@ -3665,6 +3711,8 @@ class TmuxInteractiveDispatch:
                     label=label,
                     worktree_handle=worktree_handle,
                     worktree_state=_wt_classification[0],
+                    skip_pr=_skip_pr,
+                    target_remote_head=_target_remote_head,
                 )
                 if not autopr_result.ok:
                     worker_succeeded = False

--- a/tests/test_a3_tmux_skip_pr.py
+++ b/tests/test_a3_tmux_skip_pr.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""test_a3_tmux_skip_pr.py — A3 regression: the tmux-spawn lane never wired
+``skip_pr`` (OI-1115) into ``pr_enforcement.enforce_pr_exists``, so a dispatch
+built on an existing dispatch branch (``base_ref="origin/dispatch/<id>"``)
+always opened a SECOND, duplicate PR. Measured 26-08 on main 7f93f681:
+#1685/#1686/#1687, all three closed by hand.
+
+The envelope lanes (``dispatch_envelope._enforce_push_pr``) already derived
+``skip_pr`` from ``base_ref`` via ``_is_dispatch_branch_ref`` and passed it
+through. The tmux lane (``TmuxInteractiveDispatch.dispatch`` /
+``_enforce_pr_exists``) never computed or passed it at all, so
+``enforce_pr_exists``'s default (``skip_pr=False``) always won.
+
+These tests assert on BEHAVIOR, not on the presence of the ``skip_pr`` symbol:
+they run the REAL ``pr_enforcement.enforce_pr_exists`` (never mocked) and only
+patch the ``gh_pr_ensure`` GitHub boundary, poisoning it with an
+``AssertionError`` side-effect for the skip_pr case — the test fails with an
+assertion error unless the auto-PR step is never even entered, not merely
+"returns nothing".
+
+Also covers OI-1113 parity: the tmux lane never passed ``target_remote_head``
+either, so the post-push containment check never ran there.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from runtime_coordination import init_schema
+from tmux_interactive_dispatch import TmuxInteractiveDispatch
+from tmux_worktree import ReapResult, WorktreeHandle
+
+# Reuse the FakeTmux worker-completion stub from the main tmux-dispatch test
+# module rather than re-implementing it — it is the shared fixture every other
+# tmux-lane test in this repo already relies on.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_tmux_interactive_dispatch import FakeTmux  # noqa: E402
+
+
+class _LaneTestCase(unittest.TestCase):
+    DISPATCH_ID = "20260826-a3-skippr-test"
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.state_dir = Path(self._tmp.name)
+        init_schema(self.state_dir)
+        self.receipts_file = self.state_dir / "t0_receipts.ndjson"
+
+    def _make_lane(self, fake: FakeTmux) -> TmuxInteractiveDispatch:
+        return TmuxInteractiveDispatch(
+            self.state_dir,
+            runner=fake,
+            receipts_file=self.receipts_file,
+            project_root=self.state_dir,
+        )
+
+    def _make_handle(self) -> WorktreeHandle:
+        wt_path = self.state_dir / "worktrees" / f"dispatch-{self.DISPATCH_ID}"
+        wt_path.mkdir(parents=True, exist_ok=True)
+        return WorktreeHandle(
+            path=wt_path,
+            branch=f"dispatch/{self.DISPATCH_ID}",
+            base_sha="deadbeef" * 5,
+            base_ref="origin/main",
+            dispatch_id=self.DISPATCH_ID,
+        )
+
+    def _fast_dispatch(self, lane: TmuxInteractiveDispatch, **overrides):
+        import os
+
+        kwargs = dict(
+            role="backend-developer",
+            model="sonnet",
+            deadline_seconds=5.0,
+            poll_interval=0.01,
+            warmup_timeout=0.5,
+            warmup_poll_interval=0.01,
+            isolated_worktree=True,
+        )
+        kwargs.update(overrides)
+        _env = {
+            "VNX_TMUX_PASTE_SETTLE_SECONDS": "0",
+            "VNX_TMUX_SUBMIT_RETRY_DELAY": "0",
+            "VNX_TMUX_SUBMIT_VERIFY_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_POLL": "0.02",
+        }
+        with patch.dict(os.environ, _env):
+            return lane.dispatch("Do the thing.", self.DISPATCH_ID, **kwargs)
+
+
+class TestSkipPrWiredFromBaseRef(_LaneTestCase):
+    """The forced-red/green pair (dispatch's Deliverable 1)."""
+
+    def test_existing_dispatch_branch_base_ref_suppresses_pr_creation(self):
+        """FORCED CONDITION: base_ref names an existing dispatch branch AND the
+        worktree is in the ``pushed`` state that today always triggers a PR.
+
+        Behavioral assertion: gh_pr_ensure.ensure_pr (the sole gh-pr-create
+        entry point pr_enforcement calls) must NEVER be invoked — not called-
+        and-ignored, never entered at all. A test that only checked
+        ``result.success`` or grepped for the word ``skip_pr`` would pass on
+        the pre-fix code too (the dispatch still 'succeeds', it just also opens
+        a duplicate PR) — this asserts on the actual gh-boundary call.
+        """
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        def _boom(*args, **kwargs):
+            raise AssertionError(
+                "gh_pr_ensure.ensure_pr must NEVER be called when base_ref names "
+                "an existing dispatch branch (origin/dispatch/<id>) — the PR for "
+                "that branch already exists; a second PR is the OI-1115 duplicate "
+                "this test guards against."
+            )
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="pushed"):
+                with patch(
+                    "tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)
+                ):
+                    with patch("gh_pr_ensure.ensure_pr", side_effect=_boom) as mock_ensure_pr:
+                        result = self._fast_dispatch(
+                            lane,
+                            base_ref="origin/dispatch/20260825-some-prior-dispatch",
+                        )
+
+        mock_ensure_pr.assert_not_called()
+        self.assertTrue(
+            result.success,
+            f"dispatch must still succeed (push already done, PR suppressed "
+            f"on purpose): {result.failure_reason}",
+        )
+
+    def test_normal_base_ref_still_opens_a_pr(self):
+        """MIRROR (mandatory per dispatch instructions): base_ref=origin/main
+        (a fresh branch, not built on an existing dispatch branch) must still
+        open a PR exactly as before. Without this half, a lane that stopped
+        opening PRs entirely would pass the test above and go undetected —
+        that is a worse defect than the one being fixed."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_ensure_pr = MagicMock(
+            return_value={"pr_number": 4242, "created": True, "reason": None}
+        )
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="pushed"):
+                with patch(
+                    "tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)
+                ):
+                    with patch("gh_pr_ensure.ensure_pr", mock_ensure_pr):
+                        result = self._fast_dispatch(lane, base_ref="origin/main")
+
+        mock_ensure_pr.assert_called_once()
+        self.assertTrue(result.success, result.failure_reason)
+
+
+class TestTargetRemoteHeadWiredToo(_LaneTestCase):
+    """OI-1113 parity: the tmux lane now also passes target_remote_head, so a
+    containment check can actually run. Verified via the adapter-level call
+    (mirrors test_enforcement_receives_wt_path_when_worktree_exists' style for
+    wt_path) rather than re-deriving a real force-push scenario end-to-end —
+    the containment logic itself is already covered in test_pr_enforcement.py;
+    this only pins that the tmux lane forwards the value it captures."""
+
+    def test_enforce_pr_exists_receives_target_remote_head_kwarg(self):
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_enforce = MagicMock(
+            return_value=__import__("pr_enforcement").PrEnforcementResult(
+                applicable=True, ok=True, pr_number=1, created=True,
+            )
+        )
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="pushed"):
+                with patch(
+                    "tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)
+                ):
+                    with patch("pr_enforcement.enforce_pr_exists", mock_enforce):
+                        result = self._fast_dispatch(lane, base_ref="origin/main")
+
+        self.assertTrue(result.success)
+        mock_enforce.assert_called_once()
+        call_kwargs = mock_enforce.call_args.kwargs
+        self.assertIn(
+            "target_remote_head", call_kwargs,
+            "tmux lane must pass target_remote_head through to enforce_pr_exists "
+            "(OI-1113 parity) — previously this kwarg was never sent at all",
+        )
+        self.assertIn("skip_pr", call_kwargs)
+        self.assertFalse(
+            call_kwargs["skip_pr"],
+            "base_ref=origin/main must NOT set skip_pr",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`pr_enforcement.enforce_pr_exists` has carried a `skip_pr` parameter since OI-1115 to stop a dispatch built on an existing `origin/dispatch/<id>` branch from opening a second, duplicate PR. The envelope lanes (`dispatch_envelope._enforce_push_pr`) always computed and passed it via `_is_dispatch_branch_ref(base_ref)`. The tmux-spawn lane (`TmuxInteractiveDispatch.dispatch` / `_enforce_pr_exists`) never computed or passed it at all, so `enforce_pr_exists`'s default (`False`) always won.

Measured 26-08 on main `7f93f681`: three dispatches rebuilt on top of merged PR branches (#1683, #1676, #1682) each opened a second, duplicate PR (#1685, #1686, #1687) — all closed by hand.

Also found and fixed during the parity audit: `target_remote_head` (OI-1113 containment) was never passed by this lane either.

## Changes

- `scripts/lib/pr_enforcement.py`: adds `is_dispatch_branch_ref(base_ref)` — the shared predicate both lanes now derive `skip_pr` from.
- `scripts/lib/tmux_interactive_dispatch.py`: computes `skip_pr`/`target_remote_head` after worktree allocation (mirrors the envelope lane's OI-1113/OI-1115 pre-measurement pattern) and threads them through `_enforce_pr_exists` → `enforce_pr_exists`.
- `tests/test_a3_tmux_skip_pr.py` (new): forced-red/green pair asserting on the `gh_pr_ensure.ensure_pr` boundary call (behavior), not on symbol presence, plus the mandatory mirror (`base_ref=origin/main` still opens a PR).

Full symmetry table, the (b) door-inference decision, and the `dispatch_envelope` work_ref asymmetry finding (opposite-direction, out of scope, flagged not fixed) are in the dispatch report.

## Test plan

- [x] `pytest tests/test_a3_tmux_skip_pr.py` — red confirmed pre-fix (real behavioral failures, not symbol-missing), green post-fix (3 passed)
- [x] `pytest tests/test_a3_tmux_skip_pr.py tests/test_lane_matrix_row7_push_pr.py tests/test_oi1392_pr_enforcement_work_ref.py tests/test_oi1372_pr_enforcement_branch_resolution.py tests/test_pr_enforcement.py tests/test_pr_enforcement_dirty_substantive.py tests/test_tmux_dispatch_pr_enforcement_annotation.py tests/test_tmux_interactive_dispatch.py` — 301 passed
- [x] Historical measurement reproduced read-only against the three real specs from `~/.vnx-data/vnx-dev/dispatches/pending/2026082{5,6}-t0-rebase-*` — guard fires on all three, `gh_pr_ensure.ensure_pr` never called
- [x] `python3 -m py_compile` on both touched files

Dispatch-ID: 20260826-alpha-a3-tmux-skip-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)