### PR TITLE
feat(dispatch): claude_headless becomes the default lane for claude builds (A2)

### DIFF
--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -163,6 +163,8 @@ def stage_spec_bundle(
     requires_mcp: bool = False,
     allow_headless: bool = False,
     headless_reason: Optional[str] = None,
+    force_tmux: bool = False,
+    force_tmux_reason: Optional[str] = None,
     post_merge_verification: bool = False,
     irreversible: bool = False,
     pr_id: Optional[str] = None,
@@ -242,6 +244,7 @@ def stage_spec_bundle(
     # 6. assemble + write the spec atomically. instruction_file is the literal
     #    absolute child path — a real regular file, no symlink.
     norm_reason = (headless_reason or "").strip() or None
+    norm_tmux_reason = (force_tmux_reason or "").strip() or None
     spec_payload = {
         "schema_version": 1,
         "project_id": effective_project_id,
@@ -284,6 +287,8 @@ def stage_spec_bundle(
         "instruction_sha256": instruction_sha256,
         "allow_headless": bool(allow_headless),
         "headless_reason": norm_reason,
+        "force_tmux": bool(force_tmux),
+        "force_tmux_reason": norm_tmux_reason,
         "post_merge_verification": bool(post_merge_verification),
         "irreversible": bool(irreversible),
     }
@@ -481,6 +486,8 @@ def deliver_via_door(
     deadline_seconds: Optional[int] = None,
     allow_headless: bool = False,
     headless_reason: Optional[str] = None,
+    force_tmux: bool = False,
+    force_tmux_reason: Optional[str] = None,
 ) -> bool:
     """Gated delivery for the in-process python callers (pool_worker_runner, claude_adapter,
     headless_dispatch_daemon). When ``VNX_SINGLE_ENTRY_DISPATCH=1`` route through the door
@@ -504,7 +511,15 @@ def deliver_via_door(
     claude_headless lane the same way the bridge's own ``--allow-headless`` CLI
     does. The door's validate() re-enforces the reason-required + claude-only
     rules, so a caller that skips its own check still fails loud. Defaults False /
-    None reproduce byte-identical prior behavior.
+    None reproduce byte-identical prior behavior. Since A2 (2026-08-26) headless is
+    the claude lane's DEFAULT, so these defaults now mean "accept the default"
+    rather than "stay on the old default (tmux)".
+
+    ``force_tmux`` / ``force_tmux_reason`` (A2, 2026-08-26): the mirror-image
+    explicit opt-OUT back to the tmux lane, for a caller that wants the pre-flip
+    behavior instead of the new default. Same reason-required + claude-only rules
+    at the door (validate() Rule 12b). Defaults False / None reproduce the new
+    default (claude_headless) unchanged.
 
     ``pr_id`` / ``work_ref`` / ``base_ref`` (OI-1390): threaded through to
     ``bridge_dispatch`` -> ``stage_spec_bundle`` unchanged, so a consumer-door
@@ -536,6 +551,8 @@ def deliver_via_door(
             deadline_seconds=deadline_seconds if deadline_seconds is not None else 3600,
             allow_headless=allow_headless,
             headless_reason=headless_reason,
+            force_tmux=force_tmux,
+            force_tmux_reason=force_tmux_reason,
         ) == 0
     return bool(legacy())
 
@@ -568,6 +585,10 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument("--requires-mcp", action="store_true", dest="requires_mcp")
     parser.add_argument("--allow-headless", action="store_true", dest="allow_headless")
     parser.add_argument("--headless-reason", default=None, dest="headless_reason")
+    # A2 (2026-08-26): claude_headless is now the default lane; --force-tmux is the
+    # explicit opt-out back to the tmux lane (mirrors --allow-headless's shape).
+    parser.add_argument("--force-tmux", action="store_true", dest="force_tmux")
+    parser.add_argument("--force-tmux-reason", default=None, dest="force_tmux_reason")
     parser.add_argument(
         "--post-merge-verification",
         action="store_true",
@@ -627,6 +648,8 @@ def main(argv: Optional[list] = None) -> int:
         requires_mcp=args.requires_mcp,
         allow_headless=args.allow_headless,
         headless_reason=args.headless_reason,
+        force_tmux=args.force_tmux,
+        force_tmux_reason=args.force_tmux_reason,
         post_merge_verification=args.post_merge_verification,
         target_id_override=args.target_id_override,
         dry_run=args.dry_run,

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -47,6 +47,7 @@ from dispatch_plan import (  # noqa: E402
     RuntimeSnapshot,
     claude_auth_is_api_metered,
     compile_plan,
+    resolve_claude_lane,
 )
 from dispatch_internal import (  # noqa: E402
     ExecutionPermit,
@@ -203,6 +204,8 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         instruction_sha256=(raw.get("instruction_sha256") or None),
         allow_headless=raw.get("allow_headless") is True,
         headless_reason=_sanitize_headless_reason(raw.get("headless_reason")),
+        force_tmux=raw.get("force_tmux") is True,
+        force_tmux_reason=_sanitize_headless_reason(raw.get("force_tmux_reason")),
         post_merge_verification=raw.get("post_merge_verification") is True,
         irreversible=raw.get("irreversible") is True,
     )
@@ -1596,10 +1599,16 @@ def build_runtime_snapshot(
     else:
         effective_model = spec.model or "default"
 
-    # claude-headless enforcement: allow_headless=True sets via to 'headless', which
-    # triggers the claude-headless forbid_route constraint. Normal tmux lane keeps via='cli'.
-    if is_claude_lane and spec.allow_headless:
-        via = "headless"
+    # claude-headless enforcement: via='headless' whenever THIS spec resolves to the
+    # headless lane — which since A2 (2026-08-26) is the DEFAULT for a claude spec
+    # with no explicit lane choice, not just an explicit allow_headless=True opt-in.
+    # Reuses dispatch_plan.resolve_claude_lane (the same function compile_plan's D1
+    # calls) so this can never independently drift from the actual lane decision.
+    # Normal tmux lane (default off, or an explicit force_tmux opt-out) keeps via='cli'.
+    if is_claude_lane:
+        _lane_for_via, _, _ = resolve_claude_lane(spec)
+        if _lane_for_via == "claude_headless":
+            via = "headless"
 
     # P0-1: constraint check with instruction_text + check_registry=True; FAIL-CLOSED on error
     constraint_verdicts: tuple[ConstraintVerdict, ...] = ()

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -18,11 +18,49 @@ from typing import Mapping, Optional
 
 from dispatch_spec import (
     DispatchPath,
+    DispatchSpec,
     Isolation,
     Provider,
     Reject,
     ValidatedSpec,
 )
+
+
+def resolve_claude_lane(spec: DispatchSpec) -> tuple[str, str, "str | None"]:
+    """Decide the claude-provider lane + adapter + optional plan-warning.
+
+    A2 (2026-08-26): claude_headless is the DEFAULT lane for a provider=claude
+    spec carrying no explicit lane choice (main 7f93f681 measured both prior
+    governance gaps — isolation=worktree, report-before-receipt — as closed, and
+    the tmux lane's duplicate-PR defect, OI-1115's skip_pr never wired into
+    tmux_interactive_dispatch.py, as still open). Only meaningful when the caller
+    already knows spec.provider == Provider.CLAUDE.
+
+    Single source of truth for this decision: compile_plan's D1 and
+    dispatch_cli.build_runtime_snapshot's via= (which feeds the claude-headless
+    constraint check) BOTH call this rather than re-deriving the lane
+    independently — two call sites computing the same routing fact is exactly
+    how a handler drifts from its sibling (see the codex "same fix to all
+    handlers" lesson).
+
+    Exactly one of the three branches fires; every branch names an unambiguous
+    lane. Validation (dispatch_spec.validate Rule 12a/12b/12c) already rejected
+    the contradictory allow_headless=True + force_tmux=True combination and the
+    reason-missing cases before a spec can reach here.
+    """
+    if spec.allow_headless:
+        return (
+            "claude_headless",
+            "claude_subprocess",
+            f"HEADLESS lane opted-in: {spec.headless_reason}",
+        )
+    if spec.force_tmux:
+        return (
+            "claude_tmux_subscription",
+            "tmux_claude",
+            f"TMUX lane opted-in: {spec.force_tmux_reason}",
+        )
+    return "claude_headless", "claude_subprocess", None
 
 
 # ---------------------------------------------------------------------------
@@ -258,14 +296,10 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
             "AUTO must be resolved by the capability seam before compile_plan",
         )
     is_claude_lane = provider == Provider.CLAUDE
-    is_claude_headless = is_claude_lane and spec.allow_headless
-    if is_claude_headless:
-        lane = "claude_headless"
-        adapter = "claude_subprocess"
-        warnings.append(f"HEADLESS lane opted-in: {spec.headless_reason}")
-    elif is_claude_lane:
-        lane = "claude_tmux_subscription"
-        adapter = "tmux_claude"
+    if is_claude_lane:
+        lane, adapter, lane_warning = resolve_claude_lane(spec)
+        if lane_warning is not None:
+            warnings.append(lane_warning)
     else:
         lane = "provider"
         adapter = "provider"
@@ -372,7 +406,7 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
     fired.append("D9")
 
     # D10 — warmup; headless lane has no tmux warmup
-    warmup = "verify_strict" if (is_claude_lane and not is_claude_headless) else "n/a"
+    warmup = "verify_strict" if (is_claude_lane and lane != "claude_headless") else "n/a"
     fired.append("D10")
 
     # D12 — target resolution; claude lane is leaseless (ephemeral), skip health checks

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -209,8 +209,27 @@ class DispatchSpec:
     target_id_override: Optional[str] = None
     tags: tuple[str, ...] = ()
     instruction_sha256: Optional[str] = None  # P0-3: caller may pre-bind hash; validate() verifies
+    # A2 (2026-08-26): claude_headless became the DEFAULT claude lane (see
+    # dispatch_plan.resolve_claude_lane) — main 7f93f681 measured both governance
+    # gaps the old default cited (isolation=worktree, report-before-receipt) as
+    # closed, and the tmux lane duplicate-PR defect (OI-1115 skip_pr never wired
+    # into tmux_interactive_dispatch.py) as still open. allow_headless=True is now
+    # a REDUNDANT-with-default but still meaningful explicit statement (kept for
+    # the pre-flip specs that already carry it + reason, and for any future caller
+    # that wants the choice on the record rather than implied). It no longer gates
+    # ACCESS to the lane — only whether a "HEADLESS lane opted-in" audit line is
+    # emitted for a spec that asked for it by name.
     allow_headless: bool = False              # PR-5: explicit opt-in to the claude_headless lane
     headless_reason: Optional[str] = None    # PR-5: mandatory non-empty reason when allow_headless=True
+    # A2 (2026-08-26): the mirror image of allow_headless — an explicit opt-OUT
+    # back to the (now non-default) tmux lane. False (default) means "no opinion,
+    # accept whatever the policy default resolves to" — same shape as
+    # allow_headless=False always having meant "didn't ask", never "refused".
+    # True requires force_tmux_reason (validate() Rule 12b) and is only valid for
+    # provider=claude/auto, mirroring allow_headless's own Rule 12a exactly. Never
+    # both True at once (Rule 12c) — that is a contradiction, not a choice.
+    force_tmux: bool = False
+    force_tmux_reason: Optional[str] = None
     # OI-1214: a post-merge-verification dispatch measures the CURRENT checkout
     # (proof that a just-merged PR is actually live), so it is only meaningful
     # when the local main checkout is current. This is a typed boolean declared by
@@ -435,7 +454,12 @@ def validate(
             f"got {spec.deadline_seconds}",
         )
 
-    # Rule 12 — headless opt-in requires a non-empty reason (PR-5)
+    # Rule 12a — explicit headless opt-in requires a non-empty reason (PR-5).
+    # A2 (2026-08-26): headless is now the DEFAULT claude lane, so this no longer
+    # gates ACCESS — it gates the audit-trail statement "I explicitly chose this"
+    # for the pre-flip specs (and any future caller) that still set allow_headless
+    # =True by name. Requiring a reason for silence (the default) would be
+    # nonsense; requiring one for a stated choice is still the point.
     if spec.allow_headless:
         reason = (spec.headless_reason or "").strip()
         if not reason:
@@ -451,6 +475,34 @@ def validate(
                 f"allow_headless is only valid for provider=claude, got provider={spec.provider.value!r}; "
                 "headless is a claude-only lane",
             )
+
+    # Rule 12b — explicit tmux opt-out requires a non-empty reason (A2). Mirrors
+    # Rule 12a exactly: since claude_headless is now the silent default, CHOOSING
+    # tmux instead is the deviation that must leave an audit trail, not the other
+    # way around.
+    if spec.force_tmux:
+        reason = (spec.force_tmux_reason or "").strip()
+        if not reason:
+            return Reject(
+                "force-tmux-reason-required",
+                "force_tmux=True requires a non-empty force_tmux_reason explaining "
+                "the explicit tmux-lane opt-out; set force_tmux_reason to a human-readable justification",
+            )
+        if spec.provider not in (Provider.CLAUDE, Provider.AUTO):
+            return Reject(
+                "force-tmux-claude-only",
+                f"force_tmux is only valid for provider=claude, got provider={spec.provider.value!r}; "
+                "force_tmux only overrides the claude lane's default",
+            )
+
+    # Rule 12c — the two explicit choices are mutually exclusive. A spec cannot
+    # simultaneously declare "I want headless" and "I want tmux instead".
+    if spec.allow_headless and spec.force_tmux:
+        return Reject(
+            "conflicting-lane-choice",
+            "allow_headless and force_tmux cannot both be set — choose exactly one "
+            "explicit lane, or leave both unset to accept the default",
+        )
 
     # Rule 13 — track_id format (presence + format only; existence against the tracks
     # DB is deferred to dispatch_cli's door validation, which has DB access — mirrors

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -208,14 +208,28 @@ constraints:
       cited was never carried out by Anthropic. Operator ratified 2026-08-04.
       Downgraded from blocking to warn to match routing_policy.yaml's
       lane_safety.headless_block (both gates cover the same lane; they move
-      together). USABLE, NOT YET GOVERNED: two measured gaps from 2026-08-05
-      remain open regardless of billing — the lane ignores isolation=worktree
-      (worktree created then reaped while the worker branches in the MAIN
-      checkout, leaving real work uncommitted there) and the fail-closed
-      report gate did not bite on a report missing all four mandatory
-      headings. VNX_OVERRIDE_CLAUDE_HEADLESS=1 still marks an explicit
-      per-dispatch opt-in for audit visibility even though the route no
-      longer blocks.
+      together). UPDATED 2026-08-26 (A2, dispatch-20260826-alpha-a2-headless-
+      default): the two 2026-08-05 gaps this entry used to cite are CLOSED, not
+      open. Verified directly against main 7f93f681, not taken on the doc's
+      word: isolation — run_envelope_headless_plan() calls
+      create_dispatch_worktree(), passes cwd=wt_path to the adapter, and aborts
+      hard ("no shared-checkout fallback") if worktree creation fails (PR
+      #1416, main 9f32ae84, 2026-08-08). report-gate — _govern() emits the
+      report BEFORE the receipt so a missing/invalid report cannot produce a
+      status=success receipt (PR #1420, main c28b7ac4, 2026-08-09). Tests:
+      `pytest tests/test_headless_worktree_isolation.py` 6 passed;
+      `pytest tests/ -k HeadlessIsolationGuard` 7 passed. claude_headless is now
+      the DEFAULT claude lane (dispatch_plan.resolve_claude_lane) — this warn
+      fires on every headless dispatch, default or explicit, precisely because
+      the lane choice must stay visible in the audit trail even though it no
+      longer needs gating. VNX_OVERRIDE_CLAUDE_HEADLESS=1 still marks an
+      explicit per-dispatch opt-in for audit visibility even though the route
+      no longer blocks. Separately, and NOT resolved by the above: OI-1158
+      still holds — the door itself (dispatch_plan.py) never structurally
+      verifies isolation; the guarantee lives entirely in
+      dispatch_envelope.py -> dispatch_worktree_isolation.py, a path the door
+      does not inspect. That is a different, still-true claim about what the
+      DOOR knows, not about what the LANE does.
     enforcement: code_warn
     audit_severity: warn
     override_allowed: true

--- a/scripts/lib/providers/routing_policy.yaml
+++ b/scripts/lib/providers/routing_policy.yaml
@@ -83,15 +83,14 @@ lane_safety:
   # max, scope user:inference) confirms claude -p still runs on the Max
   # subscription, same as the tmux lane. Operator ratified 2026-08-04.
   #
-  # USABLE, NOT GOVERNED. Opening the billing block does not close two
-  # measured governance gaps (2026-08-05), both still live:
-  #   1. The lane ignores isolation=worktree — the door creates a worktree,
-  #      but the worker operates in the MAIN checkout and branches there, and
-  #      the worktree is reaped while the real work sits uncommitted in the
-  #      main repo.
-  #   2. The fail-closed report gate did not bite on a report missing all
-  #      four mandatory headings.
-  # Treat headless as usable-but-not-yet-governed until those gaps close.
+  # UPDATED 2026-08-26 (A2): the two 2026-08-05 governance gaps this comment
+  # used to cite (isolation=worktree ignored; fail-closed report gate not
+  # biting) are CLOSED — verified against main 7f93f681, PR #1416 (isolation,
+  # main 9f32ae84, 2026-08-08) and PR #1420 (report-gate, main c28b7ac4,
+  # 2026-08-09). claude_headless is now the DEFAULT claude lane
+  # (dispatch_plan.resolve_claude_lane); see the claude-headless entry in
+  # provider_constraints.yaml for the full measurement and test evidence —
+  # not duplicated here to avoid the two texts drifting apart again.
   #
   # enabled: false opens the lane by default; set enabled: true to re-block.
   # override_env is kept wired (VNX_OVERRIDE_CLAUDE_HEADLESS) so that reversal

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -2,17 +2,31 @@
   "couplings": [
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 843,
+      "line": 933,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 846,
+      "line": 936,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_door_row.py",
+      "line": 538,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_door_row.py",
+      "line": 543,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope.py",

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -245,6 +245,10 @@ def test_claude_runs_compile_plan_and_constraints(tmp_path, monkeypatch):
         "provider": "claude",
         "deadline_seconds": 3600,
         "isolation": "worktree",
+        # A2: unrelated to lane choice; pin tmux to keep exercising the mocked
+        # dispatch_cli._execute_claude path below.
+        "force_tmux": True,
+        "force_tmux_reason": "test fixture pins the tmux lane",
     }
     spec_file_evil = bundle_dir / "dispatch-spec-evil.json"
     spec_file_evil.write_text(json.dumps(spec_dict), encoding="utf-8")
@@ -274,6 +278,10 @@ def test_claude_runs_compile_plan_and_constraints(tmp_path, monkeypatch):
         "provider": "claude",
         "deadline_seconds": 3600,
         "isolation": "worktree",
+        # A2: this test explicitly asserts the tmux lane below (plan_arg.lane),
+        # so pin it explicitly rather than relying on the (now headless) default.
+        "force_tmux": True,
+        "force_tmux_reason": "test fixture pins the tmux lane",
     }
     spec_file_clean = bundle_dir / "dispatch-spec-clean.json"
     spec_file_clean.write_text(json.dumps(spec_dict2), encoding="utf-8")
@@ -417,7 +425,12 @@ def test_claude_routes_to_tmux_with_permit(mock_snapshot, tmp_path):
     """
     mock_snapshot.return_value = _clean_snapshot()
     instruction_file = _make_instruction(tmp_path)
-    spec_file = _make_spec_file(tmp_path, provider="claude")
+    # A2: this test specifically exercises the tmux dispatch path, so force it
+    # explicitly — a plain claude spec now defaults to claude_headless instead.
+    spec_file = _make_spec_file(
+        tmp_path, provider="claude",
+        extra={"force_tmux": True, "force_tmux_reason": "test fixture pins the tmux lane"},
+    )
 
     # Part A: valid permit → TmuxInteractiveDispatch.dispatch called
     mock_dispatch_result = MagicMock()
@@ -726,11 +739,21 @@ def _make_bundle_spec(
     provider: str = "claude",
     target_slot: str = "T0",
     model: str | None = None,
+    force_tmux: bool = False,
 ) -> tuple[Path, Path]:
     """Build a promoted bundle under <tmp>/vnx-data with the given instruction.
 
     Returns (data_dir, spec_file). spec_file + instruction live inside the bundle so
     the staging-binding check passes and only the edge under test can reject.
+
+    ``force_tmux`` (A2, 2026-08-26): claude_headless is now the DEFAULT claude
+    lane (dispatch_plan.resolve_claude_lane), so a plain claude spec built here
+    with no explicit lane choice now resolves to claude_headless — a real,
+    unmocked code path (run_envelope_headless_plan) that tries an actual
+    worktree. Callers whose test intent is unrelated to the lane choice itself
+    (SDK-scan, track-id, model-pin routing, worker-claude-override, ...) and
+    that mock ``dispatch_cli._execute_claude`` (the tmux-lane entry point) must
+    pass force_tmux=True to keep exercising that already-mocked path.
     """
     data_dir = tmp_path / "vnx-data"
     bundle_dir = data_dir / "dispatches" / "pending" / staging_id
@@ -759,6 +782,8 @@ def _make_bundle_spec(
         "model": model,
         "deadline_seconds": 3600,
         "isolation": "worktree",
+        "force_tmux": bool(force_tmux),
+        "force_tmux_reason": "test fixture pins the tmux lane" if force_tmux else None,
     }
     spec_file = bundle_dir / "dispatch-spec.json"
     spec_file.write_text(json.dumps(spec), encoding="utf-8")
@@ -784,6 +809,7 @@ def test_sdk_block_is_whitespace_aware(tmp_path, monkeypatch, evil_line):
     data_dir, spec_file = _make_bundle_spec(
         tmp_path,
         instruction_text=f"# Dispatch\n\n{evil_line}\n",
+        force_tmux=True,  # unrelated to lane choice; keep exercising the mocked tmux path
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -801,6 +827,7 @@ def test_clean_import_mentioning_anthropic_word_not_blocked(tmp_path, monkeypatc
     data_dir, spec_file = _make_bundle_spec(
         tmp_path,
         instruction_text="# Dispatch\n\nDocument the anthropic routing policy clearly.\n",
+        force_tmux=True,  # unrelated to lane choice; keep exercising the mocked tmux path
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -1024,6 +1051,7 @@ def test_dispatch_gate_codex_deep_forms_proceed(form_id, snippet, tmp_path, monk
         instruction_text=f"# Dispatch\n\n{snippet}\n",
         staging_id=f"20260615-codex-{form_id.replace('_', '-')}",
         dispatch_id=f"20260615-codex-{form_id.replace('_', '-')}",
+        force_tmux=True,  # unrelated to lane choice; keep exercising the mocked tmux path
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -1150,6 +1178,7 @@ def test_sdk_instruction_proceeds_warn_not_block(tmp_path, monkeypatch):
     data_dir, spec_file = _make_bundle_spec(
         tmp_path,
         instruction_text="# Task\n\nimport anthropic\nclient = anthropic.Anthropic()\n",
+        force_tmux=True,  # unrelated to lane choice; keep exercising the mocked tmux path
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -1166,6 +1195,7 @@ def test_sdk_instruction_url_mention_proceeds(tmp_path, monkeypatch):
     data_dir, spec_file = _make_bundle_spec(
         tmp_path,
         instruction_text="# Task\n\nSee https://anthropic.com/docs for the routing policy.\n",
+        force_tmux=True,  # unrelated to lane choice; keep exercising the mocked tmux path
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -1676,6 +1706,10 @@ def test_raw_opus_model_on_worker_now_routes_with_default_semantics(tmp_path, mo
         "model": "opus",
         "deadline_seconds": 3600,
         "isolation": "worktree",
+        # A2: this test explicitly asserts the tmux lane below; pin it rather
+        # than relying on the (now headless) default.
+        "force_tmux": True,
+        "force_tmux_reason": "test fixture pins the tmux lane",
     }
     spec_file = bundle_dir / "dispatch-spec.json"
     spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
@@ -1716,6 +1750,7 @@ def test_default_semantics_explicit_sonnet_on_t1_routes_to_sonnet(tmp_path, monk
         provider="claude",
         target_slot="T1",
         model="sonnet",
+        force_tmux=True,  # this test explicitly asserts the tmux lane below
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -1803,6 +1838,7 @@ def test_t0_floor_semantics_coerces_explicit_model_to_opus(tmp_path, monkeypatch
         provider="claude",
         target_slot="T0",
         model="sonnet",
+        force_tmux=True,  # this test explicitly asserts the tmux lane below
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -1882,8 +1918,9 @@ def test_headless_empty_reason_rejected(mock_snapshot, tmp_path, capsys):
     assert "headless-reason-required" in err
 
 
-def test_default_claude_still_routes_tmux(tmp_path, monkeypatch):
-    """allow_headless absent/false → claude_tmux_subscription (unchanged default behavior)."""
+def test_default_claude_now_routes_headless(tmp_path, monkeypatch):
+    """A2 (2026-08-26): allow_headless/force_tmux both absent → claude_headless,
+    the NEW default. Was test_default_claude_still_routes_tmux pre-flip."""
     data_dir = tmp_path / "vnx-data"
     staging_id = "20260615-staging-default-tmux"
     bundle_dir = data_dir / "dispatches" / "pending" / staging_id
@@ -1912,20 +1949,21 @@ def test_default_claude_still_routes_tmux(tmp_path, monkeypatch):
     spec_file.write_text(json.dumps(spec_data), encoding="utf-8")
 
     with patch("dispatch_cli._execute_claude", return_value=0) as mock_tmux:
-        with patch("dispatch_cli._execute_claude_headless") as mock_headless:
+        with patch("dispatch_cli._execute_claude_headless", return_value=0) as mock_headless:
             rc = run_dispatch(spec_file)
 
     assert rc == 0
-    mock_tmux.assert_called_once()
-    mock_headless.assert_not_called()
-    plan_arg = mock_tmux.call_args[0][0]
-    assert plan_arg.lane == "claude_tmux_subscription"
+    mock_headless.assert_called_once()
+    mock_tmux.assert_not_called()
+    plan_arg = mock_headless.call_args[0][0]
+    assert plan_arg.lane == "claude_headless"
 
 
 def test_legacy_env_vars_do_not_bypass_headless_gate(tmp_path, monkeypatch):
-    """VNX_AUTO_ROUTE=1 + VNX_ADAPTER=subprocess env vars have no effect through the door.
-    Without allow_headless=true in the spec, the plan is always claude_tmux_subscription.
-    """
+    """VNX_AUTO_ROUTE=1 + VNX_ADAPTER=subprocess env vars have no effect through the
+    door — lane resolution reads only the spec's allow_headless/force_tmux fields,
+    never ambient env. A2 (2026-08-26): without either field set, the plan is now
+    claude_headless (the new default), not claude_tmux_subscription."""
     data_dir = tmp_path / "vnx-data"
     staging_id = "20260615-legacy-env-probe"
     bundle_dir = data_dir / "dispatches" / "pending" / staging_id
@@ -1956,14 +1994,14 @@ def test_legacy_env_vars_do_not_bypass_headless_gate(tmp_path, monkeypatch):
     spec_file.write_text(json.dumps(spec_data), encoding="utf-8")
 
     with patch("dispatch_cli._execute_claude", return_value=0) as mock_tmux:
-        with patch("dispatch_cli._execute_claude_headless") as mock_headless:
+        with patch("dispatch_cli._execute_claude_headless", return_value=0) as mock_headless:
             rc = run_dispatch(spec_file)
 
     assert rc == 0
-    mock_tmux.assert_called_once()
-    mock_headless.assert_not_called()
-    plan_arg = mock_tmux.call_args[0][0]
-    assert plan_arg.lane == "claude_tmux_subscription"
+    mock_headless.assert_called_once()
+    mock_tmux.assert_not_called()
+    plan_arg = mock_headless.call_args[0][0]
+    assert plan_arg.lane == "claude_headless"
 
 
 # ---------------------------------------------------------------------------
@@ -2005,7 +2043,12 @@ class TestHeadlessIsolationGuard:
         """The tmux lane's isolation is structurally verified elsewhere — no warning."""
         from dispatch_cli import _headless_isolation_guard
 
-        spec_file = _make_spec_file(tmp_path, provider="claude")
+        # A2: force the tmux lane explicitly — a plain claude spec now defaults
+        # to claude_headless instead.
+        spec_file = _make_spec_file(
+            tmp_path, provider="claude",
+            extra={"force_tmux": True, "force_tmux_reason": "test fixture pins the tmux lane"},
+        )
         spec = load_spec(spec_file)
         vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
         plan = compile_plan(vspec, _clean_snapshot())
@@ -2044,9 +2087,14 @@ class TestHeadlessIsolationGuard:
 
     @patch("dispatch_cli.build_runtime_snapshot")
     def test_dry_run_default_claude_has_no_isolation_warning(self, mock_snapshot, tmp_path, capsys):
-        """Regression pin: a normal (tmux-lane) dry-run must NOT print the OI-1158 warning."""
+        """Regression pin: a tmux-lane dry-run must NOT print the OI-1158 warning.
+        A2: claude_headless is now the default, so the tmux lane must be forced
+        explicitly to still exercise this path."""
         mock_snapshot.return_value = _clean_snapshot()
-        spec_file = _make_spec_file(tmp_path, provider="claude")
+        spec_file = _make_spec_file(
+            tmp_path, provider="claude",
+            extra={"force_tmux": True, "force_tmux_reason": "test fixture pins the tmux lane"},
+        )
 
         rc = run_dispatch(spec_file, dry_run=True)
 
@@ -2099,6 +2147,7 @@ class TestHeadlessIsolationGuard:
             staging_id="20260812-staging-oi1158-tmux",
             dispatch_id="20260812-oi1158-tmux",
             target_slot="T0",
+            force_tmux=True,  # A2: force tmux explicitly; this test is tmux-specific
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -2594,6 +2643,10 @@ class TestTrackIdEndToEnd:
             "deadline_seconds": 3600,
             "isolation": "worktree",
             "track_id": "track-linkage-enforcement",
+            # A2: unrelated to lane choice; pin tmux to keep exercising the
+            # mocked dispatch_cli._execute_claude path below.
+            "force_tmux": True,
+            "force_tmux_reason": "test fixture pins the tmux lane",
         }
         spec_file = bundle_dir / "dispatch-spec.json"
         spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
@@ -2747,6 +2800,10 @@ class TestTrackIdEndToEnd:
             "deadline_seconds": 3600,
             "isolation": "worktree",
             "tags": ["no-track:exploratory spike"],
+            # A2: unrelated to lane choice; pin tmux to keep exercising the
+            # mocked dispatch_cli._execute_claude path below.
+            "force_tmux": True,
+            "force_tmux_reason": "test fixture pins the tmux lane",
         }
         spec_file = bundle_dir / "dispatch-spec.json"
         spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
@@ -2785,6 +2842,7 @@ def test_worker_claude_override_routes_build_worker_to_claude_tmux(tmp_path, mon
         dispatch_id="20260723-escape-hatch-apply",
         provider="claude",
         target_slot="T1",
+        force_tmux=True,  # this test explicitly asserts the tmux lane below
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -2832,6 +2890,7 @@ def test_worker_claude_override_honors_requested_claude_model(tmp_path, monkeypa
         provider="claude",
         target_slot="T2",
         model="opus",
+        force_tmux=True,  # this test explicitly asserts the tmux lane below
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -2977,6 +3036,7 @@ def test_worker_claude_override_env_does_not_leak_into_t0_or_kimi(tmp_path, monk
         dispatch_id="20260723-override-t0",
         provider="claude",
         target_slot="T0",
+        force_tmux=True,  # unrelated to lane choice; keeps _execute_claude mocked/reachable
     )
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -3095,6 +3155,7 @@ class TestPersistRouteDecision:
             staging_id="20260804-staging-oi849",
             dispatch_id="20260804-oi849-integration",
             target_slot="T0",
+            force_tmux=True,  # unrelated to lane choice; keeps _execute_claude mocked/reachable
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -3225,6 +3286,7 @@ class TestRegisterDispatchCreated:
             staging_id="20260810-staging-oi1120",
             dispatch_id="20260810-oi1120-integration",
             target_slot="T0",
+            force_tmux=True,  # this test's docstring asserts the tmux lane specifically
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -3248,6 +3310,7 @@ class TestRegisterDispatchCreated:
             staging_id="20260810-staging-oi1120-fail",
             dispatch_id="20260810-oi1120-write-fail",
             target_slot="T0",
+            force_tmux=True,  # unrelated to lane choice; keeps _execute_claude mocked/reachable
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -3425,6 +3488,7 @@ class TestSmartRouterPreValidate:
             dispatch_id="20260802-oi962-t0",
             provider="auto",
             target_slot="T0",
+            force_tmux=True,  # unrelated to lane choice; keeps _execute_claude mocked/reachable
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
@@ -3471,6 +3535,7 @@ class TestSmartRouterPreValidate:
             dispatch_id="20260810-oi1050-mid",
             provider="auto",
             target_slot="T1",
+            force_tmux=True,  # this test explicitly asserts the tmux lane below
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")

--- a/tests/test_dispatch_door_row.py
+++ b/tests/test_dispatch_door_row.py
@@ -113,6 +113,16 @@ def _make_bundle(
         "provider": "claude",
         "deadline_seconds": 3600,
         "isolation": "worktree",
+        # A2 (2026-08-26): these are door tests (dispatch row creation, target_slot,
+        # gate obligations) — they don't exercise lane behavior, and they run in a
+        # tmp_path that is NOT a real git repo. Since claude_headless became the
+        # default lane, an unpinned claude spec now hits
+        # dispatch_envelope.run_envelope_headless_plan's create_dispatch_worktree,
+        # which correctly hard-aborts on a non-git cwd (the PR #1416 isolation
+        # guarantee — never soften that). Pin to the tmux lane explicitly via the
+        # opt-out these tests actually need.
+        "force_tmux": True,
+        "force_tmux_reason": "door test asserts row/obligation state, not lane behavior; tmp_path is not a real git repo",
     }
     if track_id is not None:
         spec["track_id"] = track_id
@@ -391,3 +401,59 @@ def test_oi943_target_slot_survives_through_door(tmp_path, monkeypatch):
     assert row["target_slot"] == "T0", (
         "OI-943: target_slot must survive the full door path"
     )
+
+
+# ---------------------------------------------------------------------------
+# 6. A2-ff contract (2026-08-26): an UNPINNED claude spec through the door in a
+#    non-git directory MUST fail with the isolation abort. This is PR #1416's
+#    isolation guarantee (create_dispatch_worktree hard-aborts rather than
+#    silently falling back to a shared, unisolated checkout) — not a bug to be
+#    softened. Every other test in this file pins force_tmux=True precisely
+#    because they assert door/row/obligation behavior, not lane behavior; this
+#    test is the one place that intentionally leaves the spec unpinned so the
+#    isolation contract itself stays pinned and cannot regress silently.
+# ---------------------------------------------------------------------------
+
+def test_unpinned_claude_spec_in_non_git_dir_fails_with_isolation_abort(tmp_path, monkeypatch, caplog):
+    data_dir = tmp_path / "vnx-data"
+    bundle_dir = data_dir / "dispatches" / "pending" / "20260826-staging-unpinned-abort"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    instruction = bundle_dir / "instruction.md"
+    instruction.write_text("Do something useful.", encoding="utf-8")
+    spec = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260826-unpinned-lane-abort",
+        "staging_id": "20260826-staging-unpinned-abort",
+        "instruction_file": str(instruction),
+        "role": "backend-developer",
+        "target_slot": "T0",
+        "gate": "codex_gate",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+        # Deliberately NO force_tmux / allow_headless — this is the case every
+        # other test in this file pins away. tmp_path is NOT a git repo, so the
+        # default claude_headless lane's create_dispatch_worktree must hard-abort.
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        with caplog.at_level("ERROR"):
+            rc = run_dispatch(spec_file)
+
+    assert rc != 0, (
+        "an unpinned claude spec routed through the non-git tmp_path must fail — "
+        "a silent success here would mean the headless lane stopped requiring "
+        "isolation, which is exactly the PR #1416 guarantee this test protects"
+    )
+    assert any(
+        "isolation required but worktree creation failed" in r.message
+        and "no shared-checkout fallback" in r.message
+        for r in caplog.records
+    ), "the failure must be the isolation abort specifically, not some other rejection"

--- a/tests/test_dispatch_door_row.py
+++ b/tests/test_dispatch_door_row.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -404,27 +405,61 @@ def test_oi943_target_slot_survives_through_door(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# 6. A2-ff contract (2026-08-26): an UNPINNED claude spec through the door in a
-#    non-git directory MUST fail with the isolation abort. This is PR #1416's
-#    isolation guarantee (create_dispatch_worktree hard-aborts rather than
-#    silently falling back to a shared, unisolated checkout) — not a bug to be
-#    softened. Every other test in this file pins force_tmux=True precisely
-#    because they assert door/row/obligation behavior, not lane behavior; this
-#    test is the one place that intentionally leaves the spec unpinned so the
-#    isolation contract itself stays pinned and cannot regress silently.
+# 6. A2-ff2 contract (2026-08-26): an UNPINNED claude spec through the door in
+#    a non-git directory MUST fail with the isolation abort. This is PR
+#    #1416's isolation guarantee (create_dispatch_worktree hard-aborts rather
+#    than silently falling back to a shared, unisolated checkout) — not a bug
+#    to be softened. Every other test in this file pins force_tmux=True
+#    precisely because they assert door/row/obligation behavior, not lane
+#    behavior; this test is the one place that intentionally leaves the spec
+#    unpinned so the isolation contract itself stays pinned and cannot
+#    regress silently.
+#
+#    A2-ff2 (fix-forward on top of A2-ff): the ORIGINAL version of this test
+#    assumed pytest's tmp_path would be resolved by create_dispatch_worktree
+#    as the non-git working directory. That is false on the CI runner:
+#    create_dispatch_worktree never looks at tmp_path at all — it resolves the
+#    project root via dispatch_worktree_isolation.resolve_consumer_project_root(),
+#    which (absent an override) walks to the real consumer checkout. On CI
+#    that checkout IS a valid git repo, so the isolation abort this test wants
+#    never fires and the dispatch fails for some OTHER reason instead — a
+#    reason the old caplog-substring assertion could not tell apart from the
+#    real contract. Fix: FORCE the non-git condition at the exact place
+#    create_dispatch_worktree looks (resolve_consumer_project_root), instead
+#    of hoping the ambient tmp_path happens to match.
 # ---------------------------------------------------------------------------
 
-def test_unpinned_claude_spec_in_non_git_dir_fails_with_isolation_abort(tmp_path, monkeypatch, caplog):
-    data_dir = tmp_path / "vnx-data"
-    bundle_dir = data_dir / "dispatches" / "pending" / "20260826-staging-unpinned-abort"
+def _assert_isolation_abort(rc: int, records) -> None:
+    """Shared discriminator: rc failed AND it failed via the isolation abort.
+
+    Split out so test_control_isolation_success_makes_the_abort_check_fail
+    below can run the exact same check against a setup where isolation
+    SUCCEEDS and prove it turns red — the check must never be vacuously true.
+    """
+    assert rc != 0, (
+        "an unpinned claude spec routed through a non-git working directory "
+        "must fail — a silent success here would mean the headless lane "
+        "stopped requiring isolation, which is exactly the PR #1416 "
+        "guarantee this test protects"
+    )
+    assert any(
+        "isolation required but worktree creation failed" in r.getMessage()
+        and "no shared-checkout fallback" in r.getMessage()
+        for r in records
+    ), "the failure must be the isolation abort specifically, not some other rejection"
+
+
+def _write_unpinned_claude_spec(tmp_path: Path, *, suffix: str) -> "tuple[Path, Path]":
+    data_dir = tmp_path / f"vnx-data-{suffix}"
+    bundle_dir = data_dir / "dispatches" / "pending" / f"20260826-staging-unpinned-{suffix}"
     bundle_dir.mkdir(parents=True, exist_ok=True)
     instruction = bundle_dir / "instruction.md"
     instruction.write_text("Do something useful.", encoding="utf-8")
     spec = {
         "schema_version": 1,
         "project_id": "vnx-dev",
-        "dispatch_id": "20260826-unpinned-lane-abort",
-        "staging_id": "20260826-staging-unpinned-abort",
+        "dispatch_id": f"20260826-unpinned-lane-{suffix}",
+        "staging_id": f"20260826-staging-unpinned-{suffix}",
         "instruction_file": str(instruction),
         "role": "backend-developer",
         "target_slot": "T0",
@@ -434,26 +469,86 @@ def test_unpinned_claude_spec_in_non_git_dir_fails_with_isolation_abort(tmp_path
         "deadline_seconds": 3600,
         "isolation": "worktree",
         # Deliberately NO force_tmux / allow_headless — this is the case every
-        # other test in this file pins away. tmp_path is NOT a git repo, so the
-        # default claude_headless lane's create_dispatch_worktree must hard-abort.
+        # other test in this file pins away, so the spec routes through the
+        # default claude_headless lane's create_dispatch_worktree.
     }
     spec_file = bundle_dir / "dispatch-spec.json"
     spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return data_dir, spec_file
+
+
+def test_unpinned_claude_spec_in_non_git_dir_fails_with_isolation_abort(tmp_path, monkeypatch, caplog):
+    data_dir, spec_file = _write_unpinned_claude_spec(tmp_path, suffix="abort")
+
+    # FORCE the non-git condition at the exact place create_dispatch_worktree
+    # resolves its project root — not tmp_path, which the function never
+    # consults. An empty, freshly-created directory that was never `git init`'d
+    # guarantees `git -C <dir> rev-parse origin/main` fails with "not a git
+    # repository", which is what actually trips the isolation abort.
+    non_git_root = tmp_path / "non-git-consumer-root"
+    non_git_root.mkdir()
 
     monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
 
-    with patch("dispatch_cli._execute_claude", return_value=0):
+    with patch("dispatch_cli._execute_claude", return_value=0), patch(
+        "dispatch_worktree_isolation.resolve_consumer_project_root",
+        return_value=non_git_root,
+    ):
         with caplog.at_level("ERROR"):
             rc = run_dispatch(spec_file)
 
-    assert rc != 0, (
-        "an unpinned claude spec routed through the non-git tmp_path must fail — "
-        "a silent success here would mean the headless lane stopped requiring "
-        "isolation, which is exactly the PR #1416 guarantee this test protects"
+    _assert_isolation_abort(rc, caplog.records)
+
+
+def test_control_isolation_success_makes_the_abort_check_fail(tmp_path, monkeypatch, caplog):
+    """Proves test_unpinned_claude_spec_in_non_git_dir_fails_with_isolation_abort
+    can actually go red for the right reason (OI: "a contract test that stays
+    green when the contract breaks protects nothing").
+
+    Setup: point resolve_consumer_project_root at a REAL, disposable git repo
+    (so create_dispatch_worktree's isolation succeeds), and make the
+    downstream adapter fail for an unrelated reason — mirroring the exact
+    shape CI hit while this test was broken: rc != 0, but
+    completion_len=0 error=(no error captured), i.e. NOT an isolation abort.
+    _assert_isolation_abort must then raise AssertionError: rc != 0 still
+    holds, but the isolation-abort log line is absent.
+    """
+    data_dir, spec_file = _write_unpinned_claude_spec(tmp_path, suffix="control")
+
+    fake_repo = tmp_path / "fake-consumer-repo"
+    fake_repo.mkdir()
+    env = {**os.environ, "GIT_AUTHOR_NAME": "vnx-test", "GIT_AUTHOR_EMAIL": "vnx-test@example.invalid",
+           "GIT_COMMITTER_NAME": "vnx-test", "GIT_COMMITTER_EMAIL": "vnx-test@example.invalid"}
+    subprocess.run(["git", "init", "-q"], cwd=fake_repo, check=True, env=env)
+    (fake_repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "seed.txt"], cwd=fake_repo, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "seed"], cwd=fake_repo, check=True, env=env
     )
-    assert any(
-        "isolation required but worktree creation failed" in r.message
-        and "no shared-checkout fallback" in r.message
-        for r in caplog.records
-    ), "the failure must be the isolation abort specifically, not some other rejection"
+    # create_dispatch_worktree resolves base_ref "origin/main" via
+    # `git rev-parse origin/main`, which is satisfied by a LOCAL branch
+    # literally named "origin/main" — no real remote required, keeping this
+    # repo fully disposable and disconnected from the actual project remote.
+    subprocess.run(["git", "branch", "origin/main"], cwd=fake_repo, check=True, env=env)
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    from envelope_types import _AdapterResult  # noqa: PLC0415
+
+    with patch("dispatch_cli._execute_claude", return_value=0), patch(
+        "dispatch_worktree_isolation.resolve_consumer_project_root",
+        return_value=fake_repo,
+    ), patch(
+        "dispatch_envelope.ClaudeSubprocessAdapter.run",
+        return_value=_AdapterResult(
+            returncode=1, completion_text="", status="failure", error=None
+        ),
+    ):
+        with caplog.at_level("ERROR"):
+            rc = run_dispatch(spec_file)
+
+    assert rc != 0, "sanity: the control dispatch must still fail (for the wrong reason)"
+    with pytest.raises(AssertionError, match="isolation abort specifically"):
+        _assert_isolation_abort(rc, caplog.records)

--- a/tests/test_dispatch_enforcement.py
+++ b/tests/test_dispatch_enforcement.py
@@ -152,7 +152,12 @@ class TestD12ViaAndConstraint:
             f"expected via='headless', got {captured.get('via')!r}"
         )
 
-    def test_build_snapshot_via_cli_when_allow_headless_false(self, tmp_path: Path) -> None:
+    def test_build_snapshot_via_headless_when_no_explicit_choice(self, tmp_path: Path) -> None:
+        """A2 (2026-08-26): allow_headless=False with no force_tmux opt-out is no
+        longer "the normal case" — claude_headless is the default lane, so
+        build_runtime_snapshot's via must be 'headless' here too (not just for an
+        explicit allow_headless=True), mirroring dispatch_plan.resolve_claude_lane.
+        Was test_build_snapshot_via_cli_when_allow_headless_false pre-flip."""
         captured: dict = {}
 
         def fake_check(*, via=None, **kwargs):
@@ -190,8 +195,53 @@ class TestD12ViaAndConstraint:
 
             build_runtime_snapshot(vspec, data_dir=tmp_path, spec_file=tmp_path / "spec.json")
 
+        assert captured.get("via") == "headless", (
+            f"expected via='headless' (the new default), got {captured.get('via')!r}"
+        )
+
+    def test_build_snapshot_via_cli_when_force_tmux_true(self, tmp_path: Path) -> None:
+        """A2: an explicit force_tmux=True opt-out must still resolve via='cli' —
+        the only way left to reach the non-headless constraint path."""
+        captured: dict = {}
+
+        def fake_check(*, via=None, **kwargs):
+            captured["via"] = via
+            return []
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("providers.constraint_enforcer.check_constraints", side_effect=fake_check)
+            )
+            stack.enter_context(
+                patch("staging_validator._exists_in_dir", return_value=False)
+            )
+
+            spec = DispatchSpec(
+                schema_version=1,
+                project_id="test-project",
+                dispatch_id="test-d12-force-tmux-snap",
+                staging_id="test-d12-force-tmux-snap",
+                instruction_file=tmp_path / "instruction.md",
+                role="T1",
+                target_slot="T1",
+                gate="",
+                dispatch_paths=(),
+                provider=Provider.CLAUDE,
+                force_tmux=True,
+                force_tmux_reason="unit test pins tmux",
+            )
+            inst_text = "test force-tmux instruction"
+            vspec = ValidatedSpec(
+                spec=spec,
+                instruction_text=inst_text,
+                normalized_paths=(),
+                instruction_sha256=hashlib.sha256(inst_text.encode()).hexdigest(),
+            )
+
+            build_runtime_snapshot(vspec, data_dir=tmp_path, spec_file=tmp_path / "spec.json")
+
         assert captured.get("via") == "cli", (
-            f"expected via='cli', got {captured.get('via')!r}"
+            f"expected via='cli' for an explicit force_tmux opt-out, got {captured.get('via')!r}"
         )
 
 

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -159,15 +159,57 @@ class TestAutoRejected:
 
 class TestClaudeLane:
     def test_claude_lane_fields(self, tmp_path: Path) -> None:
+        """A2 (2026-08-26): claude_headless is now the DEFAULT lane for a plain
+        claude spec carrying no explicit lane choice — see TestLaneDefaultFlip
+        for the three-state coverage (default / explicit tmux / explicit
+        headless)."""
         vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
         plan = compile_plan(vspec, _healthy_snapshot())
         assert isinstance(plan, ExecutionPlan)
-        assert plan.lane == "claude_tmux_subscription"
-        assert plan.adapter == "tmux_claude"
+        assert plan.lane == "claude_headless"
+        assert plan.adapter == "claude_subprocess"
         assert plan.billing == "subscription"
         assert plan.serialization_class == "claude-tmux"
-        assert plan.warmup == "verify_strict"
+        assert plan.warmup == "n/a"
         assert plan.target_id == "ephemeral"
+
+
+# ---------------------------------------------------------------------------
+# A2 (2026-08-26) — the three lane-choice states, forced explicitly
+# ---------------------------------------------------------------------------
+
+class TestLaneDefaultFlip:
+    """Deliverable 1 (dispatch-20260826-alpha-a2-headless-default): the three
+    states forced on GEDRAG (plan.lane), not on the absence of a symbol. A test
+    that only checks "no exception raised" would still pass pre-flip; each
+    assertion here reads the actual resolved lane."""
+
+    def test_no_explicit_choice_defaults_to_headless(self, tmp_path: Path) -> None:
+        """provider=claude, no allow_headless/force_tmux set at all → the
+        NEW default, claude_headless. This is the state that was RED before
+        the flip (plan.lane == 'claude_tmux_subscription')."""
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_headless"
+
+    def test_explicit_tmux_choice_is_honored_with_reason(self, tmp_path: Path) -> None:
+        """force_tmux=True + reason → claude_tmux_subscription, AND the reason
+        lands in plan.warnings — the lane choice is never silent."""
+        reason = "avoid headless for this interactive debugging session"
+        vspec = _make_vspec_tmux(force_tmux_reason=reason, tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_tmux_subscription"
+        assert any(reason in w for w in plan.warnings)
+
+    def test_explicit_headless_choice_unchanged(self, tmp_path: Path) -> None:
+        """allow_headless=True + reason (the existing 39-spec shape) →
+        claude_headless, unchanged behavior across the flip."""
+        vspec = _make_vspec_headless(tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_headless"
 
 
 # ---------------------------------------------------------------------------
@@ -622,6 +664,40 @@ def _make_vspec_headless(
     )
 
 
+def _make_vspec_tmux(
+    *,
+    force_tmux_reason: str = "prefer tmux for this burst",
+    target_slot: str = "T1",
+    model: str | None = None,
+    tmp_path: Path,
+) -> ValidatedSpec:
+    """Build a ValidatedSpec with an EXPLICIT force_tmux=True opt-out (A2,
+    2026-08-26) — for tests that need a genuine tmux-lane plan now that a plain
+    claude spec with no explicit choice resolves to claude_headless instead."""
+    spec = DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-tmux-dispatch",
+        staging_id="staging-tmux-001",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot=target_slot,
+        gate="codex_gate",
+        dispatch_paths=(),
+        provider=Provider.CLAUDE,
+        model=model,
+        force_tmux=True,
+        force_tmux_reason=force_tmux_reason,
+    )
+    instruction_text = "# Test instruction\n"
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=instruction_text,
+        normalized_paths=(),
+        instruction_sha256=hashlib.sha256(instruction_text.encode("utf-8")).hexdigest(),
+    )
+
+
 class TestClaudeHeadlessLane:
     def test_headless_optin_lane_fields(self, tmp_path: Path) -> None:
         """allow_headless=True → lane=claude_headless, adapter=claude_subprocess,
@@ -647,13 +723,27 @@ class TestClaudeHeadlessLane:
         assert any("HEADLESS lane opted-in" in w for w in plan.warnings)
         assert any(reason in w for w in plan.warnings)
 
-    def test_default_claude_remains_tmux(self, tmp_path: Path) -> None:
-        """Default Claude (allow_headless=False) → claude_tmux_subscription unchanged."""
+    def test_default_claude_now_headless(self, tmp_path: Path) -> None:
+        """A2 (2026-08-26): default Claude (no explicit lane choice) →
+        claude_headless. Was test_default_claude_remains_tmux pre-flip."""
         vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
         plan = compile_plan(vspec, _healthy_snapshot())
         assert isinstance(plan, ExecutionPlan)
-        assert plan.lane == "claude_tmux_subscription"
+        assert plan.lane == "claude_headless"
         assert plan.billing == "subscription"
+
+    def test_explicit_force_tmux_lane_fields(self, tmp_path: Path) -> None:
+        """force_tmux=True + reason → lane=claude_tmux_subscription, adapter=
+        tmux_claude, and a visible 'TMUX lane opted-in' warning carrying the
+        reason — the mirror image of the headless opt-in warning."""
+        reason = "keep this benchmark on the interactive lane"
+        vspec = _make_vspec_tmux(force_tmux_reason=reason, tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_tmux_subscription"
+        assert plan.adapter == "tmux_claude"
+        assert any("TMUX lane opted-in" in w for w in plan.warnings)
+        assert any(reason in w for w in plan.warnings)
 
     def test_headless_isolation_always_worktree(self, tmp_path: Path) -> None:
         """claude_headless inherits the universal isolation=WORKTREE rule."""
@@ -668,7 +758,7 @@ class TestClaudeHeadlessLane:
         serialization_class string when the lock is enabled — one shared
         account-wide slot pool, not two independent counters."""
         headless_vspec = _make_vspec_headless(tmp_path=tmp_path)
-        tmux_vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        tmux_vspec = _make_vspec_tmux(tmp_path=tmp_path)
         headless_plan = compile_plan(headless_vspec, _healthy_snapshot(claude_serial_enabled=True))
         tmux_plan = compile_plan(tmux_vspec, _healthy_snapshot(claude_serial_enabled=True))
         assert isinstance(headless_plan, ExecutionPlan)
@@ -707,16 +797,19 @@ class TestClaudeBillingAuthDerived:
         assert plan.billing == "api_metered"
 
     def test_tmux_with_key_is_api_metered(self, tmp_path: Path) -> None:
-        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        """A2: use an explicit force_tmux opt-out to get a genuine tmux-lane
+        plan now that a plain claude spec defaults to headless instead."""
+        vspec = _make_vspec_tmux(tmp_path=tmp_path)
         plan = compile_plan(vspec, _healthy_snapshot(claude_api_metered=True))
         assert isinstance(plan, ExecutionPlan)
         assert plan.lane == "claude_tmux_subscription"
         assert plan.billing == "api_metered"
 
     def test_tmux_no_key_is_subscription(self, tmp_path: Path) -> None:
-        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        vspec = _make_vspec_tmux(tmp_path=tmp_path)
         plan = compile_plan(vspec, _healthy_snapshot())
         assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "claude_tmux_subscription"
         assert plan.billing == "subscription"
 
 

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -95,6 +95,15 @@ def _make_bundle(
         "provider": "claude",
         "deadline_seconds": 3600,
         "isolation": "worktree",
+        # A2 (2026-08-26): these are door tests (gate obligation registration) — they
+        # don't exercise lane behavior, and they run in a tmp_path that is NOT a real
+        # git repo. Since claude_headless became the default lane, an unpinned claude
+        # spec now hits dispatch_envelope.run_envelope_headless_plan's
+        # create_dispatch_worktree, which correctly hard-aborts on a non-git cwd (the
+        # PR #1416 isolation guarantee — never soften that). Pin to the tmux lane
+        # explicitly via the opt-out these tests actually need.
+        "force_tmux": True,
+        "force_tmux_reason": "door test asserts gate obligation state, not lane behavior; tmp_path is not a real git repo",
     }
     spec_file = bundle_dir / "dispatch-spec.json"
     spec_file.write_text(json.dumps(spec), encoding="utf-8")

--- a/vnx_cli/commands/dispatch_agent.py
+++ b/vnx_cli/commands/dispatch_agent.py
@@ -366,6 +366,46 @@ def vnx_dispatch_agent(args) -> int:
             )
             return 1
 
+    # A2 (2026-08-26): --force-tmux / --force-tmux-reason passthrough — the
+    # mirror-image explicit opt-OUT back to the (now non-default) tmux lane.
+    # Same validation shape as --allow-headless above, plus the two flags are
+    # mutually exclusive (the door's validate() Rule 12c rejects both set, but
+    # failing fast here means a caller never even reaches staging).
+    force_tmux = getattr(args, "force_tmux", False)
+    force_tmux_reason = getattr(args, "force_tmux_reason", None)
+    if force_tmux:
+        if allow_headless:
+            print(
+                "Error: --allow-headless and --force-tmux are mutually exclusive — "
+                "choose exactly one explicit lane, or pass neither to accept the "
+                "default (claude_headless).",
+                file=sys.stderr,
+            )
+            return 1
+        if not (force_tmux_reason or "").strip():
+            print(
+                "Error: --force-tmux requires --force-tmux-reason (a human-readable "
+                "justification for the tmux-lane opt-out).",
+                file=sys.stderr,
+            )
+            return 1
+        if provider != "claude":
+            print(
+                f"Error: --force-tmux is only valid for the claude lane, got "
+                f"provider {provider!r} (resolved from --model {model!r}).",
+                file=sys.stderr,
+            )
+            return 1
+        if not single_entry_enabled():
+            print(
+                "Error: --force-tmux requires the single-entry dispatch door "
+                "(VNX_DISPATCH_LEGACY=1 / VNX_SINGLE_ENTRY_DISPATCH=0 disables it). "
+                "The legacy dispatch lane has no lane-choice knob at all. Unset "
+                "VNX_DISPATCH_LEGACY / VNX_SINGLE_ENTRY_DISPATCH to use the door.",
+                file=sys.stderr,
+            )
+            return 1
+
     # OI-1390: --base-ref / --work-ref / --pr-id passthrough — a consumer fix-forward onto an
     # existing PR branch. Unset (None) preserves exactly the current behavior (stage_spec_bundle's
     # own defaults: base_ref="origin/main", pr_id/work_ref=None, a fresh dispatch/<id> branch).
@@ -428,6 +468,8 @@ def vnx_dispatch_agent(args) -> int:
         deadline_seconds=deadline_seconds,
         allow_headless=allow_headless,
         headless_reason=headless_reason,
+        force_tmux=force_tmux,
+        force_tmux_reason=force_tmux_reason,
         base_ref=base_ref,
         work_ref=work_ref,
         pr_id=pr_id,

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -423,10 +423,11 @@ def _register_dispatch_agent_subparser(subparsers: argparse.Action) -> None:
         default=False,
         dest="allow_headless",
         help=(
-            "opt into the claude_headless lane (claude -p). Requires "
-            "--headless-reason and a claude provider. The lane runs on the "
-            "subscription unless an own ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL "
-            "is present."
+            "explicitly opt into the claude_headless lane (claude -p) — redundant "
+            "with the default since A2 (2026-08-26), kept for an explicit "
+            "audit-trail statement. Requires --headless-reason and a claude "
+            "provider. The lane runs on the subscription unless an own "
+            "ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL is present."
         ),
     )
     dispatch_parser.add_argument(
@@ -435,6 +436,24 @@ def _register_dispatch_agent_subparser(subparsers: argparse.Action) -> None:
         dest="headless_reason",
         metavar="REASON",
         help="required human-readable justification when --allow-headless is set",
+    )
+    dispatch_parser.add_argument(
+        "--force-tmux",
+        action="store_true",
+        default=False,
+        dest="force_tmux",
+        help=(
+            "opt OUT of the claude_headless default back to the "
+            "claude_tmux_subscription lane. Requires --force-tmux-reason and a "
+            "claude provider. Mutually exclusive with --allow-headless."
+        ),
+    )
+    dispatch_parser.add_argument(
+        "--force-tmux-reason",
+        default=None,
+        dest="force_tmux_reason",
+        metavar="REASON",
+        help="required human-readable justification when --force-tmux is set",
     )
     dispatch_parser.add_argument(
         "--base-ref",


### PR DESCRIPTION
## Summary

`provider=claude` with no explicit lane choice now resolves to `claude_headless` instead of `claude_tmux_subscription`.

**Why now:** both governance gaps the old default was hedging against are closed on main `7f93f681`, verified directly against code rather than taken on the doc's word:
- `isolation=worktree` — `run_envelope_headless_plan()` creates a worktree, passes `cwd=wt_path` to the adapter, and aborts hard (no shared-checkout fallback) if creation fails. PR #1416, main `9f32ae84`, 2026-08-08.
- report-before-receipt — `_govern()` emits the report before the receipt, so a missing/invalid report cannot produce a `status=success` receipt. PR #1420, main `c28b7ac4`, 2026-08-09.

**The measured reason that tips the scale:** three dispatches on 25/26-08 (`#1685`, `#1686`, `#1687`) each opened a second PR on a sha that already had one, titled "auto-created by VNX tmux-spawn lane". All three specs carried `base_ref = "origin/dispatch/<existing-branch>"` — exactly the condition OI-1115's `skip_pr` guard exists for. `grep -c skip_pr` on the two lanes: `tmux_interactive_dispatch.py` → 0, `dispatch_envelope.py` → 7. The tmux lane never wired the guard the headless lane already has. That defect gets fixed separately in A3; this PR does not touch `tmux_interactive_dispatch.py`.

## Changes

- **`scripts/lib/dispatch_spec.py`** — new `force_tmux`/`force_tmux_reason` fields (mirrors `allow_headless`/`headless_reason`) so an explicit opt-out back to tmux stays possible and auditable. `validate()` Rule 12 split into 12a (headless reason required), 12b (tmux reason required), 12c (the two are mutually exclusive). A bare bool couldn't express "no choice" vs "explicit refusal" without a third value — 968 pre-flip specs on disk carry `allow_headless: false` written by the old writer's default, never an operator's real "I refuse this" — so the new opt-out lives on its own field instead of overloading the old one, which sidesteps having to reinterpret that historical data at all.
- **`scripts/lib/dispatch_plan.py`** — `resolve_claude_lane()` is the single source of truth for the claude-lane decision (headless / tmux / default). Used by both `compile_plan`'s D1 and `dispatch_cli.build_runtime_snapshot`'s `via=` computation (which feeds the `claude-headless` constraint check) so the two can never independently drift on what "headless" means for a given spec.
- **`scripts/lib/dispatch_bridge.py`, `vnx_cli/main.py`, `vnx_cli/commands/dispatch_agent.py`** — `--force-tmux`/`--force-tmux-reason` threaded through every writer surface that already carries `--allow-headless`/`--headless-reason` (`stage_spec_bundle`, `deliver_via_door`, the bridge CLI, `vnx dispatch-agent`).
- **`scripts/lib/providers/provider_constraints.yaml`, `routing_policy.yaml`** — the `claude-headless` constraint text no longer claims the 2026-08-05 isolation/report-gate gaps are open; replaced with the PR numbers, commit shas, and test evidence that closed them (2026-08-08/09). The constraint itself is untouched (still `severity=warn`, `override_allowed=true`) — only the stale "NOT YET GOVERNED" claim was wrong. The separate OI-1158 door-side warning (the door itself never structurally verifies isolation) is left alone — that claim is still true and is a different subject.
- **Test fixes** (`test_dispatch_plan.py`, `test_dispatch_cli.py`, `test_dispatch_enforcement.py`) — updated ~30 pre-existing tests that asserted the old default (tmux) for a plain claude spec with no explicit choice; each now either asserts the new default (headless) or forces `force_tmux=True` where the test's actual intent was unrelated to lane choice (SDK-scan, model-pin routing, track-id, worker-claude-override).

Not touched, per scope: `tmux_interactive_dispatch.py` (A3), the review-gates (never routed via `allow_headless`), the `claude-headless` constraint's severity/override config, billing (D2 already auth-derived, OI-1156).

## Verification

**Deliverable 1 — red test on GEDRAG, not a missing symbol.** Before the flip, `pytest tests/test_dispatch_plan.py -q`:
```
FAILED tests/test_dispatch_plan.py::TestClaudeLane::test_claude_lane_fields
    assert 'claude_headless' == 'claude_tmux_subscription'
FAILED tests/test_dispatch_plan.py::TestClaudeHeadlessLane::test_default_claude_remains_tmux
    assert 'claude_headless' == 'claude_tmux_subscription'
FAILED tests/test_dispatch_plan.py::TestClaudeBillingAuthDerived::test_tmux_with_key_is_api_metered
    assert 'claude_headless' == 'claude_tmux_subscription'
3 failed, 112 passed in 0.30s
```
All 3 failures are on the measured `plan.lane` value (behavior), zero are `AttributeError`/missing-symbol — `plan.lane` already existed pre-change, only its resolved value needed to change. New dedicated coverage: `TestLaneDefaultFlip` in `test_dispatch_plan.py` forces all three states explicitly (no choice → headless; explicit `force_tmux` + reason → tmux, reason in warnings; explicit `allow_headless` + reason → headless, unchanged).

**Deliverable 2 — before/after on the real spec** `~/.vnx-data/vnx-dev/dispatches/pending/20260826-t0-rebase-1682-op-main/dispatch-spec.json` (read-only `compile_plan` call, nothing written to `.vnx-data/`):
- Before: `plan.lane = claude_tmux_subscription`, `plan.adapter = tmux_claude`
- After: `plan.lane = claude_headless`, `plan.adapter = claude_subprocess`

**Full targeted run** (touched files + direct neighbours, ambient `VNX_OVERRIDE_WORKER_CLAUDE` unset — see Open Items):
```
tests/test_dispatch_spec.py tests/test_dispatch_plan.py tests/test_dispatch_cli.py
tests/test_dispatch_bridge_staging.py tests/test_dispatch_agent_headless_passthrough.py
tests/test_dispatch_enforcement.py tests/test_headless_worktree_isolation.py
tests/test_lane_matrix_row7_push_pr.py tests/test_pretooluse_headless_hook.py
tests/test_routing_policy.py tests/test_dispatch_envelope_field_propagation.py
tests/test_dispatch_envelope_plan.py tests/test_dispatch_path_access_provenance.py
tests/test_door_flip_d1_routing.py tests/test_failclass_registry.py
tests/test_requires_mcp_propagation.py tests/test_dispatch_agent_deadline_passthrough.py
tests/test_dispatch_agent_lane_coercion.py tests/test_dispatch_agent_preflight.py
tests/test_dispatch_agent_ref_flags.py tests/test_vnx_cli.py
= 737 passed
```

## Test plan
- [x] `pytest tests/test_dispatch_spec.py` — 106 passed
- [x] `pytest tests/test_dispatch_plan.py` — 119 passed (includes new `TestLaneDefaultFlip`)
- [x] `pytest tests/test_dispatch_cli.py` — 156 passed
- [x] `pytest tests/test_dispatch_bridge_staging.py` — 35 passed
- [x] `pytest tests/test_dispatch_agent_headless_passthrough.py` — 12 passed
- [x] `pytest tests/test_dispatch_enforcement.py` — 18 passed
- [x] `python3 -m py_compile` on all touched `.py` files
- [x] Both edited YAML files re-parse cleanly with `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Field proof, measured after this PR was opened (2026-08-26)

The code measurement above (`skip_pr`: tmux 0, envelope 7) predicted that the headless lane would
not produce the duplicate PR the tmux lane does. That prediction was then tested in the field,
unintentionally: this PR and its two siblings each needed fix-forwards onto their **existing**
dispatch branches — exactly the `base_ref = origin/dispatch/<existing>` condition that produced
`#1685`/`#1686`/`#1687` on the tmux lane that morning.

| | dispatches | PRs opened | duplicates on the same sha |
|---|---|---|---|
| tmux-spawn lane, 25/26-08 morning | 3 | 6 | **3** (`#1685`, `#1686`, `#1687`, all "auto-created by VNX tmux-spawn lane") |
| headless lane, 26-08 (this cluster + 3 fix-forwards) | 6 | 3 | **0** |

Counted independently by two orchestrator sessions: `#1685`, `#1686` and `#1687` remain the only
three "auto-created by VNX" PRs in the entire repository, and no fourth appeared after any of the
three headless fix-forwards.

**What this does and does not isolate.** Each fix-forward spec carried `base_ref`, `work_ref` AND
`pr_id`, so the field run does not prove which of the three protections did the work. The decisive
evidence for the lane asymmetry remains the code measurement (`skip_pr` wired 7 times on one lane
and 0 times on the other, since fixed for tmux in #1689). The field result is confirmation, not
the proof itself.
