### PR TITLE
feat(review-gate): ordered takeover chain codex->kimi->glm->deepseek (BETA3-E1)

### DIFF
--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -120,6 +120,18 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "kimi_gate,glm_gate — without editing review_gate_manager.py. ci_gate is appended "
         "separately when VNX_CI_GATE_REQUIRED is on; do not include it here.", approval=True,
         subsystem="governance-enforcement-stack", status="LIVE"),
+    "VNX_REVIEW_GATE_TAKEOVER_CHAIN": _e(
+        "VNX_REVIEW_GATE_TAKEOVER_CHAIN", "string",
+        "codex_gate,kimi_gate,glm_gate,deepseek_gate", "gate",
+        "Ordered review-gate takeover chain (BETA3-E1, 26-08 operator decision). On "
+        "lane_exhausted a seat rolls over to the NEXT gate named here; deepseek_gate is a "
+        "legal end-link that is skipped with a named reason until its runner ships (E2). "
+        "ABSENT (no env/DB override) falls back to this literal default string. An EXPLICIT "
+        "empty value ('') means NO takeover chain at all -- distinct from absent. Any name "
+        "outside the known gate set, or a name repeated (a cycle), fails loud at read time. "
+        "Must match gate_request_handler._DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN verbatim "
+        "(pinned by test_beta3_e1_review_gate_chain.py).", approval=True,
+        subsystem="governance-enforcement-stack", status="LIVE"),
     "VNX_CI_GATE_REQUIRED": _e(
         "VNX_CI_GATE_REQUIRED", "bool", "1", "gate",
         "Require the CI gate before merge.", approval=True,

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -145,6 +145,37 @@ def _build_review_gate_takeover_chain() -> Dict[str, str]:
     return chain
 
 
+def _resolve_report_path(report_path: str, data_dir: Path) -> Optional[Path]:
+    """Path-safe resolve of a gate result record's ``report_path`` field.
+
+    Mirrors ``governance_emit._resolve_lane_log_path``'s defense-in-depth
+    shape (that function's docstring calls it out by name): ``report_path``
+    comes from a result record on disk -- state, not trusted input -- so a
+    ``relative_to`` escape check against the reports dir runs before any
+    read. An unconstrained ``report_path`` could point anywhere the process
+    can read; the sibling lane-log reader two functions above already gets
+    this right, this one previously did not. Returns None (refuse, no read)
+    on anything unsafe or unresolvable -- a bad lookup must never block
+    classification, only skip the report-fallback source.
+    """
+    if not report_path:
+        return None
+    reports_dir = (Path(data_dir) / "unified_reports").resolve()
+    try:
+        candidate = Path(report_path).resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        candidate.relative_to(reports_dir)
+    except ValueError:
+        logger.warning(
+            "gate_request_handler: report-path read refused -- path %s escaped %s",
+            candidate, reports_dir,
+        )
+        return None
+    return candidate
+
+
 def _scan_seat_failure_text(result: Dict[str, Any], manager: "Optional[GateRequestHandlerMixin]") -> "tuple[str, str]":
     """Scan every available raw-text source for the provider's own
     exhaustion marker via ``governance_emit._classify_lane_log_text`` --
@@ -427,32 +458,52 @@ class GateRequestHandlerMixin:
         glm-gate-pr1691-1787754901 had NO lane log at all, but its 9345-byte
         report carried the real 402 ``openrouter_credits`` body.
 
-        Returns "" on any missing dispatch_id/report_path, missing/unreadable
+        Returns "" on any missing dispatch_id/report_path, missing/empty
         file, or an unresolvable data dir -- a failed lookup must never
         raise out of a classification decision, and never fabricates text
-        from nothing.
+        from nothing. An UNREADABLE report (exists, but ``OSError`` on read)
+        is logged with its path (BETA3-E1b fix-forward) rather than
+        swallowed indistinguishably from "no report exists" -- the classifier
+        two frames up falls back to ``no_response`` either way, but an
+        operator reading logs must be able to tell "nothing to read" apart
+        from "a read failed", or a broken report-fallback source looks
+        identical to a real absence of exhaustion evidence.
+
+        ``report_path`` is on-disk STATE (a result record), not trusted
+        input, so it is resolved via ``_resolve_report_path`` and refused if
+        it would read outside the reports dir -- the SAME defense-in-depth
+        shape ``governance_emit._resolve_lane_log_path`` already applies to
+        the lane-log source two lines above.
         """
+        try:
+            data_dir = Path(self.paths["VNX_DATA_DIR"])
+        except (AttributeError, KeyError, TypeError):
+            data_dir = None
+
         dispatch_id = str(result.get("dispatch_id") or "")
-        if dispatch_id:
-            try:
-                data_dir = Path(self.paths["VNX_DATA_DIR"])
-            except (AttributeError, KeyError, TypeError):
-                data_dir = None
-            if data_dir is not None:
-                from governance_emit import _read_lane_log_text
-                lane_text = _read_lane_log_text(dispatch_id, data_dir)
-                if lane_text:
-                    return lane_text
+        if dispatch_id and data_dir is not None:
+            from governance_emit import _read_lane_log_text
+            lane_text = _read_lane_log_text(dispatch_id, data_dir)
+            if lane_text:
+                return lane_text
+
         report_path = result.get("report_path") or ""
-        if report_path:
+        if report_path and data_dir is not None:
+            report_file = _resolve_report_path(report_path, data_dir)
+            if report_file is None:
+                return ""
             try:
-                report_file = Path(report_path)
-                if report_file.is_file():
-                    text = report_file.read_text(encoding="utf-8", errors="replace")
-                    if text.strip():
-                        return text
-            except OSError:
-                pass
+                if not report_file.is_file():
+                    return ""
+                text = report_file.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                logger.warning(
+                    "gate_request_handler: report read failed dispatch=%s path=%s: %s",
+                    dispatch_id or "<unknown>", report_file, exc,
+                )
+                return ""
+            if text.strip():
+                return text
         return ""
 
     def _stamp_takeover_annotations(
@@ -826,7 +877,7 @@ class GateRequestHandlerMixin:
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
-        self._request_path("gemini_review", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        atomic_write_json(self._request_path("gemini_review", pr_number), payload)
         return payload
 
     def _build_gemini_contract_payload(
@@ -1144,7 +1195,7 @@ class GateRequestHandlerMixin:
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
-        self._request_path("codex_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        atomic_write_json(self._request_path("codex_gate", pr_number), payload)
         return payload
 
     def _request_kimi(
@@ -1180,7 +1231,7 @@ class GateRequestHandlerMixin:
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
-        self._request_path("kimi_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        atomic_write_json(self._request_path("kimi_gate", pr_number), payload)
         return payload
 
     def _request_glm(
@@ -1233,7 +1284,7 @@ class GateRequestHandlerMixin:
                 reason=reason, reason_detail=reason_detail,
                 binary_name="glm_gate.py",
             )
-        self._request_path("glm_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        atomic_write_json(self._request_path("glm_gate", pr_number), payload)
         return payload
 
     def _request_deepseek(
@@ -1288,7 +1339,7 @@ class GateRequestHandlerMixin:
                 reason=reason, reason_detail=reason_detail,
                 binary_name="deepseek_gate.py",
             )
-        self._request_path("deepseek_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        atomic_write_json(self._request_path("deepseek_gate", pr_number), payload)
         return payload
 
     def _apply_claude_github_configured_state(
@@ -1343,7 +1394,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if configured:
             self._apply_claude_github_configured_state(payload, pr_number)
-        self._request_path("claude_github_optional", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        atomic_write_json(self._request_path("claude_github_optional", pr_number), payload)
         return payload
 
     def _request_ci_gate(
@@ -1380,7 +1431,7 @@ class GateRequestHandlerMixin:
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
-        self._request_path("ci_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        atomic_write_json(self._request_path("ci_gate", pr_number), payload)
         return payload
 
     def _build_ci_gate_contract_payload(

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -32,18 +32,161 @@ from claude_github_receipt import (
 logger = logging.getLogger(__name__)
 
 
-# Fixed fallback order for review-gate takeover (review-gate-provider-agnostic
-# plan, deliverable 5). This is an OPERATOR DECISION recorded 22-08, not a
-# measured defect-recall ranking: on 22-08 glm_gate and kimi_gate gave
-# OPPOSITE verdicts on the identical diff/contract_hash -- glm FAIL with a
-# blocking finding, kimi PASS with zero findings -- so there is no measured
-# basis for which reader is the better fallback, only that a working reader
-# beats an unfilled seat. The measured variant (ordered by defect-recall) is
-# a follow-up track (plan open question 1); this mapping stays a choice under
-# uncertainty until that lands.
-_REVIEW_GATE_TAKEOVER_ORDER: Dict[str, str] = {
-    "kimi_gate": "glm_gate",
-}
+
+class ReviewGateTakeoverConfigError(ValueError):
+    """The configured review-gate takeover chain is malformed: an unknown
+    gate name, or a gate repeated (which would build a cycle in what must
+    stay a simple linear chain). Raised at READ time -- never discovered
+    later as an infinite walk, nor silently dropped into a partial chain.
+    """
+
+
+# Ordered review-gate takeover chain (BETA3-E1, 26-08 operator decision,
+# dispatch 20260826-beta3-e1-overname-keten-en-uitputtingstoets): codex_gate
+# -> kimi_gate -> glm_gate -> deepseek_gate. This SUPERSEDES the single-hop
+# dict a prior deliverable shipped, but PRESERVES that hop's own decision
+# unchanged: kimi_gate -> glm_gate is still the same pairing the 22-08
+# operator decision made (see the historical rationale this replaces, below)
+# -- it is now just one link inside a longer, explicitly configured chain
+# rather than the whole chain.
+#
+# Historical rationale for kimi_gate -> glm_gate (22-08, unchanged by this
+# dispatch): on 22-08 glm_gate and kimi_gate gave OPPOSITE verdicts on the
+# identical diff/contract_hash -- glm FAIL with a blocking finding, kimi PASS
+# with zero findings -- so there is no measured basis for which reader is the
+# better fallback, only that a working reader beats an unfilled seat. The
+# measured variant (ordered by defect-recall) is a follow-up track (plan open
+# question 1); this mapping stays a choice under uncertainty until that
+# lands.
+#
+# deepseek_gate is a legal END-LINK even though its runner does not exist yet
+# (a separate dispatch, E2, ships it): walking onto it always resolves
+# not_executable/gate_runner_missing (see `_request_deepseek`) -- a named
+# skip, never a further hop, since it is deliberately absent from the chain
+# it would otherwise continue into.
+_DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN = "codex_gate,kimi_gate,glm_gate,deepseek_gate"
+
+
+def _known_takeover_gate_names() -> "frozenset[str]":
+    """Gate names the takeover-chain CONFIG may legally name: the closed
+    ``Gate`` enum (dispatch_spec.py) PLUS ``deepseek_gate`` -- a real future
+    chain member (E2 ships its runner + its own Gate enum member) that is
+    deliberately NOT added to the Gate enum here. Adding it there without a
+    matching gate_request_handler dispatch branch AND
+    closure_verifier._GATE_HANDLERS entry would trip
+    test_closure_verifier_gate_enum_drift.py (OI-1094) -- this local addition
+    is the narrower, correct scope until E2 lands the real member.
+    """
+    from dispatch_spec import Gate
+    return frozenset(Gate._value2member_map_) | {"deepseek_gate"}
+
+
+def _parse_review_gate_takeover_chain(raw: str) -> Dict[str, str]:
+    """Parse a comma-separated ORDERED gate list into a {gate: next_gate}
+    successor map. An empty (post-strip) ``raw`` means NO takeover chain at
+    all -- returns ``{}`` -- the operator's explicit choice, distinct from an
+    absent config falling back to the built-in default (see
+    ``_build_review_gate_takeover_chain``).
+
+    Never returns a partial/best-effort map: an unknown gate name, or a gate
+    named more than once (the only way a strictly linear list can cycle back
+    on itself), raises ``ReviewGateTakeoverConfigError`` naming the offending
+    value.
+    """
+    names = [item.strip() for item in raw.split(",") if item.strip()]
+    if not names:
+        return {}
+    known = _known_takeover_gate_names()
+    seen: "set[str]" = set()
+    for name in names:
+        if name not in known:
+            raise ReviewGateTakeoverConfigError(
+                f"VNX_REVIEW_GATE_TAKEOVER_CHAIN names an unknown gate {name!r} "
+                f"(full chain: {raw!r}); known gates: {', '.join(sorted(known))}"
+            )
+        if name in seen:
+            raise ReviewGateTakeoverConfigError(
+                f"VNX_REVIEW_GATE_TAKEOVER_CHAIN contains a cycle: {name!r} appears more than "
+                f"once in {raw!r} -- a gate may take over for at most one predecessor"
+            )
+        seen.add(name)
+    return {names[i]: names[i + 1] for i in range(len(names) - 1)}
+
+
+def _build_review_gate_takeover_chain() -> Dict[str, str]:
+    """Resolve the operator's review-gate takeover chain from config
+    (BETA3-E1, 26-08), never a hardcoded dict. Reads through
+    ``config_runtime.get`` -- the SAME canonical-resolver + DB-override
+    precedence ``review_gate_manager._build_default_review_stack`` already
+    uses for ``VNX_DEFAULT_REVIEW_STACK``, and the one the OI-1462
+    cross-process contract test (PR #1694) pins -- never a raw
+    ``os.environ`` read that could silently disagree with what this same
+    module's ``_ci_gate_available`` resolves two lines away.
+
+    Resolved FRESH on every call (unlike ``DEFAULT_REVIEW_STACK``, which
+    caches at module-import time): a takeover decision is made per gate per
+    review request, so a config edit takes effect on the very next request
+    instead of needing a process restart.
+
+    Logs, at each resolution, whether the active chain came from an operator
+    override or the built-in default -- comparing the resolved string
+    against ``_DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN`` verbatim, the same
+    provenance technique ``config_registry.all_effective`` already uses
+    (``is_default = value == entry.default``).
+    """
+    import config_runtime
+    raw = config_runtime.get("VNX_REVIEW_GATE_TAKEOVER_CHAIN") or ""
+    chain = _parse_review_gate_takeover_chain(raw)
+    source = "standaard (registry default)" if raw == _DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN else "operator-configuratie"
+    logger.info(
+        "gate_request_handler: review-gate takeover chain actief -- bron=%s waarde=%r keten=%r",
+        source, raw, chain,
+    )
+    return chain
+
+
+def _scan_seat_failure_text(result: Dict[str, Any], manager: "Optional[GateRequestHandlerMixin]") -> "tuple[str, str]":
+    """Scan every available raw-text source for the provider's own
+    exhaustion marker via ``governance_emit._classify_lane_log_text`` --
+    NEVER a second, hand-rolled marker list. Tries, in order: the JSON
+    result record's own ``residual_risk``/``reason_detail``/``summary``
+    fields (populated when the #1683 lane-log lift already ran), then --
+    only when ``manager`` is not None, since the file lookup needs
+    ``manager.paths`` to resolve a data dir -- ``manager._read_lane_log_or_report_text``
+    (lane log, then the gate's own report; BETA3-E1 fix-forward).
+
+    A MODULE-LEVEL function, not a method: ``_classify_review_seat_failure``
+    is called unbound (``self=None``) by
+    ``tests/test_oi1452_lane_log_lift_provider_failed_detail.py``, so the
+    file-fallback half must be a plain, optional argument rather than
+    something that blows up on a None receiver.
+
+    Returns ``(state, detail)`` where ``state`` is ``'lane_exhausted'`` or
+    ``'no_response'``, and ``detail`` is a bounded, marker-anchored snippet
+    when ``state == 'lane_exhausted'`` (never the full multi-KB source) --
+    the SAME text ``_dispatch_review_seat`` embeds into its takeover
+    annotation, so the annotation PRESERVES the actual failure text rather
+    than only referencing whichever record it came from (a takeover
+    overwriting the source record must never erase the reason it was
+    granted on). Never raises: a missing/unreadable file source is silently
+    skipped, not a classification failure.
+    """
+    field_text = " ".join(
+        str(result.get(key, "")) for key in ("residual_risk", "reason_detail", "summary")
+    ).strip()
+    if field_text:
+        state, snippet = _classify_lane_log_text(field_text)
+        if state == "lane_exhausted":
+            return "lane_exhausted", snippet or field_text
+
+    if manager is not None:
+        file_text = manager._read_lane_log_or_report_text(result)
+        if file_text:
+            state, snippet = _classify_lane_log_text(file_text)
+            if state == "lane_exhausted":
+                return "lane_exhausted", snippet or file_text
+
+    return "no_response", (field_text or "no detail recorded")
 
 
 class GateRequestHandlerMixin:
@@ -149,6 +292,12 @@ class GateRequestHandlerMixin:
     def _glm_gate_available(self) -> bool:
         return self._glm_gate_runner_path().exists()
 
+    def _deepseek_gate_runner_path(self) -> Path:
+        return Path(__file__).resolve().parent.parent / "deepseek_gate.py"
+
+    def _deepseek_gate_available(self) -> bool:
+        return self._deepseek_gate_runner_path().exists()
+
     def _dispatch_one_review(
         self,
         gate: str,
@@ -189,6 +338,8 @@ class GateRequestHandlerMixin:
             return self._request_kimi(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
         if gate == "glm_gate":
             return self._request_glm(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+        if gate == "deepseek_gate":
+            return self._request_deepseek(pr_number, branch, risk_class, changed_files, mode, dispatch_id)
         return {"gate": gate, "status": "blocked", "reason": "unknown_review_gate"}
 
     def _read_existing_gate_result(self, gate: str, pr_number: Optional[int]) -> Optional[Dict[str, Any]]:
@@ -249,20 +400,60 @@ class GateRequestHandlerMixin:
             return "unreadable_verdict"
         if reason == "no_verdict":
             return "no_response"
-        # reason == "dispatch_error" (or an unrecognised reason): scan the
-        # RAW detail text for the provider's own exhaustion marker via the
-        # SAME classifier deliverable 0 built for the lane-log lift -- never
-        # a second hand-rolled marker scan, and never keyed on a parser-side
-        # msg field. Measured: 29 kimi cases carry
+        # reason == "dispatch_error" (or an unrecognised reason): scan for
+        # the provider's own exhaustion marker via _scan_seat_failure_text --
+        # the SAME classifier deliverable 0 built for the lane-log lift,
+        # extended (BETA3-E1) to also try the gate's own report when no lane
+        # log carries it. Never a second hand-rolled marker scan, and never
+        # keyed on a parser-side msg field. Measured: 29 kimi cases carry
         # msg='Expecting value: line 1' beside raw='Error code: 403'; a
         # msg-keyed check reads toestand 2 while the raw body says toestand 1.
-        detail_text = " ".join(
-            str(result.get(key, "")) for key in ("residual_risk", "reason_detail", "summary")
-        ).strip()
-        if not detail_text:
-            return "no_response"
-        state, _snippet = _classify_lane_log_text(detail_text)
-        return "lane_exhausted" if state == "lane_exhausted" else "no_response"
+        state, _detail = _scan_seat_failure_text(result, self)
+        return state
+
+    def _read_lane_log_or_report_text(self, result: Dict[str, Any]) -> str:
+        """Best-effort raw-text read backing the exhaustion-marker fallback
+        scan (BETA3-E1 fix-forward, T0 live finding glm-gate-pr1691-1787754901,
+        26-08): the per-dispatch lane log first (the SAME source the #1683
+        lift already reads via ``governance_emit._read_lane_log_text``), then
+        the gate's own REPORT file at ``result['report_path']`` when no lane
+        log exists for this dispatch_id at all.
+
+        Root cause this covers: the #1683 lift only ever reads the lane log.
+        When a provider error lands in the gate's own report instead (no
+        lane log for that dispatch), the marker never reaches
+        residual_risk/reason_detail/summary -- even though the SAME
+        classifier on the report's raw text finds it correctly. Measured:
+        glm-gate-pr1691-1787754901 had NO lane log at all, but its 9345-byte
+        report carried the real 402 ``openrouter_credits`` body.
+
+        Returns "" on any missing dispatch_id/report_path, missing/unreadable
+        file, or an unresolvable data dir -- a failed lookup must never
+        raise out of a classification decision, and never fabricates text
+        from nothing.
+        """
+        dispatch_id = str(result.get("dispatch_id") or "")
+        if dispatch_id:
+            try:
+                data_dir = Path(self.paths["VNX_DATA_DIR"])
+            except (AttributeError, KeyError, TypeError):
+                data_dir = None
+            if data_dir is not None:
+                from governance_emit import _read_lane_log_text
+                lane_text = _read_lane_log_text(dispatch_id, data_dir)
+                if lane_text:
+                    return lane_text
+        report_path = result.get("report_path") or ""
+        if report_path:
+            try:
+                report_file = Path(report_path)
+                if report_file.is_file():
+                    text = report_file.read_text(encoding="utf-8", errors="replace")
+                    if text.strip():
+                        return text
+            except OSError:
+                pass
+        return ""
 
     def _stamp_takeover_annotations(
         self,
@@ -273,6 +464,7 @@ class GateRequestHandlerMixin:
         failure_reason: str,
         takeover_reason: str,
         takeover_source_status: str,
+        takeover_path: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """Annotate a fallback gate's payload with takeover provenance and
         persist it into whichever on-disk record(s) ``_dispatch_one_review``
@@ -287,6 +479,14 @@ class GateRequestHandlerMixin:
         OI-1415) -- never a one-off field name a generic receipt reader would
         not recognise.
 
+        ``takeover_path`` (BETA3-E1): the FULL sequence of hops the seat took
+        to reach this gate -- one entry per exhausted predecessor, in order
+        -- so a reader sees "codex_gate exhausted, kimi_gate exhausted, glm_gate
+        decided" instead of only the last jump. Defaults to a single-entry
+        list built from the other (single-hop) arguments when the caller has
+        no multi-hop path to report, so the field is NEVER absent on a
+        takeover record.
+
         Both writes go through ``atomic_write_json`` (temp file in the same
         directory + ``os.replace``), never a bare ``write_text``. These are
         EVIDENCE files: a torn write here passes the existence check a reader
@@ -297,12 +497,20 @@ class GateRequestHandlerMixin:
         evidence record is not.
         """
         gate = payload.get("gate", "")
+        if takeover_path is None:
+            takeover_path = [{
+                "gate": takeover_from,
+                "reason": takeover_reason,
+                "detail": failure_reason,
+                "status": takeover_source_status,
+            }]
         annotations = {
             "failure_reason": failure_reason,
             "takeover": True,
             "takeover_from": takeover_from,
             "takeover_reason": takeover_reason,
             "takeover_source_status": takeover_source_status,
+            "takeover_path": takeover_path,
         }
         payload.update(annotations)
 
@@ -322,6 +530,52 @@ class GateRequestHandlerMixin:
                     atomic_write_json(result_file, result_payload)
         return payload
 
+    def _chain_exhausted_path(self, gate: str, pr_number: int) -> Path:
+        return self.results_dir / f"pr-{pr_number}-{gate}-chain-exhausted.json"
+
+    def _chain_exhausted_result(
+        self,
+        *,
+        gate: str,
+        pr_number: int,
+        branch: str,
+        dispatch_id: str,
+        path: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Named terminal end-state (BETA3-E1): the takeover chain starting
+        from ``gate`` walked every configured hop and every one of them was
+        ``lane_exhausted``, with no further successor configured. Written to
+        its OWN file (``*-chain-exhausted.json``) -- it never overwrites any
+        individual gate's own request/result record, and it is NEVER a
+        silent re-dispatch of ``gate`` itself, which ``path`` already proves
+        dead.
+        """
+        from review_gate_manager import _utc_now
+
+        failure_reason = " -- ".join(
+            f"{hop['gate']} unavailable ({hop['reason']}): {hop['detail']}" for hop in path
+        ) + " -- takeover chain exhausted, no live reader remains"
+        now = _utc_now()
+        payload: Dict[str, Any] = {
+            "gate": gate,
+            "pr_number": pr_number,
+            "branch": branch,
+            "status": "chain_exhausted",
+            "reason": "takeover_chain_exhausted",
+            "reason_detail": failure_reason,
+            "failure_reason": failure_reason,
+            "takeover": True,
+            "takeover_from": gate,
+            "takeover_path": path,
+            "summary": f"review-gate takeover chain exhausted starting from {gate}: {failure_reason}",
+            "requested_at": now,
+            "resolved_at": now,
+        }
+        if dispatch_id:
+            payload["dispatch_id"] = dispatch_id
+        atomic_write_json(self._chain_exhausted_path(gate, pr_number), payload)
+        return payload
+
     def _dispatch_review_seat(
         self,
         gate: str,
@@ -331,58 +585,112 @@ class GateRequestHandlerMixin:
         changed_files: List[str],
         mode: str,
         dispatch_id: str,
+        chain: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
-        """Dispatch one review-stack seat, taking over to the configured
-        fallback gate when the seat's last recorded result was toestand 1
-        (exhaustion with body). Overname happens on REQUEST-time -- decided
-        here, before issuing a new request -- never on attest-time (rewriting
-        an already-attested final verdict), since that would let evidence
+        """Dispatch one review-stack seat, walking the configured takeover
+        CHAIN (BETA3-E1) forward while every candidate's own last-recorded
+        result is ``lane_exhausted``, then dispatching the first candidate
+        that is not. Overname happens on REQUEST-time -- decided here,
+        before issuing a new request -- never on attest-time (rewriting an
+        already-attested final verdict), since that would let evidence
         change owners after the fact.
 
-        This is DELIBERATELY two rounds, not one: the decision reads the
-        LAST SAVED result, so a seat only gets filled on the request AFTER
-        the one that recorded its failure. A synchronous refusal (binary
-        missing) and an asynchronous one (quota 403 surfacing mid-execution)
-        would otherwise need two different in-round semantics to take over
-        immediately -- one round of latency is the price of a single,
-        uniform rule instead of two. Do not "fix" this into an in-round
-        takeover: the first round after a quota-death yields an
-        undecided/refused seat, the second round fills it, and that is the
-        intended behaviour, not a bug.
+        CHAIN WALK: starting at ``gate``, each candidate's own last result is
+        read via ``_read_existing_gate_result``. A candidate with no prior
+        result yet, or a non-``lane_exhausted`` one (``unreadable_verdict`` /
+        ``no_response`` abstain -- never take over), STOPS the walk there and
+        that candidate is (re-)dispatched live. A ``lane_exhausted``
+        candidate is recorded into ``path`` and the walk continues to
+        ``chain.get(current)``. This means a hop through an
+        ALREADY-PROVEN-dead gate (one whose own exhaustion was recorded in
+        an earlier round) costs no extra round, but a NEWLY-discovered dead
+        gate still needs its own round before the NEXT hop can act on it --
+        the two-round latency documented below is per NEW gate along the
+        path, not per round of ``request_reviews``. This is a deliberate
+        choice (dispatch 20260826-beta3-e1, plan open question "per ronde
+        een stap of binnen een ronde door?"): it lets an already-known-dead
+        multi-hop chain resolve in ONE round instead of needing N rounds to
+        walk N already-recorded hops, while still respecting the two-round
+        rule for any hop that has not yet been proven dead by an actual
+        dispatch attempt.
+
+        This is DELIBERATELY (at minimum) two rounds per NEW hop, not one:
+        the decision reads the LAST SAVED result, so a seat only gets filled
+        on the request AFTER the one that recorded its failure. A
+        synchronous refusal (binary missing) and an asynchronous one (quota
+        403 surfacing mid-execution) would otherwise need two different
+        in-round semantics to take over immediately -- one round of latency
+        is the price of a single, uniform rule instead of two. Do not "fix"
+        this into an in-round takeover for a brand-new hop: the first round
+        after a quota-death yields an undecided/refused seat, the second
+        round fills it, and that is the intended behaviour, not a bug.
+
+        If the chain runs out (no ``chain.get(current)``) while ``current``
+        is still ``lane_exhausted``, that is a NAMED terminal end-state
+        (``_chain_exhausted_result``) -- never a silent fallback to
+        re-dispatching the originally-requested ``gate``.
         """
-        existing_result = self._read_existing_gate_result(gate, pr_number)
-        fallback_gate = _REVIEW_GATE_TAKEOVER_ORDER.get(gate)
-        if existing_result is None or fallback_gate is None:
+        if chain is None:
+            chain = _build_review_gate_takeover_chain()
+
+        if gate not in chain:
+            # This gate has no configured successor at all -- either the
+            # chain is empty (operator explicitly disabled takeover) or this
+            # particular gate was never wired into it. Dispatch normally,
+            # exactly as a gate with no takeover mechanism always has --
+            # NEVER a chain_exhausted terminal state for a gate that was
+            # never part of a configured chain to begin with (that state is
+            # reserved for a chain that WAS entered and then ran out).
             return self._dispatch_one_review(gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
 
-        seat_state = self._classify_review_seat_failure(existing_result)
-        if seat_state != "lane_exhausted":
-            return self._dispatch_one_review(gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+        path: List[Dict[str, Any]] = []
+        current = gate
+        while True:
+            existing_result = self._read_existing_gate_result(current, pr_number)
+            if existing_result is None:
+                break
+            seat_state = self._classify_review_seat_failure(existing_result)
+            if seat_state != "lane_exhausted":
+                break
+            # B3: the takeover annotation is a MANDATORY, never-empty field --
+            # an empty reason here would make this a silent refusal, not a
+            # documented overname. The detail is the ACTUAL marker-anchored
+            # snippet _scan_seat_failure_text found (lane log or report),
+            # embedded here as a value -- never a pointer back to
+            # existing_result -- so a later overwrite of that gate's own
+            # result record (a separate, known issue T0 tracks independently)
+            # cannot erase the reason this hop was recorded on.
+            hop_reason = existing_result.get("reason", "unknown_reason")
+            _hop_state, hop_detail = _scan_seat_failure_text(existing_result, self)
+            path.append({
+                "gate": current,
+                "reason": hop_reason,
+                "detail": hop_detail,
+                "status": existing_result.get("status", ""),
+            })
+            next_gate = chain.get(current)
+            if next_gate is None:
+                return self._chain_exhausted_result(
+                    gate=gate, pr_number=pr_number, branch=branch, dispatch_id=dispatch_id, path=path,
+                )
+            current = next_gate
 
-        payload = self._dispatch_one_review(
-            fallback_gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id,
-        )
-        failed_reason = existing_result.get("reason", "unknown_reason")
-        failed_detail = (
-            existing_result.get("reason_detail")
-            or existing_result.get("residual_risk")
-            or existing_result.get("summary")
-            or "no detail recorded"
-        )
-        # B3: the takeover annotation is a MANDATORY, never-empty field -- an
-        # empty reason here would make this a silent refusal, not a
-        # documented overname.
-        failure_reason = (
-            f"{gate} unavailable ({failed_reason}): {failed_detail} -- "
-            f"{fallback_gate} substituted as reader"
-        )
+        payload = self._dispatch_one_review(current, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+        if not path:
+            return payload
+
+        failure_reason = " -- ".join(
+            f"{hop['gate']} unavailable ({hop['reason']}): {hop['detail']}" for hop in path
+        ) + f" -- {current} substituted as reader"
+        last_hop = path[-1]
         return self._stamp_takeover_annotations(
             payload,
             pr_number=pr_number,
-            takeover_from=gate,
+            takeover_from=last_hop["gate"],
             failure_reason=failure_reason,
-            takeover_reason=failed_reason,
-            takeover_source_status=existing_result.get("status", ""),
+            takeover_reason=last_hop["reason"],
+            takeover_source_status=last_hop["status"],
+            takeover_path=path,
         )
 
     def request_reviews(
@@ -408,8 +716,16 @@ class GateRequestHandlerMixin:
             review_stack_list = _profile_stack if _profile_stack is not None else list(DEFAULT_REVIEW_STACK)
         requested: List[Dict[str, Any]] = []
 
+        # Resolved ONCE per request_reviews() call (not per gate in the
+        # stack): every seat in this stack takes over against the SAME
+        # operator-configured chain, and a single log line per PR-review
+        # cycle is enough operator visibility without repeating it per gate.
+        chain = _build_review_gate_takeover_chain()
+
         for gate in review_stack_list:
-            payload = self._dispatch_review_seat(gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id)
+            payload = self._dispatch_review_seat(
+                gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id, chain=chain,
+            )
             requested.append(payload)
             receipt_fields: Dict[str, Any] = {}
             if payload.get("takeover"):
@@ -918,6 +1234,61 @@ class GateRequestHandlerMixin:
                 binary_name="glm_gate.py",
             )
         self._request_path("glm_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def _request_deepseek(
+        self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str,
+        dispatch_id: str = "",
+    ) -> Dict[str, Any]:
+        """deepseek_gate is a legal review-gate-takeover-CHAIN link (BETA3-E1,
+        26-08 operator decision) whose runner ships in a separate dispatch
+        (E2) — it is deliberately NOT a ``dispatch_spec.Gate`` enum member
+        yet (see ``_known_takeover_gate_names``). Until E2 lands this always
+        refuses, mirroring ``_request_glm``'s own pre-runner refusal branch:
+        a reason distinct from ``unknown_review_gate`` so an operator can
+        tell "not a real gate" apart from "real gate, runner not implemented
+        yet" — the chain's own named-skip requirement.
+        """
+        from review_gate_manager import _utc_now
+
+        available = self._deepseek_gate_available()
+        requested_at = _utc_now()
+        payload: Dict[str, Any] = {
+            "gate": "deepseek_gate",
+            "status": "requested" if available else "not_executable",
+            "provider": "deepseek",
+            "branch": branch,
+            "pr_number": pr_number,
+            "review_mode": mode,
+            "risk_class": risk_class,
+            "changed_files": changed_files,
+            "requested_at": requested_at,
+            "commit_sha": get_pr_head_sha(pr_number),
+            "report_path": self._build_report_path(
+                gate="deepseek_gate",
+                requested_at=requested_at,
+                pr_number=pr_number,
+            ) if available else "",
+        }
+        if dispatch_id:
+            payload["dispatch_id"] = dispatch_id
+        if not available:
+            reason = "gate_runner_missing"
+            reason_detail = "scripts/deepseek_gate.py does not exist yet — ships in dispatch E2"
+            payload["reason"] = reason
+            payload["reason_detail"] = reason_detail
+            payload["resolved_at"] = payload["requested_at"]
+            self._write_not_executable_result(
+                gate="deepseek_gate", pr_number=pr_number, pr_id="",
+                reason=reason, reason_detail=reason_detail,
+                dispatch_id=dispatch_id,
+            )
+            self._write_skip_rationale(
+                gate="deepseek_gate", pr_id=str(pr_number),
+                reason=reason, reason_detail=reason_detail,
+                binary_name="deepseek_gate.py",
+            )
+        self._request_path("deepseek_gate", pr_number).write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return payload
 
     def _apply_claude_github_configured_state(

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -419,27 +419,41 @@ _LANE_LOG_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _LANE_LOG_DISPLAY_MAX_CHARS = 4000
 _LANE_LOG_READ_MAX_BYTES = 2_000_000
 
-# Reason-label markers actually observed in raw provider bodies (22-08
-# measurement) for a permanent billing/quota rejection. Matched narrowly on
-# the provider's own distinguishing phrase/type label — never on a generic
-# parser-side "msg" field. kimi's raw 403 body rides in the SAME log line as
-# an unrelated JSON-decode-failure message (the CLI's own drainer trying and
-# failing to parse the non-JSON error text as an event); a classifier keyed
-# on that "msg=" text would read the parse failure and call this
-# `unreadable_verdict` instead of `lane_exhausted`. Scanning the whole raw
-# text for the provider's own label/phrase side-steps that trap entirely.
+# Reason-label markers for a permanent billing/quota rejection. Matched
+# narrowly on the provider's own distinguishing phrase/type label — never on
+# a generic parser-side "msg" field. kimi's raw 403 body rides in the SAME
+# log line as an unrelated JSON-decode-failure message (the CLI's own
+# drainer trying and failing to parse the non-JSON error text as an event);
+# a classifier keyed on that "msg=" text would read the parse failure and
+# call this `unreadable_verdict` instead of `lane_exhausted`. Scanning the
+# whole raw text for the provider's own label/phrase side-steps that trap
+# entirely.
+#
+# GEMETEN vs AANGENOMEN (BETA3-E1c, 26-08): each marker below is tagged with
+# where its wording came from. GEMETEN = matched against an actual on-disk
+# gate-result record. AANGENOMEN = modeled on a provider's documented API
+# error shape because no live record existed to measure against at the time
+# it was added. The distinction matters: the two codex markers added 26-08
+# morning (61ebb567) were AANGENOMEN on the OpenAI API's JSON 429 shape and
+# missed codex's own CLI prose that arrived hours later on
+# pr-1696/1691/1692-codex_gate.json ("You've hit your usage limit...") — a
+# two-word difference from kimi's already-GEMETEN "reached your usage limit"
+# below ("hit" vs "reached"). A marker list built on assumption fails open,
+# and silently: `_classify_lane_log_text` returns `unreadable_verdict` (not
+# an exception), which reads exactly like a normal parse-miss.
 _LANE_EXHAUSTED_MARKERS = (
-    "access_terminated_error",              # kimi 403
-    "insufficient balance",                 # deepseek 402
-    "insufficient_balance",
-    "insufficient credits",
-    "requires more credits",                # glm/openrouter 402-in-500
-    "add more credits",
-    "openrouter_credits",
-    "usage limit for this billing cycle",   # kimi 403 prose
-    "reached your usage limit",
-    "insufficient_quota",                   # codex/openai 429 quota (error `type`/`code`)
-    "exceeded your current quota",          # codex/openai quota prose
+    "access_terminated_error",              # GEMETEN: kimi 403, OI-1433 22-08 (20/20 empty-response kimi records carried this in their raw body)
+    "insufficient balance",                 # AANGENOMEN: deepseek 402 documented API error shape — deepseek_gate has no runner yet (gate_runner_missing), so no live record can exist to measure against
+    "insufficient_balance",                 # AANGENOMEN: idem
+    "insufficient credits",                 # AANGENOMEN: generic OpenRouter/credit-exhaustion phrasing family, geen specifiek live record gevonden
+    "requires more credits",                # GEMETEN: glm/openrouter 402, pr-1691-glm_gate.json real record 26-08 (see _PR1691_REAL_402_REPORT_EXCERPT in tests/test_beta3_e1_review_gate_chain.py)
+    "add more credits",                     # AANGENOMEN: generic OpenRouter/credit-exhaustion phrasing family, geen specifiek live record gevonden
+    "openrouter_credits",                   # GEMETEN: glm/openrouter 402, pr-1691-glm_gate.json real record 26-08 (metadata.limit_source field)
+    "usage limit for this billing cycle",   # GEMETEN: kimi 403 prose, OI-1433 22-08
+    "reached your usage limit",             # GEMETEN: kimi 403 prose, OI-1433 22-08
+    "insufficient_quota",                   # AANGENOMEN: codex/openai 429 quota (error `type`/`code`), OpenAI API JSON-vorm — geen live codex-record bestond op 26-08 ochtend (61ebb567)
+    "exceeded your current quota",          # AANGENOMEN: codex/openai quota prose, idem
+    "hit your usage limit",                 # GEMETEN: codex CLI-prose, pr-1696-codex_gate.json (ook pr-1691/1692-codex_gate.json, identieke tekst) 26-08 — "Subprocess exited with code 1: You've hit your usage limit..."
 )
 
 

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -438,6 +438,8 @@ _LANE_EXHAUSTED_MARKERS = (
     "openrouter_credits",
     "usage limit for this billing cycle",   # kimi 403 prose
     "reached your usage limit",
+    "insufficient_quota",                   # codex/openai 429 quota (error `type`/`code`)
+    "exceeded your current quota",          # codex/openai quota prose
 )
 
 

--- a/tests/test_beta3_e1_review_gate_chain.py
+++ b/tests/test_beta3_e1_review_gate_chain.py
@@ -20,6 +20,27 @@ residual_risk/reason_detail/summary and the classifier read no_response on
 a real exhaustion. ``_scan_seat_failure_text`` (gate_request_handler.py)
 fixes this: SAME classifier, extended read order (record fields -> lane log
 -> report), never a second marker list.
+
+BETA3-E1c fix-forward (PR #1695, 26-08 afternoon): the codex quota markers
+this file's own ``_REAL_EXHAUSTION_TEXT["codex"]`` fixture below was built
+on (``insufficient_quota`` / ``exceeded your current quota``) were
+AANGENOMEN on the OpenAI-API 429 JSON shape -- no live codex_gate
+exhaustion record existed yet when 61ebb567 added them. Hours later codex
+genuinely ran out (pr-1696-codex_gate.json, also pr-1691/1692-codex_gate.json
+today, identical text): the codex CLI writes its OWN prose, not the OpenAI
+API JSON body -- "You've hit your usage limit...", two words off kimi's
+already-covered "reached your usage limit" ("hit" vs "reached"). Measured
+against 3405a296 (pre-fix, this branch): none of the 11 markers then in
+``governance_emit._LANE_EXHAUSTED_MARKERS`` matched this text, and
+``_classify_review_seat_failure`` returned ``no_response`` -- reached via
+``_scan_seat_failure_text``'s no-match tail, which always collapses to
+``no_response`` regardless of what ``_classify_lane_log_text`` privately
+labelled the text internally (see ``test_pr1696_real_codex_exhaustion_...``
+below for the corrected-vs-dispatch-premise note). A new "hit your usage
+limit" marker closes the gap; see ``_PR1696_REAL_CODEX_RECORD`` below for
+the verbatim record and ``test_no_structural_signal_discriminates_...`` for
+the point-3 investigation into a marker-free signal (finding: none exists
+in the current schema).
 """
 from __future__ import annotations
 
@@ -121,9 +142,16 @@ def _write_result(results_dir: Path, pr_number: int, gate: str, payload: dict) -
 # ---------------------------------------------------------------------------
 
 _REAL_EXHAUSTION_TEXT = {
-    # OpenAI/codex 429 quota -- documented API error shape (type/code
-    # "insufficient_quota"), no live-store record exists for codex yet
-    # (measured 26-08: codex ran clean on PR 1693/1689 today).
+    # AANGENOMEN: OpenAI/codex 429 quota -- documented API error shape
+    # (type/code "insufficient_quota"). STALE as of 26-08 afternoon: this
+    # was written when "codex ran clean on PR 1693/1689 today" was still
+    # true, before codex genuinely ran out hours later (pr-1696-codex_gate.json,
+    # BETA3-E1c) with different, CLI-prose wording ("You've hit your usage
+    # limit..."), never this JSON shape. Kept here deliberately -- a second,
+    # still-plausible form of the same provider's exhaustion is realistic,
+    # and this text still correctly classifies lane_exhausted via the
+    # "insufficient_quota" marker. The GEMETEN counterpart is
+    # ``_PR1696_REAL_CODEX_RECORD`` further down this file.
     "codex": (
         "governed codex dispatch failed: Error code: 429 - {'error': "
         "{'message': 'You exceeded your current quota, please check your "
@@ -267,6 +295,192 @@ def test_pr1691_real_glm_exhaustion_classifies_lane_exhausted_via_report_fallbac
 
     manager = _make_manager()
     assert manager._classify_review_seat_failure(record) == "lane_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# BETA3-E1c fix-forward (PR #1695, 26-08 afternoon) -- the codex marker was
+# GEMETEN, not AANGENOMEN. Verbatim from
+# state/review_gates/results/pr-1696-codex_gate.json (identical text also
+# recorded on pr-1691/1692-codex_gate.json the same afternoon).
+# ---------------------------------------------------------------------------
+
+_PR1696_REAL_CODEX_RECORD = {
+    "gate": "codex_gate",
+    "pr_id": "1696",
+    "pr_number": 1696,
+    "status": "unavailable",
+    "reason": "exit_nonzero",
+    "reason_detail": (
+        "Subprocess exited with code 1: You've hit your usage limit. Upgrade "
+        "to Pro (https://chatgpt.com/explore/pro), visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits or "
+        "try again at 8:53 PM."
+    ),
+    "duration_seconds": 4.162857542047277,
+    "partial_output_lines": 4,
+    "runner_pid": 67702,
+    "killed_at": "2026-08-26T18:01:55Z",
+    "summary": (
+        "codex_gate UNAVAILABLE (gate did not run — exit_nonzero: "
+        "Subprocess exited with code 1: You've hit your usage limit. Upgrade "
+        "to Pro (https://chatgpt.com/explore/pro), visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits or "
+        "try again at 8:53 PM.) — NOT a review fail"
+    ),
+    "contract_hash": "",
+    "report_path": "",
+    "blocking_findings": [],
+    "advisory_findings": [],
+    "required_reruns": ["codex_gate"],
+    "residual_risk": "Gate exit_nonzero. Re-run required.",
+    "recorded_at": "2026-08-26T18:01:55Z",
+    "branch": "dispatch/20260826-beta3-f-uitval-overschrijft-verdict-niet",
+    "commit_sha": "ed3bdd97caf88094a4854067beed38594dc03d59",
+}
+
+
+def test_pr1696_real_codex_exhaustion_classifies_lane_exhausted():
+    """GEMETEN 26-08: pr-1696-codex_gate.json is codex's own CLI prose for a
+    genuine usage-limit exhaustion, not the OpenAI-API JSON 429 shape the
+    pre-fix markers were AANGENOMEN on.
+
+    Correction against this dispatch's own premise: the dispatch instruction
+    for this fix-forward claimed the pre-fix classification was
+    'unreadable_verdict'. Measured directly against this exact record on
+    3405a296 (pre-fix, before ``hit your usage limit`` was added): the
+    result was actually 'no_response', not 'unreadable_verdict'. Reason:
+    status='unavailable' + reason='exit_nonzero' skips straight past the
+    'parse_error'/'no_verdict' branches in
+    ``GateRequestHandlerMixin._classify_review_seat_failure`` into
+    ``_scan_seat_failure_text``, whose no-match tail always returns
+    ``('no_response', ...)`` -- even though
+    ``governance_emit._classify_lane_log_text`` privately labels a no-match
+    'unreadable_verdict' internally, that label never survives
+    ``_scan_seat_failure_text``'s collapse to lane_exhausted/no_response.
+    Both states mean "no takeover", so the dispatch's core finding (the
+    chain never fired) was correct even though its state label was not.
+
+    AFTER the "hit your usage limit" marker: lane_exhausted.
+    """
+    from gate_request_handler import GateRequestHandlerMixin
+    result = GateRequestHandlerMixin._classify_review_seat_failure(None, _PR1696_REAL_CODEX_RECORD)
+    assert result == "lane_exhausted", (
+        f"expected lane_exhausted on the real codex usage-limit record, got {result!r}"
+    )
+
+
+def test_codex_exhausted_real_record_rolls_to_kimi_gate(manager_env, monkeypatch):
+    """GEMETEN 26-08: with the real pr-1696 codex usage-limit record on
+    disk, request_reviews for codex_gate must walk the takeover chain
+    (BETA3-E1's codex_gate -> kimi_gate hop) to kimi_gate, carrying the real
+    usage-limit detail into the annotation -- proving the chain fires on
+    genuine production data, not just on the AANGENOMEN 429 fixture.
+    """
+    monkeypatch.chdir(manager_env["project_root"])
+    pr_number = 1696
+    _write_result(manager_env["results_dir"], pr_number, "codex_gate", _PR1696_REAL_CODEX_RECORD)
+
+    manager = _make_manager()
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number,
+            branch="dispatch/20260826-beta3-f-uitval-overschrijft-verdict-niet",
+            review_stack=["codex_gate"],
+            risk_class="medium",
+            changed_files=["scripts/foo.py"],
+            mode="per_pr",
+            dispatch_id="beta3-e1c-codex-real-takeover-test",
+        )
+
+    seat = result["requested"][0]
+    assert seat["gate"] == "kimi_gate", f"expected the walk to land on kimi_gate, got {seat['gate']!r}"
+    assert seat["takeover_from"] == "codex_gate"
+    assert "usage limit" in seat["failure_reason"].lower(), (
+        f"expected the actual usage-limit detail embedded in failure_reason: {seat['failure_reason']!r}"
+    )
+
+    on_disk_path = manager_env["requests_dir"] / f"pr-{pr_number}-kimi_gate.json"
+    assert on_disk_path.exists()
+    on_disk = json.loads(on_disk_path.read_text())
+    assert on_disk["takeover_from"] == "codex_gate"
+
+
+# ---------------------------------------------------------------------------
+# BETA3-E1c point 3 -- is there a structural signal (status code, reason
+# enum, provider identity) that discriminates a REAL exhaustion from a
+# GENERIC provider error, independent of prose? Investigated against the
+# four real failure records named in the dispatch:
+#
+#   pr-1691-glm_gate.json    real OpenRouter 402 exhaustion    reason="dispatch_error"
+#   pr-1692-glm_gate.json    generic "Content block not found" reason="dispatch_error"
+#   pr-1694-glm_gate.json    generic "Content block not found" reason="dispatch_error"
+#   pr-1696-codex_gate.json  real codex usage-limit exhaustion reason="exit_nonzero"
+#
+# (pr-1691/1692/1694-glm_gate.json have since been overwritten on the live
+# store by later gate reruns on other PRs today -- their measured content is
+# what this file's own _PR1691_RESULT/_PR1691_REAL_402_REPORT_EXCERPT and
+# _GENERIC_PROVIDER_ERROR_TEXT fixtures already captured from the BETA3-E1
+# measurement, so the case comparison below reuses those, not a re-read of
+# the now-drifted live store.)
+#
+# FINDING: no structural signal exists in the current schema. Two separate
+# dispatch mechanisms record gate failures, and `reason` is a HOW-was-the-
+# failure-detected bucket in BOTH, never a WHY:
+#   - governed-API-dispatch (glm_gate.py/kimi_gate.py): reason="dispatch_error"
+#     is set for EVERY governed-dispatch exception (glm_gate.py:565-583) and
+#     EVERY frontmatter run_failed=True (glm_gate.py:606-608), regardless of
+#     whether the underlying cause was a 402 quota body or an unrelated API
+#     error. A real exhaustion and a generic error are indistinguishable at
+#     this field.
+#   - subprocess-kill runner (codex_gate/ci_gate/gemini_review via
+#     scripts/lib/gate_recorder.py's shared EXECUTION_FAILURE_REASONS
+#     frozenset: exit_nonzero/timeout/subprocess_error/network_error/
+#     auth_error/...): reason="exit_nonzero" is the SAME value
+#     scripts/lib/gate_executor.py:210 assigns to an entirely unrelated
+#     ci_gate `gh pr checks` subprocess failure -- proving it is shared
+#     infra plumbing, not a provider-specific or exhaustion-specific signal.
+# No record in either mechanism carries a separate numeric HTTP status or
+# error-code field; the 402/403/429/"usage limit" detail lives ONLY inside
+# reason_detail/residual_risk/summary prose. A "provider" field exists but
+# only on some PASS records (glm's own governed dispatch stamps it on
+# success -- see pr-1696-glm_gate.json), never reliably on a failure record,
+# so it cannot serve as a discriminator either.
+#
+# NOTHING INVENTED: no structural signal is asserted here beyond what these
+# two tests lock down as actually measured. The marker list remains the
+# only viable signal until a gate runner is changed to capture the
+# provider's HTTP status/error code as its own field.
+# ---------------------------------------------------------------------------
+
+def test_reason_field_does_not_discriminate_glm_exhaustion_from_generic_error():
+    """governed-API-dispatch mechanism: a real 402 exhaustion (GEMETEN,
+    pr-1691) and a generic "Content block not found" error (GEMETEN,
+    pr-1692/1694) record the IDENTICAL reason -- proving `reason` alone
+    cannot pre-filter ahead of (or replace) the marker-text scan.
+    """
+    real_exhaustion_case = next(
+        r for p, c, r, _e in PROVIDER_CASES if p == "glm" and c == "real_exhaustion"
+    )
+    generic_error_case = next(
+        r for p, c, r, _e in PROVIDER_CASES if p == "glm" and c == "generic_provider_error"
+    )
+    assert real_exhaustion_case["reason"] == generic_error_case["reason"] == "dispatch_error"
+    assert _PR1691_RESULT["reason"] == "dispatch_error", "the actual live pr-1691 record, same reason"
+
+
+def test_reason_field_is_shared_infra_not_a_codex_specific_exhaustion_signal():
+    """subprocess-kill mechanism: codex's real usage-limit exhaustion
+    (GEMETEN, pr-1696) uses reason='exit_nonzero' -- the same enum value
+    ci_gate's unrelated `gh pr checks` subprocess failure uses
+    (scripts/lib/gate_executor.py:210), proving it is a how-was-it-detected
+    bucket shared across every gate on this runner, not a why.
+    """
+    from gate_recorder import EXECUTION_FAILURE_REASONS
+    assert _PR1696_REAL_CODEX_RECORD["reason"] == "exit_nonzero"
+    assert _PR1696_REAL_CODEX_RECORD["reason"] in EXECUTION_FAILURE_REASONS, (
+        "exit_nonzero is one value in a shared execution-failure enum, not a "
+        "codex- or exhaustion-specific marker"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_beta3_e1_review_gate_chain.py
+++ b/tests/test_beta3_e1_review_gate_chain.py
@@ -580,6 +580,124 @@ def test_codex_gate_added_with_kimi_gate_as_first_fallback():
 
 
 # ---------------------------------------------------------------------------
+# BETA3-E1b fix-forward (codex-poort, PR #1695, contract_hash a554cbbe33f5d102
+# on 4d010b23) -- three blocking findings on
+# ``gate_request_handler._read_lane_log_or_report_text``:
+#
+#   1. PATH-TRAVERSAL in the report fallback: ``result["report_path"]`` is
+#      on-disk STATE (a prior gate's result record), not trusted input, and
+#      the fallback read it with a bare ``Path(report_path)`` -- no escape
+#      check at all, unlike the lane-log source two lines above it
+#      (``governance_emit._resolve_lane_log_path``, which the codex-poort
+#      itself calls "defense in depth"). ``_resolve_report_path`` closes
+#      this the same way: resolve, then ``relative_to`` the reports dir, or
+#      refuse.
+#   2. A silent ``except OSError: pass`` collapsed "the report was
+#      unreadable" into the same silent no-op as "there was nothing to
+#      read" -- the exact toestand-1/2/3 conflation this whole cluster
+#      exists to stop. The read failure is now logged with its path.
+# ---------------------------------------------------------------------------
+
+def test_report_path_absolute_escape_is_refused(manager_env, monkeypatch, tmp_path, caplog):
+    """An absolute report_path pointing OUTSIDE unified_reports/ must be
+    refused -- even though the file exists and its real content (the exact
+    PR-1691 402 excerpt) would otherwise classify as lane_exhausted. Proves
+    the guard, not just its absence of a crash: the classifier must land on
+    no_response, since a path-traversal read must never smuggle a real
+    exhaustion marker in through an out-of-bounds file.
+    """
+    monkeypatch.chdir(manager_env["project_root"])
+    outside_file = tmp_path / "outside" / "not-a-report.md"
+    outside_file.parent.mkdir(parents=True, exist_ok=True)
+    outside_file.write_text(_PR1691_REAL_402_REPORT_EXCERPT, encoding="utf-8")
+
+    record = dict(_PR1691_RESULT, report_path=str(outside_file))
+    manager = _make_manager()
+
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        text = manager._read_lane_log_or_report_text(record)
+
+    assert text == "", "a report_path outside unified_reports/ must never be read"
+    assert "escaped" in caplog.text, "the refusal must be logged, citing the escape"
+    assert manager._classify_review_seat_failure(record) == "no_response", (
+        "a refused report_path must never let the real 402 marker reach the classifier"
+    )
+
+
+def test_report_path_relative_traversal_is_refused(manager_env, monkeypatch, tmp_path, caplog):
+    """Same guard, the classic ``../`` traversal shape: a relative
+    report_path resolves against cwd (``project_root``, one level below
+    ``tmp_path``), so climbing out with ``../`` reaches a real file this
+    test controls -- proving the guard is not merely "absolute paths only".
+    """
+    monkeypatch.chdir(manager_env["project_root"])
+    secret_file = tmp_path / "secret-outside.md"
+    secret_file.write_text(_PR1691_REAL_402_REPORT_EXCERPT, encoding="utf-8")
+
+    record = dict(_PR1691_RESULT, report_path="../secret-outside.md")
+    manager = _make_manager()
+
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        text = manager._read_lane_log_or_report_text(record)
+
+    assert text == "", "a relative ../ report_path escaping unified_reports/ must never be read"
+    assert "escaped" in caplog.text
+
+
+def test_report_fallback_absent_empty_unreadable_are_distinguishable(manager_env, monkeypatch, caplog):
+    """The three read states the report fallback can hit -- bestand
+    afwezig, bestand leeg, bestand onleesbaar -- must each be independently
+    reachable, and only the unreadable case may log a warning. Collapsing
+    an OSError into silence (the pre-fix ``except OSError: pass``) makes
+    "the report was corrupt/permission-denied" indistinguishable from "no
+    report exists yet" -- exactly the toestand conflation this cluster
+    exists to stop.
+    """
+    monkeypatch.chdir(manager_env["project_root"])
+    manager = _make_manager()
+    dispatch_id = "beta3-e1b-readstate-test"
+    report_file = manager_env["reports_dir"] / f"{dispatch_id}.md"
+    record = {"dispatch_id": dispatch_id, "report_path": str(report_file)}
+
+    # 1. Absent -- no file at all.
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        text = manager._read_lane_log_or_report_text(record)
+    assert text == ""
+    assert caplog.text == "", "an absent report must not log a warning"
+
+    # 2. Empty -- file exists, whitespace-only content.
+    report_file.write_text("   \n", encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        text = manager._read_lane_log_or_report_text(record)
+    assert text == ""
+    assert caplog.text == "", "an empty report must not log a warning"
+
+    # 3. Unreadable -- file exists with real content, but the read itself
+    # raises OSError (permission denied / disk error / etc, simulated).
+    report_file.write_text(_PR1691_REAL_402_REPORT_EXCERPT, encoding="utf-8")
+    real_read_text = Path.read_text
+
+    def _raise_on_report_file(self, *args, **kwargs):
+        if self == report_file:
+            raise OSError("permission denied (simulated)")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _raise_on_report_file)
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        text = manager._read_lane_log_or_report_text(record)
+    assert text == "", "a read failure must still return '' -- never raise out of classification"
+    assert str(report_file) in caplog.text and dispatch_id in caplog.text, (
+        "an unreadable report MUST log its path and dispatch_id, distinguishing "
+        "it from the silent absent/empty cases above"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helper: patch emit_governance_receipt for the duration of a `with` block,
 # same target the other review-gate test modules patch.
 # ---------------------------------------------------------------------------

--- a/tests/test_beta3_e1_review_gate_chain.py
+++ b/tests/test_beta3_e1_review_gate_chain.py
@@ -1,0 +1,589 @@
+"""tests/test_beta3_e1_review_gate_chain.py — BETA3-E1 (dispatch
+20260826-beta3-e1-overname-keten-en-uitputtingstoets): the review-gate
+takeover CHAIN (codex_gate -> kimi_gate -> glm_gate -> deepseek_gate,
+operator decision 26-08) plus the per-provider exhaustion test the chain is
+built on.
+
+Point 1 is the core of this dispatch, not the chain: measured on the live
+store (26-08), NONE of the four recorded unavailable results (glm_gate x3,
+kimi_gate x1) carried the exhaustion marker -- the takeover trigger had
+never fired on production data. This file's per-provider table proves the
+classifier CAN discriminate, per provider, a real exhaustion from everything
+that merely resembles one.
+
+Mid-build, T0 surfaced a FIFTH, freshly-measured live case
+(glm-gate-pr1691-1787754901, 26-08): a genuine OpenRouter 402
+(``openrouter_credits``) whose marker landed in the gate's own REPORT, not
+in a lane log (none existed for that dispatch) -- so the #1683 lift, which
+only ever reads the lane log, never carried it into
+residual_risk/reason_detail/summary and the classifier read no_response on
+a real exhaustion. ``_scan_seat_failure_text`` (gate_request_handler.py)
+fixes this: SAME classifier, extended read order (record fields -> lane log
+-> report), never a second marker list.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import config_registry as cr  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_config_registry(monkeypatch):
+    """Isolate config_registry's process-global DB-resolver/project state
+    from whatever another test module left wired -- same idiom
+    tests/test_config_runtime.py's ``_clean`` fixture uses. Without this, a
+    resolver left wired by an earlier test in the same pytest session could
+    leak an unrelated project's config into ``config_runtime.get(...)``
+    here.
+    """
+    import config_runtime as crt
+    for k in list(cr.CONFIG_REGISTRY):
+        monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv(f"VNX_OVERRIDE_{cr._bare(k)}", raising=False)
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    crt._wired_for.clear()
+    cr.set_db_resolver(None)
+    cr.set_default_project_id(None)
+    yield
+    crt._wired_for.clear()
+    cr.set_db_resolver(None)
+    cr.set_default_project_id(None)
+
+
+@pytest.fixture
+def manager_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / "unified_reports"
+    for d in (
+        state_dir / "review_gates" / "requests",
+        state_dir / "review_gates" / "results",
+        reports_dir,
+    ):
+        d.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(reports_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    return {
+        "project_root": project_root,
+        "data_dir": data_dir,
+        "state_dir": state_dir,
+        "reports_dir": reports_dir,
+        "requests_dir": state_dir / "review_gates" / "requests",
+        "results_dir": state_dir / "review_gates" / "results",
+    }
+
+
+def _make_manager():
+    import review_gate_manager as rgm
+    return rgm.ReviewGateManager()
+
+
+def _write_result(results_dir: Path, pr_number: int, gate: str, payload: dict) -> Path:
+    path = results_dir / f"pr-{pr_number}-{gate}.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Point 1 -- per-provider exhaustion discrimination table.
+#
+# For each of the four chain providers (codex, kimi, glm, deepseek): a REAL
+# exhaustion, a parse-miss, an empty response, and a generic provider error
+# ("API Error: Content block not found" -- the exact text measured today,
+# 26-08, on #1692/#1694). Only the first case may classify lane_exhausted;
+# the other three must NOT -- the "woordenschat-waarschuwing": the marker
+# list is tested on the NEGATIVE cases too, so a too-broad marker can never
+# pass by construction.
+# ---------------------------------------------------------------------------
+
+_REAL_EXHAUSTION_TEXT = {
+    # OpenAI/codex 429 quota -- documented API error shape (type/code
+    # "insufficient_quota"), no live-store record exists for codex yet
+    # (measured 26-08: codex ran clean on PR 1693/1689 today).
+    "codex": (
+        "governed codex dispatch failed: Error code: 429 - {'error': "
+        "{'message': 'You exceeded your current quota, please check your "
+        "plan and billing details.', 'type': 'insufficient_quota', "
+        "'code': 'insufficient_quota'}}"
+    ),
+    # kimi 403 -- real shape, tests/test_dlv5_review_gate_takeover.py's own
+    # _KIMI_LANE_EXHAUSTED_RESULT fixture.
+    "kimi": (
+        "governed kimi dispatch failed: Error code: 403 - {'error': "
+        "{'message': 'Your account has been suspended, please contact us "
+        "via api-feedback@moonshot.cn', 'type': 'access_terminated_error'}}"
+    ),
+    # glm/openrouter 402 -- real shape from _LANE_EXHAUSTED_MARKERS
+    # ("requires more credits" / "openrouter_credits"); the actual live
+    # PR-1691 case is exercised separately below via the report-fallback,
+    # since its OWN residual_risk field never carries this text at all.
+    "glm": (
+        "governed glm dispatch failed: Error code: 402 - {'error': "
+        "{'message': 'This request requires more credits, or fewer "
+        "max_tokens.', 'code': 'openrouter_credits'}}"
+    ),
+    # deepseek 402 -- real shape, governance_emit._LANE_EXHAUSTED_MARKERS'
+    # own "insufficient balance" / "insufficient_balance" entries.
+    "deepseek": (
+        "governed deepseek dispatch failed: Error code: 402 - {'error': "
+        "{'message': 'Insufficient Balance', 'type': 'insufficient_balance'}}"
+    ),
+}
+
+_GENERIC_PROVIDER_ERROR_TEXT = {
+    # Measured 26-08 on #1692/#1694 (glm_gate + kimi_gate unavailable=4 in
+    # the live store) -- a real, non-exhaustion API error text.
+    provider: f"governed {provider} dispatch failed: API Error: Content block not found"
+    for provider in ("codex", "kimi", "glm", "deepseek")
+}
+
+_PARSE_MISS_TEXT = {
+    provider: (
+        f"{provider} returned a 812-char report, but it contained no readable "
+        f"```json``` verdict block (parse miss -- {provider} did respond)"
+    )
+    for provider in ("codex", "kimi", "glm", "deepseek")
+}
+
+PROVIDER_CASES = []
+for _provider in ("codex", "kimi", "glm", "deepseek"):
+    _gate = f"{_provider}_gate"
+    PROVIDER_CASES.append((_provider, "real_exhaustion", {
+        "gate": _gate, "status": "unavailable", "reason": "dispatch_error",
+        "residual_risk": _REAL_EXHAUSTION_TEXT[_provider],
+    }, "lane_exhausted"))
+    PROVIDER_CASES.append((_provider, "parse_miss", {
+        "gate": _gate, "status": "unavailable", "reason": "parse_error",
+        "residual_risk": _PARSE_MISS_TEXT[_provider],
+    }, "unreadable_verdict"))
+    PROVIDER_CASES.append((_provider, "empty_response", {
+        "gate": _gate, "status": "unavailable", "reason": "no_verdict",
+    }, "no_response"))
+    PROVIDER_CASES.append((_provider, "generic_provider_error", {
+        "gate": _gate, "status": "unavailable", "reason": "dispatch_error",
+        "residual_risk": _GENERIC_PROVIDER_ERROR_TEXT[_provider],
+    }, "no_response"))
+
+
+@pytest.mark.parametrize(
+    "provider,case,result,expected", PROVIDER_CASES,
+    ids=[f"{p}-{c}" for p, c, _r, _e in PROVIDER_CASES],
+)
+def test_per_provider_exhaustion_discrimination(provider, case, result, expected, manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    manager = _make_manager()
+    actual = manager._classify_review_seat_failure(result)
+    assert actual == expected, (
+        f"provider={provider} case={case}: expected {expected!r}, got {actual!r} "
+        f"(result={result!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Point 1 (T0 live finding, glm-gate-pr1691-1787754901, 26-08): a REAL, fresh
+# glm_gate exhaustion -- the OpenRouter balance ran out mid-run -- where the
+# marker exists but never reaches residual_risk/reason_detail/summary
+# because NO lane log exists for this dispatch (the error landed in the
+# gate's own report instead). This is the glm counterpart to the kimi-403
+# from OI-1452, and the first freshly-measured exhaustion whose marker
+# demonstrably exists but does not arrive at the classified fields.
+# ---------------------------------------------------------------------------
+
+_PR1691_REAL_402_REPORT_EXCERPT = (
+    "governed glm dispatch failed: Error code: 402 - {'error': {'message': "
+    "'This request requires more credits, or fewer max_tokens. You "
+    "requested up to 32000 tokens, but can only afford 7702', "
+    "'code': 402, 'metadata': {'limit_source': 'openrouter_credits'}}}"
+)
+
+_PR1691_RESULT = {
+    "gate": "glm_gate",
+    "pr_number": 1691,
+    "status": "unavailable",
+    "reason": "dispatch_error",
+    "dispatch_id": "glm-gate-pr1691-1787754901",
+    # The EXACT measured shape: the record's own fields carry only the
+    # frontmatter-derived detail, never the raw 402 body.
+    "residual_risk": (
+        "glm's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=2276) — provider-side outage, not "
+        "a review outcome"
+    ),
+    "reason_detail": None,
+    "summary": "glm gate: UNAVAILABLE (provider outage/no verdict — NOT a review fail)",
+    "contract_hash": "",
+    "provider": "glm",
+    "branch": "fix/pr1691",
+}
+
+
+def test_pr1691_real_glm_exhaustion_classifies_no_response_without_report_fallback():
+    """BEFORE this dispatch's fix: the record's own fields carry no marker
+    and there is no lane log, so the classifier reads no_response on a real
+    exhaustion -- exactly what T0 measured live. Proven here WITHOUT wiring
+    a report_path at all (the record alone), matching the measured baseline.
+    """
+    from gate_request_handler import GateRequestHandlerMixin
+    assert GateRequestHandlerMixin._classify_review_seat_failure(None, _PR1691_RESULT) == "no_response"
+
+
+def test_pr1691_real_glm_exhaustion_classifies_lane_exhausted_via_report_fallback(manager_env, monkeypatch):
+    """AFTER: with report_path pointing at the gate's own real report text
+    (no lane log present for this dispatch_id -- matching the measured
+    baseline exactly), the SAME classifier now reads the marker off the
+    report and correctly returns lane_exhausted.
+    """
+    monkeypatch.chdir(manager_env["project_root"])
+    report_file = manager_env["reports_dir"] / "glm-gate-pr1691-1787754901.md"
+    report_file.write_text(_PR1691_REAL_402_REPORT_EXCERPT, encoding="utf-8")
+
+    record = dict(_PR1691_RESULT, report_path=str(report_file))
+    lane_log = manager_env["data_dir"] / "logs" / "conversations" / "glm-gate-pr1691-1787754901.log"
+    assert not lane_log.exists(), "measured baseline: no lane log exists for this dispatch"
+
+    manager = _make_manager()
+    assert manager._classify_review_seat_failure(record) == "lane_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# Point 2 -- ordered chain, three-step hop, full path carried in the
+# annotation (not just the last jump).
+# ---------------------------------------------------------------------------
+
+def test_three_step_chain_carries_full_path_in_annotation(manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    manager = _make_manager()
+    pr_number = 9501
+
+    _write_result(manager_env["results_dir"], pr_number, "codex_gate", {
+        "gate": "codex_gate", "pr_number": pr_number, "status": "unavailable",
+        "reason": "dispatch_error",
+        "residual_risk": _REAL_EXHAUSTION_TEXT["codex"],
+    })
+    _write_result(manager_env["results_dir"], pr_number, "kimi_gate", {
+        "gate": "kimi_gate", "pr_number": pr_number, "status": "unavailable",
+        "reason": "dispatch_error",
+        "residual_risk": _REAL_EXHAUSTION_TEXT["kimi"],
+    })
+
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number,
+            branch="fix/three-step-chain",
+            review_stack=["codex_gate"],
+            risk_class="medium",
+            changed_files=["scripts/lib/gate_request_handler.py"],
+            mode="per_pr",
+            dispatch_id="beta3-e1-three-step-test",
+        )
+
+    seat = result["requested"][0]
+    assert seat["gate"] == "glm_gate", f"expected the walk to land on glm_gate, got {seat['gate']!r}"
+    assert seat["takeover_from"] == "kimi_gate"
+    path = seat["takeover_path"]
+    assert [hop["gate"] for hop in path] == ["codex_gate", "kimi_gate"], (
+        f"expected the FULL walked path, not just the last hop: {path!r}"
+    )
+    assert "codex_gate" in seat["failure_reason"] and "kimi_gate" in seat["failure_reason"], (
+        f"failure_reason must name every gate on the path, not only the last: {seat['failure_reason']!r}"
+    )
+    assert "insufficient_quota" in path[0]["detail"] or "429" in path[0]["detail"]
+    assert "access_terminated_error" in path[1]["detail"] or "403" in path[1]["detail"]
+
+    # On-disk: glm_gate's OWN request record also carries the full path.
+    on_disk = json.loads((manager_env["requests_dir"] / f"pr-{pr_number}-glm_gate.json").read_text())
+    assert [hop["gate"] for hop in on_disk["takeover_path"]] == ["codex_gate", "kimi_gate"]
+
+
+# ---------------------------------------------------------------------------
+# Point 3 -- deepseek_gate as the configured end-link: glm_gate exhausted
+# (using the REAL pr-1691 record + report, T0's request) rolls to
+# deepseek_gate, which is skipped with a named reason because E2 has not
+# shipped its runner. The resulting record must be distinguishable from a
+# seat that was never requested at all.
+# ---------------------------------------------------------------------------
+
+def test_glm_exhausted_real_record_rolls_to_deepseek_named_skip(manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    pr_number = 1691
+
+    report_file = manager_env["reports_dir"] / "glm-gate-pr1691-1787754901.md"
+    report_file.write_text(_PR1691_REAL_402_REPORT_EXCERPT, encoding="utf-8")
+    _write_result(
+        manager_env["results_dir"], pr_number, "glm_gate",
+        dict(_PR1691_RESULT, report_path=str(report_file)),
+    )
+
+    manager = _make_manager()
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number,
+            branch="fix/pr1691",
+            review_stack=["glm_gate"],
+            risk_class="medium",
+            changed_files=["scripts/glm_gate.py"],
+            mode="per_pr",
+            dispatch_id="beta3-e1-deepseek-skip-test",
+        )
+
+    seat = result["requested"][0]
+    assert seat["gate"] == "deepseek_gate"
+    assert seat["status"] == "not_executable"
+    assert seat["reason"] == "gate_runner_missing"
+    assert "E2" in seat["reason_detail"] or "deepseek_gate.py" in seat["reason_detail"]
+    assert seat["takeover_from"] == "glm_gate"
+    # The REAL 402 detail is PRESERVED in the annotation, not merely a
+    # pointer back to glm_gate's own (mutable) result record.
+    assert "openrouter_credits" in seat["failure_reason"] or "more credits" in seat["failure_reason"], (
+        f"expected the actual 402 detail embedded in failure_reason: {seat['failure_reason']!r}"
+    )
+
+    # Distinguishable from "never requested": a real, non-empty on-disk
+    # record exists for deepseek_gate, with the takeover chain intact.
+    on_disk_path = manager_env["requests_dir"] / f"pr-{pr_number}-deepseek_gate.json"
+    assert on_disk_path.exists()
+    on_disk = json.loads(on_disk_path.read_text())
+    assert on_disk["takeover_path"][0]["gate"] == "glm_gate"
+
+    # Preservation check (T0's second finding): even if glm_gate's OWN
+    # result record were later overwritten, the deepseek_gate takeover
+    # record already carries its own independent copy of the reason.
+    _write_result(manager_env["results_dir"], pr_number, "glm_gate", {
+        "gate": "glm_gate", "pr_number": pr_number, "status": "pass",
+        "contract_hash": "dd5ac45f7e84535e",
+    })
+    on_disk_again = json.loads(on_disk_path.read_text())
+    assert "openrouter_credits" in on_disk_again["failure_reason"] or "more credits" in on_disk_again["failure_reason"], (
+        "the deepseek_gate takeover record must keep carrying the original 402 "
+        "detail even after glm_gate's own result record is overwritten by a "
+        "later run -- an annotation that only referenced the source record "
+        "would have silently lost this"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Point 2 -- the chain genuinely running empty (no next hop configured at
+# all, distinct from "next hop has no runner yet"): a named terminal
+# end-state, never a silent re-dispatch of the originally-requested gate.
+# ---------------------------------------------------------------------------
+
+def test_chain_runs_empty_is_named_terminal_state(manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    monkeypatch.setenv("VNX_REVIEW_GATE_TAKEOVER_CHAIN", "kimi_gate,glm_gate")
+    manager = _make_manager()
+    pr_number = 9502
+
+    _write_result(manager_env["results_dir"], pr_number, "kimi_gate", {
+        "gate": "kimi_gate", "pr_number": pr_number, "status": "unavailable",
+        "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["kimi"],
+    })
+    _write_result(manager_env["results_dir"], pr_number, "glm_gate", {
+        "gate": "glm_gate", "pr_number": pr_number, "status": "unavailable",
+        "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["glm"],
+    })
+
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number,
+            branch="fix/chain-empty",
+            review_stack=["kimi_gate"],
+            risk_class="medium",
+            changed_files=["scripts/foo.py"],
+            mode="per_pr",
+            dispatch_id="beta3-e1-chain-empty-test",
+        )
+
+    seat = result["requested"][0]
+    assert seat["status"] == "chain_exhausted"
+    assert seat["reason"] == "takeover_chain_exhausted"
+    assert [hop["gate"] for hop in seat["takeover_path"]] == ["kimi_gate", "glm_gate"]
+    assert seat["failure_reason"].strip() != ""
+
+    marker_file = manager_env["results_dir"] / f"pr-{pr_number}-kimi_gate-chain-exhausted.json"
+    assert marker_file.exists()
+    # Never overwrote kimi_gate's or glm_gate's OWN result records.
+    kimi_own = json.loads((manager_env["results_dir"] / f"pr-{pr_number}-kimi_gate.json").read_text())
+    assert kimi_own["status"] == "unavailable"
+    glm_own = json.loads((manager_env["results_dir"] / f"pr-{pr_number}-glm_gate.json").read_text())
+    assert glm_own["status"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Point 2 -- unreadable_verdict / no_response never progress the chain
+# (control, beyond dlv5's kimi-only coverage: glm and codex too).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("gate,successor", [("codex_gate", "kimi_gate"), ("glm_gate", "deepseek_gate")])
+def test_unreadable_verdict_never_takes_over(gate, successor, manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    manager = _make_manager()
+    pr_number = 9503
+
+    _write_result(manager_env["results_dir"], pr_number, gate, {
+        "gate": gate, "pr_number": pr_number, "status": "unavailable",
+        "reason": "parse_error", "residual_risk": "no readable verdict block (parse miss)",
+    })
+
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number, branch="fix/unreadable", review_stack=[gate],
+            risk_class="medium", changed_files=["scripts/foo.py"], mode="per_pr",
+            dispatch_id="beta3-e1-unreadable-test",
+        )
+    seat = result["requested"][0]
+    assert seat["gate"] == gate, f"unreadable_verdict must abstain, never take over to {successor}"
+    assert "takeover" not in seat
+
+
+@pytest.mark.parametrize("gate", ["codex_gate", "glm_gate"])
+def test_no_response_never_takes_over(gate, manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    manager = _make_manager()
+    pr_number = 9504
+
+    _write_result(manager_env["results_dir"], pr_number, gate, {
+        "gate": gate, "pr_number": pr_number, "status": "unavailable",
+        "reason": "no_verdict",
+    })
+
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number, branch="fix/no-response", review_stack=[gate],
+            risk_class="medium", changed_files=["scripts/foo.py"], mode="per_pr",
+            dispatch_id="beta3-e1-no-response-test",
+        )
+    seat = result["requested"][0]
+    assert seat["gate"] == gate
+    assert "takeover" not in seat
+
+
+# ---------------------------------------------------------------------------
+# Point 2/4 -- config validation: unknown gate name and a cycle both fail
+# loud at READ time.
+# ---------------------------------------------------------------------------
+
+def test_unknown_gate_name_in_config_fails_loud(monkeypatch):
+    from gate_request_handler import ReviewGateTakeoverConfigError, _parse_review_gate_takeover_chain
+    with pytest.raises(ReviewGateTakeoverConfigError, match="bogus_gate"):
+        _parse_review_gate_takeover_chain("kimi_gate,bogus_gate,glm_gate")
+
+
+def test_cyclic_config_fails_loud(monkeypatch):
+    from gate_request_handler import ReviewGateTakeoverConfigError, _parse_review_gate_takeover_chain
+    with pytest.raises(ReviewGateTakeoverConfigError, match="kimi_gate"):
+        _parse_review_gate_takeover_chain("kimi_gate,glm_gate,kimi_gate")
+
+
+def test_unknown_gate_name_via_full_resolution_fails_loud(manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    monkeypatch.setenv("VNX_REVIEW_GATE_TAKEOVER_CHAIN", "kimi_gate,not_a_real_gate")
+    from gate_request_handler import ReviewGateTakeoverConfigError, _build_review_gate_takeover_chain
+    with pytest.raises(ReviewGateTakeoverConfigError, match="not_a_real_gate"):
+        _build_review_gate_takeover_chain()
+
+
+# ---------------------------------------------------------------------------
+# Point 4 -- absent config falls back to the built-in standard chain; an
+# EXPLICIT empty config means no chain at all. Different outcomes.
+# ---------------------------------------------------------------------------
+
+def test_absent_config_falls_back_to_standard_chain(manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    from gate_request_handler import _build_review_gate_takeover_chain
+    chain = _build_review_gate_takeover_chain()
+    assert chain == {
+        "codex_gate": "kimi_gate",
+        "kimi_gate": "glm_gate",
+        "glm_gate": "deepseek_gate",
+    }
+
+
+def test_explicit_empty_config_means_no_chain_at_all(manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    monkeypatch.setenv("VNX_REVIEW_GATE_TAKEOVER_CHAIN", "")
+    from gate_request_handler import _build_review_gate_takeover_chain
+    assert _build_review_gate_takeover_chain() == {}
+
+
+def test_explicit_empty_config_leaves_exhausted_seat_undecided_not_chain_exhausted(manager_env, monkeypatch):
+    """An empty config is the operator's choice for NO takeover at all --
+    an exhausted seat simply stays that gate, re-dispatched normally, same
+    as before any takeover mechanism existed. It must NOT produce a
+    chain_exhausted record (that state is reserved for a chain that WAS
+    entered and then ran out)."""
+    monkeypatch.chdir(manager_env["project_root"])
+    monkeypatch.setenv("VNX_REVIEW_GATE_TAKEOVER_CHAIN", "")
+    manager = _make_manager()
+    pr_number = 9505
+
+    _write_result(manager_env["results_dir"], pr_number, "kimi_gate", {
+        "gate": "kimi_gate", "pr_number": pr_number, "status": "unavailable",
+        "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["kimi"],
+    })
+
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number, branch="fix/empty-chain", review_stack=["kimi_gate"],
+            risk_class="medium", changed_files=["scripts/foo.py"], mode="per_pr",
+            dispatch_id="beta3-e1-empty-chain-test",
+        )
+    seat = result["requested"][0]
+    assert seat["gate"] == "kimi_gate"
+    assert seat["status"] != "chain_exhausted"
+    assert "takeover" not in seat
+    assert not (manager_env["results_dir"] / f"pr-{pr_number}-kimi_gate-chain-exhausted.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Registry/module literal parity canary -- catches drift between the two
+# places the standard chain string is spelled out.
+# ---------------------------------------------------------------------------
+
+def test_registry_default_matches_module_constant():
+    from gate_request_handler import _DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN
+    assert cr.CONFIG_REGISTRY["VNX_REVIEW_GATE_TAKEOVER_CHAIN"].default == _DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN
+
+
+def test_codex_gate_added_with_kimi_gate_as_first_fallback():
+    from gate_request_handler import _parse_review_gate_takeover_chain, _DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN
+    chain = _parse_review_gate_takeover_chain(_DEFAULT_REVIEW_GATE_TAKEOVER_CHAIN)
+    assert chain["codex_gate"] == "kimi_gate", (
+        "codex_gate must be the new entry point; the 22-08 kimi_gate -> glm_gate "
+        "relationship must survive unchanged as the SECOND hop"
+    )
+    assert chain["kimi_gate"] == "glm_gate"
+    assert chain["glm_gate"] == "deepseek_gate"
+
+
+# ---------------------------------------------------------------------------
+# Helper: patch emit_governance_receipt for the duration of a `with` block,
+# same target the other review-gate test modules patch.
+# ---------------------------------------------------------------------------
+
+def _patch_governance_receipt():
+    from unittest.mock import patch
+    return patch("governance_receipts.emit_governance_receipt")


### PR DESCRIPTION
## Summary

Operator decision 26-08: the review-gate takeover order is
`codex_gate -> kimi_gate -> glm_gate -> deepseek_gate`. This PR builds the
exhaustion-classification fix the chain depends on, plus the chain itself.

- **The core fix (point 1), which is the actual heart of this dispatch, not the chain.** Measured on the live store 26-08: 0 of 4 recorded unavailable results (glm_gate x3, kimi_gate x1) ever carried the exhaustion marker — the takeover trigger had never fired on production data. A per-provider table (codex/kimi/glm/deepseek x real-exhaustion/parse-miss/empty-response/generic-provider-error, 16 cases) proves `_classify_review_seat_failure` discriminates correctly per provider, using real/documented error shapes.
- **Mid-build, T0 surfaced a fifth, freshly-measured live case**: `glm-gate-pr1691-1787754901`, a genuine OpenRouter 402 whose marker landed in the gate's own report (9345 bytes), not a lane log (none existed for that dispatch). The existing #1683 lift only ever reads the lane log, so the marker never reached `residual_risk`/`reason_detail`/`summary` even though it was real. Fixed via `_scan_seat_failure_text`: same classifier (`governance_emit._classify_lane_log_text`), extended read order — record fields → lane log → the gate's own report — never a second marker list.
- **Replaces the single-hop `_REVIEW_GATE_TAKEOVER_ORDER` dict with a config-driven, cycle-checked, ordered chain.** `VNX_REVIEW_GATE_TAKEOVER_CHAIN` (config_registry, default `codex_gate,kimi_gate,glm_gate,deepseek_gate`) — absent falls back to that built-in default; an explicit empty value means no takeover at all (distinct states); an unknown gate name or a cycle fails loud at read time, naming the offender.
- The 22-08 `kimi_gate -> glm_gate` operator decision is **preserved unchanged** — it is now the second hop inside the longer chain, not replaced.
- Chain walk: within one round, hops through gates whose OWN exhaustion was already recorded in an earlier round need no fresh dispatch; a newly-discovered dead gate still needs its own round before the next hop can act (documented two-round latency, now scoped per-NEW-gate rather than per-round).
- `deepseek_gate` is a legal chain end-link — its runner ships separately (E2, not built here). Until then it always resolves `not_executable`/`gate_runner_missing`, named and on disk, mirroring `glm_gate`'s own pre-runner refusal pattern.
- A chain that runs out mid-walk with no live reader (a genuinely short/misconfigured chain, distinct from "next gate exists but has no runner yet") is a NAMED terminal state (`chain_exhausted`), written to its own record — never a silent fallback to re-dispatching the original gate.
- The takeover annotation embeds the actual marker-anchored failure text as a VALUE at hop time, never a pointer back to the source gate's own result record — so a later overwrite of that record (a separate, known issue T0 is tracking independently) cannot erase the reason a takeover was granted on. Verified directly in `test_glm_exhausted_real_record_rolls_to_deepseek_named_skip`.

## Changes

- `scripts/lib/gate_request_handler.py` — the bulk of the change: `ReviewGateTakeoverConfigError`, `_known_takeover_gate_names`, `_parse_review_gate_takeover_chain`, `_build_review_gate_takeover_chain`, `_scan_seat_failure_text`, `_read_lane_log_or_report_text`; rewritten `_dispatch_review_seat` (chain walk), extended `_stamp_takeover_annotations` (`takeover_path`), new `_chain_exhausted_result`/`_chain_exhausted_path`, new `_request_deepseek`/`_deepseek_gate_available`/`_deepseek_gate_runner_path`, `_dispatch_one_review` gains a `deepseek_gate` branch, `request_reviews` resolves the chain once per call.
- `scripts/lib/config_registry.py` — new `VNX_REVIEW_GATE_TAKEOVER_CHAIN` entry.
- `scripts/lib/governance_emit.py` — added codex/openai quota markers (`insufficient_quota`, `exceeded your current quota`) to `_LANE_EXHAUSTED_MARKERS`.
- `tests/test_beta3_e1_review_gate_chain.py` (new, 589 lines) — per-provider table (16 cases), the live PR-1691 report-fallback case (before/after), a 3-step chain full-path test, the deepseek named-skip test using the real PR-1691 record, a chain-runs-empty test, unreadable_verdict/no_response non-progression controls, cycle/unknown-gate config-failure tests, absent-vs-empty config tests, and a registry/module literal-parity canary.

## Scope note

This PR is larger than the ~450-line guideline in the dispatch: 454 insertions/67 deletions in existing files plus a 589-line new test file (~1043 lines total). The dispatch explicitly pre-authorized exceeding the budget provided all of points 1 (exhaustion test) + 2/3/4 (chain, codex entry, config) shipped complete rather than partial — nothing was cut.

## Verification

`pytest tests/test_dlv5_review_gate_takeover.py tests/test_gate_request_handler_w3f.py -v` → 24 passed.

`pytest tests/test_beta3_e1_review_gate_chain.py -v` → 33 passed, including the 16-case per-provider table and the live PR-1691 fixture (both before-fix `no_response` and after-fix `lane_exhausted` assertions).

Full neighbor sweep (closure_verifier x4, config_registry, config_runtime, dlv1/dlv2 gates, gate_dispatch_id, gate_obligation x4, gate_recorder x2, gate_runner x3, glm/kimi_gate data-dir guards, kimi_gate provenance/unavailable, oi1433, oi1452 x2, pr_merge_review_gate, review_gate_dispatch_id, review_gate_manager, review_gate_role) → 516 passed, 1 pre-existing unrelated failure (`test_gate_dispatch_id.py::test_request_reviews_propagates_dispatch_id_to_claude_github`) — confirmed via `git stash` bisection that it fails identically on baseline (same failure PR #1694 independently documented against the same baseline).

## Test plan

- [x] `pytest tests/test_dlv5_review_gate_takeover.py tests/test_gate_request_handler_w3f.py -v`
- [x] `pytest tests/test_beta3_e1_review_gate_chain.py -v`
- [x] Full neighbor sweep, pre-existing failure isolated via stash bisection

🤖 Generated with [Claude Code](https://claude.com/claude-code)