### PR TITLE
fix(gate-recorder): refuse a write that downgrades a terminal verdict (OI-1469/OI-1470)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -740,6 +740,30 @@ def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> D
         except (OSError, json.JSONDecodeError) as exc:
             _LOG.debug("result status unreadable for pr-%s-%s: %s", pr_number, gate, exc)
 
+        # OI-1469: "provider_not_installed" means the required CLI binary was
+        # missing from THIS RUNNER's own process environment (e.g. a
+        # launchd/cron PATH that never sourced it) at the moment the shared
+        # gate engine checked ``shutil.which`` — a fact about the runner, not
+        # about the PR. Booking it in results/ would let a merge-blocking
+        # evidence trail be polluted by whichever process happened to run
+        # last without the binary on PATH (measured live: PR #1694). Remove
+        # the record this fulfilment attempt just caused the engine to write
+        # for exactly that reason — the obligation still stays pending below
+        # with a named reason, so a later run from a properly configured
+        # environment can still fulfil it and write a real result.
+        if result_status == STATUS_NOT_EXECUTABLE and result_reason == "provider_not_installed":
+            try:
+                if result_file.exists():
+                    result_file.unlink()
+                    _LOG.warning(
+                        "gate_obligation_runner: removed provider_not_installed "
+                        "result for pr=%s gate=%s — provider availability is an "
+                        "environment fact, not PR evidence (OI-1469)",
+                        pr_number, gate,
+                    )
+            except OSError as exc:
+                _LOG.debug("could not remove provider_not_installed result for pr-%s-%s: %s", pr_number, gate, exc)
+
         if result_status in _TEMPORARY_RESULT_STATUSES:
             temp_reason = "gate_run_in_progress"
             temp_detail = (

--- a/scripts/lib/gate_executor.py
+++ b/scripts/lib/gate_executor.py
@@ -312,7 +312,12 @@ class GateExecutorMixin:
             self.results_dir, gate, pr_number=pr_number, pr_id=pr_id,
         )
         if rf:
-            rf.write_text(json.dumps(result_payload, indent=2), encoding="utf-8")
+            # OI-1469/OI-1470: refuse a write that would downgrade an existing
+            # terminal, evidenced result (e.g. a stale "running" re-check must
+            # never overwrite an already-decided pass/fail).
+            result_payload, _written = _rec.write_result_guarded(
+                rf, result_payload, gate=gate, pr_ref=pr_id or str(pr_number or ""),
+            )
 
         # When checks are still running, reset request to "requested" so it
         # can be re-executed once GitHub reports a terminal conclusion.

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 from governance_receipts import utc_now_iso
 
@@ -220,15 +220,39 @@ class ResultOverwriteRefused(ValueError):
     decided one (OI-1469/OI-1470)."""
 
 
-def _read_existing_result(result_path: Path) -> Optional[Dict[str, Any]]:
-    """Best-effort read of a prior result record. None if absent/unreadable."""
+class _CorruptResult:
+    """Sentinel: the result file exists but could not be parsed as a dict.
+
+    Distinct from ``None`` (absent). Absent, empty, and corrupt are three
+    different states (OI-1469/OI-1470 advisory) -- an existing file that
+    fails to parse might be a torn write left behind by one of the
+    non-atomic writers this guard exists to police (blocking-1 is exactly
+    that: a raw ``write_text`` with no tmp+replace), and it might be hiding
+    a real terminal, evidenced verdict underneath the truncation. Collapsing
+    it into "nothing there" would fail the guard OPEN on the one case it
+    most needs to fail closed.
+    """
+
+
+_CORRUPT_RESULT = _CorruptResult()
+
+
+def _read_existing_result(result_path: Path) -> Union[Dict[str, Any], _CorruptResult, None]:
+    """Best-effort read of a prior result record.
+
+    Returns ``None`` when the file is genuinely absent, the module-level
+    :data:`_CORRUPT_RESULT` sentinel when it exists but could not be parsed
+    (OSError, invalid JSON, or JSON that isn't an object), or the parsed
+    dict on success. Callers must check for the sentinel explicitly --
+    treating it as ``None`` was the OI-1469/OI-1470 advisory gap.
+    """
     if not result_path.exists():
         return None
     try:
         data = json.loads(result_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return None
-    return data if isinstance(data, dict) else None
+        return _CORRUPT_RESULT
+    return data if isinstance(data, dict) else _CORRUPT_RESULT
 
 
 def _check_overwrite_guard(
@@ -258,6 +282,25 @@ def _check_overwrite_guard(
     from gate_status import is_terminal, has_complete_evidence, canonical_status  # noqa: PLC0415
 
     existing = _read_existing_result(result_path)
+    if existing is _CORRUPT_RESULT:
+        # Advisory (OI-1469/OI-1470): absent, empty, and corrupt are three
+        # distinct states. An unreadable-but-present file must never read as
+        # "nothing there" -- that fails the guard OPEN on exactly the shape a
+        # non-atomic writer (blocking-1's raw ``write_text`` before this fix,
+        # and every writer still listed unguarded in the dispatch report) can
+        # produce: a torn write over what may have been a decided, evidenced
+        # verdict. Refuse rather than guess.
+        logger.warning(
+            "gate_recorder: REFUSING to overwrite unreadable existing result "
+            "gate=%s pr=%s path=%s -- the file exists but could not be "
+            "parsed; it may be a truncated terminal, evidenced verdict "
+            "(OI-1469/OI-1470 advisory)",
+            gate, pr_ref, result_path,
+        )
+        raise ResultOverwriteRefused(
+            f"{gate} result for pr={pr_ref!r} at {result_path} exists but is "
+            f"unreadable/corrupt -- refusing to overwrite an unverifiable record"
+        )
     if existing is None or not is_terminal(existing):
         return
     existing_status = canonical_status(existing)
@@ -309,11 +352,18 @@ def write_result_guarded(
     route through this so the overwrite guard applies by construction.
     Returns ``(payload_on_disk, written)`` — the new payload and ``True`` on
     success, or the unchanged existing payload and ``False`` when refused.
+    On a refusal caused by an unreadable/corrupt existing file (the
+    OI-1469/OI-1470 advisory case), there is no parseable existing payload to
+    hand back — the caller gets the attempted ``payload`` instead (never the
+    internal :data:`_CORRUPT_RESULT` sentinel), which is NOT what is on disk;
+    ``written is False`` is what tells the caller the write did not land.
     """
     try:
         _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_ref)
     except ResultOverwriteRefused:
-        return _read_existing_result(result_path) or payload, False
+        existing = _read_existing_result(result_path)
+        on_disk = existing if isinstance(existing, dict) else {}
+        return on_disk or payload, False
     _write_result_atomic(result_path, payload)
     return payload, True
 

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from governance_receipts import utc_now_iso
 
@@ -215,6 +215,109 @@ def stamp_request_identity(
     return result_payload
 
 
+class ResultOverwriteRefused(ValueError):
+    """A write would replace a terminal, evidenced gate result with a less
+    decided one (OI-1469/OI-1470)."""
+
+
+def _read_existing_result(result_path: Path) -> Optional[Dict[str, Any]]:
+    """Best-effort read of a prior result record. None if absent/unreadable."""
+    if not result_path.exists():
+        return None
+    try:
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _check_overwrite_guard(
+    result_path: Path,
+    new_payload: Dict[str, Any],
+    *,
+    gate: str,
+    pr_ref: str,
+) -> None:
+    """Refuse a write that would downgrade an existing terminal result.
+
+    OI-1469/OI-1470: three independent writers (glm_gate's live run, its
+    ``--reprocess`` recovery path, and gate_obligation_runner) land in the
+    same ``results/pr-<N>-<gate>.json`` slot with no ordering guarantee —
+    whoever writes last wins, even when that write is a provider outage. A
+    real, decided verdict (``gate_status.is_terminal`` AND
+    ``gate_status.has_complete_evidence`` — contract_hash + report_path both
+    present) may only be replaced by another decided, evidenced verdict:
+    never by an in-flight/outage status (OI-1470's second glm_gate run:
+    ``pass`` -> ``unavailable`` on an OpenRouter 402), and never by an
+    evidence-less terminal placeholder such as ``not_executable`` (a
+    ``--reprocess`` refusal, or a fresh not_executable booking). A terminal
+    record with NO complete evidence (e.g. an existing not_executable) is
+    not "decided" and stays freely overwritable — it must not permanently
+    freeze the slot.
+    """
+    from gate_status import is_terminal, has_complete_evidence, canonical_status  # noqa: PLC0415
+
+    existing = _read_existing_result(result_path)
+    if existing is None or not is_terminal(existing):
+        return
+    existing_status = canonical_status(existing)
+    new_status = canonical_status(new_payload)
+    if not is_terminal(new_payload):
+        logger.warning(
+            "gate_recorder: REFUSING to overwrite terminal result gate=%s pr=%s "
+            "existing_status=%r with non-terminal status=%r — an outage or "
+            "in-flight status must never erase a decided verdict (OI-1469/OI-1470)",
+            gate, pr_ref, existing_status, new_status,
+        )
+        raise ResultOverwriteRefused(
+            f"{gate} result for pr={pr_ref!r} is terminal (status={existing_status!r}) "
+            f"— refusing to overwrite with non-terminal status={new_status!r}"
+        )
+    if has_complete_evidence(existing) and not has_complete_evidence(new_payload):
+        logger.warning(
+            "gate_recorder: REFUSING to overwrite decided result gate=%s pr=%s "
+            "existing_status=%r (complete evidence) with evidence-less terminal "
+            "status=%r",
+            gate, pr_ref, existing_status, new_status,
+        )
+        raise ResultOverwriteRefused(
+            f"{gate} result for pr={pr_ref!r} carries complete evidence "
+            f"(status={existing_status!r}) — refusing to overwrite with "
+            f"evidence-less status={new_status!r}"
+        )
+
+
+def _write_result_atomic(result_path: Path, payload: Dict[str, Any]) -> None:
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = result_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.replace(result_path)
+
+
+def write_result_guarded(
+    result_path: Path,
+    payload: Dict[str, Any],
+    *,
+    gate: str,
+    pr_ref: str,
+) -> Tuple[Dict[str, Any], bool]:
+    """Write a gate result unless it would downgrade an existing terminal one.
+
+    Shared low-level write primitive (OI-1469/OI-1470): every writer of
+    ``results/pr-<N>-<gate>.json`` that is not required to raise on refusal
+    (see :func:`record_terminal_result` for the raising variant) should
+    route through this so the overwrite guard applies by construction.
+    Returns ``(payload_on_disk, written)`` — the new payload and ``True`` on
+    success, or the unchanged existing payload and ``False`` when refused.
+    """
+    try:
+        _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_ref)
+    except ResultOverwriteRefused:
+        return _read_existing_result(result_path) or payload, False
+    _write_result_atomic(result_path, payload)
+    return payload, True
+
+
 def record_terminal_result(
     *,
     gate: str,
@@ -239,6 +342,12 @@ def record_terminal_result(
     resolves ``result_path`` itself — gate writers use different filename
     conventions (legacy ``pr-N-gate.json`` vs. ``{slug}-gate-contract.json``)
     and this function does not need to know which.
+
+    Also refuses (:class:`ResultOverwriteRefused`, a ``ValueError`` subclass)
+    a write that would downgrade an existing decided, evidenced result to a
+    less-decided one — see :func:`_check_overwrite_guard`. glm_gate.py and
+    kimi_gate.py already catch ``(OSError, ValueError)`` around this call and
+    fail loudly rather than silently overwrite (OI-1469/OI-1470).
     """
     from gate_status import is_terminal, has_producer_identity  # noqa: PLC0415
 
@@ -248,10 +357,8 @@ def record_terminal_result(
             f"({payload.get('status')!r}) but no producer identity "
             f"(dispatch_id) — refusing to write unauthenticated gate evidence"
         )
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = result_path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    tmp.replace(result_path)
+    _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_id)
+    _write_result_atomic(result_path, payload)
     return result_path
 
 
@@ -295,7 +402,9 @@ def record_not_executable(
 
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
     if rf:
-        rf.write_text(json.dumps(result_payload, indent=2), encoding="utf-8")
+        result_payload, _written = write_result_guarded(
+            rf, result_payload, gate=gate, pr_ref=pr_id or str(pr_number or ""),
+        )
 
     write_skip_rationale(
         state_dir, gate,
@@ -363,12 +472,18 @@ def record_failure(
     stamp_request_identity(failure_payload, request_payload)
 
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
+    written = True
     if rf:
-        rf.write_text(json.dumps(failure_payload, indent=2), encoding="utf-8")
+        failure_payload, written = write_result_guarded(
+            rf, failure_payload, gate=gate, pr_ref=pr_id or str(pr_number or ""),
+        )
 
     # Emit gate_failed for codex_gate only when the gate itself reported a verdict
-    # failure (not for infrastructure/execution errors like timeout or stall).
-    if gate == "codex_gate" and reason not in EXECUTION_FAILURE_REASONS:
+    # failure (not for infrastructure/execution errors like timeout or stall) AND
+    # the write actually landed — a refused write left the prior (real) result
+    # standing, so telling the register "gate_failed" would describe a write
+    # that never happened (OI-1469/OI-1470).
+    if written and gate == "codex_gate" and reason not in EXECUTION_FAILURE_REASONS:
         try:
             from gate_register_emit import emit_codex_gate_to_register
             emit_codex_gate_to_register(

--- a/scripts/lib/gate_report_generator.py
+++ b/scripts/lib/gate_report_generator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 
 class GateReportGeneratorMixin:
@@ -25,8 +25,27 @@ class GateReportGeneratorMixin:
         reason_detail: str,
         contract_hash: str = "",
         dispatch_id: str = "",
-    ) -> Dict[str, Any]:
-        """Write a not_executable result record (GATE-4)."""
+    ) -> Tuple[Dict[str, Any], bool]:
+        """Write a not_executable result record (GATE-4).
+
+        Routes through ``gate_recorder.write_result_guarded`` (OI-1469/
+        OI-1470/OI-1471) instead of a bare ``write_text``. This is a
+        REQUEST-time writer -- ``_mark_gate_unavailable`` calls it when a
+        gate is (re-)requested and its binary is unavailable, which fires
+        BEFORE any run, unlike the RESULT-time recorders in
+        ``gate_recorder.py`` that already carried the guard. Without it, a
+        request-time refusal on a PR that already carries a real, decided
+        verdict (e.g. a launchd worker missing the gate's CLI on PATH) would
+        silently erase that verdict -- measured live against PR #1691's
+        codex-gate pass (contract_hash ``466cd2ca75d7a7fb``).
+
+        Returns ``(payload_on_disk, written)``. ``payload_on_disk`` is the
+        not_executable payload just built when the write landed, or the
+        untouched pre-existing terminal record when the guard refused it.
+        ``written`` is ``False`` on refusal -- the caller must not assume
+        the constructed payload reached disk without checking it.
+        """
+        from gate_recorder import write_result_guarded
         from review_gate_manager import _utc_now
 
         now = _utc_now()
@@ -56,9 +75,10 @@ class GateReportGeneratorMixin:
         elif pr_number is not None:
             result_file = self._result_path(gate, pr_number)
         else:
-            return payload
-        result_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        return payload
+            return payload, True
+        return write_result_guarded(
+            result_file, payload, gate=gate, pr_ref=pr_id or str(pr_number or ""),
+        )
 
     def _write_skip_rationale(
         self,

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -452,7 +452,14 @@ class GateRequestHandlerMixin:
         contract_hash: str = "",
         dispatch_id: str = "",
     ) -> None:
-        """Record unavailability in payload and write skip/result records."""
+        """Record unavailability in payload and write skip/result records.
+
+        The in-memory ``payload`` (the REQUEST record) always carries
+        ``reason``/``reason_detail``/``failure_reason`` regardless of what
+        happens to the RESULT record below -- a request-time refusal is
+        never allowed to go quiet even when the guard blocks the write it
+        would otherwise cause (OI-1469/OI-1470/OI-1471).
+        """
         reason, detail = self._classify_unavailable(gate, binary_name)
         payload["reason"] = reason
         payload["reason_detail"] = detail
@@ -465,12 +472,24 @@ class GateRequestHandlerMixin:
         # field name.
         payload["failure_reason"] = detail
         payload["resolved_at"] = payload["requested_at"]
-        self._write_not_executable_result(
+        _result_payload, written = self._write_not_executable_result(
             gate=gate, pr_number=pr_number, pr_id=pr_id,
             reason=reason, reason_detail=detail,
             contract_hash=contract_hash,
             dispatch_id=dispatch_id,
         )
+        if not written:
+            # gate_recorder.write_result_guarded already logged the refusal
+            # with the existing/new status; this line makes the request-time
+            # caller's own awareness explicit (OI-1469/OI-1470/OI-1471) --
+            # the PR keeps its prior decided verdict on disk, unpolluted.
+            logger.warning(
+                "gate_request_handler: not_executable write REFUSED for "
+                "gate=%s pr=%s -- an existing terminal, evidenced result "
+                "stands; this refusal (reason=%s) was request-time only "
+                "and never reached results/",
+                gate, pr_id or pr_number, reason,
+            )
         self._write_skip_rationale(
             gate=gate, pr_id=pr_id or str(pr_number),
             reason=reason, reason_detail=detail,
@@ -907,11 +926,19 @@ class GateRequestHandlerMixin:
             payload["reason"] = reason
             payload["reason_detail"] = reason_detail
             payload["resolved_at"] = payload["requested_at"]
-            self._write_not_executable_result(
+            _result_payload, written = self._write_not_executable_result(
                 gate="glm_gate", pr_number=pr_number, pr_id="",
                 reason=reason, reason_detail=reason_detail,
                 dispatch_id=dispatch_id,
             )
+            if not written:
+                logger.warning(
+                    "gate_request_handler: not_executable write REFUSED for "
+                    "gate=glm_gate pr=%s -- an existing terminal, evidenced "
+                    "result stands; this refusal (reason=%s) was request-time "
+                    "only and never reached results/",
+                    pr_number, reason,
+                )
             self._write_skip_rationale(
                 gate="glm_gate", pr_id=str(pr_number),
                 reason=reason, reason_detail=reason_detail,

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -317,6 +317,58 @@ def test_case_d_no_checks_gh_returncode_nonzero_no_checks_message(gate_env):
 
 
 # ---------------------------------------------------------------------------
+# OI-1469/OI-1470: a re-run must never downgrade an already-decided verdict
+# ---------------------------------------------------------------------------
+
+
+def test_running_recheck_never_overwrites_a_decided_pass(gate_env):
+    """ci_gate's own terminal write (gate_executor line ~311-315, bypassing
+    gate_recorder's higher-level helpers) must route through the same
+    overwrite guard. A flaky re-check that comes back "running" must not
+    erase a prior decided pass with real evidence."""
+    executor = _make_mock_executor(gate_env)
+    pr_number = 4701
+    request_payload = _make_request_payload(
+        pr_number=pr_number,
+        headless_reports_dir=gate_env["headless_reports_dir"],
+    )
+
+    with patch("gate_executor.subprocess") as mock_sub, \
+         patch("gate_executor.shutil.which", return_value="/usr/bin/gh"):
+        checks = [{"name": "ci/test", "bucket": "pass", "state": "SUCCESS"}]
+        mock_sub.run.side_effect = _make_subprocess_run(json.dumps(checks))
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        first = executor._execute_ci_gate(
+            gate="ci_gate", pr_number=pr_number, pr_id="",
+            request_payload=dict(request_payload),
+        )
+    assert first["status"] == "pass"
+    result_file = gate_env["results_dir"] / f"pr-{pr_number}-ci_gate.json"
+    assert json.loads(result_file.read_text())["status"] == "pass"
+
+    with patch("gate_executor.subprocess") as mock_sub, \
+         patch("gate_executor.shutil.which", return_value="/usr/bin/gh"):
+        pending_checks = [{"name": "ci/test", "bucket": "pending", "state": "IN_PROGRESS"}]
+        mock_sub.run.side_effect = _make_subprocess_run(json.dumps(pending_checks))
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        second = executor._execute_ci_gate(
+            gate="ci_gate", pr_number=pr_number, pr_id="",
+            request_payload=dict(request_payload),
+        )
+
+    # The refused write returns the existing (pass) record, not a synthetic
+    # "running" one — the caller must see reality, not the rejected attempt.
+    assert second["status"] == "pass"
+    stored = json.loads(result_file.read_text())
+    assert stored["status"] == "pass", (
+        "a running re-check must never overwrite an already-decided pass "
+        "(OI-1469/OI-1470)"
+    )
+    assert stored["contract_hash"] == first["contract_hash"]
+    assert stored["report_path"] == first["report_path"]
+
+
+# ---------------------------------------------------------------------------
 # Closure verifier: ci_gate integration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -36,8 +36,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
 import gate_obligation_runner as runner
+import governance_receipts
 import producer_freshness
 from dispatch_cli import run_dispatch
+from gate_report_generator import GateReportGeneratorMixin
 from gate_obligations import (
     NO_GATE_KEY,
     REASON_NO_PR_BRANCH_GONE,
@@ -106,9 +108,19 @@ def _read_obligation(state_dir: Path, dispatch_id: str) -> dict:
     return json.loads(obligation_path(state_dir, dispatch_id).read_text(encoding="utf-8"))
 
 
-class _FakeManager:
+class _FakeManager(GateReportGeneratorMixin):
     """Stands in for ReviewGateManager: writes the request+result records the
     real manager's request_and_execute produces, without running any gate.
+
+    The not_executable result path routes through the REAL
+    ``GateReportGeneratorMixin._write_not_executable_result`` (mixed in
+    above) instead of a bare write. That method is the actual OI-1469/
+    OI-1470/OI-1471 request-time guard fix: a fake that clobbers a slot
+    unconditionally would prove nothing about whether the guard the
+    production writer now goes through actually holds. Other statuses
+    ("completed", "pass", "running", "unavailable") are synthetic
+    scaffolding for the runner's own classification logic and are not
+    produced by any single guarded writer, so they keep the plain write.
 
     ``result_status``/``result_reason`` let a test control what the gate
     RESULT record reports (e.g. ``status="not_executable", reason=
@@ -133,6 +145,10 @@ class _FakeManager:
     def _result_path(self, gate: str, pr_number: int) -> Path:
         return self.state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
 
+    def _contract_result_path(self, gate: str, pr_id: str) -> Path:
+        slug = pr_id.lower().replace("-", "")
+        return self.state_dir / "review_gates" / "results" / f"{slug}-{gate}-contract.json"
+
     def request_and_execute(self, *, pr_number, branch, review_stack, risk_class,
                             changed_files, mode, dispatch_id=""):
         self.calls.append(
@@ -145,6 +161,14 @@ class _FakeManager:
                 json.dumps({"gate": gate, "pr_number": pr_number, "status": "completed"}),
                 encoding="utf-8",
             )
+            if self.result_status == "not_executable":
+                reason = self.result_reason or "unknown_reason"
+                self._write_not_executable_result(
+                    gate=gate, pr_number=pr_number, pr_id="",
+                    reason=reason, reason_detail=reason,
+                    dispatch_id=dispatch_id,
+                )
+                continue
             result_payload = {"gate": gate, "pr_number": pr_number, "status": self.result_status}
             if self.result_reason is not None:
                 result_payload["reason"] = self.result_reason
@@ -162,6 +186,10 @@ def _patch_manager(monkeypatch, manager: "_FakeManager") -> None:
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda state_dir: "Vinix24/vnx-orchestration")
     fake_rgm = types.ModuleType("review_gate_manager")
     fake_rgm._compute_changed_files = lambda branch: ["scripts/lib/foo.py"]
+    # _write_not_executable_result (mixed into _FakeManager, real production
+    # code) imports _utc_now from review_gate_manager -- this module is
+    # monkeypatched out for the whole test, so the stand-in must carry it too.
+    fake_rgm._utc_now = governance_receipts.utc_now_iso
     monkeypatch.setitem(sys.modules, "review_gate_manager", fake_rgm)
 
 
@@ -815,11 +843,22 @@ def test_runner_removes_provider_not_installed_result_record(tmp_path, monkeypat
 
 def test_runner_leaves_pre_existing_pass_untouched_on_provider_not_installed(tmp_path, monkeypatch):
     """OI-1469/OI-1470 composition: if the slot already carries a real,
-    evidenced pass, gate_recorder's overwrite guard (OI-1470) refuses the
-    provider_not_installed write outright — the file on disk is still the
-    original pass, so this runner's own cleanup step must find nothing
-    matching provider_not_installed to remove, and the obligation must
-    report fulfilled off the real, untouched evidence."""
+    evidenced pass, gate_recorder's overwrite guard (OI-1470/OI-1471)
+    refuses the provider_not_installed write outright — the file on disk is
+    still the original pass, so this runner's own cleanup step must find
+    nothing matching provider_not_installed to remove, and the obligation
+    must report fulfilled off the real, untouched evidence.
+
+    ``request_and_execute`` runs unmodified here -- no wrapper that
+    manufactures the "unchanged" outcome the assertions below check for.
+    ``_FakeManager``'s not_executable path already routes through the real
+    ``_write_not_executable_result`` (see its class docstring), so this test
+    exercises the actual guard, not a stand-in for it. Before OI-1469/
+    OI-1470/OI-1471 (gate_report_generator._write_not_executable_result
+    routed through gate_recorder.write_result_guarded), this test failed:
+    the bare write clobbered the pass. A wrapper that read-back-and-restored
+    the file around the call made the assertions pass regardless of whether
+    the guard existed at all -- the test proved nothing."""
     state_dir = _make_state_dir(tmp_path)
     register_obligation(
         state_dir, dispatch_id="20260826-oi1469-protected-pass", gate="codex_gate",
@@ -835,20 +874,6 @@ def test_runner_leaves_pre_existing_pass_untouched_on_provider_not_installed(tmp
     }
     result_file.write_text(json.dumps(existing_pass), encoding="utf-8")
 
-    # Simulate gate_recorder's overwrite guard already having refused the
-    # write in-process: the fake manager here stands in for the whole
-    # request_and_execute call, so patch it to leave the pre-existing pass
-    # untouched instead of clobbering it, exactly like the real guarded
-    # writer would.
-    original_request_and_execute = manager.request_and_execute
-
-    def _guarded_request_and_execute(**kwargs):
-        before = result_file.read_text(encoding="utf-8")
-        response = original_request_and_execute(**kwargs)
-        result_file.write_text(before, encoding="utf-8")
-        return response
-
-    monkeypatch.setattr(manager, "request_and_execute", _guarded_request_and_execute)
     _patch_manager(monkeypatch, manager)
 
     summary = runner.run(state_dir)

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -778,6 +778,87 @@ def test_runner_leaves_pending_on_provider_disabled_result(tmp_path, monkeypatch
     assert "not broken" in record["reason_detail"]
 
 
+def test_runner_removes_provider_not_installed_result_record(tmp_path, monkeypatch):
+    """OI-1469: provider availability is a fact about THIS RUNNER's own
+    process environment (launchd/cron PATH), never about the PR. Measured
+    live against PR #1694: the engine wrote status=not_executable,
+    reason=provider_not_installed, contract_hash='' into results/ as if it
+    were PR evidence. The obligation must stay pending with a named reason
+    (unchanged OI-1400 behavior) AND no such record may survive on disk —
+    a subsequent closure/producer-freshness reader must not see a
+    not_executable "verdict" that is really just a missing binary on this
+    one runner's PATH."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260826-oi1469-not-installed", gate="codex_gate",
+        project_id="vnx-dev", pr_number=1694,
+    )
+    manager = _FakeManager(
+        state_dir, result_status="not_executable", result_reason="provider_not_installed",
+    )
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 1
+    record = _read_obligation(state_dir, "20260826-oi1469-not-installed")
+    assert record["status"] == STATUS_PENDING
+    assert record["attempts"] == 1
+    assert record["reason"] == "gate_parked"
+
+    result_file = manager._result_path("codex_gate", 1694)
+    assert not result_file.exists(), (
+        "provider_not_installed must never survive as a gate result record — "
+        "it is an environment fact about this runner, not PR evidence (OI-1469)"
+    )
+
+
+def test_runner_leaves_pre_existing_pass_untouched_on_provider_not_installed(tmp_path, monkeypatch):
+    """OI-1469/OI-1470 composition: if the slot already carries a real,
+    evidenced pass, gate_recorder's overwrite guard (OI-1470) refuses the
+    provider_not_installed write outright — the file on disk is still the
+    original pass, so this runner's own cleanup step must find nothing
+    matching provider_not_installed to remove, and the obligation must
+    report fulfilled off the real, untouched evidence."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260826-oi1469-protected-pass", gate="codex_gate",
+        project_id="vnx-dev", pr_number=1695,
+    )
+    manager = _FakeManager(state_dir, result_status="not_executable", result_reason="provider_not_installed")
+    result_file = manager._result_path("codex_gate", 1695)
+    result_file.parent.mkdir(parents=True, exist_ok=True)
+    existing_pass = {
+        "gate": "codex_gate", "pr_number": 1695, "status": "pass",
+        "contract_hash": "abc123", "report_path": "/tmp/report.md",
+        "dispatch_id": "codex-gate-pr1695-1",
+    }
+    result_file.write_text(json.dumps(existing_pass), encoding="utf-8")
+
+    # Simulate gate_recorder's overwrite guard already having refused the
+    # write in-process: the fake manager here stands in for the whole
+    # request_and_execute call, so patch it to leave the pre-existing pass
+    # untouched instead of clobbering it, exactly like the real guarded
+    # writer would.
+    original_request_and_execute = manager.request_and_execute
+
+    def _guarded_request_and_execute(**kwargs):
+        before = result_file.read_text(encoding="utf-8")
+        response = original_request_and_execute(**kwargs)
+        result_file.write_text(before, encoding="utf-8")
+        return response
+
+    monkeypatch.setattr(manager, "request_and_execute", _guarded_request_and_execute)
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260826-oi1469-protected-pass")
+    assert record["status"] == STATUS_FULFILLED
+    assert json.loads(result_file.read_text(encoding="utf-8")) == existing_pass
+
+
 def test_runner_leaves_pending_on_running_result(tmp_path, monkeypatch):
     """status=running means the CI check is still in flight — a "not yet",
     not a verdict. Must stay pending, not be marked fulfilled or terminal."""

--- a/tests/test_gate_recorder_overwrite_guard.py
+++ b/tests/test_gate_recorder_overwrite_guard.py
@@ -420,3 +420,76 @@ class TestWriteResultGuardedDirect:
         assert written is False
         assert result == pass_payload
         assert json.loads(out.read_text(encoding="utf-8")) == pass_payload
+
+
+# ---------------------------------------------------------------------------
+# Advisory (OI-1469/OI-1470): absent, empty, and corrupt are three distinct
+# states. A pre-existing file that exists but cannot be parsed must never be
+# treated the same as "nothing there" -- that fails the guard OPEN on the one
+# shape a non-atomic writer (blocking-1's raw ``write_text`` before it was
+# routed through this guard) can produce: a torn write that might be hiding a
+# real terminal, evidenced verdict underneath the truncation.
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptExistingResultFailsClosed:
+
+    def test_truncated_json_over_existing_file_refuses(self, tmp_path):
+        """A torn write (mid-write crash, disk full, concurrent writer) leaves
+        invalid JSON behind — the guard must refuse rather than guess it was
+        nothing."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        out.write_text('{"gate": "glm_gate", "status": "pass", "contract_h', encoding="utf-8")
+
+        with pytest.raises(ResultOverwriteRefused):
+            record_terminal_result(
+                gate="glm_gate", pr_id="1691", result_path=out,
+                payload={"gate": "glm_gate", "pr_id": "1691", "status": "pass",
+                         "contract_hash": "newhash", "report_path": "/tmp/r.md",
+                         "dispatch_id": "glm-gate-pr1691-2"},
+            )
+        # The corrupt content must survive untouched -- never silently
+        # replaced, since we cannot verify it wasn't a decided verdict.
+        assert out.read_text(encoding="utf-8") == '{"gate": "glm_gate", "status": "pass", "contract_h'
+
+    def test_empty_file_over_existing_slot_refuses(self, tmp_path):
+        """Absent, empty, and corrupt are three different states -- a
+        zero-byte file is not the same as no file at all. There is no
+        parseable existing payload to hand back on this refusal shape, so
+        ``written is False`` is what the caller must check, not the returned
+        payload (which echoes the attempted write, not what's on disk)."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        out.write_text("", encoding="utf-8")
+
+        payload = {"gate": "glm_gate", "pr_number": 1691, "status": "pass",
+                    "contract_hash": "h", "report_path": "/tmp/r.md"}
+        result, written = write_result_guarded(out, payload, gate="glm_gate", pr_ref="1691")
+        assert written is False
+        assert out.read_text(encoding="utf-8") == ""
+
+    def test_json_that_is_not_an_object_refuses(self, tmp_path):
+        """Valid JSON that parses to a list/string/etc. is not a result
+        record — must be treated the same as corrupt, not as absent."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        out.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+
+        payload = {"gate": "glm_gate", "pr_number": 1691, "status": "pass",
+                    "contract_hash": "h", "report_path": "/tmp/r.md"}
+        result, written = write_result_guarded(out, payload, gate="glm_gate", pr_ref="1691")
+        assert written is False
+        assert json.loads(out.read_text(encoding="utf-8")) == ["not", "a", "dict"]
+
+    def test_contrast_genuinely_absent_file_writes_normally(self, tmp_path):
+        """Contrast case: no file at all (never written, or already cleaned
+        up) is a THIRD state, distinct from empty/corrupt, and must not be
+        penalised by the advisory fix -- the guard only activates on
+        existing-but-unreadable content."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        assert not out.exists()
+
+        payload = {"gate": "glm_gate", "pr_number": 1691, "status": "pass",
+                    "contract_hash": "h", "report_path": "/tmp/r.md"}
+        result, written = write_result_guarded(out, payload, gate="glm_gate", pr_ref="1691")
+        assert written is True
+        assert result == payload
+        assert json.loads(out.read_text(encoding="utf-8")) == payload

--- a/tests/test_gate_recorder_overwrite_guard.py
+++ b/tests/test_gate_recorder_overwrite_guard.py
@@ -1,0 +1,422 @@
+"""Tests for gate_recorder's terminal-overwrite guard (OI-1469/OI-1470).
+
+The result-store slot ``results/pr-<N>-<gate>.json`` is one file per (PR,
+gate) with three independent writers (glm_gate's live run, its
+``--reprocess`` recovery path, and gate_obligation_runner) landing there with
+no ordering guarantee. Whoever writes last wins, even when that write is a
+provider outage. The guard sits in the SHARED write functions of
+gate_recorder.py (``record_terminal_result``, ``record_not_executable``,
+``record_failure``) — every writer routes through one of these three, so the
+guard applies by construction, not per call site.
+
+Rule (uses ONLY ``gate_status.is_terminal`` / ``gate_status.has_complete_evidence``,
+no second vocabulary):
+  - A terminal, evidenced record (is_terminal + has_complete_evidence) may
+    only be replaced by another terminal record.
+  - If the new record also lacks complete evidence (e.g. a fresh
+    not_executable), the write is refused too — a decided verdict must not
+    be demoted to an evidence-less placeholder.
+  - A terminal record WITHOUT complete evidence (e.g. an existing
+    not_executable) is not "decided" and stays freely overwritable.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_recorder import (
+    ResultOverwriteRefused,
+    record_failure,
+    record_not_executable,
+    record_terminal_result,
+    write_result_guarded,
+)
+
+
+def _make_pass(**overrides):
+    payload = {
+        "gate": "glm_gate",
+        "pr_id": "1691",
+        "status": "pass",
+        "contract_hash": "dd5ac45f7e84535e",
+        "report_path": "/tmp/glm-report.md",
+        "dispatch_id": "glm-gate-pr1691-1787753000",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Writer 1: glm_gate.py / kimi_gate.py — gate_recorder.record_terminal_result
+# (also exercises the --reprocess code path, which calls this same function)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordTerminalResultOverwriteGuard:
+
+    def test_unavailable_write_over_decided_pass_is_refused(self, tmp_path):
+        """OI-1470 reproduction: a second glm_gate run that fails with an
+        OpenRouter 402 must not erase the first run's real pass."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        pass_payload = _make_pass()
+        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=pass_payload)
+        assert json.loads(out.read_text(encoding="utf-8"))["status"] == "pass"
+
+        outage_payload = {
+            "gate": "glm_gate",
+            "pr_id": "1691",
+            "status": "unavailable",
+            "contract_hash": "",
+            "report_path": "",
+            "reason": "dispatch_error",
+        }
+        with pytest.raises(ResultOverwriteRefused):
+            record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=outage_payload)
+
+        # The existing pass must be completely untouched.
+        assert json.loads(out.read_text(encoding="utf-8")) == pass_payload
+
+    def test_reprocess_no_identity_anchor_over_decided_pass_is_refused(self, tmp_path):
+        """The --reprocess recovery path's own not_executable booking
+        (reason=reprocess_no_identity_anchor, all fields empty) must not
+        erase a decided pass either — it goes through the SAME function."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        pass_payload = _make_pass()
+        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=pass_payload)
+
+        reprocess_refusal = {
+            "gate": "glm_gate",
+            "pr_id": "1691",
+            "status": "unavailable",
+            "reason": "reprocess_no_identity_anchor",
+            "contract_hash": "",
+            "report_path": "",
+        }
+        with pytest.raises(ResultOverwriteRefused):
+            record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=reprocess_refusal)
+        assert json.loads(out.read_text(encoding="utf-8")) == pass_payload
+
+    def test_terminal_over_terminal_is_allowed(self, tmp_path):
+        """A hergate after a rebase must be able to lay down a fresh pass
+        over an old pass — terminal may replace terminal."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        first_pass = _make_pass(dispatch_id="glm-gate-pr1691-1")
+        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=first_pass)
+
+        second_pass = _make_pass(
+            contract_hash="freshhash123456", report_path="/tmp/glm-report-2.md",
+            dispatch_id="glm-gate-pr1691-2",
+        )
+        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=second_pass)
+        assert json.loads(out.read_text(encoding="utf-8")) == second_pass
+
+    def test_fail_over_pass_is_allowed_when_both_carry_evidence(self, tmp_path):
+        """A real fail (evidenced) may still supersede a real pass — the
+        guard protects against DOWNGRADE, not against a real regression."""
+        out = tmp_path / "pr-1691-glm_gate.json"
+        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=_make_pass())
+
+        fail_payload = _make_pass(
+            status="fail", contract_hash="failhash1", report_path="/tmp/glm-fail.md",
+            dispatch_id="glm-gate-pr1691-3",
+        )
+        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=fail_payload)
+        assert json.loads(out.read_text(encoding="utf-8"))["status"] == "fail"
+
+    def test_not_executable_may_freely_overwrite_a_prior_not_executable(self, tmp_path):
+        """A terminal record with NO complete evidence is not "decided" and
+        must stay freely overwritable — it must never permanently freeze
+        the slot."""
+        out = tmp_path / "pr-1-kimi_gate.json"
+        first = {
+            "gate": "kimi_gate", "pr_id": "1", "status": "not_executable",
+            "reason": "provider_disabled", "contract_hash": "", "report_path": "",
+            "dispatch_id": "kimi-gate-pr1-1",
+        }
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(first), encoding="utf-8")
+
+        second = {
+            "gate": "kimi_gate", "pr_id": "1", "status": "not_executable",
+            "reason": "provider_not_configured", "contract_hash": "", "report_path": "",
+            "dispatch_id": "kimi-gate-pr1-2",
+        }
+        record_terminal_result(gate="kimi_gate", pr_id="1", result_path=out, payload=second)
+        assert json.loads(out.read_text(encoding="utf-8"))["reason"] == "provider_not_configured"
+
+    def test_no_existing_file_writes_unconditionally(self, tmp_path):
+        out = tmp_path / "pr-99-kimi_gate.json"
+        payload = {
+            "gate": "kimi_gate", "pr_id": "99", "status": "unavailable",
+            "contract_hash": "", "report_path": "",
+        }
+        record_terminal_result(gate="kimi_gate", pr_id="99", result_path=out, payload=payload)
+        assert json.loads(out.read_text(encoding="utf-8")) == payload
+
+
+# ---------------------------------------------------------------------------
+# Writer 2: record_not_executable (gate_runner.py, gate_executor.py's
+# ci_gate provider_not_installed path, gate_obligation_runner's runner_error
+# fallback)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordNotExecutableOverwriteGuard:
+
+    @pytest.fixture
+    def env(self, tmp_path):
+        state_dir = tmp_path / "state"
+        requests_dir = state_dir / "review_gates" / "requests"
+        results_dir = state_dir / "review_gates" / "results"
+        requests_dir.mkdir(parents=True, exist_ok=True)
+        results_dir.mkdir(parents=True, exist_ok=True)
+        return {"state_dir": state_dir, "requests_dir": requests_dir, "results_dir": results_dir}
+
+    def test_not_executable_over_decided_pass_is_refused_and_existing_kept(self, env):
+        rf = env["results_dir"] / "pr-1694-codex_gate.json"
+        pass_payload = {
+            "gate": "codex_gate", "pr_id": "", "pr_number": 1694, "status": "pass",
+            "contract_hash": "realhash", "report_path": "/tmp/codex-report.md",
+            "dispatch_id": "codex-gate-pr1694-1",
+        }
+        rf.write_text(json.dumps(pass_payload), encoding="utf-8")
+
+        result = record_not_executable(
+            gate="codex_gate", pr_number=1694, pr_id="",
+            reason="provider_not_installed", reason_detail="codex binary not found in PATH",
+            request_payload={"gate": "codex_gate", "pr_number": 1694},
+            requests_dir=env["requests_dir"], results_dir=env["results_dir"],
+            state_dir=env["state_dir"],
+        )
+
+        # The function must report the true on-disk state, not the refused attempt.
+        assert result["status"] == "pass"
+        assert json.loads(rf.read_text(encoding="utf-8")) == pass_payload
+
+    def test_not_executable_on_empty_slot_writes_normally(self, env):
+        rf = env["results_dir"] / "pr-1700-codex_gate.json"
+        result = record_not_executable(
+            gate="codex_gate", pr_number=1700, pr_id="",
+            reason="provider_not_installed", reason_detail="codex binary not found in PATH",
+            request_payload={"gate": "codex_gate", "pr_number": 1700},
+            requests_dir=env["requests_dir"], results_dir=env["results_dir"],
+            state_dir=env["state_dir"],
+        )
+        assert result["status"] == "not_executable"
+        assert json.loads(rf.read_text(encoding="utf-8"))["status"] == "not_executable"
+
+
+# ---------------------------------------------------------------------------
+# Writer 3: record_failure (gate_runner.py / gate_executor.py timeouts,
+# gate_artifacts.materialize_artifacts failure branches)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordFailureOverwriteGuard:
+
+    @pytest.fixture
+    def env(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        requests_dir = state_dir / "review_gates" / "requests"
+        results_dir = state_dir / "review_gates" / "results"
+        requests_dir.mkdir(parents=True, exist_ok=True)
+        results_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+        return {"state_dir": state_dir, "requests_dir": requests_dir, "results_dir": results_dir}
+
+    @pytest.mark.parametrize("pr_number,contract_hash,head_sha", [
+        (1691, "466cd2ca75d7a7fb", "ab11e0c3"),
+        (1692, "9ebfe1f1c94b4243", "56b7f331"),
+    ])
+    def test_codex_usage_limit_over_completed_is_refused_live_fixture(
+        self, env, pr_number, contract_hash, head_sha,
+    ):
+        """Live fixture (2026-08-26, third independent case, second provider):
+        codex_gate held a valid `status=completed` verdict on two rebased PRs.
+        Re-gating after the rebase hit codex's usage limit mid-run — gate_runner
+        books that as ``status=failed, reason=exit_nonzero`` -> record_failure
+        classifies exit_nonzero as an EXECUTION failure and books
+        ``status=unavailable`` with empty contract_hash/report_path. Proves the
+        bug (and the guard) is NOT glm-specific: a fourth writer
+        (gate_runner._run_subprocess_path -> record_failure), a second
+        provider, and a reason (exit_nonzero) outside any explicit reason
+        allowlist all hit the exact same shared write path."""
+        rf = env["results_dir"] / f"pr-{pr_number}-codex_gate.json"
+        completed_payload = {
+            "gate": "codex_gate", "pr_id": "", "pr_number": pr_number,
+            "status": "completed", "contract_hash": contract_hash,
+            "report_path": "/tmp/codex-report.md", "commit_sha": head_sha,
+            "blocking_findings": [], "dispatch_id": f"codex-gate-pr{pr_number}-1",
+        }
+        rf.write_text(json.dumps(completed_payload), encoding="utf-8")
+
+        result = record_failure(
+            gate="codex_gate", pr_number=pr_number, pr_id="",
+            result={
+                "reason": "exit_nonzero",
+                "reason_detail": (
+                    "Subprocess exited with code 1: You've hit your usage limit. "
+                    "Upgrade to Pro ..."
+                ),
+                "duration_seconds": 42.0, "partial_output_lines": 12, "runner_pid": 1,
+            },
+            request_payload={"gate": "codex_gate", "pr_number": pr_number, "dispatch_id": f"codex-gate-pr{pr_number}-2"},
+            requests_dir=env["requests_dir"], results_dir=env["results_dir"],
+        )
+
+        assert result["status"] == "completed"
+        on_disk = json.loads(rf.read_text(encoding="utf-8"))
+        assert on_disk == completed_payload, (
+            "usage-limit unavailable must never overwrite a real completed "
+            "verdict (OI-1469/OI-1470, live fixture 2026-08-26)"
+        )
+
+    def test_refusal_does_not_branch_on_reason_code(self, env):
+        """The guard is a SHAPE check (terminal+evidence vs. non-terminal),
+        never a reason-code allowlist. A reason no writer has produced yet
+        must be refused identically to exit_nonzero/dispatch_error/
+        provider_not_installed — otherwise the next outage reason slips
+        through uncaught."""
+        rf = env["results_dir"] / "pr-1-codex_gate.json"
+        completed_payload = {
+            "gate": "codex_gate", "pr_number": 1, "status": "completed",
+            "contract_hash": "h", "report_path": "/tmp/r.md",
+        }
+        rf.write_text(json.dumps(completed_payload), encoding="utf-8")
+
+        result = record_failure(
+            gate="codex_gate", pr_number=1, pr_id="",
+            result={
+                "reason": "a_reason_nobody_has_seen_yet",
+                "reason_detail": "novel failure mode",
+                "duration_seconds": 1.0, "partial_output_lines": 0, "runner_pid": 1,
+            },
+            request_payload={"gate": "codex_gate", "pr_number": 1},
+            requests_dir=env["requests_dir"], results_dir=env["results_dir"],
+        )
+
+        assert result["status"] == "completed"
+        assert json.loads(rf.read_text(encoding="utf-8")) == completed_payload
+
+    def test_completed_over_completed_is_allowed(self, tmp_path):
+        """Codex/gemini's own PASS_STATES member is "completed", not "pass" —
+        a rebase re-gate producing a fresh completed verdict must still be
+        able to replace an old completed verdict (the mirror requirement:
+        freezing evidence on the first run is itself a new outage)."""
+        out = tmp_path / "pr-1691-codex_gate.json"
+        first = {
+            "gate": "codex_gate", "pr_number": 1691, "status": "completed",
+            "contract_hash": "466cd2ca75d7a7fb", "report_path": "/tmp/codex-1.md",
+        }
+        out.write_text(json.dumps(first), encoding="utf-8")
+
+        second, written = write_result_guarded(
+            out,
+            {
+                "gate": "codex_gate", "pr_number": 1691, "status": "completed",
+                "contract_hash": "freshhash999", "report_path": "/tmp/codex-2.md",
+            },
+            gate="codex_gate", pr_ref="1691",
+        )
+        assert written is True
+        assert second["contract_hash"] == "freshhash999"
+        assert json.loads(out.read_text(encoding="utf-8"))["contract_hash"] == "freshhash999"
+
+    def _fail_result(self, reason="timeout"):
+        return {
+            "reason": reason, "reason_detail": f"{reason} detail",
+            "duration_seconds": 300.0, "partial_output_lines": 3, "runner_pid": 1,
+        }
+
+    def test_timeout_over_decided_pass_is_refused_and_existing_kept(self, env):
+        """The exact OI-1470 shape: a real pass sits in the slot, a second
+        run times out/errors and books ``unavailable`` via record_failure —
+        the pass must survive."""
+        rf = env["results_dir"] / "pr-1691-glm_gate.json"
+        pass_payload = _make_pass()
+        rf.write_text(json.dumps(pass_payload), encoding="utf-8")
+
+        result = record_failure(
+            gate="glm_gate", pr_number=1691, pr_id="",
+            result=self._fail_result("timeout"),
+            request_payload={"gate": "glm_gate", "pr_number": 1691, "dispatch_id": "glm-gate-pr1691-2"},
+            requests_dir=env["requests_dir"], results_dir=env["results_dir"],
+        )
+
+        assert result["status"] == "pass"
+        assert json.loads(rf.read_text(encoding="utf-8")) == pass_payload
+
+    def test_timeout_on_empty_slot_writes_normally(self, env):
+        rf = env["results_dir"] / "pr-1701-glm_gate.json"
+        result = record_failure(
+            gate="glm_gate", pr_number=1701, pr_id="",
+            result=self._fail_result("timeout"),
+            request_payload={"gate": "glm_gate", "pr_number": 1701},
+            requests_dir=env["requests_dir"], results_dir=env["results_dir"],
+        )
+        assert result["status"] == "unavailable"
+        assert json.loads(rf.read_text(encoding="utf-8"))["status"] == "unavailable"
+
+    def test_refused_write_does_not_emit_gate_failed_to_register(self, env, monkeypatch):
+        """A refused write never happened — telling the register 'gate_failed'
+        would describe a write that never landed."""
+        rf = env["results_dir"] / "pr-1691-codex_gate.json"
+        pass_payload = {
+            "gate": "codex_gate", "pr_id": "1691", "pr_number": 1691, "status": "pass",
+            "contract_hash": "realhash", "report_path": "/tmp/codex-report.md",
+            "dispatch_id": "codex-gate-pr1691-1",
+        }
+        rf.write_text(json.dumps(pass_payload), encoding="utf-8")
+
+        emitted = []
+        import gate_register_emit
+        monkeypatch.setattr(
+            gate_register_emit, "emit_codex_gate_to_register",
+            lambda *a, **kw: emitted.append((a, kw)),
+        )
+
+        record_failure(
+            gate="codex_gate", pr_number=1691, pr_id="",
+            result=self._fail_result("review_verdict_blocked"),  # not an execution-failure reason
+            request_payload={"gate": "codex_gate", "pr_number": 1691, "dispatch_id": "codex-gate-pr1691-2"},
+            requests_dir=env["requests_dir"], results_dir=env["results_dir"],
+        )
+
+        assert emitted == []
+        assert json.loads(rf.read_text(encoding="utf-8")) == pass_payload
+
+
+# ---------------------------------------------------------------------------
+# write_result_guarded: shared low-level primitive used directly by
+# gate_executor's own ci_gate terminal write (bypasses the two helpers above)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteResultGuardedDirect:
+
+    def test_returns_written_true_on_success(self, tmp_path):
+        out = tmp_path / "pr-1-ci_gate.json"
+        payload = {"gate": "ci_gate", "pr_number": 1, "status": "pass", "contract_hash": "h", "report_path": "/tmp/r.md"}
+        result, written = write_result_guarded(out, payload, gate="ci_gate", pr_ref="1")
+        assert written is True
+        assert result == payload
+        assert json.loads(out.read_text(encoding="utf-8")) == payload
+
+    def test_returns_written_false_and_existing_on_refusal(self, tmp_path):
+        out = tmp_path / "pr-1-ci_gate.json"
+        pass_payload = {"gate": "ci_gate", "pr_number": 1, "status": "pass", "contract_hash": "h", "report_path": "/tmp/r.md"}
+        out.write_text(json.dumps(pass_payload), encoding="utf-8")
+
+        running_payload = {"gate": "ci_gate", "pr_number": 1, "status": "running", "contract_hash": "", "report_path": ""}
+        result, written = write_result_guarded(out, running_payload, gate="ci_gate", pr_ref="1")
+        assert written is False
+        assert result == pass_payload
+        assert json.loads(out.read_text(encoding="utf-8")) == pass_payload

--- a/tests/test_gate_recovery_wiring.py
+++ b/tests/test_gate_recovery_wiring.py
@@ -467,19 +467,42 @@ def test_reprocess_stale_commit_sha_refuses(module, gate_name, dispatch_prefix, 
 
 
 @pytest.mark.parametrize("module,gate_name,dispatch_prefix", _GATES)
-def test_reprocess_no_identity_anchor_refuses_when_result_slot_superseded(
-    module, gate_name, dispatch_prefix, tmp_path, monkeypatch,
+def test_reprocess_refuses_to_overwrite_superseded_terminal_record(
+    module, gate_name, dispatch_prefix, tmp_path, monkeypatch, capsys,
 ):
-    """A LATER dispatch for the same PR overwrote pr-<N>-<gate>.json before
-    this EARLIER dispatch_id was ever reprocessed — there is no addressable
-    historical commit_sha for THIS exact dispatch_id left on disk."""
+    """A LATER dispatch for the same PR overwrote pr-<N>-<gate>.json with a
+    real, terminal ``pass`` before this EARLIER dispatch_id was ever
+    reprocessed — there is no addressable historical commit_sha for THIS
+    exact dispatch_id left on disk, so --reprocess still computes its OWN
+    verdict as ``reason="reprocess_no_identity_anchor"`` /
+    ``status="unavailable"``.
+
+    Before the OI-1469/OI-1470 fix (gate_recorder.write_result_guarded /
+    ``_check_overwrite_guard``), this test asserted the OPPOSITE of what
+    should happen: that this refused reprocess OVERWRITES the on-disk
+    pr-777-<gate>.json, replacing the existing terminal ``status="pass"``
+    with ``status="unavailable"``. That old assertion codified the defect
+    rather than a requirement — a later dispatch's inability to verify ITS
+    OWN identity must never erase a DIFFERENT, already-decided verdict
+    sitting in the same shared results slot. Exactly this shape of write (a
+    non-terminal/outage status erasing a real terminal one) happened for
+    real FIVE times in one day (2026-08-26), across two providers (glm,
+    codex) and four independent writers — glm_gate's own live run via an
+    OpenRouter 402, glm_gate's own ``--reprocess`` refusal,
+    gate_obligation_runner (twice, one of those AFTER this exact defect
+    class had already been named, filed, and communicated), and codex_gate
+    on a usage-limit exit. The guard now refuses that specific write: the
+    refusal (``rc == 1``) still stands, but the EXISTING terminal record on
+    disk must survive completely unchanged — not merely "not literally
+    unavailable"."""
     data_dir = tmp_path / "data"
     earlier_id = f"{dispatch_prefix}-pr777-1700000000"
     later_id = f"{dispatch_prefix}-pr777-1700000999"
     _write(data_dir, earlier_id, _REAL_PASS_REPORT)
     results_dir = data_dir / "state" / "review_gates" / "results"
     results_dir.mkdir(parents=True, exist_ok=True)
-    (results_dir / f"pr-777-{gate_name}.json").write_text(
+    out = results_dir / f"pr-777-{gate_name}.json"
+    out.write_text(
         json.dumps({
             "gate": gate_name, "pr_id": "777", "dispatch_id": later_id,
             "commit_sha": "somesha", "status": "pass",
@@ -492,10 +515,51 @@ def test_reprocess_no_identity_anchor_refuses_when_result_slot_superseded(
     rc = module.main(["--pr", "777", "--reprocess", earlier_id, "--data-dir", str(data_dir)])
 
     assert rc == 1
-    out = results_dir / f"pr-777-{gate_name}.json"
+    # The refusal itself is reported (gate_recorder's overwrite-guard log
+    # line, propagated through the gate's own stderr message) — the reason
+    # is not silently swallowed, only the disk write is blocked.
+    captured = capsys.readouterr()
+    assert "refusing to overwrite" in captured.err
+    assert "status='pass'" in captured.err
+    assert "status='unavailable'" in captured.err
     record = json.loads(out.read_text(encoding="utf-8"))
+    # The EXISTING terminal record must be untouched on every identity
+    # field, not just "status didn't become unavailable".
+    assert record["status"] == "pass"
+    assert record["dispatch_id"] == later_id
+    assert record["commit_sha"] == "somesha"
+
+
+@pytest.mark.parametrize("module,gate_name,dispatch_prefix", _GATES)
+def test_reprocess_no_identity_anchor_writes_when_slot_is_empty(
+    module, gate_name, dispatch_prefix, tmp_path, monkeypatch, capsys,
+):
+    """Companion to the guard-refusal test above: when NOTHING occupies the
+    pr-<N>-<gate>.json slot yet, there is no terminal verdict to protect, so
+    --reprocess's own ``reason="reprocess_no_identity_anchor"`` /
+    ``status="unavailable"`` verdict must land on disk normally. Without
+    this case, a passing guard-refusal test alone cannot distinguish "the
+    write is correctly guarded" from "the write is silently broken for
+    everyone" — the guard must only ever protect an EXISTING terminal
+    result, never freeze the slot shut."""
+    data_dir = tmp_path / "data"
+    dispatch_id = f"{dispatch_prefix}-pr777-1700000000"
+    _write(data_dir, dispatch_id, _REAL_PASS_REPORT)
+    # Deliberately no results file/dir at all — an EMPTY slot, not a
+    # superseded one.
+    monkeypatch.setattr(module, "get_pr_head_branch", lambda pr_number: "feature/x")
+    monkeypatch.setattr(module, "get_pr_head_sha", lambda pr_number: "somesha")
+
+    rc = module.main(["--pr", "777", "--reprocess", dispatch_id, "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / f"pr-777-{gate_name}.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 1
     assert record["status"] == "unavailable"
     assert record["reason"] == "reprocess_no_identity_anchor"
+    assert record["evidence_source"] == "reprocessed"
+    captured = capsys.readouterr()
+    assert "reprocess_no_identity_anchor" in captured.out
 
 
 @pytest.mark.parametrize("module,gate_name,dispatch_prefix", _GATES)


### PR DESCRIPTION
## Summary

- `results/pr-<N>-<gate>.json` has multiple independent writers landing in the same slot with no ordering guarantee — an outage/in-flight write can silently overwrite a decided verdict. Measured live three times across two providers on 2026-08-26: a glm_gate OpenRouter 402 erased a pass, its own `--reprocess` refusal erased it a second time, and a codex usage-limit `exit_nonzero` erased two `completed` verdicts on rebased PRs (#1691, #1692).
- Adds a shared overwrite guard in `gate_recorder.py` (`write_result_guarded` / `ResultOverwriteRefused`) wired into the three shared write functions (`record_terminal_result`, `record_not_executable`, `record_failure`) and `gate_executor`'s own `ci_gate` terminal write — every writer of the results slot routes through one of these, so the guard applies by construction, not per call site.
- `gate_obligation_runner` no longer leaves a `provider_not_installed` result record behind when its own process environment (e.g. a launchd PATH) lacks the gate's CLI binary — that's an environment fact, not PR evidence. The obligation stays pending with a named reason; the record is removed instead of booked.

## Grep — all writers of `results/pr-*.json`, and guard coverage

| Writer | Routes through | Guarded? |
|---|---|---|
| `glm_gate.py` (live run) | `gate_recorder.record_terminal_result` | Yes (raises `ResultOverwriteRefused`, already caught by the existing `except (OSError, ValueError)` in `glm_gate.py`/`kimi_gate.py`) |
| `glm_gate.py --reprocess` | same function, same code path | Yes |
| `kimi_gate.py` | `gate_recorder.record_terminal_result` | Yes |
| `gate_runner.py` (gemini_review/codex_gate/claude_github_optional: binary missing, timeout, stall, vertex error) | `gate_recorder.record_not_executable` / `record_failure` | Yes |
| `gate_executor.py` `_execute_ci_gate` (provider missing, timeout, subprocess error) | `gate_recorder.record_not_executable` / `record_failure_simple` | Yes |
| `gate_executor.py` `_execute_ci_gate`'s own terminal write (pass/fail/running) | previously a raw `rf.write_text(...)`, now `gate_recorder.write_result_guarded` | Yes (newly wired) |
| `gate_artifacts.materialize_artifacts` failure branches | `gate_recorder.record_failure_simple` | Yes (transitively) |
| `gate_obligation_runner.py` (`_record_loud_not_executable`, `runner_error`) | `gate_recorder.record_not_executable` | Yes |
| `gate_artifacts._write_result_record` (materialize_artifacts success path) | raw `result_file.write_text` | **Not wired** — always writes `status="completed"` with mandatory `contract_hash`+`report_path`; never a downgrade by construction (all its failure paths already route through the guarded `record_failure_simple` above) |
| `gate_result_parser._validate_and_persist_result` (`review_gate_manager.record_result`, CLI `vnx gate record-result`) | raw `.write_text` | **Not wired** — operator-driven manual CLI, not one of the three measured writers; arbitrary `--status` argument means a real downgrade risk exists here too, flagged for a follow-up, not fixed in this PR |
| `gate_result_parser.record_claude_github_result` | raw `.write_text` | **Not wired** — defined but has no production caller (grepped repo-wide); dormant code, not touched |

## Fix-forward (2026-08-26): CI was red because a test codified the pre-fix defect

CI on this PR failed on `tests/test_gate_recovery_wiring.py::test_reprocess_no_identity_anchor_refuses_when_result_slot_superseded` (both `glm`/`kimi` parametrizations): `AssertionError: assert 'pass' == 'unavailable'`. That test built a `pass`-terminal result record, ran a `--reprocess` that the guard above correctly refuses, and then asserted the refused reprocess had OVERWRITTEN the terminal `pass` with `status="unavailable"` — i.e. it asserted the exact OI-1469/OI-1470 defect as the required behavior. The guard is correct; the test needed to change, not the guard.

Why this is worth spelling out rather than just flipping the assertion: a terminal record has been overwritten by an outage/refusal FIVE times in one day (2026-08-26):
- `glm_gate` itself, on an OpenRouter 402
- `glm_gate --reprocess`, refusing and overwriting anyway — the pre-fix version of exactly the code path this PR guards
- `gate_obligation_runner`, twice — one of those AFTER this defect class had already been named, filed, and communicated to three sessions
- `codex_gate`, on a usage-limit exit (2 records)

That's four writers, two providers, six distinct reason codes for the same defect shape: `parse_error`, `dispatch_error`, `provider_not_installed`, `reprocess_no_identity_anchor`, `not_executable`, `exit_nonzero`. Six reason codes for one defect is the proof that a reason-code allowlist never converges — which is exactly why the guard branches on the SHAPE of the record (`gate_status.is_terminal` + `gate_status.has_complete_evidence`), never on the reason string, so the next outage's reason code is covered by construction instead of needing another patch.

Test fix: `test_reprocess_no_identity_anchor_refuses_when_result_slot_superseded` is rewritten as `test_reprocess_refuses_to_overwrite_superseded_terminal_record` — the refusal (`rc == 1`) still stands, but the pre-existing terminal record must now survive completely unchanged (`status`/`dispatch_id`/`commit_sha` asserted individually, not just "not literally unavailable"), and the refusal message is asserted present in stderr so the reason is not silently swallowed. A new companion, `test_reprocess_no_identity_anchor_writes_when_slot_is_empty`, proves the guard does not freeze an EMPTY slot shut — the `reprocess_no_identity_anchor`/`unavailable` verdict still writes normally when there is nothing to protect, so a passing guard-refusal test alone can't be confused with "the write is silently broken for everyone". Verified red: reverting `gate_recorder.py` to its pre-`f7e33aab` state makes the rewritten test fail exactly as expected (the overwrite happens), while the empty-slot companion still passes.

## Changes

- `scripts/lib/gate_recorder.py`: new `ResultOverwriteRefused` exception, `_check_overwrite_guard` (uses only `gate_status.is_terminal` + `gate_status.has_complete_evidence`, no second vocabulary), `_write_result_atomic`, `write_result_guarded`. Wired into `record_terminal_result` (raises), `record_not_executable` and `record_failure` (catch-and-keep-existing, return the true on-disk payload). `record_failure` also skips the `gate_failed` register emit when the write was refused (a refused write never happened).
- `scripts/lib/gate_executor.py`: `_execute_ci_gate`'s own terminal write now routes through `gate_recorder.write_result_guarded` instead of a raw `rf.write_text(...)`.
- `scripts/gate_obligation_runner.py`: after reading back a `not_executable`/`provider_not_installed` result the manager just wrote, remove that record (it's an environment fact about this runner, not PR evidence) before falling into the existing (unchanged) pending/escalate classification.
- `tests/test_gate_recorder_overwrite_guard.py` (new): guard tests per writer, terminal-over-terminal allowed, the exact OI-1470 glm_gate repro, and a live-fixture regression test reproducing the codex `exit_nonzero` case verbatim (PR #1691/#1692 contract hashes) plus a reason-agnostic proof (an unseen reason code is refused identically).
- `tests/test_ci_gate.py`: new test proving a "running" re-check never overwrites a decided ci_gate pass.
- `tests/test_gate_obligations.py`: new tests for the `provider_not_installed` cleanup (obligation stays pending, no result record survives) and for guard/cleanup composition (a pre-existing protected pass is left untouched end-to-end).
- `tests/test_gate_recovery_wiring.py` (fix-forward): `test_reprocess_no_identity_anchor_refuses_when_result_slot_superseded` codified the pre-fix overwrite as required behavior — rewritten as `test_reprocess_refuses_to_overwrite_superseded_terminal_record` (refusal stands, existing terminal record now asserted unchanged, refusal reported in stderr) plus a new companion `test_reprocess_no_identity_anchor_writes_when_slot_is_empty` (guard must not freeze an empty slot shut). See the "Fix-forward" section above.

## Verification

- `pytest tests/test_gate_status*.py tests/test_gate_obligations.py tests/test_closure_verifier*.py tests/test_gate_recorder_overwrite_guard.py tests/test_gate_recorder_provenance.py tests/test_gate_recorder_register.py tests/test_gate_obligation_runner.py tests/test_ci_gate.py tests/test_gate_runner.py -q` → 278 passed, 1 skipped, 1 pre-existing failure (`test_gate_status_schema.py::test_closure_verifier_reads_status_completed_as_pass`, confirmed failing identically on baseline via `git stash` bisection before any of this PR's changes).
- Also ran the full neighbor set (`test_gate_runner_vertex.py`, `test_gate_artifacts_atomicity.py`, `test_gate_artifacts_register.py`, `test_dlv1_glm_gate.py`, `test_dlv2_kimi_gate_evidence.py`, `test_glm_gate_data_dir_guard.py`, `test_kimi_gate_data_dir_guard.py`, `test_kimi_gate_provenance.py`, `test_kimi_gate_unavailable.py`, `test_gate_kimi_ff849_fixes.py`, `test_dlv5_review_gate_takeover.py`, `test_gate_execution_certification.py`, `test_review_gate_manager.py`, `test_gate_obligation_retire_backlog.py`, `test_gate_obligation_runner_scope.py`) → all green except 10 pre-existing failures in `test_gate_execution_certification.py` (a `MagicMock` vs `int` comparison in a subprocess mock, confirmed identical on baseline).
- RED→GREEN proof for the exact OI-1470 shape (`record_terminal_result`, pass → glm_gate OpenRouter-402-style unavailable): captured against baseline (stashed source changes) — `second write did NOT raise (BUG: overwrote silently)` / `AssertionError: BUG REPRODUCED: pass was overwritten by 'unavailable'`; against the fix — `second write raised: ResultOverwriteRefused ...` / `OK: pass survived`.
- Item 3 (key-schema migration) — measured, not built: 18 production files / 57 line-occurrences reference the `pr-<N>-<gate>.json` naming pattern or its path-builder functions (`grep -rn 'pr-{...}-\|f"pr-{.*}-.*\.json"\|_result_path\|_request_path\|result_file_path' scripts docs`), plus 36 test files assert on the literal filename. A `(pr, gate, dispatch_id)` schema is a real migration with that many call sites and fixtures to touch — deferred out of this PR's ~350-line budget; not attempted.
- `pytest tests/test_gate_recovery_wiring.py -v` → 36 passed (18 tests × 2 gate parametrizations), including both rewritten/new reprocess-guard cases. RED proof for the rewritten test specifically: reverted `scripts/lib/gate_recorder.py` to its pre-`f7e33aab` parent commit and reran — `test_reprocess_refuses_to_overwrite_superseded_terminal_record` fails on both `[glm]`/`[kimi]` (the overwrite happens, refusal message absent from stderr) while `test_reprocess_no_identity_anchor_writes_when_slot_is_empty` still passes; restored the guarded file afterward (`git diff` clean). `pytest tests/test_gate_recorder_overwrite_guard.py tests/test_gate_obligations.py -q` → 51 passed.

## Open Items

- `gate_result_parser._validate_and_persist_result` (the `vnx gate record-result` CLI path) and `gate_artifacts._write_result_record`'s sibling `record_claude_github_result` are not wired to the guard — see the grep table above for why (one is a manual/operator CLI with an arbitrary `--status`, flagged as a real residual risk; the other has no production caller). A follow-up dispatch should wire the CLI path if operator-driven downgrades turn out to matter in practice.
- The `(pr, gate, dispatch_id)` key-schema migration from item 3 is measured but not built — see Verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
