### PR TITLE
fix(review-gate): report-path fallback finds the report on the failure path (OI-1477)

### DIFF
--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -58,15 +58,19 @@ and every one of those verdicts was permanently unable to close a PR.
 never a second hasher). ``report_path`` points at the governed dispatch's own
 unified report, already on disk by the time the dispatcher call returns.
 
-An ``unavailable`` result carries NEITHER field, and this is more subtle than
-it looks (OI-1435): ``has_complete_evidence`` only checks whether the two
-fields are non-empty — it does not check whether a verdict exists at all. An
-``unavailable`` result (``is_terminal=False``) that carried non-empty
-``contract_hash``/``report_path`` would pass ``has_complete_evidence`` while
-carrying no judgement whatsoever; the separation between "evidence exists"
-and "a verdict exists" holds today only because callers check ``is_terminal``
-first. Leaving both fields empty on every non-terminal status keeps that
-separation intact regardless of check order in any future caller.
+An ``unavailable`` result carries an empty ``contract_hash`` always, and (as
+of OI-1477) a POPULATED ``report_path`` — pointing at this gate's own report,
+which is what actually carries the provider's failure text (a 402/403 body,
+an outage message) when there is no lane log to lift it from instead. This
+does not weaken the OI-1435 guarantee: ``gate_status.has_complete_evidence``
+checks ``gate_status.is_terminal()`` BEFORE it ever looks at
+``contract_hash``/``report_path``, and ``is_terminal`` only admits
+pass/fail/not_executable — never ``unavailable``. A populated ``report_path``
+on an unavailable record therefore still cannot pass ``has_complete_evidence``
+(nor ``closure_verifier``'s merge check, which checks ``gate_is_terminal``
+first for the identical reason); only ``contract_hash`` being empty was ever
+load-bearing for that separation, and it stays empty on every non-terminal
+status.
 
 Model: GLM-5.2 only (``deprecated-glm-models``, provider_constraints.yaml,
 operator directive 2026-08-03). GLM-4.5, GLM-4.6, base GLM-5, and GLM-5.1 are
@@ -455,11 +459,12 @@ def main(argv: "list[str] | None" = None) -> int:
     test_run = bool(args.diff_file)
     branch = "" if test_run else get_pr_head_branch(pr_number)
     commit_sha = "" if test_run else get_pr_head_sha(pr_number)
-    # Informative only (OI-1435 follow-up): points a human at the governed
-    # dispatch's own unified report even on a non-terminal ``unavailable``
-    # result, where ``report_path`` is deliberately left empty so
-    # has_complete_evidence/is_terminal are never fooled into treating an
-    # outage as a decided verdict. This field is never read by either check.
+    # Points at the governed dispatch's own unified report regardless of
+    # outcome. OI-1477: this SAME string is also what ``report_path`` gets
+    # set to on a non-terminal ``unavailable`` result (see the OI-1178/
+    # OI-1435/OI-1477 block below) — never read by has_complete_evidence/
+    # is_terminal either way, since those gate on status, not on which
+    # fields happen to be populated.
     report_path_informational = str(base_data_dir / "unified_reports" / f"{dispatch_id}.md")
 
     requests_dir = base_data_dir / "state" / "review_gates" / "requests"
@@ -713,11 +718,27 @@ def main(argv: "list[str] | None" = None) -> int:
     # OI-1178 / OI-1435: a terminal verdict must carry the same evidence pair
     # codex_gate/kimi_gate stamp — contract_hash (gate_artifacts' single
     # canonical hasher) + report_path. An unavailable result (no readable
-    # verdict, or the dispatch itself failed) is deliberately left with
-    # neither field: has_complete_evidence only checks non-emptiness, not
-    # whether a verdict exists, so a filled-in unavailable record would pass
-    # the evidence check while carrying no judgement (OI-1435) — leaving both
-    # empty here is what keeps OI-1142's outage/verdict separation intact.
+    # verdict, or the dispatch itself failed) leaves contract_hash empty —
+    # THAT is what keeps OI-1142's outage/verdict separation intact, because
+    # gate_status.has_complete_evidence checks gate_status.is_terminal()
+    # BEFORE it ever looks at contract_hash/report_path, and "unavailable" is
+    # never terminal (gate_status.is_terminal only admits pass/fail/
+    # not_executable). A filled-in report_path on an unavailable record
+    # therefore still cannot pass has_complete_evidence or the merge-time
+    # evidence check (closure_verifier.check_merge_readiness) — both refuse
+    # on is_terminal()/gate_is_terminal() first, contract_hash empty or not.
+    #
+    # OI-1477: report_path used to be left empty here too (both fields
+    # blanked "for symmetry" with contract_hash), which broke the ONE case
+    # this evidence trail exists for: a real provider outage, where the
+    # report text under report_path_informational is the only place the
+    # failure reason (e.g. an OpenRouter 402) can be read from. The report
+    # file at report_path_informational is already on disk by this point
+    # (governance_emit.emit_unified_report ran inside the dispatcher call
+    # above, live or --reprocess) — populating report_path here lets
+    # gate_request_handler._read_lane_log_or_report_text find it directly
+    # off the result record instead of needing to re-derive the same path
+    # from dispatch_id as a second fallback.
     if status in {"pass", "fail"}:
         report_path = str(recovered_path) if recovered_path is not None else str(report_path_obj)
         if prompt is not None:
@@ -734,7 +755,7 @@ def main(argv: "list[str] | None" = None) -> int:
             )
     else:
         contract_hash = ""
-        report_path = ""
+        report_path = report_path_informational
 
     record = {
         "gate": "glm_gate",
@@ -750,11 +771,14 @@ def main(argv: "list[str] | None" = None) -> int:
         "summary": _status_summary(status, blocking, reason),
         "contract_hash": contract_hash,
         "report_path": report_path,
-        # Informative only — NEVER read by has_complete_evidence/is_terminal.
-        # Always the governed dispatch's own unified report path, even when
-        # ``report_path`` above is deliberately left empty on a non-terminal
-        # ``unavailable`` status, so a human can still find the real review
-        # text (OI-1435 follow-up).
+        # Kept alongside ``report_path`` for backward compatibility with any
+        # reader keyed on this field name specifically — NEVER read by
+        # has_complete_evidence/is_terminal. As of OI-1477 this is the same
+        # value as ``report_path`` on an unavailable result (see above); the
+        # two only diverge on a terminal "recovered_verdict" result, where
+        # ``report_path`` points at the companion report the verdict was
+        # actually recovered from instead of this gate's own (fence-less)
+        # report.
         "report_path_informational": report_path_informational,
         "provider": "glm-harness",
         "model": args.model,

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -83,8 +83,14 @@ own execution path calls), never a second hashing method. ``report_path``
 points at the governed dispatch's own unified report
 (``<data_dir>/unified_reports/<dispatch_id>.md``), already written to disk
 by the time the dispatcher call returns. An ``unavailable`` result (OI-1142)
-carries neither: it is not terminal and must never look like complete
-evidence.
+always carries an empty ``contract_hash`` — it is not terminal and must
+never look like complete evidence, and ``gate_status.has_complete_evidence``
+checks ``gate_status.is_terminal()`` before it ever looks at either field, so
+that stays true regardless. As of OI-1477 ``report_path`` IS populated on an
+unavailable result (pointing at this gate's own report, the one place a
+provider failure's real text — a 403 body, a quota message — can be read
+from when no lane log exists) — that does not weaken the guarantee above,
+since ``is_terminal`` never admits ``unavailable`` in the first place.
 """
 from __future__ import annotations
 
@@ -433,11 +439,12 @@ def main(argv: "list[str] | None" = None) -> int:
     test_run = bool(args.diff_file)
     branch = "" if test_run else get_pr_head_branch(pr_number)
     commit_sha = "" if test_run else get_pr_head_sha(pr_number)
-    # Informative only (OI-1178 follow-up): points a human at the governed
-    # dispatch's own unified report even on a non-terminal ``unavailable``
-    # result, where ``report_path`` is deliberately left empty so
-    # has_complete_evidence/is_terminal are never fooled into treating an
-    # outage as a decided verdict. This field is never read by either check.
+    # Points at the governed dispatch's own unified report regardless of
+    # outcome. OI-1477: this SAME string is also what ``report_path`` gets
+    # set to on a non-terminal ``unavailable`` result (see the OI-1178/
+    # OI-1477 block below) — never read by has_complete_evidence/is_terminal
+    # either way, since those gate on status, not on which fields happen to
+    # be populated.
     report_path_informational = str(base_data_dir / "unified_reports" / f"{dispatch_id}.md")
 
     requests_dir = base_data_dir / "state" / "review_gates" / "requests"
@@ -679,9 +686,27 @@ def main(argv: "list[str] | None" = None) -> int:
     # OI-1178 (DLv2): a terminal verdict must carry the same evidence pair
     # codex_gate/gemini_review stamp — contract_hash (gate_artifacts' single
     # canonical hasher) + report_path. An unavailable result (no readable
-    # verdict, or the dispatch itself failed) is deliberately left with
-    # neither field: OI-1142's outage/verdict separation must not be bypassed
-    # by a record that merely LOOKS complete.
+    # verdict, or the dispatch itself failed) leaves contract_hash empty —
+    # THAT is what keeps OI-1142's outage/verdict separation intact, because
+    # gate_status.has_complete_evidence checks gate_status.is_terminal()
+    # BEFORE it ever looks at contract_hash/report_path, and "unavailable" is
+    # never terminal (gate_status.is_terminal only admits pass/fail/
+    # not_executable). A filled-in report_path on an unavailable record
+    # therefore still cannot pass has_complete_evidence or the merge-time
+    # evidence check (closure_verifier.check_merge_readiness) — both refuse
+    # on is_terminal()/gate_is_terminal() first, contract_hash empty or not.
+    #
+    # OI-1477: report_path used to be left empty here too (both fields
+    # blanked "for symmetry" with contract_hash), which broke the ONE case
+    # this evidence trail exists for: a real provider outage, where the
+    # report text under report_path_informational is the only place the
+    # failure reason (e.g. a kimi 403) can be read from. The report file at
+    # report_path_informational is already on disk by this point
+    # (governance_emit.emit_unified_report ran inside the dispatcher call
+    # above, live or --reprocess) — populating report_path here lets
+    # gate_request_handler._read_lane_log_or_report_text find it directly
+    # off the result record instead of needing to re-derive the same path
+    # from dispatch_id as a second fallback.
     if status in {"pass", "fail"}:
         report_path = str(recovered_path) if recovered_path is not None else str(report_path_obj)
         if prompt is not None:
@@ -697,7 +722,7 @@ def main(argv: "list[str] | None" = None) -> int:
             )
     else:
         contract_hash = ""
-        report_path = ""
+        report_path = report_path_informational
 
     record = {
         "gate": "kimi_gate",
@@ -713,11 +738,14 @@ def main(argv: "list[str] | None" = None) -> int:
         "summary": _status_summary(status, blocking, reason),
         "contract_hash": contract_hash,
         "report_path": report_path,
-        # Informative only — NEVER read by has_complete_evidence/is_terminal.
-        # Always the governed dispatch's own unified report path, even when
-        # ``report_path`` above is deliberately left empty on a non-terminal
-        # ``unavailable`` status, so a human can still find the real review
-        # text.
+        # Kept alongside ``report_path`` for backward compatibility with any
+        # reader keyed on this field name specifically — NEVER read by
+        # has_complete_evidence/is_terminal. As of OI-1477 this is the same
+        # value as ``report_path`` on an unavailable result (see above); the
+        # two only diverge on a terminal "recovered_verdict" result, where
+        # ``report_path`` points at the companion report the verdict was
+        # actually recovered from instead of this gate's own (fence-less)
+        # report.
         "report_path_informational": report_path_informational,
         "provider": "kimi",
         "model": args.model,

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -448,32 +448,62 @@ class GateRequestHandlerMixin:
         26-08): the per-dispatch lane log first (the SAME source the #1683
         lift already reads via ``governance_emit._read_lane_log_text``), then
         the gate's own REPORT file at ``result['report_path']`` when no lane
-        log exists for this dispatch_id at all.
+        log exists for this dispatch_id at all, then (OI-1477) the SAME
+        report path DERIVED from ``result['dispatch_id']`` when
+        ``report_path`` itself is empty.
 
-        Root cause this covers: the #1683 lift only ever reads the lane log.
-        When a provider error lands in the gate's own report instead (no
-        lane log for that dispatch), the marker never reaches
-        residual_risk/reason_detail/summary -- even though the SAME
-        classifier on the report's raw text finds it correctly. Measured:
-        glm-gate-pr1691-1787754901 had NO lane log at all, but its 9345-byte
-        report carried the real 402 ``openrouter_credits`` body.
+        Root cause the report-path source covers (#1683/BETA3-E1): the
+        lane-log lift only ever reads the lane log. When a provider error
+        lands in the gate's own report instead (no lane log for that
+        dispatch), the marker never reaches residual_risk/reason_detail/
+        summary -- even though the SAME classifier on the report's raw text
+        finds it correctly. Measured: glm-gate-pr1691-1787754901 had NO lane
+        log at all, but its 9345-byte report carried the real 402
+        ``openrouter_credits`` body.
 
-        Returns "" on any missing dispatch_id/report_path, missing/empty
-        file, or an unresolvable data dir -- a failed lookup must never
-        raise out of a classification decision, and never fabricates text
-        from nothing. An UNREADABLE report (exists, but ``OSError`` on read)
-        is logged with its path (BETA3-E1b fix-forward) rather than
+        Root cause the derived-path source covers (OI-1477): a result
+        record whose ``report_path`` field is itself empty -- measured on
+        pr-1696-glm_gate.json (``reason=dispatch_error``, ``report_path=''``)
+        -- read as ``no_response`` even though the report existed on disk
+        (``unified_reports/glm-gate-pr1696-1787774904.md``, 9354 bytes,
+        carrying a real OpenRouter 402) and this SAME classifier reads
+        ``lane_exhausted`` off its text without trouble. The precondition
+        for a fallback to matter is exactly the failure path where evidence
+        is scarcest, so ``report_path`` being unpopulated on that path
+        (glm_gate.py/kimi_gate.py did not fill it before OI-1477; other
+        gates or older records may still not) must not end the search --
+        ``dispatch_id`` is still real on those records, and the report lives
+        at the SAME predictable location every gate writes to -- built via
+        ``report_path.canonical_report_path``, the fleet's own SSOT for this
+        exact "where does this dispatch_id's report live" question, never a
+        second hand-rolled format string. This is the one GUARD (as opposed
+        to path construction) OI-1477 spec calls for reusing verbatim rather
+        than reinventing: derive, then run the exact same
+        ``_resolve_report_path`` escape check the populated-``report_path``
+        source already uses two lines below, never a second path-safety
+        mechanism -- ``canonical_report_path`` returns an UNRESOLVED path, so
+        a ``dispatch_id`` crafted with ``../`` segments is caught there, not
+        trusted just because it came from the SSOT.
+
+        Returns "" on any missing dispatch_id/report_path (both sources),
+        missing/empty file, or an unresolvable data dir -- a failed lookup
+        must never raise out of a classification decision, and never
+        fabricates text from nothing. An UNREADABLE report (exists, but
+        ``OSError`` on read) is logged with its path and which source
+        produced it (BETA3-E1b fix-forward, extended OI-1477) rather than
         swallowed indistinguishably from "no report exists" -- the classifier
         two frames up falls back to ``no_response`` either way, but an
         operator reading logs must be able to tell "nothing to read" apart
         from "a read failed", or a broken report-fallback source looks
         identical to a real absence of exhaustion evidence.
 
-        ``report_path`` is on-disk STATE (a result record), not trusted
-        input, so it is resolved via ``_resolve_report_path`` and refused if
-        it would read outside the reports dir -- the SAME defense-in-depth
-        shape ``governance_emit._resolve_lane_log_path`` already applies to
-        the lane-log source two lines above.
+        Both ``report_path`` and the derived path are on-disk STATE (a
+        result record, or a string built from one of its fields), not
+        trusted input, so both are resolved via the SAME
+        ``_resolve_report_path`` and refused if they would read outside the
+        reports dir -- the SAME defense-in-depth shape
+        ``governance_emit._resolve_lane_log_path`` already applies to the
+        lane-log source two lines above.
         """
         try:
             data_dir = Path(self.paths["VNX_DATA_DIR"])
@@ -487,24 +517,40 @@ class GateRequestHandlerMixin:
             if lane_text:
                 return lane_text
 
+        if data_dir is None:
+            return ""
+
         report_path = result.get("report_path") or ""
-        if report_path and data_dir is not None:
-            report_file = _resolve_report_path(report_path, data_dir)
-            if report_file is None:
+        source = "report_path"
+        if not report_path and dispatch_id:
+            # report_path.py is the fleet's SSOT for "where does this
+            # dispatch_id's report live" -- never hand-roll the format string
+            # a second time (its own module docstring calls this out by
+            # name). Still passed through _resolve_report_path below, the
+            # SAME escape guard the populated-report_path source already
+            # uses: canonical_report_path builds an UNRESOLVED path, so a
+            # dispatch_id crafted with ``../`` segments must still be caught
+            # here, not trusted just because it came from the SSOT.
+            from report_path import canonical_report_path
+            report_path = str(canonical_report_path(dispatch_id, data_dir))
+            source = "derived from dispatch_id"
+        if not report_path:
+            return ""
+
+        report_file = _resolve_report_path(report_path, data_dir)
+        if report_file is None:
+            return ""
+        try:
+            if not report_file.is_file():
                 return ""
-            try:
-                if not report_file.is_file():
-                    return ""
-                text = report_file.read_text(encoding="utf-8", errors="replace")
-            except OSError as exc:
-                logger.warning(
-                    "gate_request_handler: report read failed dispatch=%s path=%s: %s",
-                    dispatch_id or "<unknown>", report_file, exc,
-                )
-                return ""
-            if text.strip():
-                return text
-        return ""
+            text = report_file.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning(
+                "gate_request_handler: report read failed dispatch=%s path=%s (source=%s): %s",
+                dispatch_id or "<unknown>", report_file, source, exc,
+            )
+            return ""
+        return text if text.strip() else ""
 
     def _stamp_takeover_annotations(
         self,

--- a/tests/test_beta3_e1_review_gate_chain.py
+++ b/tests/test_beta3_e1_review_gate_chain.py
@@ -912,6 +912,251 @@ def test_report_fallback_absent_empty_unreadable_are_distinguishable(manager_env
 
 
 # ---------------------------------------------------------------------------
+# OI-1477 (dispatch 20260826-beta3-g-oi1477-rapportpad-terugval): "de
+# rapport-terugval kan het rapport niet vinden". Measured on main (26-08,
+# AFTER #1695/299a96d4 merged the takeover chain) on a failure that arose
+# AFTER that merge -- not a historical record:
+#
+#   state/review_gates/results/pr-1696-glm_gate.json, sha cfcd8d31...
+#     status=unavailable reason=dispatch_error contract_hash='' report_path=''
+#     dispatch_id='glm-gate-pr1696-1787774904'
+#
+# The report exists (unified_reports/glm-gate-pr1696-1787774904.md, 9354
+# bytes, GEMETEN, carries a real OpenRouter 402: "requires more credits" /
+# "openrouter_credits") and the SAME classifier reads lane_exhausted off its
+# text without trouble -- but with report_path='' and no lane log,
+# _read_lane_log_or_report_text (pre-fix) had nothing to resolve, so this
+# real outage classified no_response and the takeover chain never fired.
+#
+# Two fixes, not mutually exclusive:
+#   Spoor 1 (glm_gate.py/kimi_gate.py): report_path is now populated on the
+#     failure path too (contract_hash stays empty -- has_complete_evidence
+#     still refuses via is_terminal(), see test_gate_unavailable_rollup.py's
+#     new OI-1477 case).
+#   Spoor 2 (this file's real target, gate_request_handler.py): the
+#     report-fallback now ALSO derives the report path from dispatch_id when
+#     report_path itself is empty -- robust against records already on disk
+#     before Spoor 1 shipped, using the SAME _resolve_report_path escape
+#     guard the report_path source already uses, never a second guard.
+# ---------------------------------------------------------------------------
+
+# Verbatim (status/reason/contract_hash/report_path/dispatch_id/commit_sha)
+# from state/review_gates/results/pr-1696-glm_gate.json as measured 26-08,
+# sha256 103e0c76...834386. report_path IS empty here -- this is the actual
+# record the bug was measured on, predating the Spoor 1 fix that would now
+# populate it at write time.
+_PR1696_REAL_GLM_RESULT = {
+    "gate": "glm_gate",
+    "pr_id": "1696",
+    "pr_number": 1696,
+    "test_run": False,
+    "status": "unavailable",
+    "reason": "dispatch_error",
+    "duration_seconds": 611.487,
+    "summary": "glm gate: UNAVAILABLE (provider outage/no verdict — NOT a review fail)",
+    "contract_hash": "",
+    "report_path": "",
+    "report_path_informational": (
+        "/Users/vincentvandeth/.vnx-data/vnx-dev/unified_reports/glm-gate-pr1696-1787774904.md"
+    ),
+    "provider": "glm-harness",
+    "model": "glm-5.2",
+    "dispatch_id": "glm-gate-pr1696-1787774904",
+    "blocking_findings": [],
+    "advisory_findings": [],
+    "required_reruns": [],
+    "residual_risk": (
+        "glm's own report frontmatter stamps this run as failed "
+        "(exit_code=1, token_usage.output=5846) — provider-side outage, not "
+        "a review outcome"
+    ),
+    "failure_reason": "",
+    "recorded_at": "2026-08-26T20:18:37Z",
+    "evidence_source": "live",
+    "branch": "dispatch/20260826-beta3-f-uitval-overschrijft-verdict-niet",
+    "commit_sha": "cfcd8d3181e18452949bc2130149ffc40018eb62",
+}
+
+# Trimmed but real excerpt of unified_reports/glm-gate-pr1696-1787774904.md
+# (9354 bytes on disk -- this keeps the real frontmatter + the real opening/
+# closing of the ## Response body, dropping only the ~30 repeated
+# previous_errors entries the raw OpenRouter body carries; the marker text
+# itself is verbatim).
+_PR1696_REAL_GLM_REPORT_EXCERPT = (
+    "---\n"
+    "schema_version: 1\n"
+    "dispatch_id: glm-gate-pr1696-1787774904\n"
+    "provider: glm-harness\n"
+    "sub_provider: zai\n"
+    "model: glm-5.2\n"
+    "exit_code: 1\n"
+    "token_usage:\n"
+    "  input: 32586\n"
+    "  output: 5846\n"
+    "---\n\n"
+    "# Dispatch glm-gate-pr1696-1787774904\n\n"
+    "**Dispatch-ID**: glm-gate-pr1696-1787774904\n"
+    "**Model**: glm-5.2\n"
+    "**Provider**: glm-harness\n\n"
+    "## Response\n\n"
+    "API Error: 500 Error calling litellm.acompletion for non-Anthropic model: "
+    "litellm.APIError: APIError: OpenrouterException - "
+    '{"error":{"message":"This request requires more credits, or fewer '
+    "max_tokens. You requested up to 32000 tokens, but can only afford "
+    "10699. To increase, visit https://openrouter.ai/settings/credits and "
+    'add more credits","code":402,"metadata":{"limit_source":'
+    '"openrouter_credits","remedy_hint":"Add credits at '
+    "https://openrouter.ai/settings/credits, or lower max_tokens / prompt "
+    'size to fit your remaining balance."}}}. This is a server-side issue, '
+    "usually temporary — try again in a moment. If it persists, check your "
+    "inference gateway (localhost:4141).\n"
+)
+
+
+def test_pr1696_real_glm_record_classifies_no_response_when_no_report_on_disk(manager_env, monkeypatch):
+    """BEFORE any report exists at the derived path: the record as measured
+    (report_path='', no lane log, dispatch_id populated) with nothing on
+    disk for that dispatch_id must stay no_response -- the derivation must
+    never fabricate a marker, only find real evidence that is actually
+    there."""
+    monkeypatch.chdir(manager_env["project_root"])
+    manager = _make_manager()
+    assert manager._classify_review_seat_failure(_PR1696_REAL_GLM_RESULT) == "no_response"
+
+
+def test_pr1696_real_glm_record_classifies_lane_exhausted_via_derived_dispatch_id_path(
+    manager_env, monkeypatch,
+):
+    """THE real record from the measurement, run through the fixed code: the
+    gate's own report is written to the predictable unified_reports/
+    <dispatch_id>.md location (matching the measured evidence exactly -- no
+    lane log, report_path field left empty, dispatch_id populated). Before
+    this dispatch's fix classified no_response; the fix derives the path
+    from dispatch_id and reads lane_exhausted."""
+    monkeypatch.chdir(manager_env["project_root"])
+    dispatch_id = _PR1696_REAL_GLM_RESULT["dispatch_id"]
+    report_file = manager_env["reports_dir"] / f"{dispatch_id}.md"
+    report_file.write_text(_PR1696_REAL_GLM_REPORT_EXCERPT, encoding="utf-8")
+    lane_log = manager_env["data_dir"] / "logs" / "conversations" / f"{dispatch_id}.log"
+    assert not lane_log.exists(), "measured baseline: no lane log exists for this dispatch"
+
+    manager = _make_manager()
+    result = manager._classify_review_seat_failure(_PR1696_REAL_GLM_RESULT)
+    print(f"OI-1477 real pr-1696-glm_gate.json (report_path='') classifies as: {result!r}")
+    assert result == "lane_exhausted", (
+        f"expected lane_exhausted on the real pr-1696 record via the derived "
+        f"dispatch_id path, got {result!r}"
+    )
+
+
+def test_pr1696_real_glm_record_rolls_to_deepseek_named_skip(manager_env, monkeypatch):
+    """The takeover chain itself must fire on the real record: glm_gate's
+    chain successor is deepseek_gate (codex_gate -> kimi_gate -> glm_gate ->
+    deepseek_gate) -- same named-skip shape as
+    test_glm_exhausted_real_record_rolls_to_deepseek_named_skip's pr-1691
+    fixture above, proven here on the pr-1696 record whose report_path field
+    is empty (the derivation-fallback case), not pre-populated."""
+    monkeypatch.chdir(manager_env["project_root"])
+    pr_number = 1696
+
+    report_file = manager_env["reports_dir"] / f"{_PR1696_REAL_GLM_RESULT['dispatch_id']}.md"
+    report_file.write_text(_PR1696_REAL_GLM_REPORT_EXCERPT, encoding="utf-8")
+    # report_path is deliberately NOT set on the written result record --
+    # matching the exact measured shape (report_path='') so the takeover
+    # walk is exercised through the dispatch_id-derivation path, not the
+    # already-covered populated-report_path path.
+    _write_result(manager_env["results_dir"], pr_number, "glm_gate", _PR1696_REAL_GLM_RESULT)
+
+    manager = _make_manager()
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number,
+            branch="dispatch/20260826-beta3-f-uitval-overschrijft-verdict-niet",
+            review_stack=["glm_gate"],
+            risk_class="medium",
+            changed_files=["scripts/glm_gate.py"],
+            mode="per_pr",
+            dispatch_id="beta3-g-oi1477-real-record-takeover-test",
+        )
+
+    seat = result["requested"][0]
+    print(f"OI-1477 real pr-1696-glm_gate.json takeover: {seat['gate']!r} (from {seat.get('takeover_from')!r})")
+    assert seat["gate"] == "deepseek_gate"
+    assert seat["status"] == "not_executable"
+    assert seat["reason"] == "gate_runner_missing"
+    assert seat["takeover_from"] == "glm_gate"
+    assert "openrouter_credits" in seat["failure_reason"] or "more credits" in seat["failure_reason"], (
+        f"expected the actual 402 detail embedded in failure_reason: {seat['failure_reason']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OI-1477 -- discrimination must not regress: the SAME generic-error text
+# from the per-provider table above (measured 26-08 on #1692/#1694, "API
+# Error: Content block not found") must still classify no_response, not
+# lane_exhausted, on this exact same code path (report_path empty, derived
+# from dispatch_id). A too-broad derivation-fallback that started matching
+# ANY report content, not just real exhaustion markers, would silently pass
+# every OTHER test in this file while breaking discrimination specifically
+# on the derived-path source.
+# ---------------------------------------------------------------------------
+
+
+def test_pr1477_content_block_not_found_still_not_lane_exhausted_via_derived_path(manager_env, monkeypatch):
+    monkeypatch.chdir(manager_env["project_root"])
+    dispatch_id = "glm-gate-pr9601-1787999999"
+    report_file = manager_env["reports_dir"] / f"{dispatch_id}.md"
+    report_file.write_text(_GENERIC_PROVIDER_ERROR_TEXT["glm"], encoding="utf-8")
+
+    record = {
+        "gate": "glm_gate", "pr_number": 9601, "status": "unavailable",
+        "reason": "dispatch_error", "dispatch_id": dispatch_id, "report_path": "",
+    }
+    manager = _make_manager()
+    result = manager._classify_review_seat_failure(record)
+    print(f"OI-1477 discrimination re-check ('Content block not found' via derived path): {result!r}")
+    assert result == "no_response", (
+        f"a generic provider error must still discriminate away from lane_exhausted "
+        f"via the derived-path source too, got {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OI-1477 -- the derived path reuses the SAME _resolve_report_path escape
+# guard the report_path field source already uses (BETA3-E1b), never a
+# second guard. dispatch_id is on-disk STATE (a prior result record's
+# field), not trusted input.
+# ---------------------------------------------------------------------------
+
+
+def test_derived_dispatch_id_path_escape_is_refused(manager_env, monkeypatch, caplog):
+    """A dispatch_id crafted so the derived unified_reports/<dispatch_id>.md
+    path climbs OUTSIDE unified_reports/ must be refused, exactly like an
+    out-of-bounds report_path already is -- proven by planting real
+    exhaustion-marker content at the escape target and confirming it is
+    never read."""
+    monkeypatch.chdir(manager_env["project_root"])
+    outside_file = manager_env["data_dir"] / "escape-outside-reports.md"
+    outside_file.write_text(_PR1691_REAL_402_REPORT_EXCERPT, encoding="utf-8")
+
+    record = {
+        "dispatch_id": "../escape-outside-reports", "report_path": "",
+        "status": "unavailable", "reason": "dispatch_error",
+    }
+    manager = _make_manager()
+
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        text = manager._read_lane_log_or_report_text(record)
+
+    assert text == "", "a derived path escaping unified_reports/ must never be read"
+    assert "escaped" in caplog.text, "the refusal must be logged, citing the escape"
+    assert manager._classify_review_seat_failure(record) == "no_response", (
+        "a refused derived path must never let a real exhaustion marker reach the classifier"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helper: patch emit_governance_receipt for the duration of a `with` block,
 # same target the other review-gate test modules patch.
 # ---------------------------------------------------------------------------

--- a/tests/test_dlv1_glm_gate.py
+++ b/tests/test_dlv1_glm_gate.py
@@ -207,8 +207,11 @@ def test_pass_verdict_clears_closure_verifier_merge_check(glm_gate, tmp_path, mo
 # ---------------------------------------------------------------------------
 # 3. unavailable never carries complete evidence, and is never terminal
 #    (OI-1435: has_complete_evidence only checks non-emptiness, not whether a
-#    verdict exists — the separation only holds because BOTH fields stay
-#    empty AND is_terminal is False on an unavailable record)
+#    verdict exists — the separation holds because is_terminal() is checked
+#    BEFORE contract_hash/report_path are ever consulted, and is_terminal is
+#    False on an unavailable record regardless of what those two fields
+#    contain. OI-1477: report_path is now populated even here — see below —
+#    contract_hash staying empty was always the field that mattered.)
 # ---------------------------------------------------------------------------
 
 
@@ -218,8 +221,13 @@ def test_unavailable_result_never_has_complete_evidence_and_is_not_terminal(glm_
 
     assert rc == 1
     assert record["status"] == "unavailable"
-    assert record["contract_hash"] == ""
-    assert record["report_path"] == ""
+    assert record["contract_hash"] == "", "contract_hash is the field that must stay empty on an outage"
+    # OI-1477: report_path is populated on an unavailable result too, so a
+    # takeover-time reader can find the failure text without re-deriving the
+    # path itself — it points at the same place report_path_informational
+    # always has (the file may not exist here since this test's fake
+    # dispatcher never writes one, but the path itself is real).
+    assert record["report_path"] == record["report_path_informational"]
     assert is_terminal(record) is False, "an outage is retryable, not a decided pass/fail outcome"
     assert has_complete_evidence(record) is False, "an outage must never look like complete evidence"
 

--- a/tests/test_dlv2_kimi_gate_evidence.py
+++ b/tests/test_dlv2_kimi_gate_evidence.py
@@ -158,10 +158,16 @@ def test_unavailable_result_never_has_complete_evidence(tmp_path, monkeypatch):
 
     assert rc == 1
     assert record["status"] == "unavailable"
-    assert record["contract_hash"] == ""
-    assert record["report_path"] == ""
-    # Either one alone would already keep an outage from closing a PR; both
-    # hold here, and the reason each holds is different (OI-1142 vs OI-1178):
+    assert record["contract_hash"] == "", "contract_hash is the field that must stay empty on an outage"
+    # OI-1477: report_path is populated on an unavailable result too, so a
+    # takeover-time reader can find the failure text without re-deriving the
+    # path itself — it points at the same place report_path_informational
+    # always has (the file may not exist here since this test's fake
+    # dispatcher never writes one, but the path itself is real).
+    assert record["report_path"] == record["report_path_informational"]
+    # has_complete_evidence stays False regardless: is_terminal() is checked
+    # BEFORE contract_hash/report_path are ever consulted, and is_terminal is
+    # False on an unavailable record no matter what those two fields hold.
     assert has_complete_evidence(record) is False, "an outage must never look like a decided verdict"
     assert is_terminal(record) is False, "an outage is retryable, not a decided pass/fail outcome"
 

--- a/tests/test_gate_recovery_wiring.py
+++ b/tests/test_gate_recovery_wiring.py
@@ -244,7 +244,11 @@ def test_zero_candidates_is_unavailable_recovery_empty(module, gate_name, dispat
     assert record["reason"] == "recovery_empty"
     assert rc == 1
     assert record["contract_hash"] == ""
-    assert record["report_path"] == ""
+    # OI-1477: report_path is populated on an unavailable result too (points
+    # at the gate's own report, which is real and on disk here — the search
+    # that came up empty still ran against a genuine primary response).
+    assert record["report_path"] == record["report_path_informational"]
+    assert record["report_path"] != ""
 
 
 # ---------------------------------------------------------------------------
@@ -461,7 +465,10 @@ def test_reprocess_stale_commit_sha_refuses(module, gate_name, dispatch_prefix, 
     assert record["status"] == "unavailable"
     assert record["reason"] == "reprocess_stale_evidence"
     assert record["contract_hash"] == ""
-    assert record["report_path"] == ""
+    # OI-1477: report_path is populated on an unavailable result too — the
+    # original (now-stale) primary report is real and still on disk.
+    assert record["report_path"] == record["report_path_informational"]
+    assert record["report_path"] != ""
     assert "oldsha0000" in record["residual_risk"]
     assert "newsha1111" in record["residual_risk"]
 

--- a/tests/test_gate_unavailable_rollup.py
+++ b/tests/test_gate_unavailable_rollup.py
@@ -76,6 +76,18 @@ def test_has_complete_evidence_false_on_nonterminal_record_even_with_full_eviden
     assert has_complete_evidence(record) is False
 
 
+def test_has_complete_evidence_false_on_unavailable_with_populated_report_path_empty_hash():
+    """OI-1477: glm_gate.py/kimi_gate.py now populate ``report_path`` on the
+    failure path too (see their OI-1178/OI-1435/OI-1477 evidence block),
+    while ``contract_hash`` stays empty -- that is the exact shape those
+    writers now produce. This must never be readable as complete evidence:
+    is_terminal() is checked before contract_hash/report_path are ever
+    consulted, and "unavailable" is never terminal, so a populated
+    report_path alone must not tip this to True."""
+    record = {"status": "unavailable", "contract_hash": "", "report_path": "/tmp/glm-gate-pr1696-1787774904.md"}
+    assert has_complete_evidence(record) is False
+
+
 @pytest.mark.parametrize("status", ["pending", "running", "queued", "requested"])
 def test_has_complete_evidence_false_on_inflight_status_with_full_evidence(status):
     record = {"status": status, "contract_hash": "abc123", "report_path": "/tmp/r.md"}

--- a/tests/test_glm_gate_data_dir_guard.py
+++ b/tests/test_glm_gate_data_dir_guard.py
@@ -136,12 +136,14 @@ def test_with_explicit_data_dir_flag_lands_at_exactly_that_path(tmp_path, monkey
 
 
 # ---------------------------------------------------------------------------
-# Control case 2: an unavailable record still keeps empty contract_hash and
-# report_path (the OI-1435 separation is untouched by this fix).
+# Control case 2: an unavailable record still keeps contract_hash empty (the
+# OI-1435 separation is untouched by this fix). OI-1477: report_path is now
+# populated even here — it always pointed at the same real report location
+# report_path_informational does, so the two are the same value below.
 # ---------------------------------------------------------------------------
 
 
-def test_unavailable_still_keeps_evidence_fields_empty(tmp_path, monkeypatch):
+def test_unavailable_still_keeps_contract_hash_empty(tmp_path, monkeypatch):
     diff_file = tmp_path / "x.diff"
     diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
     base_data_dir = tmp_path / "central-store"
@@ -156,7 +158,9 @@ def test_unavailable_still_keeps_evidence_fields_empty(tmp_path, monkeypatch):
     record = json.loads(out.read_text(encoding="utf-8"))
     assert record["status"] == "unavailable"
     assert record["contract_hash"] == ""
-    assert record["report_path"] == ""
+    assert record["report_path"] == record["report_path_informational"], (
+        "OI-1477: report_path is populated on an unavailable result too"
+    )
     assert has_complete_evidence(record) is False
     assert is_terminal(record) is False
     assert rc == 1
@@ -192,10 +196,19 @@ def test_report_path_and_result_path_share_the_same_resolved_base(tmp_path, monk
 # ---------------------------------------------------------------------------
 # Defect 3: an informational report-path field points a human at the real
 # report even on ``unavailable``, without ever counting as evidence.
+#
+# OI-1477: the ORIGINAL bug this test documented (report_path stayed empty
+# while a full report existed on disk with report_path_informational as the
+# only field pointing at it) is now fixed at the source — glm_gate.py stamps
+# report_path with the same value on the failure path too, so
+# gate_request_handler's takeover-time report-fallback scan can find it
+# directly off the result record. This test still proves report_path is
+# never treated AS EVIDENCE on an unavailable result (has_complete_evidence
+# gates on is_terminal() first, unaffected by which fields are populated).
 # ---------------------------------------------------------------------------
 
 
-def test_unavailable_carries_informational_report_path_but_not_as_evidence(tmp_path, monkeypatch):
+def test_unavailable_report_path_points_at_the_real_report_but_is_not_evidence(tmp_path, monkeypatch):
     diff_file = tmp_path / "x.diff"
     diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
     base_data_dir = tmp_path / "central-store"
@@ -212,13 +225,14 @@ def test_unavailable_carries_informational_report_path_but_not_as_evidence(tmp_p
     record = json.loads(out.read_text(encoding="utf-8"))
     assert rc == 1
     assert record["status"] == "unavailable"
-    # The bug this closes: a full report existed on disk while report_path
-    # was empty and no field pointed a human at it.
-    assert record["report_path"] == ""
-    assert record["report_path_informational"], "informational field must point at the real report"
-    assert Path(record["report_path_informational"]).is_file()
-    # Never counted as evidence — has_complete_evidence only reads
-    # contract_hash/report_path, never the informational field.
+    # OI-1477: report_path now points at the real, on-disk report (same
+    # value as report_path_informational) instead of staying empty.
+    assert record["report_path"] == record["report_path_informational"]
+    assert record["report_path"], "informational field must point at the real report"
+    assert Path(record["report_path"]).is_file()
+    # Never counted as evidence — has_complete_evidence gates on is_terminal()
+    # BEFORE it ever looks at contract_hash/report_path, and "unavailable" is
+    # never terminal, regardless of which of those two fields are populated.
     assert has_complete_evidence(record) is False
     assert is_terminal(record) is False
 

--- a/tests/test_kimi_gate_data_dir_guard.py
+++ b/tests/test_kimi_gate_data_dir_guard.py
@@ -112,12 +112,14 @@ def test_with_explicit_data_dir_flag_lands_at_exactly_that_path(tmp_path, monkey
 
 
 # ---------------------------------------------------------------------------
-# Control case 2: an unavailable record still keeps empty contract_hash and
-# report_path.
+# Control case 2: an unavailable record still keeps contract_hash empty.
+# OI-1477: report_path is now populated even here — it always pointed at the
+# same real report location report_path_informational does, so the two are
+# the same value below.
 # ---------------------------------------------------------------------------
 
 
-def test_unavailable_still_keeps_evidence_fields_empty(tmp_path, monkeypatch):
+def test_unavailable_still_keeps_contract_hash_empty(tmp_path, monkeypatch):
     diff_file = tmp_path / "x.diff"
     diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
     base_data_dir = tmp_path / "central-store"
@@ -132,7 +134,9 @@ def test_unavailable_still_keeps_evidence_fields_empty(tmp_path, monkeypatch):
     record = json.loads(out.read_text(encoding="utf-8"))
     assert record["status"] == "unavailable"
     assert record["contract_hash"] == ""
-    assert record["report_path"] == ""
+    assert record["report_path"] == record["report_path_informational"], (
+        "OI-1477: report_path is populated on an unavailable result too"
+    )
     assert has_complete_evidence(record) is False
     assert is_terminal(record) is False
     assert rc == 1
@@ -168,10 +172,19 @@ def test_report_path_and_result_path_share_the_same_resolved_base(tmp_path, monk
 # ---------------------------------------------------------------------------
 # Defect 3: an informational report-path field points a human at the real
 # report even on ``unavailable``, without ever counting as evidence.
+#
+# OI-1477: the ORIGINAL bug this test documented (report_path stayed empty
+# while a full report existed on disk with report_path_informational as the
+# only field pointing at it) is now fixed at the source — kimi_gate.py
+# stamps report_path with the same value on the failure path too, so
+# gate_request_handler's takeover-time report-fallback scan can find it
+# directly off the result record. This test still proves report_path is
+# never treated AS EVIDENCE on an unavailable result (has_complete_evidence
+# gates on is_terminal() first, unaffected by which fields are populated).
 # ---------------------------------------------------------------------------
 
 
-def test_unavailable_carries_informational_report_path_but_not_as_evidence(tmp_path, monkeypatch):
+def test_unavailable_report_path_points_at_the_real_report_but_is_not_evidence(tmp_path, monkeypatch):
     diff_file = tmp_path / "x.diff"
     diff_file.write_text(_FAKE_DIFF, encoding="utf-8")
     base_data_dir = tmp_path / "central-store"
@@ -188,9 +201,11 @@ def test_unavailable_carries_informational_report_path_but_not_as_evidence(tmp_p
     record = json.loads(out.read_text(encoding="utf-8"))
     assert rc == 1
     assert record["status"] == "unavailable"
-    assert record["report_path"] == ""
-    assert record["report_path_informational"], "informational field must point at the real report"
-    assert Path(record["report_path_informational"]).is_file()
+    # OI-1477: report_path now points at the real, on-disk report (same
+    # value as report_path_informational) instead of staying empty.
+    assert record["report_path"] == record["report_path_informational"]
+    assert record["report_path"], "informational field must point at the real report"
+    assert Path(record["report_path"]).is_file()
     assert has_complete_evidence(record) is False
     assert is_terminal(record) is False
 


### PR DESCRIPTION
## Summary
- The takeover chain's report-fallback (`_read_lane_log_or_report_text`) could only resolve a report via a populated `report_path` field or a per-dispatch lane log. `glm_gate.py`/`kimi_gate.py` deliberately left `report_path` empty on every `unavailable` result, so exactly the case where the report text is the sole evidence of a failure (a real provider outage, no lane log) was the case the fallback could never reach.
- Measured live on `pr-1696-glm_gate.json` (a real, freshly-arisen record — postdates #1695's merge): a genuine OpenRouter 402 (`requires more credits` / `openrouter_credits`) classified `no_response` instead of `lane_exhausted`, so the takeover chain (`glm_gate -> deepseek_gate`) never fired.
- Spoor 1 (`scripts/glm_gate.py`, `scripts/kimi_gate.py`): `report_path` is now populated on the failure path too. `contract_hash` stays empty — `gate_status.has_complete_evidence`/`is_terminal` are unaffected, since `is_terminal()` never admits `unavailable` regardless of which fields are populated.
- Spoor 2 (`scripts/lib/gate_request_handler.py`): `_read_lane_log_or_report_text` now derives the report path from `dispatch_id` (via `report_path.py`'s `canonical_report_path` SSOT) when `report_path` itself is empty, robust against records already on disk before Spoor 1 shipped. Reuses the exact same `_resolve_report_path` escape guard the populated-`report_path` source already uses — no second path-safety mechanism.

## Changes
- `scripts/glm_gate.py` / `scripts/kimi_gate.py`: unavailable results now stamp `report_path` (same value as the existing `report_path_informational` field); `contract_hash` still stays empty. Docstrings updated to reflect that `contract_hash` (not `report_path`) is the field that keeps the OI-1435 evidence separation intact.
- `scripts/lib/gate_request_handler.py`: `_read_lane_log_or_report_text` gains a third source — derive the report path from `dispatch_id` via `report_path.canonical_report_path` when `report_path` is empty, then run it through the existing `_resolve_report_path` guard. Order: lane log → `report_path` field → derived from `dispatch_id`.
- Updated stale assertions in `tests/test_dlv1_glm_gate.py`, `tests/test_dlv2_kimi_gate_evidence.py`, `tests/test_glm_gate_data_dir_guard.py`, `tests/test_kimi_gate_data_dir_guard.py`, `tests/test_gate_recovery_wiring.py` that asserted the old "`report_path` always empty on unavailable" behavior.
- `tests/test_gate_unavailable_rollup.py`: added a direct `has_complete_evidence` case for populated `report_path` + empty `contract_hash` on `unavailable`.
- `tests/test_beta3_e1_review_gate_chain.py`: new OI-1477 section — the real `pr-1696-glm_gate.json` record run through the fixed code (`no_response` → `lane_exhausted`), the takeover to `deepseek_gate`, a discrimination-regression check (`Content block not found` still classifies `no_response`), and a path-escape-guard test for the derived source.

## Verification
- `pytest tests/test_beta3_e1_review_gate_chain.py tests/test_gate_status*.py tests/test_dlv1_glm_gate.py tests/test_dlv2_kimi_gate_evidence.py tests/test_glm_gate_data_dir_guard.py tests/test_kimi_gate_data_dir_guard.py tests/test_gate_recovery_wiring.py tests/test_gate_unavailable_rollup.py tests/test_gate_obligations.py tests/test_dlv5_review_gate_takeover.py tests/test_oi1452_lane_log_lift_provider_failed_detail.py tests/test_oi1452_canonical_failure_reason.py tests/test_oi1433_lane_log_lift.py -v` → 329 passed, 1 skipped, 1 failed.
- The 1 failure (`test_gate_status_schema.py::test_closure_verifier_reads_status_completed_as_pass`) is **pre-existing and unrelated**: confirmed by stashing this branch's changes and re-running against the unmodified baseline — it fails identically there. None of this PR's files touch `closure_verifier.py` or that test.
- Real-record replay output:
  ```
  OI-1477 real pr-1696-glm_gate.json (report_path='') classifies as: 'lane_exhausted'
  OI-1477 real pr-1696-glm_gate.json takeover: 'deepseek_gate' (from 'glm_gate')
  OI-1477 discrimination re-check ('Content block not found' via derived path): 'no_response'
  ```

## Open Items
None.