### PR TITLE
fix(orphan-sweep): kind-1b owner lookup spans every project on the account (OI-1424)

### DIFF
--- a/scripts/lib/orphan_sweep.py
+++ b/scripts/lib/orphan_sweep.py
@@ -20,12 +20,21 @@ runtime objects persist forever:
    condition below must hold; process-liveness or session-age alone is never
    sufficient:
      (a) the name matches the canonical dispatch-session pattern (``_SESSION_RE``);
-     (b) the dispatch id is KNOWN to THIS project — present in the project's
-         own ``dispatch_register.ndjson`` (any event). A tmux session listing
-         is account-wide (one shared tmux server across every project on the
-         machine), so this is what keeps a sweep invoked for project X from
-         ever judging — let alone killing — a live session that belongs to
-         project Y;
+     (b) the dispatch id is KNOWN to a project's register on THIS ACCOUNT.
+         Checked first against THIS project's own ``dispatch_register.ndjson``
+         (any event). The tmux session listing is account-wide — one shared
+         tmux server across every project on the machine — so a session
+         belonging to project Y is legitimately invisible to project X's own
+         register; a sweep invoked for X used to leave every such session as
+         a permanent ``unknown_project``, no matter how long ago Y's own
+         register proved it dead (OI-1424). Unknown-to-this-project now falls
+         through to every OTHER project's register on the account
+         (``<account-root>/*/state/dispatch_register.ndjson``, lazily loaded
+         and cached per sweep run — see ``_resolve_cross_project_owner``). A
+         session is only ever judged against the register that actually
+         claims it — its owner's evidence, never a different project's — and
+         a session NO register on the account claims still reads
+         ``unknown_project`` and is left alone, exactly as before OI-1424;
      (c) the dispatch is provably COMPLETED — a ``dispatch_completed`` register
          event, or a terminal (success/failure) receipt in
          ``t0_receipts.ndjson`` per ``event_outcome_semantics.classify_event_outcome``;
@@ -315,6 +324,164 @@ def _real_capture_pane(session: str) -> "str | None":
 
 
 # ---------------------------------------------------------------------------
+# Kind 1b, condition (b) — account-wide owner lookup (OI-1424)
+#
+# The tmux session LISTING is account-wide (one shared tmux server for every
+# project on the machine), but each project's own dispatch_register.ndjson is
+# project-scoped. A sweep invoked for project X could see project Y's
+# completed session sitting there forever, unable to prove it dead, because
+# X's own register never heard of it. This searches every OTHER project's
+# register sharing this account's tmux namespace — never the other direction:
+# a session already CLAIMED by this project's own register is judged only
+# against that register (see _evaluate_completed_orphan's (b) above this).
+# ---------------------------------------------------------------------------
+
+def _account_data_root() -> Path:
+    """Account-wide root under which every project's central store lives.
+
+    Mirrors ``vnx_paths._resolve_state_root``'s ``VNX_DATA_HOME`` branch: an
+    operator who moved every project's store there (``$VNX_DATA_HOME/<pid>``)
+    gets the cross-project scan following the same root, never the hardcoded
+    ``~/.vnx-data`` when that override is active. Falls back to
+    ``~/.vnx-data`` — the fresh-install default every project resolves to
+    absent an override — when unset.
+    """
+    data_home = os.environ.get("VNX_DATA_HOME", "").strip()
+    if data_home:
+        return Path(data_home).expanduser()
+    return Path.home() / ".vnx-data"
+
+
+def _enumerate_other_project_state_dirs(
+    account_root: Path,
+    exclude_state_dir: Path,
+) -> "list[Path]":
+    """Every OTHER project's state dir sharing this account-wide tmux session
+    namespace — ``<account_root>/<project_id>/state``, identified by literally
+    having a ``dispatch_register.ndjson`` on disk (mirrors how ``~/.vnx-data``
+    mixes project dirs with account-wide non-project entries like ``locks/``
+    and ``events/`` — only a dir with a register is a project store).
+
+    A missing/empty ``account_root`` is a real, structural "there is nothing
+    else here" for ``Path.glob`` (it never raises on a missing directory,
+    unlike a tmux/register read that genuinely CAN fail) — not a measurement
+    failure to fail open on. Sorted for a deterministic scan order (first
+    matching store wins on the rare chance two claim the same id).
+    """
+    try:
+        exclude_resolved = exclude_state_dir.resolve()
+    except OSError:
+        exclude_resolved = exclude_state_dir
+    others: "list[Path]" = []
+    try:
+        candidates = sorted(account_root.glob("*/state/dispatch_register.ndjson"))
+    except OSError:
+        return others
+    for reg_path in candidates:
+        state_dir = reg_path.parent
+        try:
+            resolved = state_dir.resolve()
+        except OSError:
+            resolved = state_dir
+        if resolved == exclude_resolved:
+            continue
+        others.append(state_dir)
+    return others
+
+
+def _load_register_and_receipts(
+    state_dir: Path,
+) -> "tuple[set[str] | None, set[str] | None, dict[str, list] | None, list[dict]]":
+    """Load one project's register + receipts evidence.
+
+    Shared by ``sweep()``'s own current-project preload and the lazy
+    cross-project lookup below, so there is exactly one place that knows how
+    to turn a state_dir into (known_ids, completed_ids, receipts_index).
+    Returns ``(known_ids, completed_ids, receipts_index, errors)``; ``errors``
+    entries use the same ``{"kind": "completed_check", "error": ...}`` shape
+    ``sweep()`` already appends to ``OrphanSweepResult.errors`` — callers fold
+    them in directly (see ``_resolve_cross_project_owner``, which tags each
+    with the owning project before doing so).
+    """
+    errors: "list[dict]" = []
+    try:
+        import dispatch_register
+        register_events = dispatch_register.read_events(state_dir=state_dir)
+    except Exception as exc:
+        register_events = None
+        errors.append({
+            "kind": "completed_check",
+            "error": f"dispatch_register read failed ({state_dir}): {exc}",
+        })
+    if register_events is None:
+        known_ids: "set[str] | None" = None
+        completed_ids: "set[str] | None" = None
+    else:
+        known_ids = {ev.get("dispatch_id") for ev in register_events if ev.get("dispatch_id")}
+        completed_ids = {
+            ev.get("dispatch_id") for ev in register_events
+            if ev.get("event") == "dispatch_completed" and ev.get("dispatch_id")
+        }
+    try:
+        import dispatch_outcome_classifier
+        receipts_index: "dict[str, list] | None" = (
+            dispatch_outcome_classifier.load_receipts_index(state_dir)
+        )
+    except Exception as exc:
+        receipts_index = None
+        errors.append({
+            "kind": "completed_check",
+            "error": f"t0_receipts.ndjson read failed ({state_dir}): {exc}",
+        })
+    return known_ids, completed_ids, receipts_index, errors
+
+
+def _resolve_cross_project_owner(
+    dispatch_id: str,
+    *,
+    other_state_dirs: "list[Path]",
+    cache: "dict[Path, tuple]",
+    errors: "list[dict] | None" = None,
+) -> "tuple[str, set[str] | None, dict[str, list] | None] | None":
+    """Find the first OTHER project whose register knows ``dispatch_id``.
+
+    Lazily loads (and memoizes in ``cache``, keyed by state_dir) each
+    candidate store's evidence — at most once per store per sweep run,
+    regardless of how many sessions probe it. ``other_state_dirs`` is
+    pre-sorted by the caller (``_enumerate_other_project_state_dirs``), so
+    the first match is deterministic.
+
+    Returns ``(project_label, completed_ids, receipts_index)`` for that
+    match, or ``None`` when no other project's register names this id — a
+    real, measured "nobody on this account claims it" (kind-1b's
+    ``unknown_project``), not a failure. A store that fails to load is
+    recorded in ``errors`` (tagged with its project label) and skipped —
+    never silently treated as "doesn't know this id".
+    """
+    for state_dir in other_state_dirs:
+        if state_dir not in cache:
+            known_ids, completed_ids, receipts_index, load_errors = (
+                _load_register_and_receipts(state_dir)
+            )
+            cache[state_dir] = (known_ids, completed_ids, receipts_index)
+            if errors is not None:
+                for e in load_errors:
+                    errors.append({**e, "project": state_dir.parent.name})
+        known_ids, completed_ids, receipts_index = cache[state_dir]
+        if known_ids is not None and dispatch_id in known_ids:
+            return state_dir.parent.name, completed_ids, receipts_index
+    return None
+
+
+def _owner_tag(reason: str, owner_label: "str | None") -> str:
+    """Suffix a kind-1b reason string with its owning project when the
+    evidence came from a cross-project lookup (``owner_label is not None``);
+    unchanged when it came from this project's own register — preserves the
+    exact pre-OI-1424 reason strings for every existing caller/test."""
+    return reason if owner_label is None else f"{reason}@{owner_label}"
+
+
+# ---------------------------------------------------------------------------
 # Kind 1b — completed-dispatch orphan conjunction (OI-1353)
 # ---------------------------------------------------------------------------
 
@@ -327,6 +494,9 @@ def _evaluate_completed_orphan(
     register_completed_ids: "set[str] | None",
     receipts_index: "dict[str, list] | None",
     capture_pane: Callable[[str], "str | None"],
+    other_project_state_dirs: "list[Path] | None" = None,
+    cross_project_cache: "dict[Path, tuple] | None" = None,
+    cross_project_errors: "list[dict] | None" = None,
 ) -> "tuple[bool, str]":
     """Evaluate the completed-dispatch/still-alive-pane orphan conjunction.
 
@@ -339,28 +509,56 @@ def _evaluate_completed_orphan(
 
     (a) is enforced by the caller (only ``_SESSION_RE``-matching names reach
     here) and (f) by the caller's ``protected`` fence — neither is re-checked.
+
+    ``other_project_state_dirs`` / ``cross_project_cache`` (OI-1424): when a
+    dispatch id is unknown to THIS project's own register, these — if
+    supplied — extend (b)/(c) to every OTHER project's register on the
+    account (see ``_resolve_cross_project_owner``). Both default to ``None``,
+    which reproduces the exact pre-OI-1424 behavior (a session unknown to
+    this project's own register is always ``unknown_project``) — existing
+    callers that never pass them are unaffected.
     """
-    # (b) the dispatch id must be known to THIS project's own register.
+    # (b) the dispatch id must be known to THIS project's own register, or —
+    # since the tmux session listing is account-wide while each register is
+    # project-scoped (OI-1424) — to another project's register on this
+    # account. Whichever register claims it becomes the evidence source for
+    # (c) below; a session no register claims stays unknown_project.
     if register_known_ids is None:
         return False, "register_unmeasurable"
+
+    owner_label: "str | None" = None
+    completed_ids = register_completed_ids
+    owner_receipts_index = receipts_index
     if dispatch_id not in register_known_ids:
-        return False, "unknown_project"
+        owner = None
+        if other_project_state_dirs:
+            owner = _resolve_cross_project_owner(
+                dispatch_id,
+                other_state_dirs=other_project_state_dirs,
+                cache=cross_project_cache if cross_project_cache is not None else {},
+                errors=cross_project_errors,
+            )
+        if owner is None:
+            return False, "unknown_project"
+        owner_label, completed_ids, owner_receipts_index = owner
 
     # (c) the dispatch must be provably COMPLETED: a dispatch_completed
-    # register event, or a terminal (success/failure) receipt.
+    # register event, or a terminal (success/failure) receipt — read from
+    # whichever register claimed it in (b) above.
     evidence: "str | None" = None
-    if register_completed_ids is not None and dispatch_id in register_completed_ids:
+    if completed_ids is not None and dispatch_id in completed_ids:
         evidence = "register:dispatch_completed"
     if evidence is None:
-        if receipts_index is None:
-            return False, "receipts_unmeasurable"
-        for rec in receipts_index.get(dispatch_id) or []:
+        if owner_receipts_index is None:
+            return False, _owner_tag("receipts_unmeasurable", owner_label)
+        for rec in owner_receipts_index.get(dispatch_id) or []:
             outcome = classify_event_outcome(rec.get("event_type"), rec.get("status"))
             if outcome is not None:
                 evidence = f"receipt:{outcome}"
                 break
     if evidence is None:
-        return False, "not_completed"
+        return False, _owner_tag("not_completed", owner_label)
+    evidence = _owner_tag(evidence, owner_label)
 
     # (d) the dispatch's worktree must already be gone.
     if (worktrees_dir / f"dispatch-{dispatch_id}").exists():
@@ -459,6 +657,7 @@ def sweep(
     kill_session: Optional[Callable[[str], bool]] = None,
     pid_alive: Optional[Callable[[Optional[int]], bool]] = None,
     capture_pane: Optional[Callable[[str], "str | None"]] = None,
+    account_data_root: Optional[Path] = None,
 ) -> OrphanSweepResult:
     """Clean/mark orphaned teardown leftovers across the three kinds.
 
@@ -502,6 +701,14 @@ def sweep(
                             ``capture_pane`` feeds the kind-1b completed-
                             dispatch conjunction (OI-1353) — returning
                             ``None`` means the pane text was not measurable.
+        account_data_root: Account-wide root under which every project's
+                            central store lives, for kind-1b's OI-1424
+                            cross-project owner lookup
+                            (``<account_data_root>/<project_id>/state/...``).
+                            Defaults to ``$VNX_DATA_HOME`` or ``~/.vnx-data``
+                            (mirrors ``vnx_paths._resolve_state_root``).
+                            Tests pin this explicitly rather than touching
+                            the real account-wide store.
 
     Returns:
         :class:`OrphanSweepResult` — per-object failures are recorded in
@@ -563,38 +770,21 @@ def sweep(
     # dispatches known" (this is exactly how the repo-local, never-populated
     # state directory next to the checkout used to read as a silent, valid
     # zero — OI-1353 follow-up).
-    try:
-        import dispatch_register
-        register_events = dispatch_register.read_events(state_dir=state_dir)
-    except Exception as exc:
-        register_events = None
-        result.errors.append({
-            "kind": "completed_check",
-            "error": f"dispatch_register read failed: {exc}",
-        })
-    if register_events is None:
-        register_known_ids: "set[str] | None" = None
-        register_completed_ids: "set[str] | None" = None
-    else:
-        register_known_ids = {
-            ev.get("dispatch_id") for ev in register_events if ev.get("dispatch_id")
-        }
-        register_completed_ids = {
-            ev.get("dispatch_id") for ev in register_events
-            if ev.get("event") == "dispatch_completed" and ev.get("dispatch_id")
-        }
+    register_known_ids, register_completed_ids, receipts_index, load_errors = (
+        _load_register_and_receipts(state_dir)
+    )
+    result.errors.extend(load_errors)
 
-    try:
-        import dispatch_outcome_classifier
-        receipts_index: "dict[str, list] | None" = (
-            dispatch_outcome_classifier.load_receipts_index(state_dir)
-        )
-    except Exception as exc:
-        receipts_index = None
-        result.errors.append({
-            "kind": "completed_check",
-            "error": f"t0_receipts.ndjson read failed: {exc}",
-        })
+    # ── OI-1424: other projects' state dirs sharing this account's tmux
+    # namespace, for kind-1b's cross-project owner lookup. Cheap (one glob);
+    # each candidate's own register/receipts are loaded lazily, at most once
+    # per store, only if some session actually turns out unknown to THIS
+    # project's own register (see _resolve_cross_project_owner).
+    other_project_state_dirs = _enumerate_other_project_state_dirs(
+        account_data_root if account_data_root is not None else _account_data_root(),
+        exclude_state_dir=state_dir,
+    )
+    cross_project_cache: "dict[Path, tuple]" = {}
 
     # ── kind 1: dead-pane tmux sessions ──────────────────────────────────────
     # ``surviving_ids`` is the set of dispatch ids whose worktree is still
@@ -645,6 +835,9 @@ def sweep(
                 register_completed_ids=register_completed_ids,
                 receipts_index=receipts_index,
                 capture_pane=capture_fn,
+                other_project_state_dirs=other_project_state_dirs,
+                cross_project_cache=cross_project_cache,
+                cross_project_errors=result.errors,
             )
             entry = {"session": name, "dispatch_id": sid, "reason": reason}
             if is_orphan:

--- a/scripts/orphan_sweep.py
+++ b/scripts/orphan_sweep.py
@@ -74,6 +74,14 @@ def main(argv: "list[str] | None" = None) -> int:
              "central-store resolver, same as --data-dir).",
     )
     parser.add_argument(
+        "--account-data-root",
+        default=None,
+        help="Account-wide root under which every project's central store "
+             "lives, for the kind-1b OI-1424 cross-project owner lookup "
+             "(<root>/<project_id>/state/...). Default: $VNX_DATA_HOME or "
+             "~/.vnx-data.",
+    )
+    parser.add_argument(
         "--project-id",
         default=os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
         help="Project id for the lease PID lookup (default: $VNX_PROJECT_ID or vnx-dev).",
@@ -123,6 +131,9 @@ def main(argv: "list[str] | None" = None) -> int:
     # instead of this CLI's own (formerly repo-relative) guess.
     data_dir = Path(args.data_dir).expanduser() if args.data_dir else None
     state_dir = Path(args.state_dir).expanduser() if args.state_dir else None
+    account_data_root = (
+        Path(args.account_data_root).expanduser() if args.account_data_root else None
+    )
 
     result = sweep(
         repo_root=repo_root,
@@ -132,6 +143,7 @@ def main(argv: "list[str] | None" = None) -> int:
         current_dispatch_id=args.current_dispatch,
         max_orphans=args.max_orphans,
         dry_run=args.dry_run,
+        account_data_root=account_data_root,
     )
 
     if args.json:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,17 @@ os.environ["VNX_DATA_DIR"] = _CONFTEST_ISOLATION_TMP
 for _env_key, _subdir in _VNX_SUBSYSTEM_DIRS.items():
     os.environ[_env_key] = str(Path(_CONFTEST_ISOLATION_TMP) / _subdir)
 del _env_key, _subdir
+# VNX_DATA_HOME (scripts/lib/vnx_paths.py's operator-chosen "$VNX_DATA_HOME/
+# <project_id>" root, also the account-wide root orphan_sweep.py's OI-1424
+# cross-project owner lookup scans for OTHER projects' registers) is not one
+# of the per-project subsystem dirs above -- it is the ACCOUNT-wide parent a
+# real ~/.vnx-data would be. Left unset, any code that reads it directly
+# (nothing did before OI-1424) would resolve straight to the real ~/.vnx-data
+# and glob actual account data during a test run. Pinned here for the same
+# reason as VNX_DATA_DIR above -- tests that need it unset/pointed elsewhere
+# already delenv/setenv it themselves (test_data_dir_guard.py,
+# test_path_resolution_regression.py, etc.) and win via monkeypatch.
+os.environ["VNX_DATA_HOME"] = str(Path(_CONFTEST_ISOLATION_TMP) / "account-home")
 # Keep the new data-dir guard from emitting warnings during normal tests.
 # Tests that exercise the guard override this explicitly.
 os.environ.setdefault("VNX_DATA_DIR_GUARD", "off")
@@ -154,6 +165,10 @@ def pin_vnx_data_dir(monkeypatch: pytest.MonkeyPatch, data_dir: Path) -> None:
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
     for env_key, subdir in _VNX_SUBSYSTEM_DIRS.items():
         monkeypatch.setenv(env_key, str(data_dir / subdir))
+    # VNX_DATA_HOME is the ACCOUNT-wide parent (sibling to data_dir here, not
+    # a subsystem dir under it) -- see the module-level pin's comment above
+    # for why this needs isolating too (OI-1424's cross-project owner scan).
+    monkeypatch.setenv("VNX_DATA_HOME", str(data_dir.parent / "_vnx_account_home"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_oi897_bare_repo_data_dir.py
+++ b/tests/test_oi897_bare_repo_data_dir.py
@@ -91,7 +91,15 @@ def central_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     for key in ("VNX_PROJECT_ID", "VNX_OPERATOR_ID", "VNX_DATA_DIR",
                 "VNX_STATE_DIR", "VNX_DISPATCH_DIR", "VNX_LOGS_DIR",
                 "VNX_DATA_DIR_EXPLICIT", "VNX_HOME", "PROJECT_ROOT",
-                "VNX_PROJECT_ROOT", "VNX_BIN"):
+                "VNX_PROJECT_ROOT", "VNX_BIN",
+                # VNX_DATA_HOME outranks the Path.home()-based default this
+                # fixture exists to exercise (_resolve_state_root priority 2
+                # beats priority 3) -- conftest.py's autouse pin sets it for
+                # every test to keep the suite off the real ~/.vnx-data, so
+                # it must be unset here the same way the other ambient
+                # overrides above are, or resolution never reaches the HOME
+                # fallback this fixture pins.
+                "VNX_DATA_HOME"):
         monkeypatch.delenv(key, raising=False)
     return home
 
@@ -130,7 +138,12 @@ def _run_horizon_list(repo: Path, home: Path) -> subprocess.CompletedProcess:
     for key in ("VNX_PROJECT_ID", "VNX_OPERATOR_ID", "VNX_DATA_DIR",
                 "VNX_STATE_DIR", "VNX_DISPATCH_DIR", "VNX_LOGS_DIR",
                 "VNX_DATA_DIR_EXPLICIT", "VNX_HOME", "PROJECT_ROOT",
-                "VNX_PROJECT_ROOT", "VNX_BIN"):
+                "VNX_PROJECT_ROOT", "VNX_BIN",
+                # see central_home's matching comment: must drop the
+                # account-wide pin too, or the subprocess inherits it from
+                # the parent test process's os.environ and never reaches the
+                # HOME-based central default this subprocess is meant to hit.
+                "VNX_DATA_HOME"):
         env.pop(key, None)
     env["HOME"] = str(home)
     env["PYTHONPATH"] = str(ROOT)

--- a/tests/test_orphan_sweep.py
+++ b/tests/test_orphan_sweep.py
@@ -1035,6 +1035,337 @@ def test_cli_dry_run_json(env, tmp_path):
     assert handle.path.is_dir()
 
 
+# ---------------------------------------------------------------------------
+# OI-1424 — the tmux session listing is account-wide, but kind-1b's (b) check
+# used to consult only THIS project's own register. A session belonging to a
+# DIFFERENT project on the same account (own tmux server, own dispatch ids)
+# read as unknown_project FOREVER, no matter how provably completed it was in
+# ITS OWN project's register. This extends (b)/(c) to search every OTHER
+# project's register sharing the account
+# (<account-root>/<project_id>/state/dispatch_register.ndjson) once a
+# session's dispatch id is unknown to the sweeping project's own register.
+# ---------------------------------------------------------------------------
+
+def _write_register_event_for_project(
+    account_root: Path, project_id: str, event: str, dispatch_id: str,
+) -> None:
+    """Write a raw register event under <account_root>/<project_id>/state/ —
+    simulates ANOTHER project's own dispatch_register.ndjson sharing this
+    account (mirrors _write_register_event's raw-append style)."""
+    state_dir = account_root / project_id / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "dispatch_register.ndjson"
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "timestamp": "2026-08-21T00:00:00.000000Z",
+            "event": event,
+            "dispatch_id": dispatch_id,
+        }) + "\n")
+
+
+def test_sweep_cross_project_owner_killed_and_inflight_preserved(env, tmp_path, monkeypatch):
+    """The OI-1424 red-test target. Two REAL project stores: project-a's own
+    register knows 'cross-done-1' as COMPLETED and 'cross-live-1' as still in
+    flight; the sweeping project's own register (`env`) knows NEITHER id at
+    all. Both sessions are alive on the (account-wide) shared tmux server.
+
+    After the fix, a sweep run from the OWN project must (1) recognize
+    cross-done-1 as a killable completed orphan using project-a's evidence,
+    and (2) leave cross-live-1 alone. Both assertions live in one test on
+    purpose: testing only the kill half would also pass an overly-aggressive
+    sweep that treats every session unknown to its own project as completed
+    by default — exactly the safety regression this must never introduce.
+
+    On main pre-OI-1424 this fails on BEHAVIOR, not a missing symbol: sweep()
+    runs to completion (VNX_DATA_HOME is simply never read), but BOTH
+    sessions land in tmux_completed_orphans_preserved with reason
+    "unknown_project" — project-a is never consulted, so cross-done-1 is
+    never recognized as an orphan and never killed.
+    """
+    local = _git_repo(tmp_path)
+    account_root = tmp_path / "account-root"
+    _write_register_event_for_project(account_root, "project-a", "dispatch_created", "cross-done-1")
+    _write_register_event_for_project(account_root, "project-a", "dispatch_completed", "cross-done-1")
+    _write_register_event_for_project(account_root, "project-a", "dispatch_created", "cross-live-1")
+    # Default resolution path (no explicit account_data_root kwarg) — proves
+    # the fix's env-var fallback, not just its explicit-override plumbing.
+    monkeypatch.setenv("VNX_DATA_HOME", str(account_root))
+
+    killed = []
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,  # this project's OWN register — knows neither id
+        list_sessions=lambda: ["vnx-cross-done-1", "vnx-cross-live-1"],
+        probe_liveness=lambda s: True,
+        kill_session=lambda s: (killed.append(s), True)[1],
+        capture_pane=lambda s: "",
+    )
+
+    killed_ids = {e["dispatch_id"] for e in res.tmux_completed_orphans_killed}
+    preserved = {e["dispatch_id"]: e["reason"] for e in res.tmux_completed_orphans_preserved}
+
+    # Half 1: the completed orphan owned by project-a IS recognized and killed.
+    assert killed_ids == {"cross-done-1"}, (
+        f"expected only cross-done-1 to be killed via project-a's evidence, "
+        f"got killed={killed_ids} preserved={preserved}"
+    )
+    assert killed == ["vnx-cross-done-1"]
+    assert res.tmux_completed_orphans_killed[0]["reason"] == (
+        "register:dispatch_completed@project-a;pane=dead"
+    )
+
+    # Half 2: the still-in-flight session owned by project-a is LEFT ALONE —
+    # proves the fix does not just kill every unknown-to-this-project session.
+    assert preserved.get("cross-live-1") == "not_completed@project-a", (
+        f"cross-live-1 must be preserved on project-a's not_completed ground, "
+        f"got preserved={preserved}"
+    )
+    assert "vnx-cross-live-1" not in killed
+    assert "vnx-cross-live-1" in res.tmux_skipped_alive
+
+
+def test_sweep_cross_project_lookup_disabled_by_default_kwargs(tmp_path):
+    """Direct unit-level control: _evaluate_completed_orphan with the new
+    cross-project kwargs OMITTED must reproduce the exact pre-OI-1424
+    behavior — existing callers that never pass them are unaffected."""
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids=set(),
+        register_completed_ids=set(),
+        receipts_index={},
+        capture_pane=lambda s: "",
+    )
+    assert (is_orphan, reason) == (False, "unknown_project")
+
+
+def test_evaluate_completed_orphan_cross_project_completed(tmp_path):
+    """Direct unit test: dispatch id unknown to this project's register, but
+    another project's register (injected via other_project_state_dirs) shows
+    it COMPLETED — the conjunction succeeds using THAT project's evidence."""
+    account_root = tmp_path / "account"
+    _write_register_event_for_project(account_root, "other-proj", "dispatch_completed", "y-1")
+
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-y-1", "y-1",
+        worktrees_dir=tmp_path,
+        register_known_ids=set(),       # unknown to THIS project
+        register_completed_ids=set(),
+        receipts_index={},
+        capture_pane=lambda s: "",
+        other_project_state_dirs=[account_root / "other-proj" / "state"],
+        cross_project_cache={},
+    )
+    assert is_orphan is True
+    assert reason == "register:dispatch_completed@other-proj;pane=dead"
+
+
+def test_evaluate_completed_orphan_cross_project_not_completed(tmp_path):
+    """The flip side: another project's register knows the id but has NOT
+    proven a terminal outcome — never an orphan, ground is preserved and
+    attributed to the correct owner."""
+    account_root = tmp_path / "account"
+    _write_register_event_for_project(account_root, "other-proj", "dispatch_created", "y-2")
+
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-y-2", "y-2",
+        worktrees_dir=tmp_path,
+        register_known_ids=set(),
+        register_completed_ids=set(),
+        receipts_index={},
+        capture_pane=lambda s: "",
+        other_project_state_dirs=[account_root / "other-proj" / "state"],
+        cross_project_cache={},
+    )
+    assert (is_orphan, reason) == (False, "not_completed@other-proj")
+
+
+def test_evaluate_completed_orphan_cross_project_via_receipt(tmp_path):
+    """Cross-project completion evidence via a terminal RECEIPT (not a
+    register event) — mirrors the existing same-project receipt test."""
+    account_root = tmp_path / "account"
+    other_state_dir = account_root / "other-proj" / "state"
+    _write_register_event_for_project(account_root, "other-proj", "dispatch_created", "y-3")
+
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-y-3", "y-3",
+        worktrees_dir=tmp_path,
+        register_known_ids=set(),
+        register_completed_ids=set(),
+        receipts_index={},
+        capture_pane=lambda s: "",
+        other_project_state_dirs=[other_state_dir],
+        cross_project_cache={
+            other_state_dir: (
+                {"y-3"}, set(), {"y-3": [{"event_type": "task_complete", "status": "success"}]},
+            ),
+        },
+    )
+    assert is_orphan is True
+    assert reason == "receipt:success@other-proj;pane=dead"
+
+
+def test_evaluate_completed_orphan_no_project_claims_it_stays_unknown(tmp_path):
+    """No register — not this project's, not any other project's — has ever
+    heard of this dispatch id. Must stay unknown_project, exactly as before
+    OI-1424: absence everywhere is a real, measured 'nobody claims this', not
+    a reason to guess."""
+    account_root = tmp_path / "account"
+    _write_register_event_for_project(account_root, "other-proj", "dispatch_completed", "unrelated-id")
+
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-z-1", "z-1",
+        worktrees_dir=tmp_path,
+        register_known_ids=set(),
+        register_completed_ids=set(),
+        receipts_index={},
+        capture_pane=lambda s: "",
+        other_project_state_dirs=[account_root / "other-proj" / "state"],
+        cross_project_cache={},
+    )
+    assert (is_orphan, reason) == (False, "unknown_project")
+
+
+def test_evaluate_completed_orphan_cross_project_own_project_takes_precedence(tmp_path):
+    """A dispatch id known to THIS project's own register must be judged
+    against ITS OWN evidence, never fall through to a cross-project lookup —
+    even when other_project_state_dirs is populated with a store that would
+    otherwise satisfy the conjunction differently."""
+    account_root = tmp_path / "account"
+    # A different project's register also knows this id but says NOT completed
+    # — if own-project evidence didn't take precedence, this would wrongly win.
+    _write_register_event_for_project(account_root, "other-proj", "dispatch_created", "x-1")
+
+    is_orphan, reason = osweep._evaluate_completed_orphan(
+        "vnx-x-1", "x-1",
+        worktrees_dir=tmp_path,
+        register_known_ids={"x-1"},          # THIS project already knows it
+        register_completed_ids={"x-1"},      # and has proven it completed
+        receipts_index={},
+        capture_pane=lambda s: "",
+        other_project_state_dirs=[account_root / "other-proj" / "state"],
+        cross_project_cache={},
+    )
+    assert is_orphan is True
+    assert reason == "register:dispatch_completed;pane=dead"  # no @owner suffix
+
+
+def test_resolve_cross_project_owner_memoizes_per_state_dir(tmp_path):
+    """Each candidate store is loaded at most once per sweep run, even when
+    multiple sessions probe it — verifies the cache is actually consulted
+    rather than re-reading the register from disk every call."""
+    account_root = tmp_path / "account"
+    other_state_dir = account_root / "other-proj" / "state"
+    _write_register_event_for_project(account_root, "other-proj", "dispatch_completed", "m-1")
+
+    cache: "dict" = {}
+    owner1 = osweep._resolve_cross_project_owner(
+        "m-1", other_state_dirs=[other_state_dir], cache=cache,
+    )
+    assert owner1 is not None
+    assert owner1[0] == "other-proj"
+    assert other_state_dir in cache
+
+    # Corrupt the on-disk register — a fresh (uncached) read would now see it
+    # as unmeasurable/empty. The cached answer must still be returned as-is.
+    (other_state_dir / "dispatch_register.ndjson").write_text("not json at all\n")
+    owner2 = osweep._resolve_cross_project_owner(
+        "m-1", other_state_dirs=[other_state_dir], cache=cache,
+    )
+    assert owner2 == owner1
+
+
+def test_resolve_cross_project_owner_none_when_no_store_claims_id(tmp_path):
+    account_root = tmp_path / "account"
+    _write_register_event_for_project(account_root, "other-proj", "dispatch_completed", "known-1")
+
+    owner = osweep._resolve_cross_project_owner(
+        "totally-unclaimed-id",
+        other_state_dirs=[account_root / "other-proj" / "state"],
+        cache={},
+    )
+    assert owner is None
+
+
+def test_enumerate_other_project_state_dirs_excludes_own_and_finds_others(tmp_path):
+    account_root = tmp_path / "account"
+    own_state_dir = account_root / "vnx-dev" / "state"
+    own_state_dir.mkdir(parents=True)
+    (own_state_dir / "dispatch_register.ndjson").write_text("")
+    other_a = account_root / "project-a" / "state"
+    other_a.mkdir(parents=True)
+    (other_a / "dispatch_register.ndjson").write_text("")
+    other_b = account_root / "project-b" / "state"
+    other_b.mkdir(parents=True)
+    (other_b / "dispatch_register.ndjson").write_text("")
+    # A non-project account entry (e.g. locks/) with no register must never
+    # be mistaken for a project store.
+    (account_root / "locks").mkdir(parents=True)
+
+    others = osweep._enumerate_other_project_state_dirs(
+        account_root, exclude_state_dir=own_state_dir,
+    )
+
+    assert sorted(p.parent.name for p in others) == ["project-a", "project-b"]
+    assert own_state_dir.resolve() not in [p.resolve() for p in others]
+
+
+def test_enumerate_other_project_state_dirs_missing_root_is_empty_not_error(tmp_path):
+    """A missing account root is a real 'nothing else here', not a
+    measurement failure — Path.glob never raises on a missing directory."""
+    others = osweep._enumerate_other_project_state_dirs(
+        tmp_path / "does-not-exist", exclude_state_dir=tmp_path / "state",
+    )
+    assert others == []
+
+
+def test_account_data_root_prefers_explicit_env_over_home_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("VNX_DATA_HOME", str(tmp_path / "custom-home"))
+    assert osweep._account_data_root() == tmp_path / "custom-home"
+
+
+def test_account_data_root_falls_back_to_home_vnx_data(monkeypatch):
+    monkeypatch.delenv("VNX_DATA_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/fake/home")))
+    assert osweep._account_data_root() == Path("/fake/home") / ".vnx-data"
+
+
+def test_sweep_cross_project_errors_recorded_and_fail_open(env, tmp_path, monkeypatch):
+    """An unreadable OTHER project's register must be recorded in errors and
+    must never be read as 'this id is completed' — fails open exactly like
+    every other unmeasurable signal in this module."""
+    local = _git_repo(tmp_path)
+    account_root = tmp_path / "account-root"
+    other_state_dir = account_root / "broken-proj" / "state"
+    other_state_dir.mkdir(parents=True)
+    (other_state_dir / "dispatch_register.ndjson").write_text("")
+
+    import dispatch_register
+
+    def _fake_read_events(*, since_iso=None, state_dir=None):
+        if state_dir is not None and Path(state_dir).resolve() == other_state_dir.resolve():
+            raise RuntimeError("other project's register blew up")
+        return []  # this project's own (empty, never-written) register
+
+    monkeypatch.setattr(dispatch_register, "read_events", _fake_read_events)
+
+    res = osweep.sweep(
+        repo_root=local,
+        data_dir=env,
+        account_data_root=account_root,
+        list_sessions=lambda: ["vnx-broken-1"],
+        probe_liveness=lambda s: True,
+        capture_pane=lambda s: "",
+    )
+
+    assert res.tmux_completed_orphans_killed == []
+    assert res.tmux_completed_orphans_preserved[0]["reason"] == "unknown_project"
+    assert any(
+        e.get("kind") == "completed_check" and e.get("project") == "broken-proj"
+        for e in res.errors
+    )
+
+
 if __name__ == "__main__":
     import unittest
 


### PR DESCRIPTION
## Summary

The tmux session listing is account-wide (one shared tmux server across every project on the machine), but the orphan sweep's kind-1b completed-dispatch conjunction (OI-1353) only ever consulted the *sweeping* project's own `dispatch_register.ndjson`. A session belonging to a different project on the same account read as `unknown_project` forever, no matter how provably completed it was in its own project's register.

This builds on #1679 (OI-1427, `_dispatch_known_inflight`) — reuses its register/receipt evidence loading shape rather than re-deriving it, and does not touch kind 2 (worktrees), which stays scoped to that PR.

## Changes

- `scripts/lib/orphan_sweep.py`:
  - `_evaluate_completed_orphan`'s (b)/(c) now falls through to every OTHER project's register sharing the account (`<account-root>/<project_id>/state/dispatch_register.ndjson`) once a dispatch id is unknown to the sweeping project's own register. A session no register on the account claims still reads `unknown_project`, unchanged.
  - New helpers: `_account_data_root` (mirrors `vnx_paths`' `VNX_DATA_HOME` branch), `_enumerate_other_project_state_dirs`, `_load_register_and_receipts` (factored out of `sweep()`'s own preload, reused for both), `_resolve_cross_project_owner` (lazy, memoized per sweep run), `_owner_tag`.
  - `sweep()` gains an `account_data_root` parameter (explicit override; defaults to `$VNX_DATA_HOME` or `~/.vnx-data`).
  - Existing callers that never pass the new `_evaluate_completed_orphan` kwargs are byte-for-byte unaffected — verified by a dedicated regression test.
- `scripts/orphan_sweep.py`: new `--account-data-root` CLI flag.
- `tests/conftest.py`: pins `VNX_DATA_HOME` to an isolated tmp dir (module-level + per-test `pin_vnx_data_dir`) so the new cross-project scan never touches the real `~/.vnx-data` during test runs — mirrors the existing `VNX_DATA_DIR` isolation. Tests that need it unset/pointed elsewhere already `delenv`/`setenv` it themselves and win.
- `tests/test_orphan_sweep.py`: 14 new tests.

## Route chosen

Route (b) — one account-wide-aware sweep, not one sweep-per-project (route a). Measured 6 other project stores on this account (`mission-control`, `other-proj`, `pacompany-engine`, `proj-x`, `sales-copilot`, `seocrawler-v2`) plus `vnx-dev` itself = 7 total `~/.vnx-data/*/state/dispatch_register.ndjson`. Route (a) would require a fabric-wide consumer update across all 7; route (b) stays entirely inside this repo.

## Verification

**Deliverable 1 — red test on behavior** (`test_sweep_cross_project_owner_killed_and_inflight_preserved`): two real project stores, project-a knows `cross-done-1` as completed and `cross-live-1` as still in flight; the sweeping project's own register knows neither. Run against the pre-fix code (temporarily swapped in via `git show HEAD:...`, confirmed identical, then restored):

```
AssertionError: expected only cross-done-1 to be killed via project-a's evidence,
got killed=set() preserved={'cross-done-1': 'unknown_project', 'cross-live-1': 'unknown_project'}
```

Pure behavioral failure — no `account_data_root` kwarg used in this test (env-var path only), so `sweep()`'s signature is unchanged pre-fix and the failure is not a missing symbol. After the fix: `cross-done-1` killed via `register:dispatch_completed@project-a;pane=dead`; `cross-live-1` preserved via `not_completed@project-a` and left alive — both assertions in one test, since only testing the kill half would also pass an overly-aggressive sweep.

**Deliverable 2 — before/after on the real repo** (`--dry-run --json`, main `7f93f681`):

Before (this session's start):
```json
"tmux_completed_orphans_preserved": [
  {"session": "...beta3-a...", "reason": "not_completed"},
  {"session": "...beta3-c...", "reason": "not_completed"},
  {"session": "vnx-D-fceda213", "dispatch_id": "D-fceda213", "reason": "unknown_project"}
]
```

After:
```json
"tmux_completed_orphans_preserved": [
  {"session": "...beta3-a...", "reason": "not_completed"},
  {"session": "...beta3-b...", "reason": "not_completed"},   <- new session spawned between captures, unrelated
  {"session": "...beta3-c...", "reason": "not_completed"},
  {"session": "vnx-D-fceda213", "dispatch_id": "D-fceda213", "reason": "not_completed@seocrawler-v2"}
]
```

`D-fceda213` reclassifies from `unknown_project` to `not_completed@seocrawler-v2` — correctly attributed to its true owner (`seocrawler-v2`'s register has a `dispatch_created` event for it, 2026-08-21, no completion evidence), and correctly still preserved, never killed. The other two `unknown_project` sessions from the original 23-08 measurement (`D-03d4ca33`, `D-101ddf46`) no longer have live tmux sessions as of 26-08 — not reproducible in this before/after.

**Test run**: `python3 -m pytest tests/test_orphan_sweep.py -q` → 62 passed (48 pre-existing + 14 new). Also ran `tests/test_data_dir_guard.py tests/test_path_resolution_regression.py tests/test_state_root_lockstep.py tests/test_horizon_parity.py tests/test_vnx_data_dir_real_store_guard.py tests/test_cli_init.py tests/test_path_parity_hook.py tests/test_open_items_state_dir_resolution.py tests/test_horizon_cli.py tests/test_pr_dispatch_integration.py tests/test_pr_recommendation_integration.py` (all reference `VNX_DATA_HOME` or `pin_vnx_data_dir`) → 262 passed, no regressions from the conftest change.

## Open Items

None.

**Dispatch-ID**: 20260826-alpha-a4-accountbrede-opruiming
**Model**: sonnet
**Provider**: claude