### PR TITLE
test(review-gate): cross-process contract for eiser/vervuller gate-flag split (OI-1462)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1200,6 +1200,19 @@ def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
                 ),
             )
             return
+        # OI-1462: stamp what THIS process (the eiser) resolved for the
+        # gate-requirement flags at registration time, so a fulfiller running
+        # later in a different environment can be checked against it
+        # (gate_obligations.check_gate_requirement_mismatch) instead of the
+        # two sides silently disagreeing. Best-effort: a config_runtime import
+        # failure here must never block obligation registration itself.
+        try:
+            import config_runtime
+            gate_requirement_resolution = {
+                "VNX_CI_GATE_REQUIRED": config_runtime.get_bool("VNX_CI_GATE_REQUIRED"),
+            }
+        except Exception:  # noqa: BLE001 — resolution snapshot is best-effort
+            gate_requirement_resolution = None
         register_obligation(
             state_dir,
             dispatch_id=spec.dispatch_id,
@@ -1207,6 +1220,7 @@ def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
             project_id=spec.project_id,
             pr_number=pr_number_from_pr_id(spec.pr_id),
             pr_id=spec.pr_id,
+            gate_requirement_resolution=gate_requirement_resolution,
         )
     except Exception as exc:  # noqa: BLE001 — door bookkeeping must never raise
         logger.debug("[dispatch_cli] gate obligation register skipped: %s", exc)

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1204,15 +1204,27 @@ def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
         # gate-requirement flags at registration time, so a fulfiller running
         # later in a different environment can be checked against it
         # (gate_obligations.check_gate_requirement_mismatch) instead of the
-        # two sides silently disagreeing. Best-effort: a config_runtime import
-        # failure here must never block obligation registration itself.
+        # two sides silently disagreeing. A capture FAILURE is a distinct,
+        # loud state (status="failed") -- never collapsed into "never
+        # attempted" (None), which would blind check_gate_requirement_mismatch
+        # to exactly the broken-read scenario OI-1462 exists to catch.
         try:
             import config_runtime
             gate_requirement_resolution = {
-                "VNX_CI_GATE_REQUIRED": config_runtime.get_bool("VNX_CI_GATE_REQUIRED"),
+                "status": "captured",
+                "flags": {"VNX_CI_GATE_REQUIRED": config_runtime.get_bool("VNX_CI_GATE_REQUIRED")},
+                "error": None,
             }
-        except Exception:  # noqa: BLE001 — resolution snapshot is best-effort
-            gate_requirement_resolution = None
+        except Exception as exc:  # vnx-silent-except: obligation registration must never block the door on a config-read failure; the failure is captured as an explicit, loud "failed" state below, never swallowed silently
+            logger.warning(
+                "[dispatch_cli] gate_requirement_resolution capture failed for dispatch=%s: %s",
+                spec.dispatch_id, exc,
+            )
+            gate_requirement_resolution = {
+                "status": "failed",
+                "flags": None,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
         register_obligation(
             state_dir,
             dispatch_id=spec.dispatch_id,

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -187,14 +187,25 @@ def register_obligation(
     for numeric pr_ids, so alphanumeric labels (PR-HYG-1) would otherwise be
     unfindable at merge time.
 
-    ``gate_requirement_resolution`` (OI-1462): a snapshot of the gate-requirement
-    config flags (e.g. ``{"VNX_CI_GATE_REQUIRED": True}``) as THIS process —
-    the eiser — resolved them at registration time. The fulfiller process runs
-    later, in a different environment, and may resolve the same flags
-    differently; :func:`check_gate_requirement_mismatch` compares the two.
-    None (the default) when the caller has no resolution to stamp — a record
-    written before this field existed, or by a caller that never captured
-    one, carries no resolution info; that is UNKNOWN, never "no requirement".
+    ``gate_requirement_resolution`` (OI-1462): a snapshot of what THIS
+    process — the eiser — resolved for the gate-requirement config flags at
+    registration time. The fulfiller process runs later, in a different
+    environment, and may resolve the same flags differently;
+    :func:`check_gate_requirement_mismatch` compares the two. Shape (when
+    the caller attempted a capture):
+    ``{"status": "captured", "flags": {"VNX_CI_GATE_REQUIRED": True}, "error": None}``
+    on success, or ``{"status": "failed", "flags": None, "error": "<reason>"}``
+    when the capture itself raised. THREE distinct states, never collapsed
+    to two (OI-1462 residu — a Codex-gate finding on this very obligation
+    mechanism): ``None`` (the default) means the caller never attempted a
+    capture at all — UNKNOWN, never "no requirement"; ``status="failed"``
+    means it tried and the read itself broke — a FAULT, distinguishable from
+    both "unknown" and "captured false"; ``status="captured"`` means the
+    snapshot is trustworthy. Collapsing "failed" into ``None`` (as an earlier
+    version of this fix did) makes a broken flag-read at the eiser
+    indistinguishable from "nobody ever asked" — and blinds
+    :func:`check_gate_requirement_mismatch` to precisely the OI-1462 failure
+    mode: the read that breaks.
     """
     gate = (gate or "").strip()
     dispatch_id = (dispatch_id or "").strip()
@@ -242,24 +253,51 @@ def check_gate_requirement_mismatch(
     the vervuller run in different processes / environments and can resolve
     the SAME config flag through ``config_runtime.get_bool`` differently).
 
-    Returns None when there is nothing to compare — the obligation predates
-    :data:`register_obligation`'s ``gate_requirement_resolution`` field, or
-    never had ``flag`` stamped, or the two sides agree. An absent resolution
-    is UNKNOWN, never "no requirement": this deliberately never manufactures
-    a mismatch (or a match) out of missing data.
+    Three input states, THREE different answers — never collapsed to two:
 
-    Returns a mismatch dict — never a bare bool — so the caller has concrete
-    values to log and persist instead of a silent skip.
+      1. No resolution was ever captured (``gate_requirement_resolution`` is
+         absent/not a dict, or its ``status`` field is missing/unrecognised):
+         returns None. UNKNOWN, never "no requirement" — this never
+         manufactures a mismatch (or a match) out of missing data.
+      2. The writer's OWN capture attempt failed (``status == "failed"``):
+         returns a ``"kind": "writer_capture_failed"`` finding. This is
+         DISTINCT from case 1 — the writer tried and its own flag-read broke,
+         which is exactly the OI-1462 failure mode this function exists to
+         surface, not silence. No value comparison is possible (there is
+         nothing trustworthy to compare against), but the finding itself is
+         not nothing: it says the obligation's requirement was never
+         reliably established.
+      3. The writer captured a real value (``status == "captured"``) and it
+         either matches the reader's (returns None — genuine agreement) or
+         diverges (returns a ``"kind": "value_mismatch"`` finding with both
+         values).
+
+    Returns a dict — never a bare bool — so the caller has concrete detail to
+    log and persist instead of a silent skip, for either finding kind.
     """
     resolution = record.get("gate_requirement_resolution")
-    if not isinstance(resolution, dict) or flag not in resolution:
+    if not isinstance(resolution, dict):
         return None
-    writer_value = bool(resolution[flag])
+    status = resolution.get("status")
+    if status == "failed":
+        return {
+            "flag": flag,
+            "kind": "writer_capture_failed",
+            "writer_error": resolution.get("error"),
+            "detected_at": _utc_now_iso(),
+        }
+    if status != "captured":
+        return None
+    flags = resolution.get("flags")
+    if not isinstance(flags, dict) or flag not in flags:
+        return None
+    writer_value = bool(flags[flag])
     reader_value = bool(reader_value)
     if writer_value == reader_value:
         return None
     return {
         "flag": flag,
+        "kind": "value_mismatch",
         "writer_value": writer_value,
         "reader_value": reader_value,
         "detected_at": _utc_now_iso(),

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -171,6 +171,7 @@ def register_obligation(
     pr_number: Optional[int] = None,
     pr_id: Optional[str] = None,
     branch: Optional[str] = None,
+    gate_requirement_resolution: Optional[Dict[str, Any]] = None,
 ) -> Optional[Path]:
     """Register the review-gate obligation for a door-accepted dispatch.
 
@@ -185,6 +186,15 @@ def register_obligation(
     gate uses to find a PR's declared gate: ``pr_number`` is only derivable
     for numeric pr_ids, so alphanumeric labels (PR-HYG-1) would otherwise be
     unfindable at merge time.
+
+    ``gate_requirement_resolution`` (OI-1462): a snapshot of the gate-requirement
+    config flags (e.g. ``{"VNX_CI_GATE_REQUIRED": True}``) as THIS process —
+    the eiser — resolved them at registration time. The fulfiller process runs
+    later, in a different environment, and may resolve the same flags
+    differently; :func:`check_gate_requirement_mismatch` compares the two.
+    None (the default) when the caller has no resolution to stamp — a record
+    written before this field existed, or by a caller that never captured
+    one, carries no resolution info; that is UNKNOWN, never "no requirement".
     """
     gate = (gate or "").strip()
     dispatch_id = (dispatch_id or "").strip()
@@ -212,6 +222,7 @@ def register_obligation(
             "result_path": None,
             "reason": None,
             "reason_detail": None,
+            "gate_requirement_resolution": gate_requirement_resolution,
         }
         _atomic_write_json(path, record)
         return path
@@ -221,6 +232,38 @@ def register_obligation(
             dispatch_id, gate, exc,
         )
         return None
+
+
+def check_gate_requirement_mismatch(
+    record: Dict[str, Any], *, flag: str, reader_value: bool,
+) -> Optional[Dict[str, Any]]:
+    """Compare a fulfiller's own resolution of ``flag`` against the value the
+    obligation's writer stamped at registration time (OI-1462: the eiser and
+    the vervuller run in different processes / environments and can resolve
+    the SAME config flag through ``config_runtime.get_bool`` differently).
+
+    Returns None when there is nothing to compare — the obligation predates
+    :data:`register_obligation`'s ``gate_requirement_resolution`` field, or
+    never had ``flag`` stamped, or the two sides agree. An absent resolution
+    is UNKNOWN, never "no requirement": this deliberately never manufactures
+    a mismatch (or a match) out of missing data.
+
+    Returns a mismatch dict — never a bare bool — so the caller has concrete
+    values to log and persist instead of a silent skip.
+    """
+    resolution = record.get("gate_requirement_resolution")
+    if not isinstance(resolution, dict) or flag not in resolution:
+        return None
+    writer_value = bool(resolution[flag])
+    reader_value = bool(reader_value)
+    if writer_value == reader_value:
+        return None
+    return {
+        "flag": flag,
+        "writer_value": writer_value,
+        "reader_value": reader_value,
+        "detected_at": _utc_now_iso(),
+    }
 
 
 def register_no_gate_obligation(
@@ -345,6 +388,7 @@ __all__ = [
     "pr_number_from_pr_id",
     "register_obligation",
     "register_no_gate_obligation",
+    "check_gate_requirement_mismatch",
     "iter_obligations",
     "update_obligation",
 ]

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -7,6 +7,7 @@ Methods handle creating gate request payloads for Gemini, Codex, and Claude GitH
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -27,6 +28,8 @@ from claude_github_receipt import (
     STATE_BLOCKED,
     STATE_COMPLETED,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # Fixed fallback order for review-gate takeover (review-gate-provider-agnostic
@@ -58,6 +61,51 @@ class GateRequestHandlerMixin:
     def _ci_gate_available(self) -> bool:
         import config_runtime
         return config_runtime.get_bool("VNX_CI_GATE_REQUIRED") and shutil.which("gh") is not None
+
+    def _check_ci_gate_requirement_mismatch(self, dispatch_id: str) -> None:
+        """OI-1462: compare THIS process's (the vervuller's) own resolution of
+        ``VNX_CI_GATE_REQUIRED`` against what the obligation's writer (the
+        eiser, running earlier in a possibly different environment) stamped
+        at registration time. A mismatch is a benoemde condition — logged
+        loudly and persisted onto the obligation record — never a silent
+        skip, since the whole defect class is two processes disagreeing on
+        the same flag with nothing noticing.
+
+        Best-effort: dispatch_id may be blank (non-obligation call sites),
+        the obligation may not exist yet, or bookkeeping may fail — none of
+        that may ever break an actual gate request.
+        """
+        if not dispatch_id:
+            return
+        try:
+            import config_runtime
+            from gate_obligations import (
+                check_gate_requirement_mismatch,
+                obligation_path,
+                update_obligation,
+            )
+            path = obligation_path(self.state_dir, dispatch_id)
+            if not path.exists():
+                return
+            record = json.loads(path.read_text(encoding="utf-8"))
+            mismatch = check_gate_requirement_mismatch(
+                record, flag="VNX_CI_GATE_REQUIRED",
+                reader_value=config_runtime.get_bool("VNX_CI_GATE_REQUIRED"),
+            )
+            if mismatch is None:
+                return
+            logger.warning(
+                "gate_request_handler: cross-process gate-requirement mismatch "
+                "for dispatch=%s flag=%s writer=%s reader=%s -- the eiser and "
+                "the vervuller resolved VNX_CI_GATE_REQUIRED differently",
+                dispatch_id, mismatch["flag"], mismatch["writer_value"], mismatch["reader_value"],
+            )
+            update_obligation(path, gate_requirement_mismatch=mismatch)
+        except Exception as exc:  # noqa: BLE001 — mismatch detection must never block a gate request
+            logger.debug(
+                "gate_request_handler: ci_gate requirement-mismatch check skipped for dispatch=%s: %s",
+                dispatch_id, exc,
+            )
 
     def _kimi_gate_runner_path(self) -> Path:
         return Path(__file__).resolve().parent.parent / "kimi_gate.py"
@@ -904,6 +952,7 @@ class GateRequestHandlerMixin:
         from review_gate_manager import _utc_now
 
         available = self._ci_gate_available()
+        self._check_ci_gate_requirement_mismatch(dispatch_id)
         requested_at = _utc_now()
         payload: Dict[str, Any] = {
             "gate": "ci_gate",

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -66,10 +66,16 @@ class GateRequestHandlerMixin:
         """OI-1462: compare THIS process's (the vervuller's) own resolution of
         ``VNX_CI_GATE_REQUIRED`` against what the obligation's writer (the
         eiser, running earlier in a possibly different environment) stamped
-        at registration time. A mismatch is a benoemde condition — logged
-        loudly and persisted onto the obligation record — never a silent
-        skip, since the whole defect class is two processes disagreeing on
-        the same flag with nothing noticing.
+        at registration time. A finding is a benoemde condition — logged
+        loudly, ledgered (ADR-005: an NDJSON event before the obligation
+        record mutation, never only the mutation), and persisted onto the
+        obligation record — never a silent skip, since the whole defect
+        class is two processes disagreeing on the same flag with nothing
+        noticing. Two distinct finding kinds
+        (``gate_obligations.check_gate_requirement_mismatch``):
+        ``value_mismatch`` (both sides captured a value, and they differ) and
+        ``writer_capture_failed`` (the eiser's OWN flag-read broke — a fault,
+        not a value to compare against).
 
         Best-effort: dispatch_id may be blank (non-obligation call sites),
         the obligation may not exist yet, or bookkeeping may fail — none of
@@ -84,6 +90,8 @@ class GateRequestHandlerMixin:
                 obligation_path,
                 update_obligation,
             )
+            from review_gate_manager import emit_governance_receipt
+
             path = obligation_path(self.state_dir, dispatch_id)
             if not path.exists():
                 return
@@ -94,14 +102,36 @@ class GateRequestHandlerMixin:
             )
             if mismatch is None:
                 return
-            logger.warning(
-                "gate_request_handler: cross-process gate-requirement mismatch "
-                "for dispatch=%s flag=%s writer=%s reader=%s -- the eiser and "
-                "the vervuller resolved VNX_CI_GATE_REQUIRED differently",
-                dispatch_id, mismatch["flag"], mismatch["writer_value"], mismatch["reader_value"],
+            if mismatch["kind"] == "writer_capture_failed":
+                logger.warning(
+                    "gate_request_handler: dispatch=%s flag=%s -- the eiser's "
+                    "OWN gate-requirement capture FAILED at registration time "
+                    "(%s); this obligation's requirement was never reliably "
+                    "established and cannot be cross-checked",
+                    dispatch_id, mismatch["flag"], mismatch["writer_error"],
+                )
+            else:
+                logger.warning(
+                    "gate_request_handler: cross-process gate-requirement mismatch "
+                    "for dispatch=%s flag=%s writer=%s reader=%s -- the eiser and "
+                    "the vervuller resolved VNX_CI_GATE_REQUIRED differently",
+                    dispatch_id, mismatch["flag"], mismatch["writer_value"], mismatch["reader_value"],
+                )
+            # ADR-005: the ledger is canonical, before any other durable
+            # mutation -- emit the NDJSON event first, then mutate the
+            # obligation record, so an operator tailing t0_receipts.ndjson
+            # sees this finding without having to know to go read obligation
+            # JSON files.
+            emit_governance_receipt(
+                "gate_requirement_mismatch",
+                receipt_kind="review_gate",
+                status="mismatch",
+                dispatch_id=dispatch_id,
+                gate="ci_gate",
+                **mismatch,
             )
             update_obligation(path, gate_requirement_mismatch=mismatch)
-        except Exception as exc:  # noqa: BLE001 — mismatch detection must never block a gate request
+        except Exception as exc:  # vnx-silent-except: mismatch detection is diagnostic tooling on the read path -- it must never block or fail an actual gate request; failures here are logged at debug with dispatch_id + reason so they stay visible without risking the gate itself
             logger.debug(
                 "gate_request_handler: ci_gate requirement-mismatch check skipped for dispatch=%s: %s",
                 dispatch_id, exc,

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -844,6 +844,62 @@ def test_request_ci_gate_with_contract_creates_contract_file(gate_env, monkeypat
     assert stored["gate"] == "ci_gate"
 
 
+def test_request_ci_gate_stamps_requirement_mismatch_onto_obligation(gate_env, monkeypatch):
+    """OI-1462: when the vervuller's own resolution of VNX_CI_GATE_REQUIRED
+    disagrees with what the obligation's writer (the eiser) stamped at
+    registration time, that mismatch must land on the obligation record --
+    never a silent skip."""
+    import review_gate_manager as rgm
+    from gate_obligations import obligation_path, register_obligation
+
+    state_dir = gate_env["state_dir"]
+    dispatch_id = "20260826-oi1462-mismatch"
+    register_obligation(
+        state_dir, dispatch_id=dispatch_id, gate="ci_gate", project_id="vnx-dev",
+        gate_requirement_resolution={"VNX_CI_GATE_REQUIRED": True},
+    )
+
+    manager = rgm.ReviewGateManager()
+    monkeypatch.setattr("config_runtime.get_bool", lambda key: False)
+
+    with patch("gate_request_handler.shutil.which", return_value="/usr/bin/gh"):
+        manager._request_ci_gate(
+            pr_number=999, branch="feat/test", risk_class="medium",
+            changed_files=[], mode="per_pr", dispatch_id=dispatch_id,
+        )
+
+    record = json.loads(obligation_path(state_dir, dispatch_id).read_text())
+    mismatch = record["gate_requirement_mismatch"]
+    assert mismatch["flag"] == "VNX_CI_GATE_REQUIRED"
+    assert mismatch["writer_value"] is True
+    assert mismatch["reader_value"] is False
+
+
+def test_request_ci_gate_no_mismatch_when_resolutions_agree(gate_env, monkeypatch):
+    """Control case: when both sides agree, no mismatch field is written."""
+    import review_gate_manager as rgm
+    from gate_obligations import obligation_path, register_obligation
+
+    state_dir = gate_env["state_dir"]
+    dispatch_id = "20260826-oi1462-agree"
+    register_obligation(
+        state_dir, dispatch_id=dispatch_id, gate="ci_gate", project_id="vnx-dev",
+        gate_requirement_resolution={"VNX_CI_GATE_REQUIRED": False},
+    )
+
+    manager = rgm.ReviewGateManager()
+    monkeypatch.setattr("config_runtime.get_bool", lambda key: False)
+
+    with patch("gate_request_handler.shutil.which", return_value="/usr/bin/gh"):
+        manager._request_ci_gate(
+            pr_number=998, branch="feat/test", risk_class="medium",
+            changed_files=[], mode="per_pr", dispatch_id=dispatch_id,
+        )
+
+    record = json.loads(obligation_path(state_dir, dispatch_id).read_text())
+    assert "gate_requirement_mismatch" not in record
+
+
 def test_ci_gate_contract_result_discoverable_by_find_gate_result(gate_env):
     """Finding 2: ci_gate result written with pr_id='PR-73' is found by _find_gate_result('ci_gate','PR-73',...)."""
     import closure_verifier as cv

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -848,7 +848,7 @@ def test_request_ci_gate_stamps_requirement_mismatch_onto_obligation(gate_env, m
     """OI-1462: when the vervuller's own resolution of VNX_CI_GATE_REQUIRED
     disagrees with what the obligation's writer (the eiser) stamped at
     registration time, that mismatch must land on the obligation record --
-    never a silent skip."""
+    never a silent skip -- AND on the NDJSON ledger (ADR-005)."""
     import review_gate_manager as rgm
     from gate_obligations import obligation_path, register_obligation
 
@@ -856,7 +856,9 @@ def test_request_ci_gate_stamps_requirement_mismatch_onto_obligation(gate_env, m
     dispatch_id = "20260826-oi1462-mismatch"
     register_obligation(
         state_dir, dispatch_id=dispatch_id, gate="ci_gate", project_id="vnx-dev",
-        gate_requirement_resolution={"VNX_CI_GATE_REQUIRED": True},
+        gate_requirement_resolution={
+            "status": "captured", "flags": {"VNX_CI_GATE_REQUIRED": True}, "error": None,
+        },
     )
 
     manager = rgm.ReviewGateManager()
@@ -870,9 +872,23 @@ def test_request_ci_gate_stamps_requirement_mismatch_onto_obligation(gate_env, m
 
     record = json.loads(obligation_path(state_dir, dispatch_id).read_text())
     mismatch = record["gate_requirement_mismatch"]
+    assert mismatch["kind"] == "value_mismatch"
     assert mismatch["flag"] == "VNX_CI_GATE_REQUIRED"
     assert mismatch["writer_value"] is True
     assert mismatch["reader_value"] is False
+
+    # ADR-005: the ledger is canonical -- the mismatch finding must also be
+    # visible in t0_receipts.ndjson, not only on the obligation JSON file.
+    receipts_file = state_dir / "t0_receipts.ndjson"
+    assert receipts_file.exists(), "the mismatch finding must be ledgered (ADR-005)"
+    ledgered = [
+        json.loads(line) for line in receipts_file.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    events = [r for r in ledgered if r.get("event_type") == "gate_requirement_mismatch"]
+    assert len(events) == 1
+    assert events[0]["dispatch_id"] == dispatch_id
+    assert events[0]["kind"] == "value_mismatch"
+    assert events[0]["receipt_kind"] == "review_gate"
 
 
 def test_request_ci_gate_no_mismatch_when_resolutions_agree(gate_env, monkeypatch):
@@ -884,7 +900,9 @@ def test_request_ci_gate_no_mismatch_when_resolutions_agree(gate_env, monkeypatc
     dispatch_id = "20260826-oi1462-agree"
     register_obligation(
         state_dir, dispatch_id=dispatch_id, gate="ci_gate", project_id="vnx-dev",
-        gate_requirement_resolution={"VNX_CI_GATE_REQUIRED": False},
+        gate_requirement_resolution={
+            "status": "captured", "flags": {"VNX_CI_GATE_REQUIRED": False}, "error": None,
+        },
     )
 
     manager = rgm.ReviewGateManager()
@@ -898,6 +916,47 @@ def test_request_ci_gate_no_mismatch_when_resolutions_agree(gate_env, monkeypatc
 
     record = json.loads(obligation_path(state_dir, dispatch_id).read_text())
     assert "gate_requirement_mismatch" not in record
+
+
+def test_request_ci_gate_writer_capture_failed_is_a_distinct_ledgered_finding(gate_env, monkeypatch):
+    """OI-1462 three-bucket fix: when the OBLIGATION'S OWN writer-side
+    capture failed (status="failed"), the vervuller's mismatch check must
+    still say something concrete -- a "writer_capture_failed" finding,
+    ledgered and persisted -- never silence (which is what an obligation
+    with no gate_requirement_resolution field at all would produce)."""
+    import review_gate_manager as rgm
+    from gate_obligations import obligation_path, register_obligation
+
+    state_dir = gate_env["state_dir"]
+    dispatch_id = "20260826-oi1462-writer-failed"
+    register_obligation(
+        state_dir, dispatch_id=dispatch_id, gate="ci_gate", project_id="vnx-dev",
+        gate_requirement_resolution={
+            "status": "failed", "flags": None, "error": "RuntimeError: config store unreachable",
+        },
+    )
+
+    manager = rgm.ReviewGateManager()
+    monkeypatch.setattr("config_runtime.get_bool", lambda key: True)
+
+    with patch("gate_request_handler.shutil.which", return_value="/usr/bin/gh"):
+        manager._request_ci_gate(
+            pr_number=997, branch="feat/test", risk_class="medium",
+            changed_files=[], mode="per_pr", dispatch_id=dispatch_id,
+        )
+
+    record = json.loads(obligation_path(state_dir, dispatch_id).read_text())
+    finding = record["gate_requirement_mismatch"]
+    assert finding["kind"] == "writer_capture_failed"
+    assert "config store unreachable" in finding["writer_error"]
+
+    receipts_file = state_dir / "t0_receipts.ndjson"
+    ledgered = [
+        json.loads(line) for line in receipts_file.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    events = [r for r in ledgered if r.get("event_type") == "gate_requirement_mismatch"]
+    assert len(events) == 1
+    assert events[0]["kind"] == "writer_capture_failed"
 
 
 def test_ci_gate_contract_result_discoverable_by_find_gate_result(gate_env):

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -48,6 +48,7 @@ from gate_obligations import (
     STATUS_RETIRED,
     STATUS_UNRESOLVABLE,
     TERMINAL_STATUSES,
+    check_gate_requirement_mismatch,
     obligation_path,
     pr_number_from_pr_id,
     register_obligation,
@@ -195,6 +196,36 @@ def test_door_registers_obligation_for_declared_gate(tmp_path, monkeypatch):
     assert record["dispatch_id"] == "20260731-oi876-declared-gate"
 
 
+def test_door_stamps_gate_requirement_resolution_on_registration(tmp_path, monkeypatch):
+    """OI-1462: the door (the eiser) must snapshot its OWN resolution of
+    VNX_CI_GATE_REQUIRED into the obligation record at registration time, so
+    a fulfiller running later in a different environment can be checked
+    against it (gate_obligations.check_gate_requirement_mismatch)."""
+    import config_runtime
+
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260826-staging-oi1462-resolution",
+        dispatch_id="20260826-oi1462-resolution",
+        gate="ci_gate",
+    )
+    _make_state_dir(tmp_path)
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    real_get_bool = config_runtime.get_bool
+    monkeypatch.setattr(
+        config_runtime, "get_bool",
+        lambda key: True if key == "VNX_CI_GATE_REQUIRED" else real_get_bool(key),
+    )
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        rc = run_dispatch(spec_file)
+    assert rc == 0
+
+    record = _read_obligation(data_dir / "state", "20260826-oi1462-resolution")
+    assert record["gate_requirement_resolution"] == {"VNX_CI_GATE_REQUIRED": True}
+
+
 def test_door_without_declared_gate_derives_obligation(tmp_path, monkeypatch):
     """Punt 7 (gate-weight-by-variant): a silent spec now derives a gate.
 
@@ -275,6 +306,63 @@ def test_register_obligation_never_resets_fulfilled(tmp_path):
     assert _read_obligation(state_dir, "d-1")["status"] == STATUS_FULFILLED, (
         "a retry/fix-forward must never reset a fulfilled obligation to pending"
     )
+
+
+# ---------------------------------------------------------------------------
+# OI-1462: gate_requirement_resolution stamp + cross-process mismatch check.
+# ---------------------------------------------------------------------------
+
+
+def test_register_obligation_stamps_gate_requirement_resolution(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="d-resolution", gate="ci_gate", project_id="vnx-dev",
+        gate_requirement_resolution={"VNX_CI_GATE_REQUIRED": True},
+    )
+    record = _read_obligation(state_dir, "d-resolution")
+    assert record["gate_requirement_resolution"] == {"VNX_CI_GATE_REQUIRED": True}
+
+
+def test_register_obligation_without_resolution_defaults_to_none(tmp_path):
+    """A caller that never captures a resolution (or an old codepath) must
+    stamp None, never fabricate a value -- absent is UNKNOWN, not "off"."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(state_dir, dispatch_id="d-no-resolution", gate="codex_gate")
+    record = _read_obligation(state_dir, "d-no-resolution")
+    assert record["gate_requirement_resolution"] is None
+
+
+def test_check_gate_requirement_mismatch_flags_divergence():
+    record = {"gate_requirement_resolution": {"VNX_CI_GATE_REQUIRED": True}}
+    mismatch = check_gate_requirement_mismatch(
+        record, flag="VNX_CI_GATE_REQUIRED", reader_value=False,
+    )
+    assert mismatch == {
+        "flag": "VNX_CI_GATE_REQUIRED",
+        "writer_value": True,
+        "reader_value": False,
+        "detected_at": mismatch["detected_at"],
+    }
+
+
+def test_check_gate_requirement_mismatch_agrees_when_values_match():
+    record = {"gate_requirement_resolution": {"VNX_CI_GATE_REQUIRED": True}}
+    assert check_gate_requirement_mismatch(
+        record, flag="VNX_CI_GATE_REQUIRED", reader_value=True,
+    ) is None
+
+
+def test_check_gate_requirement_mismatch_absent_resolution_is_unknown_not_mismatch():
+    """A record predating this field (or one whose resolution never captured
+    this flag) must read as UNKNOWN -- never as a manufactured mismatch and
+    never as a false agreement."""
+    assert check_gate_requirement_mismatch(
+        {}, flag="VNX_CI_GATE_REQUIRED", reader_value=True,
+    ) is None
+    assert check_gate_requirement_mismatch(
+        {"gate_requirement_resolution": {"OTHER_FLAG": True}},
+        flag="VNX_CI_GATE_REQUIRED", reader_value=True,
+    ) is None
 
 
 def test_pr_number_from_pr_id_shapes():

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -223,7 +223,58 @@ def test_door_stamps_gate_requirement_resolution_on_registration(tmp_path, monke
     assert rc == 0
 
     record = _read_obligation(data_dir / "state", "20260826-oi1462-resolution")
-    assert record["gate_requirement_resolution"] == {"VNX_CI_GATE_REQUIRED": True}
+    assert record["gate_requirement_resolution"] == {
+        "status": "captured", "flags": {"VNX_CI_GATE_REQUIRED": True}, "error": None,
+    }
+
+
+def test_door_stamps_capture_failure_as_a_distinct_state_not_none(tmp_path, monkeypatch, caplog):
+    """OI-1462 residu (Codex-gate finding on this exact obligation mechanism):
+    when the door's OWN flag-resolution snapshot fails, that must land in the
+    record as an explicit ``status="failed"`` -- a THIRD state, never
+    collapsed into the same ``None`` a caller-never-attempted record would
+    carry. Also: the failure must be logged loudly (with the dispatch_id),
+    never swallowed silently."""
+    import logging
+
+    import config_runtime
+
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260826-staging-oi1462-capture-fail",
+        dispatch_id="20260826-oi1462-capture-fail",
+        gate="ci_gate",
+    )
+    _make_state_dir(tmp_path)
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    real_get_bool = config_runtime.get_bool
+
+    def _boom(key):
+        if key == "VNX_CI_GATE_REQUIRED":
+            raise RuntimeError("config store unreachable")
+        return real_get_bool(key)
+
+    monkeypatch.setattr(config_runtime, "get_bool", _boom)
+
+    with patch("dispatch_cli._execute_claude", return_value=0), \
+         caplog.at_level(logging.WARNING, logger="dispatch_cli"):
+        rc = run_dispatch(spec_file)
+    assert rc == 0
+
+    record = _read_obligation(data_dir / "state", "20260826-oi1462-capture-fail")
+    resolution = record["gate_requirement_resolution"]
+    assert resolution["status"] == "failed", (
+        f"a broken flag-read must be recorded as failed, not silently as "
+        f"None (indistinguishable from 'never attempted'): {resolution}"
+    )
+    assert resolution["flags"] is None
+    assert "config store unreachable" in resolution["error"]
+    assert any(
+        "20260826-oi1462-capture-fail" in rec.message and "gate_requirement_resolution" in rec.message
+        for rec in caplog.records
+    ), "the capture failure must be logged loudly, with the dispatch_id, not swallowed silently"
 
 
 def test_door_without_declared_gate_derives_obligation(tmp_path, monkeypatch):
@@ -315,12 +366,13 @@ def test_register_obligation_never_resets_fulfilled(tmp_path):
 
 def test_register_obligation_stamps_gate_requirement_resolution(tmp_path):
     state_dir = _make_state_dir(tmp_path)
+    resolution = {"status": "captured", "flags": {"VNX_CI_GATE_REQUIRED": True}, "error": None}
     path = register_obligation(
         state_dir, dispatch_id="d-resolution", gate="ci_gate", project_id="vnx-dev",
-        gate_requirement_resolution={"VNX_CI_GATE_REQUIRED": True},
+        gate_requirement_resolution=resolution,
     )
     record = _read_obligation(state_dir, "d-resolution")
-    assert record["gate_requirement_resolution"] == {"VNX_CI_GATE_REQUIRED": True}
+    assert record["gate_requirement_resolution"] == resolution
 
 
 def test_register_obligation_without_resolution_defaults_to_none(tmp_path):
@@ -332,13 +384,28 @@ def test_register_obligation_without_resolution_defaults_to_none(tmp_path):
     assert record["gate_requirement_resolution"] is None
 
 
+# ---------------------------------------------------------------------------
+# check_gate_requirement_mismatch: three input buckets, three distinct
+# answers -- (a) never attempted, (b) attempted and FAILED, (c) captured a
+# real value. Collapsing (a) and (b) into the same None was itself an
+# OI-1462-shaped bug (a Codex-gate finding on this very mechanism): a broken
+# flag-read at the writer must never look identical to "nobody ever asked".
+# ---------------------------------------------------------------------------
+
+
 def test_check_gate_requirement_mismatch_flags_divergence():
-    record = {"gate_requirement_resolution": {"VNX_CI_GATE_REQUIRED": True}}
+    """Bucket (c): both sides captured a real value, and they differ."""
+    record = {
+        "gate_requirement_resolution": {
+            "status": "captured", "flags": {"VNX_CI_GATE_REQUIRED": True}, "error": None,
+        },
+    }
     mismatch = check_gate_requirement_mismatch(
         record, flag="VNX_CI_GATE_REQUIRED", reader_value=False,
     )
     assert mismatch == {
         "flag": "VNX_CI_GATE_REQUIRED",
+        "kind": "value_mismatch",
         "writer_value": True,
         "reader_value": False,
         "detected_at": mismatch["detected_at"],
@@ -346,23 +413,64 @@ def test_check_gate_requirement_mismatch_flags_divergence():
 
 
 def test_check_gate_requirement_mismatch_agrees_when_values_match():
-    record = {"gate_requirement_resolution": {"VNX_CI_GATE_REQUIRED": True}}
+    """Bucket (c), agreement case: no finding."""
+    record = {
+        "gate_requirement_resolution": {
+            "status": "captured", "flags": {"VNX_CI_GATE_REQUIRED": True}, "error": None,
+        },
+    }
     assert check_gate_requirement_mismatch(
         record, flag="VNX_CI_GATE_REQUIRED", reader_value=True,
     ) is None
 
 
 def test_check_gate_requirement_mismatch_absent_resolution_is_unknown_not_mismatch():
-    """A record predating this field (or one whose resolution never captured
-    this flag) must read as UNKNOWN -- never as a manufactured mismatch and
-    never as a false agreement."""
+    """Bucket (a): a record predating this field, one whose resolution never
+    captured this flag, or a resolution with no recognised status must read
+    as UNKNOWN -- never as a manufactured mismatch and never as a false
+    agreement."""
     assert check_gate_requirement_mismatch(
         {}, flag="VNX_CI_GATE_REQUIRED", reader_value=True,
     ) is None
     assert check_gate_requirement_mismatch(
-        {"gate_requirement_resolution": {"OTHER_FLAG": True}},
+        {"gate_requirement_resolution": {
+            "status": "captured", "flags": {"OTHER_FLAG": True}, "error": None,
+        }},
         flag="VNX_CI_GATE_REQUIRED", reader_value=True,
     ) is None
+    assert check_gate_requirement_mismatch(
+        {"gate_requirement_resolution": {"status": "unrecognised_future_status"}},
+        flag="VNX_CI_GATE_REQUIRED", reader_value=True,
+    ) is None
+
+
+def test_check_gate_requirement_mismatch_writer_capture_failed_is_a_distinct_loud_finding():
+    """Bucket (b) -- THE point of the three-bucket fix: when the writer's OWN
+    flag-read broke (status="failed"), that must NOT read as bucket (a)
+    (nothing to see) -- the function must return a real, distinct finding
+    that says something concrete: capture failed, for this reason, so the
+    obligation's requirement was never reliably established. This is what an
+    earlier version of this fix got wrong by collapsing "failed" into None."""
+    record = {
+        "gate_requirement_resolution": {
+            "status": "failed", "flags": None, "error": "RuntimeError: config store unreachable",
+        },
+    }
+    finding = check_gate_requirement_mismatch(
+        record, flag="VNX_CI_GATE_REQUIRED", reader_value=True,
+    )
+    assert finding is not None, (
+        "a writer capture FAILURE must produce a real finding, not the same "
+        "None a never-attempted resolution would produce"
+    )
+    assert finding["kind"] == "writer_capture_failed"
+    assert finding["flag"] == "VNX_CI_GATE_REQUIRED"
+    assert "config store unreachable" in finding["writer_error"]
+    # Distinguishable from bucket (a) by construction: bucket (a) always
+    # returns bare None, never a dict.
+    assert finding != check_gate_requirement_mismatch(
+        {}, flag="VNX_CI_GATE_REQUIRED", reader_value=True,
+    )
 
 
 def test_pr_number_from_pr_id_shapes():

--- a/tests/test_gate_stack_cross_process_contract.py
+++ b/tests/test_gate_stack_cross_process_contract.py
@@ -1,0 +1,263 @@
+"""test_gate_stack_cross_process_contract.py — OI-1462: the gate-eis and the
+gate-vervulling run in different processes and can resolve the SAME config
+flag differently.
+
+Root cause under test: two independent read-sites --
+``review_gate_manager._build_default_review_stack()`` (the eiser, runs at
+MODULE-IMPORT time) and ``gate_request_handler._ci_gate_available()`` (the
+vervuller, runs later, possibly in a different process) -- both call
+``config_runtime.get_bool("VNX_CI_GATE_REQUIRED")``. PR #1684 fixed the
+LEESPAD (``config_runtime._resolve_state_dir`` now falls back to
+``vnx_paths.resolve_paths()`` when ``$VNX_STATE_DIR`` is unset), but nothing
+detects it when the two sides still disagree -- e.g. because one process can
+reach the operator's config store and the other cannot.
+
+A same-process test with monkeypatch is NOT a substitute here: the whole bug
+is that the environment differs PER PROCESS. Every test below spawns two REAL
+subprocesses (``subprocess.run([sys.executable, "-c", ...])``) with
+deliberately different ``env=``.
+
+Measured 2026-08-26 (T0, on main @7f93f681): three real processes differing
+ONLY in environment (state-dir set / unset, cwd inside/outside the repo) all
+read True for VNX_CI_GATE_REQUIRED, because (a) #1684's resolver fallback
+finds this repo's real central store regardless of cwd, and (b) the registry
+default flipped "0" -> "1" (OI-1385) since this flag was PARK on 21-08. A
+test that seeds the DB with the SAME value as the registry default is green
+for the wrong reason: a process that cannot reach the DB at all would still
+read the matching default and look identical to one that read the real
+override. Every test below therefore seeds an operator override that
+DIVERGES from the registry default, and asserts on WHERE the value came from
+(``autowired``: True = read from the DB, False = env/registry fallback) --
+not only on what the value was. Two processes that coincidentally name the
+same number from different sources is not the contract being pinned here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(LIB_DIR))
+
+import config_registry as cr  # noqa: E402
+import config_store_db as cs  # noqa: E402
+
+FLAG = "VNX_CI_GATE_REQUIRED"
+PID = "gatecontracttest"
+
+# Process A driver -- the EISER: imports review_gate_manager, which resolves
+# DEFAULT_REVIEW_STACK at MODULE-IMPORT time via config_runtime.get_bool.
+_PROC_A_CODE = """
+import json, sys
+sys.path.insert(0, sys.argv[1]); sys.path.insert(0, sys.argv[2])
+import config_runtime
+autowired = config_runtime.autowire()
+import review_gate_manager as rgm
+print(json.dumps({
+    "stack": rgm.DEFAULT_REVIEW_STACK,
+    "flag_value": config_runtime.get_bool("VNX_CI_GATE_REQUIRED"),
+    "autowired": autowired,
+}))
+"""
+
+# Process B driver -- the VERVULLER: calls the real fulfilment-decision
+# method. shutil.which is pinned to a fixed path so the gh binary's local
+# presence can never be the variable that differs between A and B -- only
+# the config-flag resolution may differ.
+_PROC_B_CODE = """
+import json, sys
+sys.path.insert(0, sys.argv[1]); sys.path.insert(0, sys.argv[2])
+import config_runtime
+autowired = config_runtime.autowire()
+import gate_request_handler as grh
+grh.shutil.which = lambda name: "/usr/bin/gh"
+print(json.dumps({
+    "flag_value": config_runtime.get_bool("VNX_CI_GATE_REQUIRED"),
+    "ci_gate_available": grh.GateRequestHandlerMixin._ci_gate_available(None),
+    "autowired": autowired,
+}))
+"""
+
+# Probe driver -- asks, under a GIVEN env, what state dir vnx_paths'
+# canonical resolver (the #1684 fallback) would compute, so a test can seed a
+# store at EXACTLY that path without hardcoding this repo's project_id.
+_PROBE_CODE = """
+import json, sys
+sys.path.insert(0, sys.argv[1]); sys.path.insert(0, sys.argv[2])
+import vnx_paths
+print(json.dumps(vnx_paths.resolve_paths()))
+"""
+
+
+def _seed_state_dir(tmp_path: Path, value: str, *, project_id: str = PID) -> Path:
+    """Build a REAL runtime_coordination.db carrying an explicit operator
+    override for VNX_CI_GATE_REQUIRED, via the same config_store_db API the
+    dashboard uses -- never hand-written SQL."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(state_dir / "runtime_coordination.db")
+    try:
+        cs.set_config(conn, project_id, FLAG, value, actor="test", approval_id="test-approval")
+    finally:
+        conn.close()
+    return state_dir
+
+
+def _run(code: str, env_overrides: dict, cwd: Path) -> dict:
+    env = {"PATH": os.environ.get("PATH", "")}
+    env.update(env_overrides)
+    result = subprocess.run(
+        [sys.executable, "-c", code, str(SCRIPTS_DIR), str(LIB_DIR)],
+        env=env, cwd=str(cwd), capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode})\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    try:
+        return json.loads(result.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError) as exc:
+        raise AssertionError(
+            f"subprocess produced non-JSON output: stdout={result.stdout!r} stderr={result.stderr!r}"
+        ) from exc
+
+
+def _probe_canonical_state_dir(fake_home: Path, cwd: Path) -> Path:
+    data = _run(_PROBE_CODE, {"HOME": str(fake_home)}, cwd)
+    return Path(data["VNX_STATE_DIR"])
+
+
+# ---------------------------------------------------------------------------
+# RED: the eiser and the vervuller resolve VNX_CI_GATE_REQUIRED differently,
+# because they run in different environments/processes.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_process_flag_divergence_when_vervuller_cannot_see_the_db(tmp_path):
+    """Two REAL subprocesses, deliberately different env=.
+
+    Seeds an operator override of "0" in a fresh DB -- the OPPOSITE of the
+    current registry default "1" (see module docstring for why the default
+    must be diverged from, not matched). Process A can reach that DB
+    (explicit VNX_STATE_DIR + VNX_PROJECT_ID) and must read the override.
+    Process B gets neither, plus a FAKE, empty $HOME so the #1684
+    canonical-resolver fallback genuinely cannot find ANY project_config --
+    not this test's store, not this machine's own real ~/.vnx-data/<project>
+    store. cwd alone does NOT achieve that isolation: vnx_paths resolves
+    VNX_HOME from its own __file__ location, not from cwd, so a bare
+    cwd=/tmp outside the repo still finds this repo's real central store on
+    a dev machine (measured). Faking $HOME is what actually severs that
+    lookup, deterministically, on any machine.
+    """
+    assert cr.CONFIG_REGISTRY[FLAG].default == "1", (
+        "this test's whole premise is an override that diverges from the "
+        "registry default -- if the default ever flips back to '0' this "
+        "seed must flip too, or the test goes back to being green for the "
+        "wrong reason (a store-blind process would then coincidentally "
+        "read the same value as the store-connected one)"
+    )
+    state_dir = _seed_state_dir(tmp_path, "0")
+
+    a_result = _run(
+        _PROC_A_CODE,
+        {"VNX_STATE_DIR": str(state_dir), "VNX_PROJECT_ID": PID},
+        tmp_path,
+    )
+
+    fake_home = tmp_path / "fake_home_unreachable"
+    fake_home.mkdir()
+    outside_cwd = tmp_path / "outside_repo_cwd"
+    outside_cwd.mkdir()
+    b_result = _run(_PROC_B_CODE, {"HOME": str(fake_home)}, outside_cwd)
+
+    # Provenance first: a value that merely LOOKS the same from two
+    # different sources is not a passing contract, so assert where each
+    # value came from before asserting what it was.
+    assert a_result["autowired"] is True, (
+        f"process A must have wired the DB and read the operator override; got {a_result}"
+    )
+    assert b_result["autowired"] is False, (
+        f"process B must NOT have found any project_config -- it has no "
+        f"VNX_STATE_DIR and a fake, empty $HOME; got {b_result}"
+    )
+    assert a_result["flag_value"] is False, f"A must read the DB override (0): {a_result}"
+    assert b_result["flag_value"] is True, f"B must fall back to the registry default (1): {b_result}"
+
+    # The named, measurable divergence this dispatch exists to catch: same
+    # flag, same instant, two different real values from two different
+    # sources -- not a coincidence of matching numbers.
+    assert a_result["flag_value"] != b_result["flag_value"], (
+        f"expected a genuine cross-process divergence on {FLAG}, got A={a_result} B={b_result}"
+    )
+    assert "ci_gate" not in a_result["stack"], (
+        f"A resolved the operator's off-override and must exclude ci_gate "
+        f"from the default review stack: {a_result['stack']}"
+    )
+    assert b_result["ci_gate_available"] is True, (
+        "B, unable to see the operator's off-override, considers ci_gate "
+        f"available anyway -- the two processes disagree on whether the "
+        f"operator required this gate at all: {b_result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GREEN: regression guard for PR #1684 -- once the vervuller CAN reach the
+# SAME store the eiser read (here: purely via vnx_paths.resolve_paths()'s
+# canonical-resolver fallback, the exact code path #1684 added, with no
+# VNX_STATE_DIR/VNX_PROJECT_ID at all), both sides must agree.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_process_flag_agreement_when_vervuller_finds_store_via_canonical_resolver(tmp_path):
+    """Before #1684, a process with no VNX_STATE_DIR could never see an
+    operator override at all, regardless of environment. This pins that it
+    now can, via the SAME canonical-resolver path #1684 added -- and that
+    when it does, the two processes' reads agree.
+    """
+    fake_home = tmp_path / "fake_home_reachable"
+    fake_home.mkdir()
+
+    # Ask a subprocess -- under the exact env B will use -- what state dir
+    # the canonical resolver computes, so the store gets seeded at that path
+    # without hardcoding this repo's project_id.
+    resolved_state_dir = _probe_canonical_state_dir(fake_home, tmp_path)
+    project_id = resolved_state_dir.parent.name
+    resolved_state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(resolved_state_dir / "runtime_coordination.db")
+    try:
+        cs.set_config(conn, project_id, FLAG, "0", actor="test", approval_id="test-approval")
+    finally:
+        conn.close()
+
+    a_result = _run(
+        _PROC_A_CODE,
+        {"VNX_STATE_DIR": str(resolved_state_dir), "VNX_PROJECT_ID": project_id},
+        tmp_path,
+    )
+    # Process B: no explicit env at all -- must find the SAME store purely
+    # via the canonical resolver fallback.
+    b_result = _run(_PROC_B_CODE, {"HOME": str(fake_home)}, tmp_path)
+
+    assert a_result["autowired"] is True
+    assert b_result["autowired"] is True, (
+        f"the #1684 canonical-resolver fallback must find this store with "
+        f"no VNX_STATE_DIR at all; got {b_result}"
+    )
+    assert a_result["flag_value"] is False
+    assert b_result["flag_value"] is False, (
+        f"once B can see the SAME operator override A saw, it must read "
+        f"the same value: {b_result}"
+    )
+    assert "ci_gate" not in a_result["stack"]
+    assert b_result["ci_gate_available"] is False, (
+        f"the two sides must agree once the store is reachable from both: "
+        f"A={a_result} B={b_result}"
+    )

--- a/tests/test_gate_stack_cross_process_contract.py
+++ b/tests/test_gate_stack_cross_process_contract.py
@@ -79,8 +79,13 @@ LIB_DIR = SCRIPTS_DIR / "lib"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(LIB_DIR))
 
-import config_registry as cr  # noqa: E402
-import config_store_db as cs  # noqa: E402
+# config_registry / config_store_db are imported lazily, inside the
+# functions that use them (below) -- they live under scripts/lib, which is
+# only on sys.path after the inserts above, so a module-level import here
+# would need a `# noqa: E402` suppression the repo's Lint Patterns gate
+# rejects. Not a workaround: this is the same lazy-import convention used
+# throughout scripts/lib itself (e.g. dispatch_cli.py's `import config_runtime`
+# inside functions rather than at module scope).
 
 FLAG = "VNX_CI_GATE_REQUIRED"
 PID = "gatecontracttest"
@@ -163,6 +168,8 @@ def _seed_state_dir(tmp_path: Path, value: str, *, project_id: str = PID) -> Pat
     """Build a REAL runtime_coordination.db carrying an explicit operator
     override for VNX_CI_GATE_REQUIRED, via the same config_store_db API the
     dashboard uses -- never hand-written SQL."""
+    import config_store_db as cs
+
     state_dir = tmp_path / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(state_dir / "runtime_coordination.db")
@@ -219,6 +226,8 @@ def test_cross_process_flag_divergence_when_vervuller_cannot_see_the_db(tmp_path
     ``~/.vnx-data/<project>`` store, and not whatever ``.vnx-data`` may have
     accumulated next to the real checkout this test file itself lives in.
     """
+    import config_registry as cr
+
     assert cr.CONFIG_REGISTRY[FLAG].default == "1", (
         "this test's whole premise is an override that diverges from the "
         "registry default -- if the default ever flips back to '0' this "
@@ -312,6 +321,8 @@ def test_cross_process_flag_agreement_when_vervuller_finds_store_via_canonical_r
         f"tmp_path -- a test must never write an operator override into a "
         f"real, shared store; got {resolved_state_dir} (tmp_path={tmp_path})"
     )
+    import config_store_db as cs
+
     resolved_state_dir.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(resolved_state_dir / "runtime_coordination.db")
     try:

--- a/tests/test_gate_stack_cross_process_contract.py
+++ b/tests/test_gate_stack_cross_process_contract.py
@@ -30,12 +30,44 @@ DIVERGES from the registry default, and asserts on WHERE the value came from
 (``autowired``: True = read from the DB, False = env/registry fallback) --
 not only on what the value was. Two processes that coincidentally name the
 same number from different sources is not the contract being pinned here.
+
+SECOND round of the same lesson (T0 review, 2026-08-26): the first version of
+this file isolated the vervuller with a fake, empty $HOME and a cwd outside
+the repo -- and was ITSELF environment-dependent, exactly the defect class it
+exists to catch. ``vnx_paths._resolve_vnx_home()`` derives ``VNX_HOME`` from
+its OWN ``__file__`` location, not from cwd or $HOME. When the scripts a
+subprocess imports live inside a REAL, long-lived dev checkout,
+``_resolve_state_root``'s "existing dev checkout: keep resolving to
+``<project_root>/.vnx-data``" branch (step 4) finds whatever real
+``.vnx-data`` has accumulated there from actual day-to-day use -- BEFORE the
+fake-$HOME central-store check or the fresh-install fallback are ever
+reached. Measured: the real ``~/Development/vnx-orchestration`` checkout
+carries an 835 KB ``runtime_coordination.db`` from 2026-08-15. A subprocess
+whose scripts live there resolves ``autowired=True`` regardless of $HOME,
+and the "GREEN" test would have written an operator override into that real,
+shared store (with a nonsense ``project_id=".vnx-data"``, since it derived
+the id from ``resolved_state_dir.parent.name``).
+
+The fix: every subprocess whose resolution must be test-controlled runs
+against an ISOLATED COPY of ``scripts/`` placed under ``tmp_path``
+(:func:`_isolated_scripts_copy`), never against this test file's own
+checkout. A copy with no ``.git`` and no ``.vnx-project-id`` marker makes
+``vnx_paths._resolve_state_root`` fall through to its explicit
+collision-safe branch ("no resolvable project_id -> stay project-local"),
+which computes a path entirely under ``tmp_path`` -- deterministically, on
+any machine, regardless of what real state sits next to whatever checkout
+hosts this test file. The GREEN case additionally plants an ISOLATED
+``.vnx-project-id`` marker (also under ``tmp_path``) so the vervuller can
+resolve a project_id purely through the file-based marker mechanism -- the
+same mechanism a real project checkout uses -- without ever touching a real
+identity registry or a real state store.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -55,6 +87,9 @@ PID = "gatecontracttest"
 
 # Process A driver -- the EISER: imports review_gate_manager, which resolves
 # DEFAULT_REVIEW_STACK at MODULE-IMPORT time via config_runtime.get_bool.
+# A always uses the REAL scripts/ (never the isolated copy): it addresses
+# its store via an explicit VNX_STATE_DIR, so it never calls
+# vnx_paths.resolve_paths() at all -- there is nothing for it to isolate.
 _PROC_A_CODE = """
 import json, sys
 sys.path.insert(0, sys.argv[1]); sys.path.insert(0, sys.argv[2])
@@ -71,7 +106,9 @@ print(json.dumps({
 # Process B driver -- the VERVULLER: calls the real fulfilment-decision
 # method. shutil.which is pinned to a fixed path so the gh binary's local
 # presence can never be the variable that differs between A and B -- only
-# the config-flag resolution may differ.
+# the config-flag resolution may differ. Always run against an ISOLATED
+# scripts copy (see module docstring) so its vnx_paths resolution can never
+# land next to a real, already-populated checkout.
 _PROC_B_CODE = """
 import json, sys
 sys.path.insert(0, sys.argv[1]); sys.path.insert(0, sys.argv[2])
@@ -88,13 +125,38 @@ print(json.dumps({
 
 # Probe driver -- asks, under a GIVEN env, what state dir vnx_paths'
 # canonical resolver (the #1684 fallback) would compute, so a test can seed a
-# store at EXACTLY that path without hardcoding this repo's project_id.
+# store at EXACTLY that path. Always run against the isolated scripts copy,
+# for the same reason as process B.
 _PROBE_CODE = """
 import json, sys
 sys.path.insert(0, sys.argv[1]); sys.path.insert(0, sys.argv[2])
 import vnx_paths
 print(json.dumps(vnx_paths.resolve_paths()))
 """
+
+
+def _isolated_scripts_copy(tmp_path: Path) -> tuple[Path, Path]:
+    """Copy the real scripts/ tree under ``tmp_path`` so a subprocess
+    importing vnx_paths from the copy can never resolve ``VNX_HOME`` (derived
+    from vnx_paths.py's own ``__file__``) back to THIS test file's checkout.
+
+    Deliberately carries no ``.git`` and no ``.vnx-project-id`` marker: that
+    forces ``vnx_paths._resolve_state_project_id`` to come up with no
+    resolvable project_id (no env, no marker, no git remote), which routes
+    ``_resolve_state_root`` through its explicit collision-safe fallback
+    ("no resolvable project_id -> stay project-local") -- a path computed
+    entirely under ``tmp_path``, regardless of what real ``.vnx-data`` sits
+    next to whatever checkout actually hosts this test file (measured: a
+    real dev checkout carries one from actual use; a disposable dispatch
+    worktree does not -- the isolation must not depend on which is true).
+
+    Excludes ``__pycache__``/``*.pyc`` -- copying the real tree (~16 MB) with
+    those still takes well under a second locally; without them it is
+    faster still and never leaks stale bytecode into the copy.
+    """
+    dest = tmp_path / "isolated_vnx_repo" / "scripts"
+    shutil.copytree(SCRIPTS_DIR, dest, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    return dest, dest / "lib"
 
 
 def _seed_state_dir(tmp_path: Path, value: str, *, project_id: str = PID) -> Path:
@@ -111,11 +173,11 @@ def _seed_state_dir(tmp_path: Path, value: str, *, project_id: str = PID) -> Pat
     return state_dir
 
 
-def _run(code: str, env_overrides: dict, cwd: Path) -> dict:
+def _run(code: str, env_overrides: dict, cwd: Path, *, scripts_dir: Path, lib_dir: Path) -> dict:
     env = {"PATH": os.environ.get("PATH", "")}
     env.update(env_overrides)
     result = subprocess.run(
-        [sys.executable, "-c", code, str(SCRIPTS_DIR), str(LIB_DIR)],
+        [sys.executable, "-c", code, str(scripts_dir), str(lib_dir)],
         env=env, cwd=str(cwd), capture_output=True, text=True, timeout=30,
     )
     assert result.returncode == 0, (
@@ -130,8 +192,8 @@ def _run(code: str, env_overrides: dict, cwd: Path) -> dict:
         ) from exc
 
 
-def _probe_canonical_state_dir(fake_home: Path, cwd: Path) -> Path:
-    data = _run(_PROBE_CODE, {"HOME": str(fake_home)}, cwd)
+def _probe_canonical_state_dir(fake_home: Path, cwd: Path, *, scripts_dir: Path, lib_dir: Path) -> Path:
+    data = _run(_PROBE_CODE, {"HOME": str(fake_home)}, cwd, scripts_dir=scripts_dir, lib_dir=lib_dir)
     return Path(data["VNX_STATE_DIR"])
 
 
@@ -142,20 +204,20 @@ def _probe_canonical_state_dir(fake_home: Path, cwd: Path) -> Path:
 
 
 def test_cross_process_flag_divergence_when_vervuller_cannot_see_the_db(tmp_path):
-    """Two REAL subprocesses, deliberately different env=.
+    """Two REAL subprocesses, deliberately different env= AND, for B, an
+    isolated copy of scripts/ so its vnx_paths resolution is independent of
+    whatever real checkout hosts this test file (see module docstring).
 
     Seeds an operator override of "0" in a fresh DB -- the OPPOSITE of the
     current registry default "1" (see module docstring for why the default
     must be diverged from, not matched). Process A can reach that DB
-    (explicit VNX_STATE_DIR + VNX_PROJECT_ID) and must read the override.
-    Process B gets neither, plus a FAKE, empty $HOME so the #1684
-    canonical-resolver fallback genuinely cannot find ANY project_config --
-    not this test's store, not this machine's own real ~/.vnx-data/<project>
-    store. cwd alone does NOT achieve that isolation: vnx_paths resolves
-    VNX_HOME from its own __file__ location, not from cwd, so a bare
-    cwd=/tmp outside the repo still finds this repo's real central store on
-    a dev machine (measured). Faking $HOME is what actually severs that
-    lookup, deterministically, on any machine.
+    (explicit VNX_STATE_DIR + VNX_PROJECT_ID, real scripts/) and must read
+    the override. Process B gets neither env var, plus a FAKE, empty $HOME
+    AND the isolated scripts copy -- carrying no ``.git``/marker -- so the
+    #1684 canonical-resolver fallback genuinely cannot find ANY
+    project_config: not this test's store, not this machine's own real
+    ``~/.vnx-data/<project>`` store, and not whatever ``.vnx-data`` may have
+    accumulated next to the real checkout this test file itself lives in.
     """
     assert cr.CONFIG_REGISTRY[FLAG].default == "1", (
         "this test's whole premise is an override that diverges from the "
@@ -170,13 +232,18 @@ def test_cross_process_flag_divergence_when_vervuller_cannot_see_the_db(tmp_path
         _PROC_A_CODE,
         {"VNX_STATE_DIR": str(state_dir), "VNX_PROJECT_ID": PID},
         tmp_path,
+        scripts_dir=SCRIPTS_DIR, lib_dir=LIB_DIR,
     )
 
+    iso_scripts, iso_lib = _isolated_scripts_copy(tmp_path)
     fake_home = tmp_path / "fake_home_unreachable"
     fake_home.mkdir()
     outside_cwd = tmp_path / "outside_repo_cwd"
     outside_cwd.mkdir()
-    b_result = _run(_PROC_B_CODE, {"HOME": str(fake_home)}, outside_cwd)
+    b_result = _run(
+        _PROC_B_CODE, {"HOME": str(fake_home)}, outside_cwd,
+        scripts_dir=iso_scripts, lib_dir=iso_lib,
+    )
 
     # Provenance first: a value that merely LOOKS the same from two
     # different sources is not a passing contract, so assert where each
@@ -186,7 +253,8 @@ def test_cross_process_flag_divergence_when_vervuller_cannot_see_the_db(tmp_path
     )
     assert b_result["autowired"] is False, (
         f"process B must NOT have found any project_config -- it has no "
-        f"VNX_STATE_DIR and a fake, empty $HOME; got {b_result}"
+        f"VNX_STATE_DIR, a fake empty $HOME, and an isolated (git-less, "
+        f"marker-less) scripts copy; got {b_result}"
     )
     assert a_result["flag_value"] is False, f"A must read the DB override (0): {a_result}"
     assert b_result["flag_value"] is True, f"B must fall back to the registry default (1): {b_result}"
@@ -221,30 +289,49 @@ def test_cross_process_flag_agreement_when_vervuller_finds_store_via_canonical_r
     operator override at all, regardless of environment. This pins that it
     now can, via the SAME canonical-resolver path #1684 added -- and that
     when it does, the two processes' reads agree.
+
+    Both the probe and process B run against an isolated scripts copy (see
+    module docstring) with an ISOLATED ``.vnx-project-id`` marker planted
+    under ``tmp_path`` -- so the resolved store lives entirely under
+    ``tmp_path`` (asserted explicitly below) and this test can never write
+    an operator override into a real, shared store.
     """
+    iso_scripts, iso_lib = _isolated_scripts_copy(tmp_path)
+    (tmp_path / ".vnx-project-id").write_text(PID + "\n", encoding="utf-8")
     fake_home = tmp_path / "fake_home_reachable"
     fake_home.mkdir()
 
     # Ask a subprocess -- under the exact env B will use -- what state dir
-    # the canonical resolver computes, so the store gets seeded at that path
-    # without hardcoding this repo's project_id.
-    resolved_state_dir = _probe_canonical_state_dir(fake_home, tmp_path)
-    project_id = resolved_state_dir.parent.name
+    # the canonical resolver computes, so the store gets seeded at that path.
+    resolved_state_dir = _probe_canonical_state_dir(
+        fake_home, tmp_path, scripts_dir=iso_scripts, lib_dir=iso_lib,
+    )
+    resolved_tmp_path = tmp_path.resolve()
+    assert resolved_state_dir.resolve().is_relative_to(resolved_tmp_path), (
+        f"the canonical resolver must land entirely under this test's own "
+        f"tmp_path -- a test must never write an operator override into a "
+        f"real, shared store; got {resolved_state_dir} (tmp_path={tmp_path})"
+    )
     resolved_state_dir.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(resolved_state_dir / "runtime_coordination.db")
     try:
-        cs.set_config(conn, project_id, FLAG, "0", actor="test", approval_id="test-approval")
+        cs.set_config(conn, PID, FLAG, "0", actor="test", approval_id="test-approval")
     finally:
         conn.close()
 
     a_result = _run(
         _PROC_A_CODE,
-        {"VNX_STATE_DIR": str(resolved_state_dir), "VNX_PROJECT_ID": project_id},
+        {"VNX_STATE_DIR": str(resolved_state_dir), "VNX_PROJECT_ID": PID},
         tmp_path,
+        scripts_dir=SCRIPTS_DIR, lib_dir=LIB_DIR,
     )
-    # Process B: no explicit env at all -- must find the SAME store purely
-    # via the canonical resolver fallback.
-    b_result = _run(_PROC_B_CODE, {"HOME": str(fake_home)}, tmp_path)
+    # Process B: no explicit VNX_STATE_DIR/VNX_PROJECT_ID at all -- must find
+    # the SAME store purely via the canonical resolver fallback (state dir)
+    # plus the isolated .vnx-project-id marker (project_id).
+    b_result = _run(
+        _PROC_B_CODE, {"HOME": str(fake_home)}, tmp_path,
+        scripts_dir=iso_scripts, lib_dir=iso_lib,
+    )
 
     assert a_result["autowired"] is True
     assert b_result["autowired"] is True, (


### PR DESCRIPTION
## Summary

- Adds `tests/test_gate_stack_cross_process_contract.py`: two REAL-subprocess tests (deliberately different `env=`) that pin the cross-process contract between the review-gate **eiser** (`review_gate_manager.DEFAULT_REVIEW_STACK`, resolved at module-import time) and the **vervuller** (`gate_request_handler._ci_gate_available`), both of which independently call `config_runtime.get_bool("VNX_CI_GATE_REQUIRED")`.
- Adds the "luide detectie" half so the class of bug can't come back silently: `register_obligation` now stamps the writer's own flag resolution onto the obligation record (`gate_requirement_resolution`), and a new `gate_obligations.check_gate_requirement_mismatch` lets the fulfiller compare its own reading against it. `gate_request_handler._request_ci_gate` calls this and, on a mismatch, logs a WARNING and persists a named `gate_requirement_mismatch` field onto the obligation — never a silent skip.

## Why the test needed a specific construction (see module docstring)

Measured live on main (2026-08-26): `VNX_CI_GATE_REQUIRED`'s registry default flipped `0` → `1` (OI-1385) after this dispatch's premise was written, and PR #1684's canonical-resolver fallback finds this repo's real central store regardless of cwd. A naive test that seeds the DB with `1` (matching the default) is green for the wrong reason — a process that can't reach the DB at all would coincidentally read the same value from the fallback default. Both tests instead seed an operator override (`0`) that **diverges** from the registry default, and assert on **provenance** (`autowired`: DB vs. fallback) in addition to the value, so a passing test actually proves the two sides read from the same source — not that they merely named the same number.

## Changes

- `tests/test_gate_stack_cross_process_contract.py` (new): RED case (vervuller can't reach the store — fake, empty `$HOME` defeats the canonical resolver deterministically, since `vnx_paths` resolves `VNX_HOME` from its own `__file__` location, not cwd) and GREEN case (regression guard for #1684: vervuller finds the *same* store purely via the canonical resolver, no `VNX_STATE_DIR` at all).
- `scripts/lib/gate_obligations.py`: `register_obligation(..., gate_requirement_resolution=...)` + new `check_gate_requirement_mismatch()`.
- `scripts/lib/dispatch_cli.py`: `_register_gate_obligation` snapshots `VNX_CI_GATE_REQUIRED` at registration time.
- `scripts/lib/gate_request_handler.py`: new `_check_ci_gate_requirement_mismatch()`, wired into `_request_ci_gate` (the path the obligation runner actually exercises for `gate=ci_gate`).
- `tests/test_gate_obligations.py`, `tests/test_ci_gate.py`: unit/integration coverage for the new stamp + mismatch check.

## Verification

`pytest tests/test_gate_stack_cross_process_contract.py tests/test_config_runtime.py -v` → 13 passed.

Full neighbor sweep (`test_gate_obligations.py`, `test_ci_gate.py`, `test_dispatch_cli.py`, `test_gate_request_handler_w3f.py`, `test_review_gate_manager.py`, `test_dlv5_review_gate_takeover.py`, `test_gate_obligation_runner*.py`, `test_gate_runner.py`) → 362 passed.

Proven RED: temporarily reverted the #1684 fallback in `config_runtime._resolve_state_dir` — the GREEN regression-guard test failed loudly with a named mismatch (`got {'flag_value': True, ..., 'autowired': False}`), then the revert was undone (`git diff` on that file is clean).

One pre-existing, unrelated failure confirmed via `git stash` bisection against baseline: `tests/test_gate_dispatch_id.py::TestRequestHandlerDispatchId::test_request_reviews_propagates_dispatch_id_to_claude_github` — fails identically with my changes stashed out, not touched by this PR.

## Test plan

- [x] `pytest tests/test_gate_stack_cross_process_contract.py tests/test_config_runtime.py -v`
- [x] Neighbor sweep listed above green
- [x] Confirmed pre-existing unrelated failure via stash bisection

🤖 Generated with [Claude Code](https://claude.com/claude-code)