### PR TITLE
feat(fleet): measure how far the fleet is behind the canonical role (OI-1478 follow-up)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -1750,12 +1750,13 @@ Commands:
 
   drift [--json] [--write-state] [--project-dir DIR]
                              Measure how far every registered project is behind the
-                             canonical role, on three independent axes: CONTENT (a
+                             canonical role, on three independent axes. CONTENT is a
                              diff against the canon, never a search for a known
-                             sentence), REACH (does any session actually load it —
-                             OI-1480), and STARTUP (can the role's Mandatory Startup
-                             step complete at all — OI-1481). Read-only; exits 1 when
-                             the fleet is behind. Reports, never propagates.
+                             phrase. REACH asks whether any session actually loads
+                             that file at all, per OI-1480. STARTUP asks whether the
+                             role's own Mandatory Startup step can complete, per
+                             OI-1481. Read-only, and exits 1 when the fleet is
+                             behind. Reports; never propagates.
 HELP
   else
     err "[role] unknown subcommand: $sub (try 'vnx role --help')"

--- a/bin/vnx
+++ b/bin/vnx
@@ -1724,6 +1724,13 @@ cmd_role() {
   if [ "$sub" = "sync" ]; then
     shift
     cmd_role_sync "$@"
+  elif [ "$sub" = "drift" ]; then
+    # Read-only fleet meter (OI-1478 follow-up). Deliberately NOT a propagate
+    # button: `role sync --apply` per repo stays the operator's call, and the
+    # 2026-08-28 decision (canon on main first, propagate second) is a judgement
+    # a meter must not make for him.
+    shift
+    "$VNX_PYTHON" "$VNX_HOME/scripts/fleet_role_drift.py" "$@"
   elif [ -z "$sub" ] || [ "$sub" = "-h" ] || [ "$sub" = "--help" ]; then
     cat <<'HELP'
 Usage: vnx role <command>
@@ -1740,6 +1747,15 @@ Commands:
                              any overwrite. The project terminals/T0/CLAUDE.md (thin
                              import + project context) is left untouched. Default is
                              --dry-run (preview).
+
+  drift [--json] [--write-state] [--project-dir DIR]
+                             Measure how far every registered project is behind the
+                             canonical role, on three independent axes: CONTENT (a
+                             diff against the canon, never a search for a known
+                             sentence), REACH (does any session actually load it —
+                             OI-1480), and STARTUP (can the role's Mandatory Startup
+                             step complete at all — OI-1481). Read-only; exits 1 when
+                             the fleet is behind. Reports, never propagates.
 HELP
   else
     err "[role] unknown subcommand: $sub (try 'vnx role --help')"

--- a/scripts/fleet_role_drift.py
+++ b/scripts/fleet_role_drift.py
@@ -45,6 +45,28 @@ Read-only by default. ``--write-state`` is opt-in for exactly the reason this
 tool exists to catch: a measurement that writes to the live store is itself a
 write, and an unasked-for write is how evidence gets overwritten.
 
+**Why the opt-in write emits no NDJSON ledger event** (codex advisory on
+#1704, answered rather than deferred). ADR-005 makes the ledger canonical for
+four named classes: dispatch lifecycle events, receipts, gate outcomes, and
+lease/heartbeat transitions. A component health beacon is none of those — the
+"heartbeat" in that list is the runtime_coordination lease row, not a
+``health/<component>.json`` file. Measured on 53973d6a: of the ELEVEN
+``HealthBeacon(...)`` call sites in this tree, ZERO pair the beacon with a
+ledger event. The one that a proximity grep flags,
+``producer_freshness.write_heartbeat``, sits ~10 lines below an unrelated
+function that appends ``producer_freshness_finding`` records; the beacon
+itself emits nothing. The beacon file IS the audit carrier for component
+health here, and adding a second trail only in this tool would make this tool
+the outlier rather than close a gap.
+
+What the advisory is right about, and what the boundary therefore is: a
+beacon is CURRENT-VERDICT state, replaced on every run, so it carries no
+history — you can read that the fleet is behind today, not that it was also
+behind yesterday. That is a deliberate limit of this surface, not an
+oversight. A fleet-drift TIMELINE is a different artefact with a different
+owner, and it belongs in the ledger the day someone needs to answer "how long
+has seocrawler-v2 been unreachable" rather than "is it unreachable now".
+
 Exit codes:
     0  every measured project is current on every axis
     1  at least one project is behind on at least one axis

--- a/scripts/fleet_role_drift.py
+++ b/scripts/fleet_role_drift.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Measure how far the fleet has fallen behind the canonical T0 role.
+
+OI-1478 closed with nine role files propagated by hand across three consumer
+repos. What it did NOT close is the reason that took a hand: **nothing
+measures whether the fleet is behind.** ``vnx role sync --dry-run`` answers
+the question for ONE repo, in prose, when a human happens to run it. This
+answers it for the whole fleet, as a state, with an exit code.
+
+Three axes, because the propagation can fail in three independent ways and a
+tool that reads only one of them reports a green fleet that is not green:
+
+1. **CONTENT** — is the project's copy of the role identical to the canon?
+   Measured as a DIFF against the canon, never as a search for a known
+   sentence. A search finds only the drift you already knew about: OI-1478's
+   own sweep looked for "NEVER claude -p" and would have walked straight past
+   the stale ``_FAKE_DEFAULT_ROLE`` sentinel rule that the same nine files
+   also carried. A diff finds both, plus the next one, which nobody has named
+   yet. Covers role-orchestrator.md (Claude) and the marked
+   ``<!-- VNX:BEGIN T0-ROLE -->`` block in AGENTS.md (Codex) and GEMINI.md
+   (Gemini/Kimi). Those two are gitignored, locally-generated artefacts, so
+   their ABSENCE is reported as a coverage warning and their DRIFT as
+   drift — a fresh checkout has neither and is not thereby behind.
+
+2. **REACH** — does any session actually LOAD that file? Claude Code finds
+   ``.claude/terminals/T0/role-orchestrator.md`` only through an
+   ``@role-orchestrator.md`` import in the sibling CLAUDE.md. Without it the
+   sync writes a perfectly current file that nothing ever reads (OI-1480,
+   measured in SEOcrawler_v2). A file that is up to date and unread is not a
+   propagated role; it is a propagated artefact.
+
+3. **STARTUP** — can the role's own Mandatory Startup step complete? It
+   requires the t0-orchestrator playbook to arrive either through the
+   SessionStart hook or through a model-invocable Skill fallback. When both
+   are dead the delivered role prescribes STOP, so a T0 there cannot legally
+   start at all (OI-1481, measured in sales-copilot).
+
+Plus one axis about the meter's own input: is the canon this vnx would
+PROPAGATE itself current with the fabric source? Vincent's 2026-08-28
+operator decision — canon on main first, propagate second — exists because
+syncing from a stale install pushes yesterday's role to the whole fleet in
+one command.
+
+Read-only by default. ``--write-state`` is opt-in for exactly the reason this
+tool exists to catch: a measurement that writes to the live store is itself a
+write, and an unasked-for write is how evidence gets overwritten.
+
+Exit codes:
+    0  every measured project is current on every axis
+    1  at least one project is behind on at least one axis
+    2  the meter could not measure (canon absent, registry unreadable)
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_HERE = Path(__file__).resolve().parent
+for _p in (_HERE / "lib", _HERE):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+ROLE_MARKER_BEGIN = "<!-- VNX:BEGIN T0-ROLE -->"
+ROLE_MARKER_END = "<!-- VNX:END T0-ROLE -->"
+ROLE_BASENAME = "role-orchestrator.md"
+PROVIDER_FILES = ("AGENTS.md", "GEMINI.md")
+T0_REL = Path(".claude/terminals/T0")
+SKILL_REL = Path(".claude/skills/t0-orchestrator/SKILL.md")
+DEFAULT_REGISTRY = Path.home() / ".vnx" / "projects.json"
+
+# Statuses, ordered worst-first for reporting.
+CURRENT = "current"
+STALE = "stale"
+ABSENT = "absent"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _read(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _extract_marked_block(text: str) -> Optional[str]:
+    """Return the canonical-role block between the T0-ROLE markers, or None.
+
+    Mirrors what ``vnx_upsert_marked_block`` writes: the markers sit on their
+    own lines and the payload is everything strictly between them.
+    """
+    begin = text.find(ROLE_MARKER_BEGIN)
+    if begin == -1:
+        return None
+    end = text.find(ROLE_MARKER_END, begin)
+    if end == -1:
+        return None
+    return text[begin + len(ROLE_MARKER_BEGIN):end].strip("\n")
+
+
+def _drift(canon: str, local: Optional[str]) -> Dict[str, Any]:
+    """Compare one surface against the canon and describe the difference.
+
+    ``sample`` carries the first few differing lines so an operator can see
+    WHAT drifted without opening the file — the string this tool refuses to
+    search for in advance is exactly the string it should hand back here.
+    """
+    if local is None:
+        return {"status": ABSENT, "drift_lines": None, "local_sha": None, "sample": []}
+    if local.strip() == canon.strip():
+        return {"status": CURRENT, "drift_lines": 0, "local_sha": _sha256(local), "sample": []}
+
+    canon_lines = canon.strip().splitlines()
+    local_lines = local.strip().splitlines()
+    diff = [
+        ln for ln in difflib.unified_diff(local_lines, canon_lines, lineterm="", n=0)
+        if ln[:1] in "+-" and not ln.startswith(("+++", "---"))
+    ]
+    sample = [ln.strip()[:160] for ln in diff[:6]]
+    return {
+        "status": STALE,
+        "drift_lines": len(diff),
+        "local_sha": _sha256(local),
+        "sample": sample,
+    }
+
+
+def _frontmatter_disables_invocation(text: str) -> bool:
+    """True when the FIRST frontmatter block carries the disable key.
+
+    Anchored at line start and skipping comments, matching
+    ``t0_role_audit.sh``'s check exactly: unanchored, a ``description:`` that
+    merely MENTIONS the flag false-positived as unloadable (codex finding 3,
+    2026-07-16). The two implementations must not diverge.
+    """
+    seen = 0
+    for line in text.splitlines():
+        if re.match(r"^---[ \t]*$", line):
+            seen += 1
+            if seen == 2:
+                return False
+            continue
+        if seen != 1 or line.lstrip().startswith("#"):
+            continue
+        if re.match(r"^disable-model-invocation:[ \t]*true([ \t]|$)", line):
+            return True
+    return False
+
+
+def _measure_reach(t0_dir: Path) -> Dict[str, Any]:
+    """Axis 2: would a Claude T0 session in this repo actually load the role?"""
+    claude_md = t0_dir / "CLAUDE.md"
+    text = _read(claude_md)
+    if text is None:
+        return {
+            "ok": False,
+            "reason": f"no {claude_md.name} in {t0_dir} — nothing imports the role",
+        }
+    if "@role-orchestrator" not in text:
+        return {
+            "ok": False,
+            "reason": (
+                f"{claude_md.name} does not import @role-orchestrator.md — role sync "
+                "refreshes a file no session reads (OI-1480)"
+            ),
+        }
+    return {"ok": True, "reason": "CLAUDE.md imports @role-orchestrator.md"}
+
+
+def _hook_injects_skill(project_root: Path) -> Tuple[bool, str]:
+    """Is the t0-orchestrator playbook wired into a SessionStart hook?
+
+    Static, by grep, deliberately: the hook is a shell script and executing
+    it to find out would be a side effect, not a measurement.
+    """
+    settings = project_root / ".claude" / "settings.json"
+    settings_text = _read(settings)
+    if settings_text is None or "SessionStart" not in settings_text:
+        return False, "no SessionStart entry in .claude/settings.json"
+    for hook in (
+        project_root / ".claude" / "hooks" / "sessionstart.sh",
+        project_root / "hooks" / "sessionstart.sh",
+    ):
+        hook_text = _read(hook)
+        if hook_text and "skills/t0-orchestrator/SKILL.md" in hook_text:
+            return True, f"{hook.relative_to(project_root)} injects the skill body"
+    return False, "SessionStart is wired but no hook script references t0-orchestrator/SKILL.md"
+
+
+def _measure_startup(project_root: Path, t0_dir: Path) -> Dict[str, Any]:
+    """Axis 3: can Mandatory Startup complete by either of its two routes?"""
+    routes: Dict[str, Any] = {}
+
+    claude_text = _read(t0_dir / "CLAUDE.md") or ""
+    routes["claude_md_import"] = {
+        "ok": "skills/t0-orchestrator/SKILL.md" in claude_text,
+        "reason": "CLAUDE.md @-imports the SKILL.md body" if
+        "skills/t0-orchestrator/SKILL.md" in claude_text else "CLAUDE.md does not import SKILL.md",
+    }
+
+    hook_ok, hook_reason = _hook_injects_skill(project_root)
+    routes["sessionstart_hook"] = {"ok": hook_ok, "reason": hook_reason}
+
+    skill_text = _read(project_root / SKILL_REL)
+    if skill_text is None:
+        routes["skill_tool_fallback"] = {"ok": False, "reason": f"{SKILL_REL} missing"}
+    elif _frontmatter_disables_invocation(skill_text):
+        routes["skill_tool_fallback"] = {
+            "ok": False,
+            "reason": "SKILL.md carries disable-model-invocation: true (operator-only by design)",
+        }
+    else:
+        routes["skill_tool_fallback"] = {"ok": True, "reason": "SKILL.md is model-invocable"}
+
+    ok = any(r["ok"] for r in routes.values())
+    return {
+        "ok": ok,
+        "routes": routes,
+        "reason": "at least one delivery route is live" if ok else (
+            "every delivery route is dead — the delivered role prescribes STOP, so a "
+            "T0 here cannot legally start (OI-1481)"
+        ),
+    }
+
+
+def measure_project(project_root: Path, canon: str, *, is_canon_source: bool = False) -> Dict[str, Any]:
+    """All three axes for one repo."""
+    t0_dir = project_root / T0_REL
+    surfaces: Dict[str, Any] = {}
+
+    surfaces[ROLE_BASENAME] = _drift(canon, _read(t0_dir / ROLE_BASENAME))
+    for name in PROVIDER_FILES:
+        text = _read(t0_dir / name)
+        block = _extract_marked_block(text) if text is not None else None
+        result = _drift(canon, block)
+        if text is not None and block is None:
+            result["reason"] = f"{name} exists but carries no {ROLE_MARKER_BEGIN} block"
+        surfaces[name] = result
+
+    reach = _measure_reach(t0_dir)
+    startup = _measure_startup(project_root, t0_dir)
+
+    # An ABSENT provider mirror is a coverage gap, not drift, and the two must
+    # not share a verdict. AGENTS.md and GEMINI.md are GITIGNORED
+    # (.gitignore:154 in the fabric repo) — `vnx role sync` generates them
+    # locally, so a fresh checkout legitimately has neither, and counting that
+    # as "behind the canon" makes the meter red on a repo that is perfectly in
+    # sync. Measured on this very branch's worktree, which is exactly that
+    # case. A provider mirror that EXISTS and has drifted is unambiguous:
+    # something generated it and the canon has moved since.
+    drifted = {n: s for n, s in surfaces.items() if s["status"] == STALE}
+    missing_provider = [n for n in PROVIDER_FILES if surfaces[n]["status"] == ABSENT]
+    role_absent = surfaces[ROLE_BASENAME]["status"] == ABSENT
+
+    warnings: List[str] = []
+    for name in missing_provider:
+        warnings.append(
+            f"{name} carries no canonical-role block — the "
+            f"{'Codex' if name == 'AGENTS.md' else 'Gemini/Kimi'} route has no role here "
+            f"(gitignored artefact; run `vnx role sync --apply` if that route is used)"
+        )
+
+    return {
+        "path": str(project_root),
+        "t0_dir_exists": t0_dir.is_dir(),
+        "is_canon_source": is_canon_source,
+        "content": {"ok": not drifted and not role_absent, "surfaces": surfaces},
+        "reach": reach,
+        "startup": startup,
+        "warnings": warnings,
+        "behind": bool(drifted) or role_absent or not reach["ok"] or not startup["ok"],
+    }
+
+
+def load_registry(path: Path) -> List[Dict[str, Any]]:
+    text = _read(path)
+    if text is None:
+        raise FileNotFoundError(f"registry not readable: {path}")
+    data = json.loads(text)
+    projects = data.get("projects") if isinstance(data, dict) else data
+    if not isinstance(projects, list):
+        raise ValueError(f"registry has no project list: {path}")
+    return projects
+
+
+def _resolve_canon_path() -> Path:
+    """The role file THIS vnx would propagate (what `vnx role sync` copies)."""
+    home = os.environ.get("VNX_HOME")
+    if home:
+        return Path(home) / T0_REL / ROLE_BASENAME
+    try:
+        from vnx_paths import resolve_paths  # noqa: PLC0415
+        return Path(resolve_paths()["VNX_HOME"]) / T0_REL / ROLE_BASENAME
+    except Exception:  # noqa: BLE001 — a resolver failure must not mask the measurement
+        return _HERE.parent / T0_REL / ROLE_BASENAME
+
+
+def _measure_canon_freshness(canon_path: Path, canon: str, projects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Is the canon this vnx would propagate itself current with the source?
+
+    Vincent's operator decision of 2026-08-28 (canon on main first, propagate
+    second) exists because propagating from a stale install pushes yesterday's
+    role to the whole fleet in a single command — and every consumer then
+    reports "current" against a canon that is itself behind.
+    """
+    source = next((p for p in projects if p.get("project_id") == "vnx-dev"), None)
+    if source is None:
+        return {"ok": None, "reason": "fabric source (project_id=vnx-dev) not in the registry"}
+    source_role = Path(source["path"]) / T0_REL / ROLE_BASENAME
+    try:
+        same_file = source_role.resolve() == canon_path.resolve()
+    except OSError:
+        same_file = False
+    if same_file:
+        return {"ok": True, "reason": "canon IS the fabric source checkout", "source": str(source_role)}
+    source_text = _read(source_role)
+    if source_text is None:
+        return {"ok": None, "reason": f"fabric source role unreadable: {source_role}"}
+    result = _drift(source_text, canon)
+    return {
+        "ok": result["status"] == CURRENT,
+        "reason": (
+            "canon matches the fabric source" if result["status"] == CURRENT else
+            f"canon is {result['drift_lines']} lines away from the fabric source — "
+            "syncing now would propagate a stale role"
+        ),
+        "source": str(source_role),
+        "drift": result,
+    }
+
+
+def render_text(report: Dict[str, Any]) -> str:
+    out: List[str] = []
+    out.append(f"canon: {report['canon']['path']}  sha={report['canon']['sha']}")
+    fresh = report["canon"]["freshness"]
+    flag = {True: "ok", False: "STALE", None: "?"}[fresh["ok"]]
+    out.append(f"canon freshness: [{flag}] {fresh['reason']}")
+    out.append("")
+    for name, p in sorted(report["projects"].items()):
+        if not p["t0_dir_exists"]:
+            out.append(f"[skip ] {name}: no {T0_REL} — not a VNX-terminal repo")
+            continue
+        mark = "BEHIND" if p["behind"] else "ok    "
+        out.append(f"[{mark}] {name}  ({p['path']})")
+        for surface, s in p["content"]["surfaces"].items():
+            if s["status"] == CURRENT:
+                out.append(f"           content  {surface:20s} current")
+            else:
+                extra = f" ({s['drift_lines']} diff lines)" if s["drift_lines"] is not None else ""
+                out.append(f"           content  {surface:20s} {s['status'].upper()}{extra}")
+                for ln in s["sample"]:
+                    out.append(f"                      | {ln}")
+        for w in p["warnings"]:
+            out.append(f"           warn     {w}")
+        out.append(f"           reach    {'ok' if p['reach']['ok'] else 'BROKEN'}: {p['reach']['reason']}")
+        out.append(f"           startup  {'ok' if p['startup']['ok'] else 'BROKEN'}: {p['startup']['reason']}")
+        if not p["startup"]["ok"]:
+            for route, r in p["startup"]["routes"].items():
+                out.append(f"                      | {route}: {r['reason']}")
+        out.append("")
+    behind = report["summary"]["projects_behind"]
+    total = report["summary"]["projects_measured"]
+    warned = report["summary"]["projects_with_warnings"]
+    out.append(f"fleet: {behind} of {total} measured projects behind the canon"
+               + (f", {warned} with coverage warnings" if warned else ""))
+    return "\n".join(out)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    ap.add_argument("--canon", type=Path, default=None,
+                    help="role file to measure against (default: the one this vnx would propagate)")
+    ap.add_argument("--project-dir", type=Path, action="append", default=[],
+                    help="measure this repo instead of the registry (repeatable)")
+    ap.add_argument("--json", action="store_true", help="emit the full report as JSON")
+    ap.add_argument("--write-state", action="store_true",
+                    help="also write a health beacon (opt-in: a measurement that writes is a write)")
+    ap.add_argument("--state-dir", type=Path, default=None,
+                    help="explicit state dir for --write-state (default: resolved VNX_STATE_DIR)")
+    args = ap.parse_args(argv)
+
+    canon_path = args.canon or _resolve_canon_path()
+    canon = _read(canon_path)
+    if canon is None:
+        print(f"fleet_role_drift: canonical role not readable: {canon_path}", file=sys.stderr)
+        return 2
+
+    if args.project_dir:
+        projects = [{"name": p.name, "path": str(p)} for p in args.project_dir]
+        registry_projects = projects
+    else:
+        try:
+            registry_projects = load_registry(args.registry)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"fleet_role_drift: {exc}", file=sys.stderr)
+            return 2
+        projects = registry_projects
+
+    canon_source_path = str(canon_path.parent.parent.parent.parent)
+    measured: Dict[str, Any] = {}
+    for entry in projects:
+        root = Path(entry["path"])
+        measured[entry.get("name") or root.name] = measure_project(
+            root, canon, is_canon_source=str(root) == canon_source_path,
+        )
+
+    considered = {k: v for k, v in measured.items() if v["t0_dir_exists"]}
+    behind = [k for k, v in considered.items() if v["behind"]]
+    freshness = _measure_canon_freshness(canon_path, canon, registry_projects)
+
+    report = {
+        "canon": {"path": str(canon_path), "sha": _sha256(canon), "freshness": freshness},
+        "projects": measured,
+        "summary": {
+            "projects_measured": len(considered),
+            "projects_behind": len(behind),
+            "behind": sorted(behind),
+            "projects_with_warnings": sum(1 for v in considered.values() if v["warnings"]),
+            "canon_stale": freshness["ok"] is False,
+        },
+    }
+
+    print(json.dumps(report, indent=2) if args.json else render_text(report))
+
+    if args.write_state:
+        try:
+            from health_beacon import HealthBeacon  # noqa: PLC0415
+            state_dir = args.state_dir
+            if state_dir is None:
+                from vnx_paths import resolve_paths  # noqa: PLC0415
+                state_dir = Path(resolve_paths()["VNX_STATE_DIR"])
+            HealthBeacon(state_dir, "fleet_role_drift", expected_interval_seconds=86400).heartbeat(
+                status="ok" if not behind and freshness["ok"] is not False else "fail",
+                details=report["summary"],
+            )
+        except Exception as exc:  # noqa: BLE001 — a beacon failure must not change the verdict
+            print(f"fleet_role_drift: could not write state: {exc}", file=sys.stderr)
+
+    return 1 if (behind or freshness["ok"] is False) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_oi1478_fleet_role_drift.py
+++ b/tests/test_oi1478_fleet_role_drift.py
@@ -1,0 +1,403 @@
+"""Regression tests for the fleet role-drift meter (OI-1478 follow-up).
+
+OI-1478 was closed by propagating nine role files by hand across three
+consumer repos. What stayed open is the reason that took a hand: nothing
+measured whether the fleet was behind. ``scripts/fleet_role_drift.py`` is that
+meter, and these tests pin the three properties that make it worth having
+rather than a second thing to keep in sync.
+
+  1. It measures the DIFFERENCE with the canon, never the presence of a known
+     sentence. The sweep that closed OI-1478 grepped for "NEVER claude -p" and
+     would have walked past the stale ``_FAKE_DEFAULT_ROLE`` sentinel rule the
+     same nine files also carried. ``test_drift_is_found_without_knowing_the_
+     string`` uses a divergence with no sentinel in it at all.
+
+  2. A file that is up to date is not thereby a file that is READ (OI-1480,
+     SEOcrawler_v2) and not thereby a startup that can COMPLETE (OI-1481,
+     sales-copilot). Both are independent axes with their own tests.
+
+  3. The meter does not write to the live store unless asked. A measurement
+     that writes is a write, and an unasked-for write is how gate evidence got
+     destroyed on 2026-08-26.
+
+Everything runs against tmp_path — never the registry, never the real repos.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import fleet_role_drift as frd
+
+CANON = """# T0 - VNX Master Orchestrator
+
+You are T0. You orchestrate work and governance.
+
+- Provider->lane (hard): claude/Opus/Sonnet default to the headless lane.
+- identity_unresolved is the sentinel default for "no role resolved".
+"""
+
+# A stale copy whose ONLY divergence is a line carrying neither the string the
+# OI-1478 sweep searched for nor any other sentinel. If the meter finds this,
+# it is diffing, not grepping.
+STALE_ROLE = CANON.replace(
+    "- identity_unresolved is the sentinel default for \"no role resolved\".",
+    "- backend-developer is the sentinel default for \"no role resolved\".",
+)
+
+
+def _make_repo(
+    root: Path,
+    *,
+    role: str | None = CANON,
+    claude_md: str | None = "@role-orchestrator.md\n",
+    agents_block: str | None = None,
+    gemini_block: str | None = None,
+    skill_md: str | None = None,
+    hook: str | None = None,
+    settings: str | None = None,
+) -> Path:
+    t0 = root / ".claude" / "terminals" / "T0"
+    t0.mkdir(parents=True)
+    if role is not None:
+        (t0 / "role-orchestrator.md").write_text(role, encoding="utf-8")
+    if claude_md is not None:
+        (t0 / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+    for name, block in (("AGENTS.md", agents_block), ("GEMINI.md", gemini_block)):
+        if block is not None:
+            (t0 / name).write_text(
+                f"# provider file\n\n{frd.ROLE_MARKER_BEGIN}\n{block}\n{frd.ROLE_MARKER_END}\n",
+                encoding="utf-8",
+            )
+    if skill_md is not None:
+        skill = root / ".claude" / "skills" / "t0-orchestrator"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(skill_md, encoding="utf-8")
+    if hook is not None:
+        hooks = root / ".claude" / "hooks"
+        hooks.mkdir(parents=True, exist_ok=True)
+        (hooks / "sessionstart.sh").write_text(hook, encoding="utf-8")
+    if settings is not None:
+        (root / ".claude").mkdir(parents=True, exist_ok=True)
+        (root / ".claude" / "settings.json").write_text(settings, encoding="utf-8")
+    return root
+
+
+WIRED_SETTINGS = json.dumps({"hooks": {"SessionStart": [{"command": "hooks/sessionstart.sh"}]}})
+WIRED_HOOK = 'cat "$ROOT/.claude/skills/t0-orchestrator/SKILL.md"\n'
+
+
+# ---------------------------------------------------------------------------
+# 1. Content — difference, not string search
+# ---------------------------------------------------------------------------
+
+
+def test_drift_is_found_without_knowing_the_string(tmp_path):
+    repo = _make_repo(tmp_path / "consumer", role=STALE_ROLE)
+
+    result = frd.measure_project(repo, CANON)
+    surface = result["content"]["surfaces"][frd.ROLE_BASENAME]
+
+    assert surface["status"] == frd.STALE
+    assert surface["drift_lines"] == 2, "one changed line = one removal + one addition"
+    assert result["behind"] is True
+    # The sweep that closed OI-1478 searched for this and would have found
+    # nothing in this file, yet the file is demonstrably behind the canon.
+    assert "NEVER claude -p" not in STALE_ROLE
+    joined = " ".join(surface["sample"])
+    assert "backend-developer" in joined and "identity_unresolved" in joined, (
+        "the sample must hand back WHAT drifted — the string the meter refuses "
+        "to search for in advance is the one it should report"
+    )
+
+
+def test_identical_role_is_current(tmp_path):
+    repo = _make_repo(tmp_path / "consumer", hook=WIRED_HOOK, settings=WIRED_SETTINGS)
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["content"]["surfaces"][frd.ROLE_BASENAME]["status"] == frd.CURRENT
+    assert result["behind"] is False
+
+
+def test_absent_role_file_is_behind(tmp_path):
+    repo = _make_repo(tmp_path / "consumer", role=None)
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["content"]["surfaces"][frd.ROLE_BASENAME]["status"] == frd.ABSENT
+    assert result["behind"] is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Provider mirrors — absence is a warning, drift is drift
+# ---------------------------------------------------------------------------
+
+
+def test_absent_provider_mirrors_warn_but_do_not_read_as_drift(tmp_path):
+    """AGENTS.md/GEMINI.md are gitignored, locally generated by role sync. A
+    fresh checkout has neither and is not thereby behind — measured on this
+    branch's own worktree, where the first version of the meter went red."""
+    repo = _make_repo(tmp_path / "consumer", hook=WIRED_HOOK, settings=WIRED_SETTINGS)
+
+    result = frd.measure_project(repo, CANON)
+
+    assert [s["status"] for s in result["content"]["surfaces"].values()].count(frd.ABSENT) == 2
+    assert result["behind"] is False
+    assert len(result["warnings"]) == 2
+    assert any("Codex" in w for w in result["warnings"])
+
+
+def test_stale_provider_block_is_drift(tmp_path):
+    repo = _make_repo(tmp_path / "consumer", agents_block=STALE_ROLE, gemini_block=CANON)
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["content"]["surfaces"]["AGENTS.md"]["status"] == frd.STALE
+    assert result["content"]["surfaces"]["GEMINI.md"]["status"] == frd.CURRENT
+    assert result["behind"] is True
+
+
+def test_provider_file_without_a_marker_block_says_so(tmp_path):
+    repo = _make_repo(tmp_path / "consumer")
+    (repo / ".claude" / "terminals" / "T0" / "AGENTS.md").write_text(
+        "# hand-written, never synced\n", encoding="utf-8",
+    )
+
+    result = frd.measure_project(repo, CANON)
+    surface = result["content"]["surfaces"]["AGENTS.md"]
+
+    assert surface["status"] == frd.ABSENT
+    assert "no <!-- VNX:BEGIN T0-ROLE --> block" in surface["reason"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Reach — an updated file is not a read file (OI-1480)
+# ---------------------------------------------------------------------------
+
+
+def test_role_current_but_never_imported_is_behind(tmp_path):
+    """SEOcrawler_v2's exact shape: sync writes a perfectly current role and no
+    session ever loads it."""
+    repo = _make_repo(
+        tmp_path / "consumer", claude_md="# project context, no import\n",
+        skill_md="---\nname: t0-orchestrator\n---\n",
+    )
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["content"]["ok"] is True, "content is current — that is the trap"
+    assert result["reach"]["ok"] is False
+    assert "OI-1480" in result["reach"]["reason"]
+    assert result["behind"] is True
+
+
+def test_missing_claude_md_breaks_reach(tmp_path):
+    repo = _make_repo(tmp_path / "consumer", claude_md=None)
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["reach"]["ok"] is False
+    assert result["behind"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Startup — the role prescribes STOP when every route is dead (OI-1481)
+# ---------------------------------------------------------------------------
+
+
+def test_every_delivery_route_dead_is_behind(tmp_path):
+    """sales-copilot's exact shape."""
+    repo = _make_repo(tmp_path / "consumer")
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["startup"]["ok"] is False
+    assert "OI-1481" in result["startup"]["reason"]
+    assert result["behind"] is True
+    assert result["startup"]["routes"]["skill_tool_fallback"]["ok"] is False
+
+
+def test_wired_sessionstart_hook_satisfies_startup(tmp_path):
+    repo = _make_repo(tmp_path / "consumer", hook=WIRED_HOOK, settings=WIRED_SETTINGS)
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["startup"]["routes"]["sessionstart_hook"]["ok"] is True
+    assert result["startup"]["ok"] is True
+    assert result["behind"] is False
+
+
+def test_settings_wired_but_hook_does_not_inject_is_not_enough(tmp_path):
+    """The measured sales-copilot state: SessionStart exists, the script does
+    not mention the skill. Wired is not injecting."""
+    repo = _make_repo(
+        tmp_path / "consumer", hook="echo hello\n", settings=WIRED_SETTINGS,
+    )
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["startup"]["routes"]["sessionstart_hook"]["ok"] is False
+    assert "no hook script references" in result["startup"]["routes"]["sessionstart_hook"]["reason"]
+
+
+def test_model_invocable_skill_satisfies_startup(tmp_path):
+    repo = _make_repo(
+        tmp_path / "consumer",
+        skill_md="---\nname: t0-orchestrator\nuser-invocable: true\n---\n\n# T0 Orchestrator\n",
+    )
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["startup"]["routes"]["skill_tool_fallback"]["ok"] is True
+    assert result["startup"]["ok"] is True
+
+
+def test_disabled_skill_is_not_a_fallback(tmp_path):
+    repo = _make_repo(
+        tmp_path / "consumer",
+        skill_md="---\nname: t0-orchestrator\ndisable-model-invocation: true\n---\n",
+    )
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["startup"]["routes"]["skill_tool_fallback"]["ok"] is False
+
+
+def test_description_mentioning_the_flag_is_not_a_disabled_skill(tmp_path):
+    """codex finding 3 (2026-07-16): an unanchored grep read a description that
+    merely DOCUMENTS the flag as the flag itself. t0_role_audit.sh carries the
+    anchored check; this one must not diverge from it."""
+    repo = _make_repo(
+        tmp_path / "consumer",
+        skill_md=(
+            "---\n"
+            "name: t0-orchestrator\n"
+            "description: explains disable-model-invocation: true and when to set it\n"
+            "---\n"
+        ),
+    )
+
+    result = frd.measure_project(repo, CANON)
+
+    assert result["startup"]["routes"]["skill_tool_fallback"]["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# 5. The meter's own input — a stale canon propagates yesterday's role
+# ---------------------------------------------------------------------------
+
+
+def test_canon_behind_the_fabric_source_is_reported(tmp_path):
+    """Vincent's 2026-08-28 decision (canon on main first, propagate second)
+    exists because a stale install pushes an old role to the whole fleet in one
+    command, and every consumer then reports current against it."""
+    source = _make_repo(tmp_path / "fabric", role=CANON)
+    install = _make_repo(tmp_path / "install", role=STALE_ROLE)
+    canon_path = install / ".claude" / "terminals" / "T0" / "role-orchestrator.md"
+
+    freshness = frd._measure_canon_freshness(
+        canon_path, STALE_ROLE,
+        [{"project_id": "vnx-dev", "path": str(source), "name": "vnx-orchestration"}],
+    )
+
+    assert freshness["ok"] is False
+    assert "stale role" in freshness["reason"]
+
+
+def test_canon_that_is_the_source_is_fresh(tmp_path):
+    source = _make_repo(tmp_path / "fabric", role=CANON)
+    canon_path = source / ".claude" / "terminals" / "T0" / "role-orchestrator.md"
+
+    freshness = frd._measure_canon_freshness(
+        canon_path, CANON, [{"project_id": "vnx-dev", "path": str(source)}],
+    )
+
+    assert freshness["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# 6. Exit codes and the no-write default
+# ---------------------------------------------------------------------------
+
+
+def _canon_arg(tmp_path) -> list[str]:
+    canon_repo = _make_repo(tmp_path / "canonrepo", role=CANON)
+    return ["--canon", str(canon_repo / ".claude" / "terminals" / "T0" / "role-orchestrator.md")]
+
+
+def test_exit_zero_when_the_fleet_is_current(tmp_path, capsys):
+    clean = _make_repo(tmp_path / "clean", hook=WIRED_HOOK, settings=WIRED_SETTINGS)
+
+    rc = frd.main([*_canon_arg(tmp_path), "--project-dir", str(clean)])
+
+    assert rc == 0
+    assert "0 of 1 measured projects behind" in capsys.readouterr().out
+
+
+def test_exit_one_when_a_project_is_behind(tmp_path):
+    stale = _make_repo(tmp_path / "stale", role=STALE_ROLE, hook=WIRED_HOOK, settings=WIRED_SETTINGS)
+
+    rc = frd.main([*_canon_arg(tmp_path), "--project-dir", str(stale)])
+
+    assert rc == 1
+
+
+def test_exit_two_when_the_canon_cannot_be_read(tmp_path, capsys):
+    rc = frd.main(["--canon", str(tmp_path / "nope.md"), "--project-dir", str(tmp_path)])
+
+    assert rc == 2
+    assert "canonical role not readable" in capsys.readouterr().err
+
+
+def test_exit_two_on_an_unreadable_registry(tmp_path, capsys):
+    bad = tmp_path / "projects.json"
+    bad.write_text("{not json", encoding="utf-8")
+
+    rc = frd.main([*_canon_arg(tmp_path), "--registry", str(bad)])
+
+    assert rc == 2
+
+
+def test_measuring_writes_nothing_without_write_state(tmp_path):
+    """A measurement that writes is a write. The gate-evidence losses of
+    2026-08-26 all came from a tool that wrote while it was 'just checking'."""
+    clean = _make_repo(tmp_path / "clean", hook=WIRED_HOOK, settings=WIRED_SETTINGS)
+    state = tmp_path / "state"
+    state.mkdir()
+
+    frd.main([*_canon_arg(tmp_path), "--project-dir", str(clean), "--state-dir", str(state)])
+
+    assert list(state.rglob("*")) == [], "the default run must leave the store untouched"
+
+
+def test_write_state_is_opt_in_and_lands(tmp_path):
+    clean = _make_repo(tmp_path / "clean", hook=WIRED_HOOK, settings=WIRED_SETTINGS)
+    state = tmp_path / "state"
+    state.mkdir()
+
+    frd.main([*_canon_arg(tmp_path), "--project-dir", str(clean),
+              "--state-dir", str(state), "--write-state"])
+
+    beacon = state / "health" / "fleet_role_drift.json"
+    assert beacon.exists()
+    payload = json.loads(beacon.read_text(encoding="utf-8"))
+    assert payload["status"] == "ok"
+    assert payload["details"]["projects_behind"] == 0
+
+
+def test_json_output_is_machine_readable(tmp_path, capsys):
+    stale = _make_repo(tmp_path / "stale", role=STALE_ROLE)
+
+    frd.main([*_canon_arg(tmp_path), "--project-dir", str(stale), "--json"])
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["summary"]["projects_behind"] == 1
+    assert report["summary"]["behind"] == ["stale"]


### PR DESCRIPTION
## Wat er ontbrak

OI-1478 is gesloten door negen rolbestanden met de hand over drie consumer-repo's te propageren. Wat NIET gesloten is, is de reden dat daar een mens voor nodig was: **er is geen enkele plek die meet of de vloot achterloopt.** `vnx role sync --dry-run` beantwoordt die vraag voor EEN repo, in proza, als iemand hem toevallig draait.

`vnx role drift` beantwoordt hem voor de hele vloot, als toestand, met een exit-code.

## Drie assen, want propageren faalt op drie onafhankelijke manieren

| As | Wat het meet | Waarom apart |
|---|---|---|
| **CONTENT** | diff tegen de canon | een zoekopdracht vindt alleen de drift die je al kende |
| **REACH** | importeert CLAUDE.md `@role-orchestrator.md`? | OI-1480: bijgewerkt is niet gelezen |
| **STARTUP** | kan Mandatory Startup uberhaupt slagen? | OI-1481: allebei de routes dood betekent STOP |

### CONTENT, en waarom het een diff is en geen grep

De sweep die OI-1478 sloot zocht op `NEVER claude -p`. Diezelfde negen bestanden droegen ook de verouderde sentinel-regel (`backend-developer` als `_FAKE_DEFAULT_ROLE`, terwijl de canon `identity_unresolved` zegt). Die tweede vindt een grep op de eerste nooit.

Gemeten tegen de echte rol van voor #1701:

```
grep -c 'NEVER claude -p'      -> 0      (de sweep zou dit bestand schoon noemen)
vnx role drift                 -> STALE, 2 diff-regels, met de gewijzigde regels erbij
```

Een diff vindt allebei, plus de volgende, die nog niemand een naam heeft gegeven.

### De as over de meter zelf

Is de canon die DEZE vnx zou propageren zelf actueel met de fabric-bron? Vincents besluit van 28-08 (eerst de canon op main, dan pas propageren) bestaat precies omdat synchroniseren vanuit een verouderde installatie de rol van gisteren in een commando over de hele vloot uitrolt. Elke consumer meldt daarna keurig "current" tegen een canon die zelf achterloopt.

## Gedraaid tegen de echte registry

```
canon freshness: [ok] canon matches the fabric source

[ok    ] mission-control     content current   reach ok     startup ok
[BEHIND] sales-copilot       content current   reach ok     startup BROKEN (OI-1481)
[BEHIND] seocrawler-v2       content current   reach BROKEN startup ok      (OI-1480)
[ok    ] vnx-orchestration   content current   reach ok     startup ok

fleet: 2 of 4 measured projects behind the canon        EXIT=1
```

Het reproduceert OI-1480 en OI-1481 **zonder dat het naar die twee is gaan zoeken**. Let op de content-kolom: overal groen, want jij hebt gisteren gesynct. Een meter die alleen content leest had de vloot dus in orde verklaard. Dat is het hele argument voor drie assen.

## Wat het NIET doet

Rapporteren, niet propageren. `role sync --apply` per repo blijft een operator-besluit, en het besluit "canon eerst" is een oordeel dat een meter niet voor je hoort te nemen. Read-only als default; `--write-state` is opt-in, want een meting die schrijft is een schrijfactie, en dat is precies de faalklasse van 26-08.

Geen CI-koppeling: GitHub-runners hebben geen consumer-repo's, dus een CI-check hierop zou een lege verzameling toetsen en groen geven. Dat is de val uit [[nul-runs-leest-als-niets-roods]].

## De meter ving een fout in zichzelf

AGENTS.md en GEMINI.md zijn **gitignored** (`.gitignore:154`), lokaal gegenereerd door role sync. Een verse checkout heeft ze dus niet. De eerste versie las dat als drift en stond rood op zijn eigen worktree. Afwezigheid is nu een dekkingswaarschuwing; drift in een blok dat WEL bestaat blijft drift.

## Buiten scope, met reden

De vondst dat `open_items_manager amend --closed-reason-file` bestaat en niemand hem kende hoort in dezelfde familie (een oppervlak dat wordt onderhouden en niet gelezen), maar niet in deze meter. De methode hier is "diff tegen een canon", en een CLI-vlag heeft geen canon om tegen te diffen. Meten of iemand weet dat iets bestaat is geen eigenschap van een bestand. Het is wel als correctie in de projectmemory geland.

## Tests

23, allemaal tegen `tmp_path`, nooit tegen de registry of de echte repo's. Inclusief de regressie op codex-bevinding 3 van 16-07 (een `description:` die de vlag noemt is niet de vlag) en een test dat een gewone run niets in de store schrijft.

Buren groen (390 passed) op `tests/test_future_state_reconciliation.py` na, dat ook op `53973d6a` rood staat en onder OI-1227 in `scripts/ci/test_exclusions.txt` staat. Baseline apart gemeten op een schone origin/main-worktree.

Dispatch-ID: `20260828-alpha-oi1478-vloot-drift-meter`