### PR TITLE
feat(ci-contexts): tell "not created yet" apart from "never created" (#1691/#1701)

### DIFF
--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""ci_contexts.py — required-vs-actual CI context classification.
+
+``gh pr checks`` lists the contexts that EXIST on a commit. Branch protection
+enforces the contexts that are REQUIRED. Those are two different sets, and the
+gap between them is invisible in every green-looking checks listing.
+
+PR #1691 is the measured case: nine ``pass`` lines, zero ``fail`` lines, and
+the merge was still refused — five of the fourteen required contexts had never
+been created at all during a GitHub Actions outage. A reader who only counts
+what is present sees "9 pass / 0 fail" and reads it as ready.
+
+The naive fix — "a required context with no check run blocks the merge" — is
+worse than the bug. PR #1701 measured the false alarm: twelve green, ``Profile
+B`` and ``Profile C`` absent, which reads as exactly the #1691 shape. It was
+not. Both declare ``needs: profile-a`` (vnx-ci.yml), so neither EXISTS until
+Profile A finishes. Absent meant "not created yet". A guard that cannot tell
+those apart blocks every PR in the first minutes of its own CI.
+
+So this module distinguishes the states that actually differ:
+
+  ``passed``            the context exists and concluded in a passing state
+  ``failed``            the context exists and concluded in a failing state
+  ``running``           the context exists and has not concluded yet
+  ``waiting_upstream``  the context does not exist, but its producing workflow
+                        run is still alive, so it can still appear — WAIT,
+                        never a merge blocker's fault
+  ``never_created``     the context does not exist and nothing on this commit
+                        can still create it: the producing run is finished, or
+                        a job the producing job depends on already concluded
+                        in a non-passing state. This is the #1691 trap.
+  ``no_run``            the producing workflow never started on this commit at
+                        all — the run has to be started before anything else
+                        can be said
+  ``unverified``        this module could not establish which of the above
+                        applies (no workflow file produces the context, the
+                        graph failed to parse, a gh call failed)
+
+``unverified`` is never collapsed into a pass and never into a fail. A guard
+that cannot see must say so — the same fail-loud contract
+``pre_merge_gate.check_ci_workflow`` already holds for SKIPPED_UNVERIFIED.
+
+The dependency graph comes from the workflow YAML in the checkout, not from
+GitHub: the ``needs:`` edges are what separate ``waiting_upstream`` from
+``never_created``, and there is no API that reports "this job has not been
+created yet, and here is why". A PR that itself edits ``.github/workflows``
+therefore gets classified against the graph in ``workflows_dir``; pass the
+PR's own checkout when that distinction matters.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# States
+# ---------------------------------------------------------------------------
+
+STATE_PASSED = "passed"
+STATE_FAILED = "failed"
+STATE_RUNNING = "running"
+STATE_WAITING_UPSTREAM = "waiting_upstream"
+STATE_NEVER_CREATED = "never_created"
+STATE_NO_RUN = "no_run"
+STATE_UNVERIFIED = "unverified"
+
+#: An allowlist, not a blocklist of failures: a state added later blocks until
+#: someone decides otherwise, never silently mergeable.
+NON_BLOCKING_STATES = frozenset({STATE_PASSED})
+
+#: "This commit can still produce the context if you wait." Distinct from
+#: blocking-ness: a waiting context blocks now, but the fix is time, not a re-run.
+TRANSIENT_STATES = frozenset({STATE_RUNNING, STATE_WAITING_UPSTREAM})
+
+#: Check-run conclusions that satisfy a required status check. ``skipped`` and
+#: ``neutral`` pass for branch protection — a path-filtered job that legitimately
+#: did not apply must not read as a failure.
+PASSING_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
+
+#: A workflow run or check run in any status other than this is still alive.
+COMPLETED_STATUS = "completed"
+
+
+@dataclass(frozen=True)
+class JobNode:
+    """One workflow job, keyed by the check-run context name it produces."""
+
+    context: str
+    job_key: str
+    workflow_name: str
+    workflow_file: str
+    needs: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class WorkflowGraph:
+    """Context name -> producing job, parsed from the checkout's workflows."""
+
+    by_context: Mapping[str, JobNode]
+    #: (workflow_file, job_key) -> JobNode, for resolving ``needs`` edges.
+    by_job: Mapping[tuple, JobNode]
+    #: Files that could not be parsed, with the reason. Never swallowed: a
+    #: context whose workflow failed to parse resolves to ``unverified``,
+    #: and this list says why.
+    parse_errors: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ContextState:
+    """The classification of one required branch-protection context."""
+
+    context: str
+    state: str
+    detail: str
+    conclusion: Optional[str] = None
+    workflow_name: Optional[str] = None
+    job_key: Optional[str] = None
+
+    @property
+    def blocking(self) -> bool:
+        return self.state not in NON_BLOCKING_STATES
+
+    @property
+    def transient(self) -> bool:
+        return self.state in TRANSIENT_STATES
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "context": self.context,
+            "state": self.state,
+            "detail": self.detail,
+            "conclusion": self.conclusion,
+            "workflow_name": self.workflow_name,
+            "job_key": self.job_key,
+            "blocking": self.blocking,
+            "transient": self.transient,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Workflow graph
+# ---------------------------------------------------------------------------
+
+
+def _normalise_needs(raw: Any) -> Sequence[str]:
+    """``needs:`` is a string, a list, or absent. Return it as a tuple."""
+    if isinstance(raw, str):
+        return (raw,)
+    if isinstance(raw, list):
+        return tuple(str(item) for item in raw if isinstance(item, (str, int)))
+    return ()
+
+
+def parse_workflow_graph(workflows_dir: Path) -> WorkflowGraph:
+    """Parse ``.github/workflows/*.y[a]ml`` into a context -> job mapping.
+
+    A job's context name is its ``name:`` when it declares one, and its job key
+    otherwise — the rule GitHub itself applies. Matrix jobs are NOT resolved:
+    their real context names carry the matrix values, so they never match a
+    plain required-context name and correctly land in ``unverified`` rather
+    than on a confidently wrong job.
+
+    A file that fails to parse is recorded in ``parse_errors`` and contributes
+    no jobs — never skipped silently, so a context a broken workflow would
+    have produced lands in ``unverified``, not in "nothing requires it".
+    """
+    by_context: Dict[str, JobNode] = {}
+    by_job: Dict[tuple, JobNode] = {}
+    errors: List[str] = []
+
+    if not workflows_dir.is_dir():
+        return WorkflowGraph(
+            by_context={},
+            by_job={},
+            parse_errors=(f"workflows directory not found: {workflows_dir}",),
+        )
+
+    paths = sorted(
+        [p for p in workflows_dir.iterdir() if p.suffix in (".yml", ".yaml") and p.is_file()]
+    )
+    for path in paths:
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            errors.append(f"{path.name}: {type(exc).__name__}: {exc}")
+            continue
+        if not isinstance(document, dict):
+            errors.append(f"{path.name}: top level is {type(document).__name__}, expected a mapping")
+            continue
+        workflow_name = document.get("name")
+        if not isinstance(workflow_name, str) or not workflow_name.strip():
+            workflow_name = path.stem
+        jobs = document.get("jobs")
+        if not isinstance(jobs, dict):
+            errors.append(f"{path.name}: no 'jobs' mapping")
+            continue
+        for job_key, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            declared = job.get("name")
+            context = declared if isinstance(declared, str) and declared.strip() else str(job_key)
+            node = JobNode(
+                context=context,
+                job_key=str(job_key),
+                workflow_name=workflow_name.strip(),
+                workflow_file=path.name,
+                needs=_normalise_needs(job.get("needs")),
+            )
+            by_job[(path.name, str(job_key))] = node
+            # First writer wins, and a genuine collision is an error rather
+            # than a silent overwrite: two jobs producing one context name
+            # makes the "which job is late" answer ambiguous.
+            if context in by_context:
+                errors.append(
+                    f"duplicate context {context!r}: "
+                    f"{by_context[context].workflow_file}:{by_context[context].job_key} "
+                    f"and {path.name}:{job_key}"
+                )
+                continue
+            by_context[context] = node
+
+    return WorkflowGraph(by_context=by_context, by_job=by_job, parse_errors=tuple(errors))
+
+
+def _upstream_chain(graph: WorkflowGraph, node: JobNode) -> List[JobNode]:
+    """All transitive ``needs`` ancestors of ``node``, nearest first.
+
+    Cycle-safe: a ``needs`` cycle is invalid on GitHub's side, but this walk
+    must terminate regardless of what the file says.
+    """
+    seen: Set[str] = {node.job_key}
+    ordered: List[JobNode] = []
+    frontier = list(node.needs)
+    while frontier:
+        job_key = str(frontier.pop(0))
+        if job_key in seen:
+            continue
+        seen.add(job_key)
+        parent = graph.by_job.get((node.workflow_file, job_key))
+        if parent is None:
+            continue
+        ordered.append(parent)
+        frontier.extend(parent.needs)
+    return ordered
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _index_check_runs(check_runs: Iterable[Mapping[str, Any]]) -> Dict[str, List[Mapping[str, Any]]]:
+    """Group check runs by name. One name can carry several runs — the same
+    workflow triggered by both ``push`` and ``pull_request`` produces two.
+    """
+    indexed: Dict[str, List[Mapping[str, Any]]] = {}
+    for run in check_runs:
+        name = run.get("name")
+        if isinstance(name, str) and name:
+            indexed.setdefault(name, []).append(run)
+    return indexed
+
+
+def _classify_present(context: str, runs: Sequence[Mapping[str, Any]], node: Optional[JobNode]) -> ContextState:
+    """Classify a context that HAS at least one check run on the commit.
+
+    Conservative on duplicates: any non-terminal run keeps the context
+    ``running``, and any terminal non-passing conclusion makes it ``failed``,
+    even when a sibling run of the same name passed. A merge gate resolving a
+    disagreement in favour of the passing copy is exactly the green-lie this
+    module exists to remove.
+    """
+    workflow_name = node.workflow_name if node else None
+    job_key = node.job_key if node else None
+
+    unfinished = [r for r in runs if (r.get("status") or "") != COMPLETED_STATUS]
+    if unfinished:
+        return ContextState(
+            context=context,
+            state=STATE_RUNNING,
+            detail=f"still running ({unfinished[0].get('status') or 'unknown status'})",
+            conclusion=None,
+            workflow_name=workflow_name,
+            job_key=job_key,
+        )
+
+    conclusions = [(r.get("conclusion") or "") for r in runs]
+    failing = [c for c in conclusions if c not in PASSING_CONCLUSIONS]
+    if failing:
+        return ContextState(
+            context=context,
+            state=STATE_FAILED,
+            detail=f"concluded {failing[0] or 'with no conclusion'}",
+            conclusion=failing[0] or None,
+            workflow_name=workflow_name,
+            job_key=job_key,
+        )
+    return ContextState(
+        context=context,
+        state=STATE_PASSED,
+        detail=f"concluded {conclusions[0]}",
+        conclusion=conclusions[0],
+        workflow_name=workflow_name,
+        job_key=job_key,
+    )
+
+
+def _pending_upstream(
+    graph: WorkflowGraph,
+    node: JobNode,
+    runs: Sequence[Mapping[str, Any]],
+    jobs_by_run_id: Mapping[Any, Sequence[Mapping[str, Any]]],
+) -> Set[str]:
+    """Ancestor context names that have not concluded yet, for the WAIT text.
+
+    An ancestor absent from a run's job list counts as pending: GitHub does
+    not list a job before it is created, and "not created yet" is precisely
+    the state that makes the child context wait.
+    """
+    pending: Set[str] = set()
+    for parent in _upstream_chain(graph, node):
+        for run in runs:
+            observed = next(
+                (j for j in jobs_by_run_id.get(run.get("id"), ()) if j.get("name") == parent.context),
+                None,
+            )
+            if observed is None or (observed.get("status") or "") != COMPLETED_STATUS:
+                pending.add(parent.context)
+    return pending
+
+
+def _failed_upstream(
+    graph: WorkflowGraph,
+    node: JobNode,
+    runs: Sequence[Mapping[str, Any]],
+    jobs_by_run_id: Mapping[Any, Sequence[Mapping[str, Any]]],
+) -> Optional[tuple]:
+    """First (ancestor, conclusion) that concluded in a non-passing state.
+
+    Returns None when every observed ancestor either passed or has not
+    concluded. An unobserved ancestor is never treated as failed — absence of
+    evidence stays absence of evidence here, and the caller falls through to
+    the wait/never-created decision that has real evidence behind it.
+    """
+    for run in runs:
+        job_states = {
+            j.get("name"): j
+            for j in jobs_by_run_id.get(run.get("id"), ())
+            if isinstance(j.get("name"), str)
+        }
+        for parent in _upstream_chain(graph, node):
+            observed = job_states.get(parent.context)
+            if observed is None:
+                continue
+            if (observed.get("status") or "") != COMPLETED_STATUS:
+                continue
+            conclusion = observed.get("conclusion") or ""
+            if conclusion not in PASSING_CONCLUSIONS:
+                return (parent, conclusion)
+    return None
+
+
+def _classify_absent(
+    context: str,
+    node: JobNode,
+    graph: WorkflowGraph,
+    workflow_runs: Sequence[Mapping[str, Any]],
+    jobs_by_run_id: Mapping[Any, Sequence[Mapping[str, Any]]],
+) -> ContextState:
+    """Classify a required context with NO check run on the commit.
+
+    This is the whole point of the module: separating "not created yet"
+    (#1701, Profile B/C behind ``needs: profile-a``) from "never created"
+    (#1691, five contexts lost to an Actions outage).
+    """
+    own_runs = [r for r in workflow_runs if r.get("name") == node.workflow_name]
+    if not own_runs:
+        return ContextState(
+            context=context,
+            state=STATE_NO_RUN,
+            detail=(
+                f"workflow {node.workflow_name!r} ({node.workflow_file}) has no run on this "
+                "commit — nothing is started that could produce this context"
+            ),
+            workflow_name=node.workflow_name,
+            job_key=node.job_key,
+        )
+
+    # An ancestor that already concluded in a non-passing state settles the
+    # question whether or not the run is still alive: the producing job will
+    # not execute, so waiting cannot help.
+    failed = _failed_upstream(graph, node, own_runs, jobs_by_run_id)
+    if failed is not None:
+        parent, conclusion = failed
+        return ContextState(
+            context=context,
+            state=STATE_NEVER_CREATED,
+            detail=(
+                f"job {node.job_key!r} needs {parent.job_key!r}, which concluded "
+                f"{conclusion or 'with no conclusion'} — this context can no longer be "
+                "produced on this commit"
+            ),
+            workflow_name=node.workflow_name,
+            job_key=node.job_key,
+        )
+
+    alive = [r for r in own_runs if (r.get("status") or "") != COMPLETED_STATUS]
+    if alive:
+        pending = _pending_upstream(graph, node, own_runs, jobs_by_run_id)
+        if pending:
+            reason = f"waiting on {', '.join(sorted(pending))}"
+        elif node.needs:
+            reason = f"declares needs: {', '.join(node.needs)}"
+        else:
+            reason = "the run has not created this job yet"
+        return ContextState(
+            context=context,
+            state=STATE_WAITING_UPSTREAM,
+            detail=(
+                f"workflow {node.workflow_name!r} is still running ({reason}) — "
+                "the context can still appear"
+            ),
+            workflow_name=node.workflow_name,
+            job_key=node.job_key,
+        )
+
+    conclusions = ", ".join(sorted({(r.get("conclusion") or "none") for r in own_runs}))
+    return ContextState(
+        context=context,
+        state=STATE_NEVER_CREATED,
+        detail=(
+            f"workflow {node.workflow_name!r} finished ({conclusions}) without ever creating "
+            "this context — re-run the workflow; this is the #1691 shape"
+        ),
+        workflow_name=node.workflow_name,
+        job_key=node.job_key,
+    )
+
+
+def classify_contexts(
+    required_contexts: Iterable[str],
+    check_runs: Iterable[Mapping[str, Any]],
+    workflow_runs: Iterable[Mapping[str, Any]],
+    graph: WorkflowGraph,
+    jobs_by_run_id: Optional[Mapping[Any, Sequence[Mapping[str, Any]]]] = None,
+) -> List[ContextState]:
+    """Classify every REQUIRED context against what exists on the commit.
+
+    Pure: every input is data, so the decision table is testable without a
+    network. ``jobs_by_run_id`` may be empty — the classification degrades to
+    "the run is alive, so wait" instead of naming which ancestor it waits on,
+    which is a weaker message but never a wrong verdict.
+
+    Contexts are iterated in the order given so the output is stable.
+    """
+    runs = list(workflow_runs)
+    jobs = dict(jobs_by_run_id or {})
+    indexed = _index_check_runs(check_runs)
+
+    states: List[ContextState] = []
+    for context in required_contexts:
+        node = graph.by_context.get(context)
+        present = indexed.get(context)
+        if present:
+            states.append(_classify_present(context, present, node))
+            continue
+        if node is None:
+            hint = (
+                f" (workflow parse errors: {'; '.join(graph.parse_errors)})"
+                if graph.parse_errors
+                else ""
+            )
+            states.append(
+                ContextState(
+                    context=context,
+                    state=STATE_UNVERIFIED,
+                    detail=(
+                        "no check run on this commit and no workflow job in the checkout "
+                        f"produces this context — cannot tell 'not yet' from 'never'{hint}"
+                    ),
+                )
+            )
+            continue
+        states.append(_classify_absent(context, node, graph, runs, jobs))
+    return states
+
+
+def summarise(states: Sequence[ContextState]) -> Dict[str, Any]:
+    """Counts + the blocking subset, for a caller that renders a verdict."""
+    blocking = [s for s in states if s.blocking]
+    return {
+        "total": len(states),
+        "passed": len([s for s in states if s.state == STATE_PASSED]),
+        "blocking": len(blocking),
+        "transient": len([s for s in states if s.transient]),
+        "never_created": len([s for s in states if s.state == STATE_NEVER_CREATED]),
+        "no_run": len([s for s in states if s.state == STATE_NO_RUN]),
+        "unverified": len([s for s in states if s.state == STATE_UNVERIFIED]),
+        "by_state": {s.context: s.state for s in states},
+        "blocking_contexts": [s.to_dict() for s in blocking],
+    }
+
+
+# ---------------------------------------------------------------------------
+# GitHub evidence collection
+# ---------------------------------------------------------------------------
+
+
+class CIContextsError(RuntimeError):
+    """A required piece of evidence could not be read.
+
+    Raised rather than returned as a degraded result: every caller in this
+    fabric turns an unreadable answer into a loud blocking state, and an
+    exception makes forgetting that impossible.
+    """
+
+
+def _gh_json(args: Sequence[str], project_root: Path, timeout: int) -> Any:
+    """Run ``gh`` and parse its JSON stdout, or raise :class:`CIContextsError`."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise CIContextsError(f"gh CLI not available: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CIContextsError(f"gh {' '.join(args)} timed out after {timeout}s") from exc
+    if proc.returncode != 0:
+        raise CIContextsError(
+            f"gh {' '.join(args)} failed (rc={proc.returncode}): {(proc.stderr or '').strip()[:300]}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise CIContextsError(f"gh {' '.join(args)} returned unparseable JSON: {exc}") from exc
+
+
+def fetch_required_contexts(project_root: Path, branch: str = "main", timeout: int = 20) -> List[str]:
+    """The branch-protection required contexts — what SHOULD exist.
+
+    Reads both shapes GitHub has shipped (``contexts`` and ``checks[].context``)
+    and returns their union, sorted. An empty result is returned as-is and is
+    NOT a pass: a caller that finds no required contexts on a branch it
+    believes is protected is looking at a misconfiguration, and this function
+    refuses to paper over it by inventing a default list.
+    """
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/branches/{branch}/protection"], project_root, timeout
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"branch protection payload is {type(payload).__name__}, expected a mapping")
+    required = payload.get("required_status_checks") or {}
+    contexts: Set[str] = set(required.get("contexts") or [])
+    for check in required.get("checks") or []:
+        if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
+            contexts.add(check["context"])
+    return sorted(contexts)
+
+
+def fetch_check_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
+    """The check runs that DO exist on ``head_sha``."""
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs?per_page=100", "--paginate"],
+        project_root,
+        timeout,
+    )
+    runs: List[Dict[str, Any]] = []
+    for page in payload if isinstance(payload, list) else [payload]:
+        if isinstance(page, dict):
+            runs.extend([r for r in (page.get("check_runs") or []) if isinstance(r, dict)])
+    return runs
+
+
+def fetch_workflow_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
+    """The workflow runs on ``head_sha``, with id/name/status/conclusion."""
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/actions/runs?head_sha={head_sha}&per_page=100"],
+        project_root,
+        timeout,
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"actions/runs payload is {type(payload).__name__}, expected a mapping")
+    return [r for r in (payload.get("workflow_runs") or []) if isinstance(r, dict)]
+
+
+def fetch_run_jobs(project_root: Path, run_id: Any, timeout: int = 20) -> List[Dict[str, Any]]:
+    """The jobs of one workflow run, with name/status/conclusion."""
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/jobs?per_page=100"],
+        project_root,
+        timeout,
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"actions/runs/{run_id}/jobs payload is {type(payload).__name__}")
+    return [j for j in (payload.get("jobs") or []) if isinstance(j, dict)]
+
+
+def evaluate_commit(
+    project_root: Path,
+    head_sha: str,
+    *,
+    branch: str = "main",
+    workflows_dir: Optional[Path] = None,
+    timeout: int = 20,
+    required_contexts: Optional[Sequence[str]] = None,
+) -> List[ContextState]:
+    """Classify the protected branch's required contexts against ``head_sha``.
+
+    Two-pass on purpose. The first pass runs with no per-run job data, which
+    costs zero extra API calls and is already conclusive for every context
+    that has a check run — the all-green case, i.e. most of them. Only when a
+    context is genuinely missing does the second pass fetch the jobs of the
+    runs that could still produce it, which is the only place the ``needs``
+    chain has to be resolved against live state.
+
+    Raises :class:`CIContextsError` when the branch-protection list, the check
+    runs, or the workflow runs cannot be read. Job-level detail is the one
+    piece allowed to degrade: a failure there costs the "waiting on X"
+    wording, never the verdict.
+    """
+    root = Path(project_root)
+    contexts = list(required_contexts) if required_contexts is not None else fetch_required_contexts(root, branch, timeout)
+    graph = parse_workflow_graph(workflows_dir or (root / ".github" / "workflows"))
+    check_runs = fetch_check_runs(root, head_sha, timeout)
+    workflow_runs = fetch_workflow_runs(root, head_sha, timeout)
+
+    first = classify_contexts(contexts, check_runs, workflow_runs, graph)
+    interesting = {
+        s.workflow_name
+        for s in first
+        if s.state in (STATE_WAITING_UPSTREAM, STATE_NEVER_CREATED) and s.workflow_name
+    }
+    if not interesting:
+        return first
+
+    jobs_by_run_id: Dict[Any, Sequence[Mapping[str, Any]]] = {}
+    for run in workflow_runs:
+        if run.get("name") not in interesting:
+            continue
+        try:
+            jobs_by_run_id[run.get("id")] = fetch_run_jobs(root, run.get("id"), timeout)
+        except CIContextsError as exc:
+            # Degrade the WORDING, never the verdict: without job data the
+            # classifier still separates alive-run from finished-run, which is
+            # the decision that blocks or releases a merge.
+            jobs_by_run_id[run.get("id")] = ()
+            graph = WorkflowGraph(
+                by_context=graph.by_context,
+                by_job=graph.by_job,
+                parse_errors=tuple(graph.parse_errors) + (f"jobs for run {run.get('id')}: {exc}",),
+            )
+    return classify_contexts(contexts, check_runs, workflow_runs, graph, jobs_by_run_id)

--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -54,7 +54,7 @@ import json
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set
 
 import yaml
 
@@ -85,6 +85,21 @@ PASSING_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
 
 #: A workflow run or check run in any status other than this is still alive.
 COMPLETED_STATUS = "completed"
+
+
+class RequiredCheck(NamedTuple):
+    """One required status check, with the app binding branch protection gave it.
+
+    GitHub's newer ``checks[]`` shape carries ``app_id``; the legacy
+    ``contexts[]`` list does not. When an ``app_id`` is present the requirement
+    is "a check with THIS name FROM THIS app" — matching on the name alone
+    would let a same-named check from any other app satisfy it. ``app_id`` is
+    None for a legacy entry, which means the name is genuinely all branch
+    protection asks for.
+    """
+
+    context: str
+    app_id: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -267,6 +282,26 @@ def _index_check_runs(check_runs: Iterable[Mapping[str, Any]]) -> Dict[str, List
     return indexed
 
 
+def _split_by_app(
+    runs: Sequence[Mapping[str, Any]], app_id: Optional[int]
+) -> tuple:
+    """Split check runs into those the requirement accepts and those it does not.
+
+    With no app binding every same-named run counts, which is exactly what the
+    legacy ``contexts[]`` shape asks for. With a binding, only runs whose
+    ``app.id`` matches count — a run missing the ``app`` object does NOT match,
+    since an unidentifiable producer cannot be shown to be the required one.
+    """
+    if app_id is None:
+        return list(runs), []
+    matching, foreign = [], []
+    for run in runs:
+        app = run.get("app")
+        observed = app.get("id") if isinstance(app, dict) else None
+        (matching if observed == app_id else foreign).append(run)
+    return matching, foreign
+
+
 def _classify_present(context: str, runs: Sequence[Mapping[str, Any]], node: Optional[JobNode]) -> ContextState:
     """Classify a context that HAS at least one check run on the commit.
 
@@ -444,7 +479,7 @@ def _classify_absent(
 
 
 def classify_contexts(
-    required_contexts: Iterable[str],
+    required_contexts: Iterable[Any],
     check_runs: Iterable[Mapping[str, Any]],
     workflow_runs: Iterable[Mapping[str, Any]],
     graph: WorkflowGraph,
@@ -464,9 +499,28 @@ def classify_contexts(
     indexed = _index_check_runs(check_runs)
 
     states: List[ContextState] = []
-    for context in required_contexts:
+    for required in required_contexts:
+        check = required if isinstance(required, RequiredCheck) else RequiredCheck(str(required))
+        context = check.context
         node = graph.by_context.get(context)
-        present = indexed.get(context)
+        named = indexed.get(context) or []
+        present, wrong_app = _split_by_app(named, check.app_id)
+        if wrong_app and not present:
+            states.append(
+                ContextState(
+                    context=context,
+                    state=STATE_UNVERIFIED,
+                    detail=(
+                        f"{len(wrong_app)} check run(s) named {context!r} exist on this commit "
+                        f"but none is from the required app (app_id={check.app_id}) — branch "
+                        "protection would not accept them, and matching on the name alone "
+                        "would turn a foreign check into a green light"
+                    ),
+                    workflow_name=node.workflow_name if node else None,
+                    job_key=node.job_key if node else None,
+                )
+            )
+            continue
         if present:
             states.append(_classify_present(context, present, node))
             continue
@@ -545,14 +599,19 @@ def _gh_json(args: Sequence[str], project_root: Path, timeout: int) -> Any:
         raise CIContextsError(f"gh {' '.join(args)} returned unparseable JSON: {exc}") from exc
 
 
-def fetch_required_contexts(project_root: Path, branch: str = "main", timeout: int = 20) -> List[str]:
-    """The branch-protection required contexts — what SHOULD exist.
+def fetch_required_checks(
+    project_root: Path, branch: str = "main", timeout: int = 20
+) -> List[RequiredCheck]:
+    """The branch-protection required checks — what SHOULD exist, with app bindings.
 
-    Reads both shapes GitHub has shipped (``contexts`` and ``checks[].context``)
-    and returns their union, sorted. An empty result is returned as-is and is
-    NOT a pass: a caller that finds no required contexts on a branch it
-    believes is protected is looking at a misconfiguration, and this function
-    refuses to paper over it by inventing a default list.
+    Reads both shapes GitHub has shipped. ``checks[]`` carries ``app_id`` and
+    wins over a same-named legacy ``contexts[]`` entry, because dropping the
+    app binding would widen the requirement rather than narrow it.
+
+    An empty result is returned as-is and is NOT a pass: a caller that finds no
+    required checks on a branch it believes is protected is looking at a
+    misconfiguration, and this function refuses to paper over it by inventing
+    a default list.
     """
     payload = _gh_json(
         ["api", f"repos/{{owner}}/{{repo}}/branches/{branch}/protection"], project_root, timeout
@@ -560,17 +619,36 @@ def fetch_required_contexts(project_root: Path, branch: str = "main", timeout: i
     if not isinstance(payload, dict):
         raise CIContextsError(f"branch protection payload is {type(payload).__name__}, expected a mapping")
     required = payload.get("required_status_checks") or {}
-    contexts: Set[str] = set(required.get("contexts") or [])
+
+    bound: Dict[str, Optional[int]] = {}
+    for name in required.get("contexts") or []:
+        if isinstance(name, str) and name:
+            bound.setdefault(name, None)
     for check in required.get("checks") or []:
-        if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
-            contexts.add(check["context"])
-    return sorted(contexts)
+        if not isinstance(check, dict):
+            continue
+        name = check.get("context")
+        if not isinstance(name, str) or not name:
+            continue
+        app_id = check.get("app_id")
+        bound[name] = app_id if isinstance(app_id, int) else None
+    return [RequiredCheck(name, bound[name]) for name in sorted(bound)]
 
 
 def fetch_check_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
     """The check runs that DO exist on ``head_sha``."""
+    # --slurp is required, not decorative: this endpoint returns an OBJECT, and
+    # `gh api --paginate` emits one document per page. Measured on a 16-run
+    # commit at per_page=5 — four pages, and json.loads fails with "Extra data"
+    # at char 15511. --slurp wraps the pages in an outer array instead, which is
+    # the shape the loop below already expects.
     payload = _gh_json(
-        ["api", f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs?per_page=100", "--paginate"],
+        [
+            "api",
+            f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs?per_page=100",
+            "--paginate",
+            "--slurp",
+        ],
         project_root,
         timeout,
     )
@@ -612,7 +690,7 @@ def evaluate_commit(
     branch: str = "main",
     workflows_dir: Optional[Path] = None,
     timeout: int = 20,
-    required_contexts: Optional[Sequence[str]] = None,
+    required_contexts: Optional[Sequence[Any]] = None,
 ) -> List[ContextState]:
     """Classify the protected branch's required contexts against ``head_sha``.
 
@@ -629,7 +707,11 @@ def evaluate_commit(
     wording, never the verdict.
     """
     root = Path(project_root)
-    contexts = list(required_contexts) if required_contexts is not None else fetch_required_contexts(root, branch, timeout)
+    contexts = (
+        list(required_contexts)
+        if required_contexts is not None
+        else fetch_required_checks(root, branch, timeout)
+    )
     graph = parse_workflow_graph(workflows_dir or (root / ".github" / "workflows"))
     check_runs = fetch_check_runs(root, head_sha, timeout)
     workflow_runs = fetch_workflow_runs(root, head_sha, timeout)

--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -673,6 +673,66 @@ def fetch_check_runs(project_root: Path, head_sha: str, timeout: int = 20) -> Li
     return runs
 
 
+#: Commit-status states mapped onto the check-run vocabulary the classifier
+#: already speaks. GitHub's two mechanisms are separate APIs but branch
+#: protection treats their contexts as one namespace, so the classifier must
+#: too — otherwise a required context satisfied by a STATUS reads as absent.
+_STATUS_STATE_TO_CONCLUSION = {
+    "success": ("completed", "success"),
+    "failure": ("completed", "failure"),
+    "error": ("completed", "failure"),
+    "pending": ("in_progress", None),
+}
+
+
+def fetch_commit_statuses(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
+    """Legacy commit statuses on ``head_sha``, in check-run shape.
+
+    Branch protection's legacy ``contexts[]`` can be satisfied by a commit
+    STATUS (the Statuses API) rather than a check run (the Checks API) — a
+    non-Actions CI, or anything posting through ``POST /statuses``. Reading
+    only check runs leaves such a context permanently unseen, so a PR whose
+    required context genuinely passed would be blocked forever on evidence
+    that was there all along.
+
+    Only the most recent status per context is returned: GitHub's combined
+    endpoint lists the history newest-first, and an older superseded state is
+    not what branch protection evaluates.
+
+    An unrecognised state maps to a non-terminal status rather than to a
+    conclusion, so a future state value holds the verdict at "running" instead
+    of silently passing or failing.
+    """
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/commits/{head_sha}/status?per_page=100"],
+        project_root,
+        timeout,
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"commit status payload is {type(payload).__name__}, expected a mapping")
+    seen: Set[str] = set()
+    out: List[Dict[str, Any]] = []
+    for status in payload.get("statuses") or []:
+        if not isinstance(status, dict):
+            continue
+        context = status.get("context")
+        if not isinstance(context, str) or not context or context in seen:
+            continue
+        seen.add(context)
+        state, conclusion = _STATUS_STATE_TO_CONCLUSION.get(
+            (status.get("state") or "").lower(), ("in_progress", None)
+        )
+        entry: Dict[str, Any] = {"name": context, "status": state, "conclusion": conclusion}
+        # A status has no Checks-API app object unless GitHub supplies one; an
+        # app-bound requirement is a `checks[]` entry, which only check runs
+        # satisfy, so leaving this absent is the correct answer rather than a
+        # gap.
+        if isinstance(status.get("app"), dict):
+            entry["app"] = status["app"]
+        out.append(entry)
+    return out
+
+
 def fetch_workflow_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
     """The workflow runs on ``head_sha``, with id/name/status/conclusion."""
     payload = _gh_json(
@@ -727,7 +787,9 @@ def evaluate_commit(
         else fetch_required_checks(root, branch, timeout)
     )
     graph = parse_workflow_graph(workflows_dir or (root / ".github" / "workflows"))
-    check_runs = fetch_check_runs(root, head_sha, timeout)
+    check_runs = fetch_check_runs(root, head_sha, timeout) + fetch_commit_statuses(
+        root, head_sha, timeout
+    )
     workflow_runs = fetch_workflow_runs(root, head_sha, timeout)
 
     first = classify_contexts(contexts, check_runs, workflow_runs, graph)

--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -87,14 +87,24 @@ PASSING_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
 COMPLETED_STATUS = "completed"
 
 
+#: GitHub's sentinel in ``checks[].app_id`` for "any app may set this status"
+#: (the branch-protection API's explicit allow-any value). It is an int, so a
+#: naive ``isinstance(app_id, int)`` keeps it as if it named a real producer —
+#: and then NO run matches it, turning every any-app required check into a
+#: false ``unverified``. It has to be normalised to "no binding" at the edge.
+ANY_APP_ID = -1
+
+
 class RequiredCheck(NamedTuple):
     """One required status check, with the app binding branch protection gave it.
 
     GitHub's newer ``checks[]`` shape carries ``app_id``; the legacy
-    ``contexts[]`` list does not. When an ``app_id`` is present the requirement
-    is "a check with THIS name FROM THIS app" — matching on the name alone
-    would let a same-named check from any other app satisfy it. ``app_id`` is
-    None for a legacy entry, which means the name is genuinely all branch
+    ``contexts[]`` list does not. When an ``app_id`` names a real app the
+    requirement is "a check with THIS name FROM THIS app" — matching on the
+    name alone would let a same-named check from any other app satisfy it.
+
+    ``app_id`` is None for a legacy entry AND for GitHub's explicit
+    :data:`ANY_APP_ID` sentinel: both mean the name is genuinely all branch
     protection asks for.
     """
 
@@ -631,7 +641,11 @@ def fetch_required_checks(
         if not isinstance(name, str) or not name:
             continue
         app_id = check.get("app_id")
-        bound[name] = app_id if isinstance(app_id, int) else None
+        # ANY_APP_ID is an int and would otherwise survive as a concrete
+        # producer that nothing can ever match.
+        bound[name] = (
+            app_id if isinstance(app_id, int) and app_id != ANY_APP_ID else None
+        )
     return [RequiredCheck(name, bound[name]) for name in sorted(bound)]
 
 

--- a/scripts/lib/required_contexts_gate.py
+++ b/scripts/lib/required_contexts_gate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""required_contexts_gate.py — the merge-gate verdict for required CI contexts.
+
+``ci_contexts`` answers a factual question: for each context branch protection
+requires, does it exist on this commit, and if not, can it still appear?
+This module answers the gate's question: does that add up to permission to
+merge? The two are kept apart deliberately — the classifier has no opinion
+about merges, and the gate has no opinion about GitHub's job graph.
+
+It lives beside ``pre_merge_gate.py`` rather than inside it because that file
+is already 1522 lines on main, past the 1200-line hard ceiling
+``quality_advisory`` enforces. Growing it further to add a check would trade
+one governance finding for another.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path
+from typing import Any, Dict
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in _sys.path:
+    _sys.path.insert(0, str(_LIB_DIR))
+
+import ci_contexts  # noqa: E402
+
+#: Mirrors pre_merge_gate.SKIPPED_UNVERIFIED. Defined here rather than imported
+#: to keep the dependency one-way: pre_merge_gate imports this module, so an
+#: import back would be a cycle. The value is asserted equal in the tests.
+SKIPPED_UNVERIFIED = "SKIPPED_UNVERIFIED"
+
+CHECK_NAME = "required_contexts"
+
+
+def check_required_contexts(
+    project_root: Path,
+    *,
+    head_sha: str,
+    protected_branch: str = "main",
+    timeout: int = 20,
+) -> Dict[str, Any]:
+    """Check that every REQUIRED branch-protection context exists on the PR head.
+
+    ``pre_merge_gate.check_ci_workflow`` answers "did the configured CI
+    workflow run and succeed on this commit". That is a different question
+    from "is every check branch protection insists on actually present", and
+    #1691 is the case where the two answers disagreed: nine visible passes,
+    zero fails, and five of the fourteen required contexts never created at
+    all during an Actions outage. Counting what is present cannot see that.
+
+    The naive form of this check is worse than the gap it closes. #1701
+    measured that: twelve green, Profile B and Profile C absent because both
+    declare ``needs: profile-a`` and profile-a had not finished. A guard that
+    reads "absent" as "never created" blocks every PR in the first minutes of
+    its own CI. The verdict therefore keeps four outcomes apart:
+
+      - every context passed                      -> GO
+      - a context is missing for good, or failed  -> HOLD, named per context
+      - a context is still coming                 -> HOLD, reported as in
+        flight, so the reader knows the fix is time and not a re-run
+      - anything unmeasurable                     -> SKIPPED_UNVERIFIED
+
+    SKIPPED_UNVERIFIED, never GO, on an unreadable branch-protection list or
+    an unreachable gh: ``run_gate_checks`` treats it as blocking, and a merge
+    gate that could not look must not grant permission because it failed to
+    look (the OI-1140 contract, applied to this second question).
+    """
+    try:
+        states = ci_contexts.evaluate_commit(
+            project_root, head_sha, branch=protected_branch, timeout=timeout,
+        )
+    except ci_contexts.CIContextsError as exc:
+        return {
+            "check": CHECK_NAME,
+            "status": SKIPPED_UNVERIFIED,
+            "detail": f"required contexts could not be read: {exc}",
+            "contexts": [],
+            "summary": None,
+        }
+
+    summary = ci_contexts.summarise(states)
+    payload: Dict[str, Any] = {
+        "check": CHECK_NAME,
+        "contexts": [s.to_dict() for s in states],
+        "summary": summary,
+    }
+
+    if not states:
+        payload["status"] = SKIPPED_UNVERIFIED
+        payload["detail"] = (
+            f"branch protection on {protected_branch!r} lists no required contexts — "
+            "nothing to verify, which is a misconfiguration rather than a pass"
+        )
+        return payload
+
+    if summary["unverified"]:
+        unverified = [s.context for s in states if s.state == ci_contexts.STATE_UNVERIFIED]
+        payload["status"] = SKIPPED_UNVERIFIED
+        payload["detail"] = (
+            f"{len(unverified)} of {summary['total']} required contexts could not be "
+            f"classified: {', '.join(unverified)}"
+        )
+        return payload
+
+    blocking = [s for s in states if s.blocking]
+    if not blocking:
+        payload["status"] = "GO"
+        payload["detail"] = f"all {summary['total']} required contexts passed on {head_sha[:12]}"
+        return payload
+
+    payload["status"] = "HOLD"
+    payload["detail"] = _describe_blocking(blocking, summary["total"], head_sha)
+    return payload
+
+
+def _describe_blocking(blocking, total: int, head_sha: str) -> str:
+    """One line naming what blocks, with settled and in-flight kept apart."""
+    settled = [s for s in blocking if not s.transient]
+    in_flight = [s for s in blocking if s.transient]
+    parts = []
+    if settled:
+        parts.append(
+            "not satisfied: " + "; ".join(f"{s.context} [{s.state}] {s.detail}" for s in settled)
+        )
+    if in_flight:
+        parts.append("still in flight: " + ", ".join(f"{s.context} [{s.state}]" for s in in_flight))
+    return (
+        f"{len(blocking)} of {total} required contexts block the merge on "
+        f"{head_sha[:12]} — " + " | ".join(parts)
+    )

--- a/scripts/pre_merge_gate.py
+++ b/scripts/pre_merge_gate.py
@@ -48,6 +48,7 @@ from quality_advisory import (
 )
 from cqs_calculator import calculate_cqs
 from gate_findings_bridge import record_gate_finding, resolve_gate_finding
+from required_contexts_gate import check_required_contexts
 
 # CQS threshold: dispatches below this score get a HOLD
 CQS_THRESHOLD = 50.0
@@ -1322,6 +1323,14 @@ def run_gate_checks(
             ))
     else:
         checks.append(check_ci_workflow(project_root, workflow_name=ci_workflow_name))
+
+    # #1691/#1701: what EXISTS on the head is a different question from what
+    # branch protection REQUIRES, and only the second one can see a context
+    # that was never created. Meaningful only for a resolved PR head — a local
+    # working copy has no protected-branch contract to compare against, so the
+    # check is omitted rather than answered with a guess.
+    if pr_head is not None and pr_head.head_ref:
+        checks.append(check_required_contexts(project_root, head_sha=pr_head.head_ref))
 
     if not skip_pytest:
         checks.append(check_pytest(project_root))

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -471,3 +471,35 @@ def test_gh_failure_raises_rather_than_returning_an_empty_list(tmp_path):
     with pytest.raises(cc.CIContextsError) as excinfo:
         cc._gh_json(["api", "repos/{owner}/{repo}/nope"], tmp_path, timeout=10)
     assert "failed" in str(excinfo.value) or "not available" in str(excinfo.value)
+
+
+def test_the_any_app_sentinel_is_normalised_to_no_binding(monkeypatch, tmp_path):
+    """GitHub's branch-protection API uses app_id -1 for "any app may set this
+    status". It is an int, so a naive isinstance check keeps it as if it named
+    a real producer — and then NO run matches it, turning every any-app
+    required check into a false `unverified`.
+    """
+    payload = {
+        "required_status_checks": {
+            "contexts": [],
+            "checks": [
+                {"context": "any app", "app_id": cc.ANY_APP_ID},
+                {"context": "bound", "app_id": 15368},
+            ],
+        }
+    }
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
+    assert cc.fetch_required_checks(tmp_path) == [
+        cc.RequiredCheck("any app", None),
+        cc.RequiredCheck("bound", 15368),
+    ]
+
+
+def test_an_any_app_requirement_is_satisfied_by_any_producer(graph):
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", None)],
+        [_app_check("Profile A", 777)],
+        [_run()],
+        graph,
+    )
+    assert state.state == cc.STATE_PASSED

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -350,21 +350,121 @@ def test_summarise_counts_each_state_separately(graph):
     assert summary["by_state"]["Profile B"] == cc.STATE_NEVER_CREATED
 
 
-def test_required_contexts_unions_both_github_shapes(monkeypatch, tmp_path):
+def test_required_checks_unions_both_github_shapes(monkeypatch, tmp_path):
     payload = {
         "required_status_checks": {
             "contexts": ["legacy only", "shared"],
-            "checks": [{"context": "shared"}, {"context": "checks only"}, {"no_context": 1}],
+            "checks": [
+                {"context": "shared", "app_id": 15368},
+                {"context": "checks only", "app_id": 15368},
+                {"no_context": 1},
+            ],
         }
     }
     monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
-    assert cc.fetch_required_contexts(tmp_path) == ["checks only", "legacy only", "shared"]
+    assert cc.fetch_required_checks(tmp_path) == [
+        cc.RequiredCheck("checks only", 15368),
+        cc.RequiredCheck("legacy only", None),
+        cc.RequiredCheck("shared", 15368),
+    ]
 
 
-def test_required_contexts_refuses_a_non_mapping_payload(monkeypatch, tmp_path):
+def test_the_app_bound_shape_wins_over_the_legacy_name_only_entry(monkeypatch, tmp_path):
+    """Dropping the app binding would WIDEN the requirement, not narrow it."""
+    payload = {
+        "required_status_checks": {
+            "contexts": ["shared"],
+            "checks": [{"context": "shared", "app_id": 42}],
+        }
+    }
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
+    assert cc.fetch_required_checks(tmp_path) == [cc.RequiredCheck("shared", 42)]
+
+
+def test_required_checks_refuses_a_non_mapping_payload(monkeypatch, tmp_path):
     monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: ["not", "a", "mapping"])
     with pytest.raises(cc.CIContextsError):
-        cc.fetch_required_contexts(tmp_path)
+        cc.fetch_required_checks(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# The app binding branch protection actually enforces
+# ---------------------------------------------------------------------------
+
+
+def _app_check(name, app_id, conclusion="success"):
+    return {"name": name, "status": "completed", "conclusion": conclusion, "app": {"id": app_id}}
+
+
+def test_a_check_from_the_required_app_satisfies_the_requirement(graph):
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_app_check("Profile A", 15368)], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+def test_a_same_named_check_from_another_app_is_never_a_pass(graph):
+    """Branch protection would not accept it. Matching on the name alone turns
+    a foreign check into a green light."""
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_app_check("Profile A", 999)], [_run()], graph
+    )
+    assert state.state == cc.STATE_UNVERIFIED
+    assert state.blocking is True
+    assert "none is from the required app" in state.detail
+
+
+def test_a_check_run_with_no_app_object_does_not_satisfy_a_binding(graph):
+    """An unidentifiable producer cannot be shown to be the required one."""
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_check("Profile A")], [_run()], graph
+    )
+    assert state.state == cc.STATE_UNVERIFIED
+
+
+def test_without_a_binding_any_app_satisfies_the_legacy_requirement(graph):
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", None)], [_app_check("Profile A", 999)], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+def test_a_bound_context_with_only_foreign_runs_is_not_reported_as_never_created(graph):
+    """The distinction matters for the cost line: a foreign check is a
+    configuration problem, not a workflow that has to be re-run."""
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_app_check("Profile A", 999)], [], graph
+    )
+    assert state.state != cc.STATE_NEVER_CREATED
+
+
+def test_a_bare_string_requirement_still_works_as_an_unbound_check(graph):
+    [state] = cc.classify_contexts(["Profile A"], [_check("Profile A")], [_run()], graph)
+    assert state.state == cc.STATE_PASSED
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+def test_check_runs_are_fetched_with_slurp(monkeypatch, tmp_path):
+    """`gh api --paginate` emits one document per page for an OBJECT response.
+    Measured on a 16-run commit at per_page=5: four pages, and json.loads fails
+    with "Extra data" at char 15511. Without --slurp this check blocks every
+    PR whose commit has more than 100 check runs, for no real reason.
+    """
+    captured = {}
+
+    def fake(args, project_root, timeout):
+        captured["args"] = list(args)
+        return [{"check_runs": [{"name": "a"}]}, {"check_runs": [{"name": "b"}]}]
+
+    monkeypatch.setattr(cc, "_gh_json", fake)
+    runs = cc.fetch_check_runs(tmp_path, "a" * 40)
+    assert "--slurp" in captured["args"]
+    assert "--paginate" in captured["args"]
+    assert [r["name"] for r in runs] == ["a", "b"], "every page must be flattened, not just the first"
 
 
 def test_gh_failure_raises_rather_than_returning_an_empty_list(tmp_path):

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -503,3 +503,98 @@ def test_an_any_app_requirement_is_satisfied_by_any_producer(graph):
         graph,
     )
     assert state.state == cc.STATE_PASSED
+
+
+# ---------------------------------------------------------------------------
+# Legacy commit statuses — the other half of the namespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state,expected_status,expected_conclusion",
+    [
+        ("success", "completed", "success"),
+        ("failure", "completed", "failure"),
+        ("error", "completed", "failure"),
+        ("pending", "in_progress", None),
+    ],
+)
+def test_commit_statuses_map_onto_the_check_run_vocabulary(
+    monkeypatch, tmp_path, state, expected_status, expected_conclusion
+):
+    monkeypatch.setattr(
+        cc, "_gh_json", lambda *a, **k: {"statuses": [{"context": "legacy ci", "state": state}]}
+    )
+    [entry] = cc.fetch_commit_statuses(tmp_path, "a" * 40)
+    assert entry["name"] == "legacy ci"
+    assert entry["status"] == expected_status
+    assert entry["conclusion"] == expected_conclusion
+
+
+def test_an_unrecognised_status_state_holds_the_verdict_rather_than_deciding_it(
+    monkeypatch, tmp_path
+):
+    """A future state value must not silently pass or fail."""
+    monkeypatch.setattr(
+        cc, "_gh_json", lambda *a, **k: {"statuses": [{"context": "x", "state": "warped"}]}
+    )
+    [entry] = cc.fetch_commit_statuses(tmp_path, "a" * 40)
+    assert entry["status"] == "in_progress" and entry["conclusion"] is None
+
+
+def test_only_the_newest_status_per_context_counts(monkeypatch, tmp_path):
+    """GitHub lists the history newest-first; a superseded older state is not
+    what branch protection evaluates."""
+    monkeypatch.setattr(
+        cc, "_gh_json",
+        lambda *a, **k: {"statuses": [
+            {"context": "legacy ci", "state": "success"},
+            {"context": "legacy ci", "state": "failure"},
+        ]},
+    )
+    entries = cc.fetch_commit_statuses(tmp_path, "a" * 40)
+    assert len(entries) == 1 and entries[0]["conclusion"] == "success"
+
+
+def test_a_required_context_satisfied_by_a_status_is_not_reported_as_missing(graph):
+    """Branch protection's legacy `contexts[]` can be satisfied by a commit
+    STATUS rather than a check run. Reading only check runs left such a
+    context permanently unseen, blocking a PR on evidence that was there all
+    along. Found by codex_gate on this PR.
+    """
+    status_evidence = {"name": "legacy ci", "status": "completed", "conclusion": "success"}
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("legacy ci", None)], [status_evidence], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+def test_commit_statuses_refuse_a_non_mapping_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: [1, 2, 3])
+    with pytest.raises(cc.CIContextsError):
+        cc.fetch_commit_statuses(tmp_path, "a" * 40)
+
+
+def test_evaluate_commit_consults_both_evidence_sources(monkeypatch, tmp_path):
+    """The wiring itself, not just the fetcher. A required context satisfied
+    only by a commit status must come back `passed` from the top-level entry
+    point — dropping the status source from evaluate_commit is a one-line
+    regression that every fetcher-level test would survive.
+    """
+    workflows = _write_workflow(tmp_path, "vnx-ci.yml", _GRAPH_BODY)
+    monkeypatch.setattr(
+        cc, "fetch_required_checks",
+        lambda *a, **k: [cc.RequiredCheck("Profile A", None), cc.RequiredCheck("legacy ci", None)],
+    )
+    monkeypatch.setattr(cc, "fetch_check_runs", lambda *a, **k: [_check("Profile A")])
+    monkeypatch.setattr(
+        cc, "fetch_commit_statuses",
+        lambda *a, **k: [{"name": "legacy ci", "status": "completed", "conclusion": "success"}],
+    )
+    monkeypatch.setattr(cc, "fetch_workflow_runs", lambda *a, **k: [_run()])
+
+    states = cc.evaluate_commit(tmp_path, "a" * 40, workflows_dir=workflows)
+    assert {s.context: s.state for s in states} == {
+        "Profile A": cc.STATE_PASSED,
+        "legacy ci": cc.STATE_PASSED,
+    }

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -1,0 +1,373 @@
+"""Regression guards for scripts/lib/ci_contexts.py.
+
+Two measured cases anchor this file and they look identical from the outside:
+
+  #1691 — five of fourteen required contexts were never created during an
+          Actions outage. ``gh pr checks`` showed nine passes, zero fails.
+  #1701 — twelve of fourteen green, Profile B and Profile C absent because
+          both declare ``needs: profile-a`` and profile-a had not finished.
+
+The first must block loudly. The second must say "wait". A guard that
+collapses them is either useless or blocks every PR in its first minutes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import ci_contexts as cc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Graph parsing
+# ---------------------------------------------------------------------------
+
+
+def _write_workflow(tmp_path: Path, filename: str, body: str) -> Path:
+    workflows = tmp_path / "workflows"
+    workflows.mkdir(exist_ok=True)
+    (workflows / filename).write_text(body, encoding="utf-8")
+    return workflows
+
+
+def test_graph_uses_job_name_as_context_and_falls_back_to_job_key(tmp_path):
+    workflows = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+name: Demo CI
+on: [push]
+jobs:
+  named:
+    name: Profile A (doctor + core tests)
+    runs-on: ubuntu-latest
+  unnamed:
+    runs-on: ubuntu-latest
+""",
+    )
+    graph = cc.parse_workflow_graph(workflows)
+    assert "Profile A (doctor + core tests)" in graph.by_context
+    assert graph.by_context["Profile A (doctor + core tests)"].job_key == "named"
+    # No `name:` — GitHub uses the job key as the context, and so do we.
+    assert "unnamed" in graph.by_context
+    assert graph.parse_errors == ()
+
+
+@pytest.mark.parametrize(
+    "needs_literal,expected",
+    [("profile-a", ("profile-a",)), ("[profile-a, profile-d]", ("profile-a", "profile-d"))],
+)
+def test_graph_normalises_needs_string_and_list(tmp_path, needs_literal, expected):
+    workflows = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        f"""
+name: Demo CI
+on: [push]
+jobs:
+  profile-a:
+    name: A
+    runs-on: ubuntu-latest
+  profile-d:
+    name: D
+    runs-on: ubuntu-latest
+  profile-b:
+    name: B
+    needs: {needs_literal}
+    runs-on: ubuntu-latest
+""",
+    )
+    graph = cc.parse_workflow_graph(workflows)
+    assert tuple(graph.by_context["B"].needs) == expected
+
+
+def test_graph_records_unparseable_file_instead_of_skipping_it(tmp_path):
+    workflows = _write_workflow(tmp_path, "broken.yml", "name: [unclosed\njobs:\n")
+    graph = cc.parse_workflow_graph(workflows)
+    assert graph.by_context == {}
+    assert len(graph.parse_errors) == 1
+    assert "broken.yml" in graph.parse_errors[0]
+
+
+def test_graph_reports_duplicate_context_rather_than_overwriting(tmp_path):
+    workflows = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+name: Demo CI
+on: [push]
+jobs:
+  first:
+    name: Shared
+    runs-on: ubuntu-latest
+  second:
+    name: Shared
+    runs-on: ubuntu-latest
+""",
+    )
+    graph = cc.parse_workflow_graph(workflows)
+    assert graph.by_context["Shared"].job_key == "first"
+    assert any("duplicate context" in e for e in graph.parse_errors)
+
+
+def test_graph_on_missing_directory_is_an_error_not_an_empty_pass(tmp_path):
+    graph = cc.parse_workflow_graph(tmp_path / "does-not-exist")
+    assert graph.by_context == {}
+    assert graph.parse_errors and "not found" in graph.parse_errors[0]
+
+
+def test_real_vnx_ci_still_gates_profile_b_and_c_behind_profile_a():
+    """The #1701 fact this module is calibrated against, guarded in place.
+
+    If vnx-ci.yml ever drops ``needs: profile-a`` from Profile B/C, the
+    waiting_upstream classification stops describing this repo and the guard
+    silently changes meaning.
+    """
+    graph = cc.parse_workflow_graph(REPO_ROOT / ".github" / "workflows")
+    for context in ("Profile B (snapshot integration)", "Profile C (adoption smoke tests)"):
+        node = graph.by_context[context]
+        assert node.workflow_file == "vnx-ci.yml"
+        assert "profile-a" in node.needs
+
+
+# ---------------------------------------------------------------------------
+# Classification — contexts that exist
+# ---------------------------------------------------------------------------
+
+_GRAPH_BODY = """
+name: VNX CI
+on: [push]
+jobs:
+  profile-a:
+    name: Profile A
+    runs-on: ubuntu-latest
+  profile-b:
+    name: Profile B
+    needs: profile-a
+    runs-on: ubuntu-latest
+"""
+
+
+@pytest.fixture()
+def graph(tmp_path):
+    return cc.parse_workflow_graph(_write_workflow(tmp_path, "vnx-ci.yml", _GRAPH_BODY))
+
+
+def _run(status="completed", conclusion="success", name="VNX CI", run_id=1):
+    return {"id": run_id, "name": name, "status": status, "conclusion": conclusion}
+
+
+def _check(name, status="completed", conclusion="success"):
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+def test_present_and_successful_is_the_only_non_blocking_state(graph):
+    [state] = cc.classify_contexts(["Profile A"], [_check("Profile A")], [_run()], graph)
+    assert state.state == cc.STATE_PASSED
+    assert state.blocking is False
+
+
+@pytest.mark.parametrize("conclusion", ["skipped", "neutral"])
+def test_skipped_and_neutral_conclusions_count_as_passing(graph, conclusion):
+    [state] = cc.classify_contexts(
+        ["Profile A"], [_check("Profile A", conclusion=conclusion)], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "timed_out", "action_required", ""])
+def test_terminal_non_passing_conclusion_is_failed(graph, conclusion):
+    [state] = cc.classify_contexts(
+        ["Profile A"], [_check("Profile A", conclusion=conclusion)], [_run()], graph
+    )
+    assert state.state == cc.STATE_FAILED
+    assert state.blocking is True
+
+
+def test_unfinished_check_run_is_running_not_failed(graph):
+    [state] = cc.classify_contexts(
+        ["Profile A"],
+        [_check("Profile A", status="in_progress", conclusion=None)],
+        [_run(status="in_progress", conclusion=None)],
+        graph,
+    )
+    assert state.state == cc.STATE_RUNNING
+    assert state.blocking is True and state.transient is True
+
+
+def test_duplicate_check_runs_resolve_to_the_failing_one(graph):
+    """One context, two runs (push + pull_request). The passing copy must not
+    win: resolving a disagreement in favour of green is the green-lie itself.
+    """
+    [state] = cc.classify_contexts(
+        ["Profile A"],
+        [_check("Profile A"), _check("Profile A", conclusion="failure")],
+        [_run()],
+        graph,
+    )
+    assert state.state == cc.STATE_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Classification — contexts that do NOT exist (the whole point)
+# ---------------------------------------------------------------------------
+
+
+def test_1701_shape_absent_context_behind_a_running_dependency_says_wait(graph):
+    """Profile B absent, VNX CI alive, profile-a not finished — WAIT."""
+    jobs = {1: [{"name": "Profile A", "status": "in_progress", "conclusion": None}]}
+    [state] = cc.classify_contexts(
+        ["Profile B"],
+        [_check("Profile A", status="in_progress", conclusion=None)],
+        [_run(status="in_progress", conclusion=None)],
+        graph,
+        jobs,
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert state.transient is True
+    assert "Profile A" in state.detail
+
+
+def test_1691_shape_absent_context_on_a_finished_run_is_never_created(graph):
+    """VNX CI concluded, Profile B never appeared — the outage shape. Blocks."""
+    jobs = {1: [{"name": "Profile A", "status": "completed", "conclusion": "success"}]}
+    [state] = cc.classify_contexts(
+        ["Profile B"], [_check("Profile A")], [_run()], graph, jobs
+    )
+    assert state.state == cc.STATE_NEVER_CREATED
+    assert state.blocking is True and state.transient is False
+    assert "#1691" in state.detail
+
+
+def test_absent_context_whose_dependency_failed_can_never_be_created(graph):
+    """Run still alive, but profile-a already failed: waiting cannot help."""
+    jobs = {1: [{"name": "Profile A", "status": "completed", "conclusion": "failure"}]}
+    [state] = cc.classify_contexts(
+        ["Profile B"],
+        [_check("Profile A", conclusion="failure")],
+        [_run(status="in_progress", conclusion=None)],
+        graph,
+        jobs,
+    )
+    assert state.state == cc.STATE_NEVER_CREATED
+    assert "profile-a" in state.detail
+
+
+def test_absent_context_with_no_workflow_run_at_all_is_no_run(graph):
+    [state] = cc.classify_contexts(["Profile A"], [], [], graph)
+    assert state.state == cc.STATE_NO_RUN
+    assert state.blocking is True
+
+
+def test_absent_context_no_job_produces_it_is_unverified_never_green(graph):
+    [state] = cc.classify_contexts(["Some App Check"], [], [_run()], graph)
+    assert state.state == cc.STATE_UNVERIFIED
+    assert state.blocking is True
+    assert "cannot tell" in state.detail
+
+
+def test_waiting_names_the_dependency_even_without_job_data(graph):
+    """Job-level detail may fail to load. The verdict must survive that.
+
+    With no job list, an unobserved ancestor counts as pending — "not created
+    yet" is exactly the state that makes the child wait — so the message still
+    names Profile A instead of degrading to a bare "still running".
+    """
+    [state] = cc.classify_contexts(
+        ["Profile B"], [], [_run(status="queued", conclusion=None)], graph
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert "waiting on Profile A" in state.detail
+
+
+def test_waiting_falls_back_to_declared_needs_when_the_dependency_is_unresolvable(tmp_path):
+    """``needs:`` naming a job that does not exist in the file.
+
+    The ancestor cannot be resolved to a context name, so there is nothing to
+    report as pending — the message falls back to the raw declaration rather
+    than claiming the run simply has not got round to the job.
+    """
+    broken = cc.parse_workflow_graph(
+        _write_workflow(
+            tmp_path,
+            "vnx-ci.yml",
+            """
+name: VNX CI
+on: [push]
+jobs:
+  profile-b:
+    name: Profile B
+    needs: ghost-job
+    runs-on: ubuntu-latest
+""",
+        )
+    )
+    [state] = cc.classify_contexts(
+        ["Profile B"], [], [_run(status="queued", conclusion=None)], broken
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert "declares needs: ghost-job" in state.detail
+
+
+def test_missing_context_without_dependencies_on_a_live_run_still_waits(graph):
+    [state] = cc.classify_contexts(
+        ["Profile A"], [], [_run(status="queued", conclusion=None)], graph
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert "has not created this job yet" in state.detail
+
+
+# ---------------------------------------------------------------------------
+# Contract guards
+# ---------------------------------------------------------------------------
+
+
+def test_only_passed_is_non_blocking():
+    """An allowlist, so a state added later blocks until someone decides."""
+    assert cc.NON_BLOCKING_STATES == frozenset({cc.STATE_PASSED})
+
+
+def test_summarise_counts_each_state_separately(graph):
+    states = cc.classify_contexts(
+        ["Profile A", "Profile B", "Some App Check"],
+        [_check("Profile A")],
+        [_run()],
+        graph,
+        {1: [{"name": "Profile A", "status": "completed", "conclusion": "success"}]},
+    )
+    summary = cc.summarise(states)
+    assert summary["total"] == 3
+    assert summary["passed"] == 1
+    assert summary["never_created"] == 1
+    assert summary["unverified"] == 1
+    assert summary["blocking"] == 2
+    assert summary["by_state"]["Profile B"] == cc.STATE_NEVER_CREATED
+
+
+def test_required_contexts_unions_both_github_shapes(monkeypatch, tmp_path):
+    payload = {
+        "required_status_checks": {
+            "contexts": ["legacy only", "shared"],
+            "checks": [{"context": "shared"}, {"context": "checks only"}, {"no_context": 1}],
+        }
+    }
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
+    assert cc.fetch_required_contexts(tmp_path) == ["checks only", "legacy only", "shared"]
+
+
+def test_required_contexts_refuses_a_non_mapping_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: ["not", "a", "mapping"])
+    with pytest.raises(cc.CIContextsError):
+        cc.fetch_required_contexts(tmp_path)
+
+
+def test_gh_failure_raises_rather_than_returning_an_empty_list(tmp_path):
+    with pytest.raises(cc.CIContextsError) as excinfo:
+        cc._gh_json(["api", "repos/{owner}/{repo}/nope"], tmp_path, timeout=10)
+    assert "failed" in str(excinfo.value) or "not available" in str(excinfo.value)

--- a/tests/test_pre_merge_gate_pr_ref.py
+++ b/tests/test_pre_merge_gate_pr_ref.py
@@ -211,6 +211,18 @@ class TestRunGateChecksPRHead:
                 "net_line_deletion_warn": False, "file_deletion_warn": False,
             },
         )
+        # required_contexts runs only for a resolved PR head, which the tests
+        # in this class supply. Stubbed so orchestration tests stay hermetic:
+        # the real check shells out to `gh api .../branches/main/protection`,
+        # and measuring this suite showed exactly one such live call escaping
+        # per run. Its own coverage is in test_pre_merge_gate_required_contexts.py.
+        monkeypatch.setattr(
+            pre_merge_gate, "check_required_contexts",
+            lambda project_root, **kw: {
+                "check": "required_contexts", "status": "GO", "detail": "stub",
+                "contexts": [], "summary": None,
+            },
+        )
 
     def test_without_pr_head_measures_head(self, state_dir, dispatch_dir, tmp_path, monkeypatch):
         captured = {}
@@ -274,6 +286,18 @@ class TestRunGateChecksCIHead:
                 "check": "net_deletion", "status": "GO", "detail": "stub",
                 "deleted_count": 0, "deleted_files": [], "net_line_deletion": 0,
                 "net_line_deletion_warn": False, "file_deletion_warn": False,
+            },
+        )
+        # required_contexts runs only for a resolved PR head, which the tests
+        # in this class supply. Stubbed so orchestration tests stay hermetic:
+        # the real check shells out to `gh api .../branches/main/protection`,
+        # and measuring this suite showed exactly one such live call escaping
+        # per run. Its own coverage is in test_pre_merge_gate_required_contexts.py.
+        monkeypatch.setattr(
+            pre_merge_gate, "check_required_contexts",
+            lambda project_root, **kw: {
+                "check": "required_contexts", "status": "GO", "detail": "stub",
+                "contexts": [], "summary": None,
             },
         )
 

--- a/tests/test_pre_merge_gate_required_contexts.py
+++ b/tests/test_pre_merge_gate_required_contexts.py
@@ -1,0 +1,185 @@
+"""pre_merge_gate.check_required_contexts — the merge-gate half of #1691/#1701.
+
+The classifier itself is covered in tests/test_ci_contexts.py. This file
+covers the translation from its states into a gate verdict, where the two
+mistakes that matter are opposite: reading an unmeasurable answer as GO, and
+reading "not created yet" as "never created".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import ci_contexts  # noqa: E402
+import pre_merge_gate  # noqa: E402
+from pre_merge_gate import SKIPPED_UNVERIFIED, run_gate_checks  # noqa: E402
+from required_contexts_gate import check_required_contexts  # noqa: E402
+import required_contexts_gate  # noqa: E402
+from pre_merge_gate import ResolvedPRRef  # noqa: E402
+
+HEAD = "a" * 40
+
+
+def test_the_mirrored_sentinel_matches_the_gate_it_mirrors():
+    """required_contexts_gate re-declares SKIPPED_UNVERIFIED to avoid an
+    import cycle. If the two ever drift, an unverifiable answer stops being
+    recognised as blocking by run_gate_checks and reads as an unknown status.
+    """
+    assert required_contexts_gate.SKIPPED_UNVERIFIED == SKIPPED_UNVERIFIED
+
+
+def _state(context, state, detail="d"):
+    return ci_contexts.ContextState(context=context, state=state, detail=detail)
+
+
+def _stub_states(monkeypatch, states):
+    monkeypatch.setattr(ci_contexts, "evaluate_commit", lambda *a, **k: states)
+
+
+def test_all_passed_is_go(monkeypatch, tmp_path):
+    _stub_states(monkeypatch, [_state("Profile A", ci_contexts.STATE_PASSED)])
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == "GO"
+    assert "all 1 required contexts passed" in result["detail"]
+
+
+def test_never_created_holds_and_names_the_context(monkeypatch, tmp_path):
+    """The #1691 shape: the gate must say WHICH context is missing."""
+    _stub_states(
+        monkeypatch,
+        [
+            _state("Profile A", ci_contexts.STATE_PASSED),
+            _state("Profile B", ci_contexts.STATE_NEVER_CREATED, "run finished without it"),
+        ],
+    )
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == "HOLD"
+    assert "Profile B" in result["detail"]
+    assert "not satisfied" in result["detail"]
+    assert result["summary"]["never_created"] == 1
+
+
+def test_waiting_holds_but_is_reported_as_in_flight(monkeypatch, tmp_path):
+    """The #1701 shape: still blocking, but the fix is time, not a re-run."""
+    _stub_states(
+        monkeypatch,
+        [
+            _state("Profile A", ci_contexts.STATE_PASSED),
+            _state("Profile B", ci_contexts.STATE_WAITING_UPSTREAM, "waiting on Profile A"),
+        ],
+    )
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == "HOLD"
+    assert "still in flight" in result["detail"]
+    assert "not satisfied" not in result["detail"]
+
+
+def test_unverified_context_is_skipped_unverified_never_go(monkeypatch, tmp_path):
+    _stub_states(
+        monkeypatch,
+        [
+            _state("Profile A", ci_contexts.STATE_PASSED),
+            _state("Some App Check", ci_contexts.STATE_UNVERIFIED),
+        ],
+    )
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == SKIPPED_UNVERIFIED
+    assert "Some App Check" in result["detail"]
+
+
+def test_unreadable_branch_protection_is_skipped_unverified(monkeypatch, tmp_path):
+    def _boom(*a, **k):
+        raise ci_contexts.CIContextsError("gh api failed (rc=1): not a git repository")
+
+    monkeypatch.setattr(ci_contexts, "evaluate_commit", _boom)
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == SKIPPED_UNVERIFIED
+    assert "not a git repository" in result["detail"]
+
+
+def test_empty_required_list_is_a_misconfiguration_not_a_pass(monkeypatch, tmp_path):
+    """Zero required contexts must never read as "everything required passed"."""
+    _stub_states(monkeypatch, [])
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == SKIPPED_UNVERIFIED
+    assert "misconfiguration" in result["detail"]
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ci_contexts.STATE_FAILED,
+        ci_contexts.STATE_NO_RUN,
+        ci_contexts.STATE_NEVER_CREATED,
+        ci_contexts.STATE_RUNNING,
+        ci_contexts.STATE_WAITING_UPSTREAM,
+    ],
+)
+def test_no_non_passing_state_ever_yields_go(monkeypatch, tmp_path, state):
+    _stub_states(monkeypatch, [_state("Profile A", state)])
+    assert check_required_contexts(tmp_path, head_sha=HEAD)["status"] != "GO"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator wiring
+# ---------------------------------------------------------------------------
+
+
+def _quiet_orchestrator(monkeypatch):
+    for name, payload in (
+        ("check_pr_size", {"check": "pr_size", "status": "GO", "detail": "stub"}),
+        ("check_ci_workflow", {"check": "ci_workflow", "status": "GO", "detail": "stub"}),
+        ("check_net_deletion", {"check": "net_deletion", "status": "GO", "detail": "stub"}),
+    ):
+        monkeypatch.setattr(pre_merge_gate, name, lambda project_root, _p=payload, **kw: dict(_p))
+
+
+def test_orchestrator_omits_the_check_without_a_resolved_pr_head(monkeypatch, tmp_path):
+    """A local working copy has no protected-branch contract to compare to."""
+    _quiet_orchestrator(monkeypatch)
+    called = []
+    monkeypatch.setattr(
+        pre_merge_gate, "check_required_contexts",
+        lambda *a, **kw: called.append(kw) or {"check": "required_contexts", "status": "GO"},
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    dispatch_dir = tmp_path / "dispatches"
+    for sub in ("pending", "active", "completed", "staging"):
+        (dispatch_dir / sub).mkdir(parents=True)
+
+    result = run_gate_checks(
+        pr_id="PR-6", project_root=tmp_path, state_dir=state_dir,
+        dispatch_dir=dispatch_dir, skip_pytest=True,
+    )
+    assert called == []
+    assert not any(c["check"] == "required_contexts" for c in result["checks"])
+
+
+def test_orchestrator_binds_the_check_to_the_pr_head(monkeypatch, tmp_path):
+    """Never the local HEAD: the required contexts live on the PR's commit."""
+    _quiet_orchestrator(monkeypatch)
+    called = []
+    monkeypatch.setattr(
+        pre_merge_gate, "check_required_contexts",
+        lambda *a, **kw: called.append(kw) or {"check": "required_contexts", "status": "GO"},
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    dispatch_dir = tmp_path / "dispatches"
+    for sub in ("pending", "active", "completed", "staging"):
+        (dispatch_dir / sub).mkdir(parents=True)
+
+    run_gate_checks(
+        pr_id="1522", project_root=tmp_path, state_dir=state_dir,
+        dispatch_dir=dispatch_dir, skip_pytest=True,
+        pr_head=ResolvedPRRef("1522", "b" * 40, "feature/x", "c" * 40),
+    )
+    assert called and called[0]["head_sha"] == "b" * 40


### PR DESCRIPTION
## What

`gh pr checks` lists the contexts that **exist** on a commit. Branch protection enforces the contexts that are **required**. #1691 is the measured case where the two disagreed: nine visible passes, zero fails, and five of the fourteen required contexts never created at all during an Actions outage.

The naive fix is worse than the bug. #1701 measured the false alarm: twelve green, `Profile B` and `Profile C` absent because both declare `needs: profile-a` (vnx-ci.yml:384, :448) and profile-a had not finished. Absent meant *not created yet*. A guard that reads that as *never created* blocks every PR in the first minutes of its own CI.

## How

`scripts/lib/ci_contexts.py` classifies each required context into the states that actually differ:

| state | meaning | blocks | fix |
|---|---|---|---|
| `passed` | exists, passing conclusion | no | — |
| `failed` | exists, non-passing terminal conclusion | yes | fix the code |
| `running` | exists, not concluded | yes | wait |
| `waiting_upstream` | absent, producing run alive | yes | **wait** (the #1701 shape) |
| `never_created` | absent, run finished or a dependency already failed | yes | **re-run** (the #1691 shape) |
| `no_run` | producing workflow never started on this commit | yes | start CI |
| `unverified` | cannot be classified | yes | investigate |

The `waiting_upstream` / `never_created` split needs the `needs:` graph, which no API reports — it is parsed from the workflow YAML in the checkout and combined with the liveness of the producing workflow run.

`unverified` is never collapsed into a pass. That is the OI-1140 contract (`check_ci_workflow`'s `SKIPPED_UNVERIFIED`), applied to the second question.

`scripts/lib/required_contexts_gate.py` turns those states into `GO` / `HOLD` / `SKIPPED_UNVERIFIED`. `pre_merge_gate` calls it for a **resolved PR head only** — a local working copy has no protected-branch contract to compare against, so the check is omitted rather than answered with a guess.

## Why the verdict logic is not inside pre_merge_gate.py

`scripts/pre_merge_gate.py` is 1522 lines on `main`, already past the 1200-line hard ceiling `quality_advisory` enforces. Adding ~100 lines there would have traded one governance finding for another. The wiring in that file is 9 lines.

## Verification

- `tests/test_ci_contexts.py` — 31 tests. Both measured shapes are named tests: `test_1701_shape_absent_context_behind_a_running_dependency_says_wait` and `test_1691_shape_absent_context_on_a_finished_run_is_never_created`.
- `tests/test_pre_merge_gate_required_contexts.py` — 12 tests over the verdict translation and the orchestrator wiring.
- **Mutation-checked**, three decision branches, each caught by a distinct test:
  - run always reads as alive → `test_1691_shape...` + `test_summarise...` fail
  - failed upstream ignored → `test_absent_context_whose_dependency_failed...` fails
  - duplicate check-runs resolve to the first → `test_duplicate_check_runs_resolve_to_the_failing_one` fails
- **Live**: `evaluate_commit` on #1701's head (`86bcb512`) classifies all 14 required contexts `passed`, with **zero** extra API calls — job data is fetched only for a context that is actually missing.
- `pytest tests/test_ci_contexts.py tests/test_pre_merge_gate_required_contexts.py tests/test_pre_merge_gate.py tests/test_pre_merge_gate_pr_ref.py tests/test_vnx_cli_gate_check.py tests/test_pre_merge_gate_net_deletion.py` → **167 passed**.
- `scripts/ci_lint_patterns.py --scan-stdin` over the added lines → clean.
- Instrumenting `subprocess.run` showed the `pr_ref` suite was leaking exactly **one live `gh api .../branches/main/protection` call per run**. Stubbing `check_required_contexts` in both `_stub_heavy` definitions removes it; the only `gh` invocation left in these suites is the deliberate negative-path test that proves `_gh_json` raises instead of returning an empty list.

## Known, not introduced here

`scripts/pre_merge_gate.py` exceeds the 1200-line hard ceiling on `main` (1522 → 1531). `quality_advisory` books that as the one blocking finding for any PR that touches the file. Splitting it is its own PR.

## Size

~1400 lines added, over the 300-line guidance. The classifier, its verdict translation and their tests are one unit: shipping the classifier without a consumer would be dead code, and shipping either without the mutation-checked tests would leave the #1691/#1701 distinction unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018u28zASUuaqYqLWbRpe3XN