### PR TITLE
fix(closure-verifier): invariant 7 compares structured fields, not negated prose (OI-1473)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -1240,20 +1240,132 @@ def _extract_normalized_findings_section(content: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
-def _count_report_blocking_indicators(content: str) -> int:
-    """Count blocking-severity indicators in a normalized report.
+# Matches a gate report's own trailing verdict fence — the SAME shape
+# glm_gate._extract_verdict / kimi_gate._extract_verdict parse (OI-1473).
+# Kept as its own copy for the same reason those two don't share one: each
+# reader stays self-contained, but the RULE must never diverge.
+_VERDICT_FENCE_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+_FENCE_VALID_VERDICTS = frozenset({"pass", "fail", "blocked", "block"})
+_FENCE_BLOCKING_SEVERITIES = frozenset({"blocking", "error"})
 
-    Looks for patterns that indicate blocking findings in headless review reports.
+
+def _extract_report_verdict_fence(content: str) -> Optional[Dict[str, Any]]:
+    """Return the report's own trailing ```json``` verdict fence as a dict.
+
+    Scans fenced JSON blocks from the END of the document and returns the
+    first one (i.e. the LAST fence in the report) whose ``verdict`` field is
+    a real verdict value — mirroring glm_gate/kimi_gate's own
+    ``_extract_verdict``, so a review-gate report and the gate script that
+    produced it can never read two different "actual answers" out of the
+    same text. This also means an echoed instruction template earlier in the
+    report (whose ``verdict`` field is the literal placeholder
+    "pass|fail|blocked") is skipped exactly like it is at the gate script
+    itself, never mistaken for a real verdict here.
+
+    Returns None when no such fence exists — the caller falls back to the
+    normalized ``## Findings`` section, then the prose scan.
+    """
+    for block in reversed(_VERDICT_FENCE_RE.findall(content or "")):
+        try:
+            obj = json.loads(block)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict) and str(obj.get("verdict", "")).strip().lower() in _FENCE_VALID_VERDICTS:
+            return obj
+    return None
+
+
+def _count_fence_blocking_indicators(fence: Dict[str, Any]) -> int:
+    """Count blocking-severity indicators in an already-parsed verdict fence.
+
+    Reads two STRUCTURED fields, never prose: the fence's own ``verdict``
+    (non-pass counts once) and each ``findings[]`` entry's ``severity``
+    field (``blocking``/``error`` counts once each). A finding's free-text
+    ``message`` is never scanned — that is exactly the loose-word matching
+    this invariant must not do (OI-1473).
+    """
+    count = 0
+    verdict = str(fence.get("verdict", "")).strip().lower()
+    if verdict and verdict != "pass":
+        count += 1
+    findings = fence.get("findings")
+    if isinstance(findings, list):
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            severity = str(finding.get("severity", "")).strip().lower()
+            if severity in _FENCE_BLOCKING_SEVERITIES:
+                count += 1
+    return count
+
+
+# Negation markers that flip a blocking-shaped word into its own denial — a
+# reviewer writing "Not blocking: ..." or "niet-blocking" is asserting the
+# ABSENCE of a blocking finding, and a scan that flags the denial punishes
+# the more precise report (OI-1473, live on PR #1691). Checked against the
+# few characters immediately preceding a match, case-insensitively.
+_NEGATION_MARKERS = ("niet-", "non-", "no ", "not ", "geen ")
+_NEGATION_LOOKBACK = 15
+
+# Structural severity-field markers: each requires the literal field prefix
+# the report writers emit (gate_artifacts._format_findings_section's
+# "[BLOCKING]"/"(severity: ...)" shapes), never a bare word in prose. Safe to
+# scan within a normalized ``## Findings`` section on its own.
+_FINDINGS_SECTION_PATTERNS = (
+    r"\[BLOCKING\]",
+    r"\*\*Severity\*\*:\s*blocking",
+    r"severity:\s*blocking",
+)
+
+# Vangnet patterns for reports with neither a verdict fence nor a normalized
+# findings section — the same field markers above, plus two looser prose
+# markers that only apply as a last resort.
+_PROSE_FALLBACK_PATTERNS = _FINDINGS_SECTION_PATTERNS + (
+    r"BLOCK(?:ER|ING)\s*:",
+    r"Status:\s*FAIL",
+)
+
+
+def _count_matches_excluding_negations(patterns: Sequence[str], text: str) -> int:
+    """Count regex matches across *patterns* in *text*, skipping any match
+    immediately preceded by a negation marker (see ``_NEGATION_MARKERS``)."""
+    count = 0
+    for pattern in patterns:
+        for match in re.finditer(pattern, text, re.IGNORECASE):
+            window_start = max(0, match.start() - _NEGATION_LOOKBACK)
+            preceding = text[window_start:match.start()].lower()
+            if any(marker in preceding for marker in _NEGATION_MARKERS):
+                continue
+            count += 1
+    return count
+
+
+def _count_report_blocking_indicators(content: str) -> int:
+    """Count blocking-severity indicators in a gate report, on STRUCTURED
+    evidence wherever it exists — never a loose word in prose (OI-1473).
+
     Excludes lines written by the closure verifier itself (``- [FAIL] ...``)
     to prevent a self-reference loop where the verifier's own output is
-    counted as a blocking indicator on re-read.
+    counted as a blocking indicator on re-read. Three tiers, each used only
+    when the previous one found nothing to read a verdict from:
 
-    When the report carries a normalized ``## Findings`` section (see
-    ``_extract_normalized_findings_section``), only that section is scanned —
-    never the raw tool-output transcript that follows it, which can contain
-    read-but-not-judged source text that happens to match these patterns
-    (OI-1394). Reports without such a section fall back to a full-content
-    scan, matching prior behavior.
+    1. Primary — the report's own trailing ```json``` verdict fence (see
+       ``_extract_report_verdict_fence``): a contradiction is the fence's
+       ``verdict`` being non-pass, or any ``findings[]`` entry carrying
+       severity ``blocking``/``error``. When a fence exists, it is
+       authoritative — the count it produces is returned as-is, even 0.
+    2. Secondary — the normalized ``## Findings`` section (see
+       ``_extract_normalized_findings_section``), scanned for structural
+       severity-field markers only (``_FINDINGS_SECTION_PATTERNS``). Also
+       authoritative when present, even 0.
+    3. Vangnet — neither of the above exists: a full-content prose scan
+       (``_PROSE_FALLBACK_PATTERNS``) that skips any match preceded by a
+       negation marker, so "Not blocking: ..." / "niet-blocking" cannot
+       trip a contradiction a reviewer explicitly ruled out.
+
+    A report with no fence, no findings section, and no vangnet match is
+    genuinely silent on blocking evidence — that is an absence of evidence,
+    not evidence of contradiction, so it returns 0 (fail-open by design).
     """
     filtered_lines = [
         line for line in content.splitlines()
@@ -1261,20 +1373,15 @@ def _count_report_blocking_indicators(content: str) -> int:
     ]
     filtered = "\n".join(filtered_lines)
 
-    findings_section = _extract_normalized_findings_section(filtered)
-    scan_target = findings_section if findings_section is not None else filtered
+    fence = _extract_report_verdict_fence(filtered)
+    if fence is not None:
+        return _count_fence_blocking_indicators(fence)
 
-    count = 0
-    blocking_patterns = [
-        r"\[BLOCKING\]",
-        r"\*\*Severity\*\*:\s*blocking",
-        r"severity:\s*blocking",
-        r"BLOCK(?:ER|ING)\s*:",
-        r"Status:\s*FAIL",
-    ]
-    for pattern in blocking_patterns:
-        count += len(re.findall(pattern, scan_target, re.IGNORECASE))
-    return count
+    findings_section = _extract_normalized_findings_section(filtered)
+    if findings_section is not None:
+        return _count_matches_excluding_negations(_FINDINGS_SECTION_PATTERNS, findings_section)
+
+    return _count_matches_excluding_negations(_PROSE_FALLBACK_PATTERNS, filtered)
 
 
 def verify_closure(

--- a/tests/test_oi1473_invariant7_negation.py
+++ b/tests/test_oi1473_invariant7_negation.py
@@ -1,0 +1,232 @@
+"""Regression tests for OI-1473: invariant 7 must compare structured fields,
+not loose words in prose (dispatch 20260826-t0-invariant7-negatie).
+
+Measured live on PR #1691 (``unified_reports/glm-gate-pr1691-1787770872.md``):
+``closure_verifier._count_report_blocking_indicators`` scanned the report with
+``r"BLOCK(?:ER|ING)\\s*:"`` (case-insensitive) and matched a NEGATION:
+
+    regel 49: "**Twee bevindingen, beide niet-blocking:**"        -> matched "blocking:"
+    regel 61: "Not blocking: no current code path returns None."  -> matched "blocking:"
+
+The gate result record said ``status=pass``, ``blocking_findings=[]``, and the
+report's own two findings carried severity ``warning``/``info`` — the report
+said TWICE, explicitly, that nothing was blocking. Invariant 7
+(``closure_verifier.check_review_gate_for_merge``) read the negated match as a
+gate/report contradiction and refused the merge (PR #1691 was otherwise ready:
+VNX CI green, glm pass with a real contract_hash, report present).
+
+The fix makes ``_count_report_blocking_indicators`` compare STRUCTURED fields
+in priority order — the report's own trailing ```json``` verdict fence, then
+the normalized ``## Findings`` section's severity markers, and only then a
+prose vangnet that now excludes matches immediately preceded by a negation
+marker (``niet-``, ``non-``, ``no ``, ``not ``, ``geen ``). A report with none
+of the three sources contradicts nothing: fail-open, not fail-closed on
+absence of evidence.
+
+Covers the dispatch's required evidence:
+  1. Both measured negation phrasings, run through the REAL
+     ``check_review_gate_for_merge`` merge check, with a json verdict fence
+     present (the real glm_gate/kimi_gate report shape) -> GO, no
+     contradiction.
+  2. The SAME two phrasings with no fence and no normalized findings section
+     (isolating the vangnet tier itself) -> zero indicators.
+  3. The mandatory inverse: a genuine contradiction (fence findings carrying
+     severity ``blocking``, or a fence ``verdict: fail``) paired with a
+     record that claims ``status=pass`` -> invariant 7 MUST still refuse.
+  4. A report with no fence, no findings section, and no vangnet match at all
+     -> zero indicators (fail-open on absence of evidence, not fail-closed).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv
+
+
+def _write_result(results_dir: Path, pr_id: str, gate: str, data: dict) -> Path:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    slug = pr_id.lower().replace("-", "")
+    path = results_dir / f"{slug}-{gate}-contract.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _passing_record(report_file: Path, **overrides) -> dict:
+    data = {
+        "gate": "glm_gate",
+        "pr_id": "PR-1691",
+        "status": "pass",
+        "blocking_count": 0,
+        "blocking_findings": [],
+        "contract_hash": "abcdef1234567890",
+        "report_path": str(report_file),
+        "branch": "feature/oi-1473",
+    }
+    data.update(overrides)
+    return data
+
+
+# The two measured negation strings from PR #1691's report, verbatim.
+_MEASURED_NIET_BLOCKING_LINE = "**Twee bevindingen, beide niet-blocking:**"
+_MEASURED_NOT_BLOCKING_LINE = "Not blocking: no current code path returns None here."
+
+
+def _real_report_shape(negation_line: str) -> str:
+    """A faithful shrink of the real PR #1691 report shape: prose carrying
+    the measured negation line, followed by the worker's own trailing
+    ```json``` verdict fence (the same shape glm_gate/kimi_gate's
+    ``_VERDICT_CONTRACT`` requires) with a clean pass verdict and
+    warning/info-severity findings — never ``blocking``/``error``."""
+    return (
+        "# glm_gate — Headless Gate Report\n\n"
+        "Ik heb de diff beoordeeld op correctheid en governance-impact.\n\n"
+        f"{negation_line}\n\n"
+        "1. Kleine naming-inconsistentie in de nieuwe helper.\n"
+        "2. Ontbrekende docstring op de publieke functie.\n\n"
+        "```json\n"
+        + json.dumps({
+            "verdict": "pass",
+            "findings": [
+                {"severity": "warning", "message": "naming inconsistency"},
+                {"severity": "info", "message": "missing docstring"},
+            ],
+            "residual_risk": None,
+        })
+        + "\n```\n"
+    )
+
+
+class TestInvariant7DoesNotBlockOnNegatedProse:
+    """Evidence 1 (required): the real PR #1691 shape, through the REAL merge
+    check, must clear invariant 7 — the fence is primary evidence and the
+    report explicitly says nothing is blocking."""
+
+    def test_niet_blocking_header_clears_merge_check(self, tmp_path):
+        report = tmp_path / "glm-gate-pr1691.md"
+        report.write_text(_real_report_shape(_MEASURED_NIET_BLOCKING_LINE), encoding="utf-8")
+        results_dir = tmp_path / "results"
+        _write_result(results_dir, "PR-1691", "glm_gate", _passing_record(report))
+
+        gate = cv.check_review_gate_for_merge(
+            "PR-1691", "glm_gate", results_dir, branch="feature/oi-1473",
+        )
+
+        assert gate["verdict"] == "GO", gate["message"]
+
+    def test_not_blocking_line_clears_merge_check(self, tmp_path):
+        report = tmp_path / "glm-gate-pr1691.md"
+        report.write_text(_real_report_shape(_MEASURED_NOT_BLOCKING_LINE), encoding="utf-8")
+        results_dir = tmp_path / "results"
+        _write_result(results_dir, "PR-1691", "glm_gate", _passing_record(report))
+
+        gate = cv.check_review_gate_for_merge(
+            "PR-1691", "glm_gate", results_dir, branch="feature/oi-1473",
+        )
+
+        assert gate["verdict"] == "GO", gate["message"]
+
+
+class TestProseVangnetExcludesNegations:
+    """Evidence 2: isolate the vangnet tier itself (no fence, no normalized
+    ``## Findings`` section) against the two measured negation lines — proves
+    the fix is in the fallback scan, not merely masked by fence priority."""
+
+    def test_niet_blocking_prefix_not_counted(self):
+        report = (
+            "# Gemini Review\n\n"
+            f"{_MEASURED_NIET_BLOCKING_LINE}\n\n"
+            "1. Style nit only.\n"
+        )
+        assert cv._count_report_blocking_indicators(report) == 0
+
+    def test_not_blocking_prefix_not_counted(self):
+        report = f"# Gemini Review\n\n{_MEASURED_NOT_BLOCKING_LINE}\n"
+        assert cv._count_report_blocking_indicators(report) == 0
+
+    def test_genuine_unnegated_blocker_still_counted(self):
+        """Negative control: the negation exclusion must not blind the
+        vangnet to a real, unnegated blocking marker."""
+        report = "# Gemini Review\n\nBLOCKER: missing auth check on the new endpoint.\n"
+        assert cv._count_report_blocking_indicators(report) >= 1
+
+
+class TestInvariant7StillCatchesRealContradictions:
+    """Evidence 3 (mandatory inverse): a control that can't fail is not a
+    control. A record claiming ``status=pass`` paired with a report whose OWN
+    verdict fence disagrees must still refuse the merge."""
+
+    def test_fence_blocking_severity_finding_still_blocks(self, tmp_path):
+        report = tmp_path / "glm-gate-pr1691.md"
+        report.write_text(
+            "# glm_gate — Headless Gate Report\n\n"
+            "Ik heb de diff beoordeeld.\n\n"
+            "```json\n"
+            + json.dumps({
+                "verdict": "pass",
+                "findings": [
+                    {"severity": "blocking", "message": "SQL injection in query_builder.py"},
+                ],
+                "residual_risk": "unsanitized input",
+            })
+            + "\n```\n",
+            encoding="utf-8",
+        )
+        results_dir = tmp_path / "results"
+        _write_result(results_dir, "PR-1691", "glm_gate", _passing_record(report))
+
+        gate = cv.check_review_gate_for_merge(
+            "PR-1691", "glm_gate", results_dir, branch="feature/oi-1473",
+        )
+
+        assert gate["verdict"] == "NO-GO"
+        assert "bewijs spreekt zichzelf tegen" in gate["message"]
+
+    def test_fence_verdict_fail_still_blocks(self, tmp_path):
+        report = tmp_path / "glm-gate-pr1691.md"
+        report.write_text(
+            "# glm_gate — Headless Gate Report\n\n"
+            "Ik heb de diff beoordeeld.\n\n"
+            "```json\n"
+            + json.dumps({
+                "verdict": "fail",
+                "findings": [{"severity": "warning", "message": "style nit only"}],
+                "residual_risk": None,
+            })
+            + "\n```\n",
+            encoding="utf-8",
+        )
+        results_dir = tmp_path / "results"
+        _write_result(results_dir, "PR-1691", "glm_gate", _passing_record(report))
+
+        gate = cv.check_review_gate_for_merge(
+            "PR-1691", "glm_gate", results_dir, branch="feature/oi-1473",
+        )
+
+        assert gate["verdict"] == "NO-GO"
+        assert "bewijs spreekt zichzelf tegen" in gate["message"]
+
+
+class TestFailOpenOnAbsenceOfEvidence:
+    """No fence, no normalized findings section, no vangnet match at all: an
+    absence of evidence is not evidence of a contradiction."""
+
+    def test_no_source_at_all_is_zero_never_blocks(self, tmp_path):
+        report = tmp_path / "report.md"
+        report.write_text("# Review\n\nEverything looks fine, approved.\n", encoding="utf-8")
+        results_dir = tmp_path / "results"
+        _write_result(results_dir, "PR-1691", "glm_gate", _passing_record(report))
+
+        gate = cv.check_review_gate_for_merge(
+            "PR-1691", "glm_gate", results_dir, branch="feature/oi-1473",
+        )
+
+        assert gate["verdict"] == "GO", gate["message"]
+        assert cv._count_report_blocking_indicators(report.read_text(encoding="utf-8")) == 0


### PR DESCRIPTION
## Summary
- `closure_verifier._count_report_blocking_indicators` regex-scanned report prose with `BLOCK(?:ER|ING)\s*:`, which matches a NEGATION. Measured live on PR #1691: a report that said twice, explicitly, "niet-blocking"/"Not blocking: ..." tripped invariant 7 (`check_review_gate_for_merge`) and refused a merge whose gate JSON was clean (status=pass, blocking_findings=[]).
- The scan now reads STRUCTURED evidence in priority order: (1) the report's own trailing ```json``` verdict fence — `verdict` + `findings[].severity`, mirroring `glm_gate`/`kimi_gate`'s own `_extract_verdict` — (2) the normalized `## Findings` section's severity-field markers, and only then (3) a prose vangnet that now excludes matches immediately preceded by a negation marker (`niet-`, `non-`, `no `, `not `, `geen `).
- No source found (no fence, no findings section, no vangnet match) → 0 (fail-open on absence of evidence, unchanged principle from before). A genuine contradiction (a `blocking`/`error`-severity finding, or `verdict: fail/block/blocked` in the fence) still refuses the merge — verified with a mandatory inverse test.

## Changes
- `scripts/closure_verifier.py`: added `_extract_report_verdict_fence`, `_count_fence_blocking_indicators`, `_count_matches_excluding_negations`, split pattern lists into `_FINDINGS_SECTION_PATTERNS` (structural) vs `_PROSE_FALLBACK_PATTERNS` (vangnet), and rewrote `_count_report_blocking_indicators` as the tiered fence → findings-section → vangnet scan described above. This function is shared by both `check_review_gate_for_merge` (invariant 7) and `_detect_gate_report_contradictions`, so the fix applies to both call sites.
- `tests/test_oi1473_invariant7_negation.py` (new): regression tests using the exact measured PR #1691 strings, the mandatory inverse (still-blocks) tests, a fail-open test, and a vangnet-tier-only negation test.

## Verification
- New tests, run against this fix: `python3 -m pytest tests/test_oi1473_invariant7_negation.py -q` → 8 passed.
- Same new tests run against unmodified `origin/main`'s `closure_verifier.py` (`git show HEAD:scripts/closure_verifier.py`): 6 of 8 red (the two false-positive-avoidance and the two mandatory-inverse fence tests fail as expected; the two fail-open/no-op assertions already passed trivially).
- Full closure_verifier-adjacent regression sweep (fix applied): `python3 -m pytest tests/test_ci_gate.py tests/test_cli_flag_forwarding.py tests/test_closure_verifier_evidence_contract.py tests/test_closure_verifier_gate_enum_drift.py tests/test_closure_verifier_unknown_gate.py tests/test_closure_verifier.py tests/test_config_registry.py tests/test_dlv1_glm_gate.py tests/test_dlv2_kimi_gate_evidence.py tests/test_dlv45_gate_recognition.py tests/test_gate_evidence_accuracy.py tests/test_gate_evidence_certification.py tests/test_gate_evidence_enforcement.py tests/test_gate_status_schema.py tests/test_oi1394_gate_indicator_scope.py tests/test_oi1473_invariant7_negation.py tests/test_per_pr_closure.py tests/test_pr_merge_review_gate.py tests/test_queue_reconciliation_certification.py tests/test_governance_blockers_fix.py -q` → 21 failed, 374 passed, 1 skipped.
- All 21 failures were independently confirmed to be pre-existing and identical (same test names) against unmodified `origin/main` with the SAME test files — none are caused by this change. They live in unrelated areas (`governance_emit`/`coordination_db` source-inspection assertions, and several `gate_evidence`/`queue_reconciliation` contradiction-detail-key assertions that are stale against current check-name wiring, unrelated to `_count_report_blocking_indicators`).
- `python3 -m pytest tests/test_closure_verifier.py -q` → all pass (part of the sweep above).

## Open Items
None.

Dispatch-ID: 20260826-t0-invariant7-negatie
**Model**: sonnet
**Provider**: claude