### PR TITLE
feat(pr-ready): one command for what a PR still needs to merge

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -349,6 +349,9 @@ Permission relay (detached-worker prompt governance):
 
 Gate commands (pre-merge verification):
   gate-check --pr <ID>  Run deterministic pre-merge gate checks (GO/HOLD verdict)
+  pr-ready <N> [<N>..]  Merge readiness: required contexts + gate evidence on the
+                        current head, and what closing each gap costs
+                        (exit 0 ready, 1 not ready, 2 unmeasurable)
   roadmap <sub>       Roadmap orchestration and auto-next feature loading
 
 Planning commands (strategic-layer read surface):
@@ -2548,6 +2551,9 @@ main() {
       ;;
     gate-check)
       "$VNX_PYTHON" "$VNX_HOME/scripts/pre_merge_gate.py" "$@"
+      ;;
+    pr-ready)
+      "$VNX_PYTHON" "$VNX_HOME/scripts/pr_ready.py" "$@"
       ;;
     dispatch)
       cmd_dispatch "$@"

--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""ci_contexts.py — required-vs-actual CI context classification.
+
+``gh pr checks`` lists the contexts that EXIST on a commit. Branch protection
+enforces the contexts that are REQUIRED. Those are two different sets, and the
+gap between them is invisible in every green-looking checks listing.
+
+PR #1691 is the measured case: nine ``pass`` lines, zero ``fail`` lines, and
+the merge was still refused — five of the fourteen required contexts had never
+been created at all during a GitHub Actions outage. A reader who only counts
+what is present sees "9 pass / 0 fail" and reads it as ready.
+
+The naive fix — "a required context with no check run blocks the merge" — is
+worse than the bug. PR #1701 measured the false alarm: twelve green, ``Profile
+B`` and ``Profile C`` absent, which reads as exactly the #1691 shape. It was
+not. Both declare ``needs: profile-a`` (vnx-ci.yml), so neither EXISTS until
+Profile A finishes. Absent meant "not created yet". A guard that cannot tell
+those apart blocks every PR in the first minutes of its own CI.
+
+So this module distinguishes the states that actually differ:
+
+  ``passed``            the context exists and concluded in a passing state
+  ``failed``            the context exists and concluded in a failing state
+  ``running``           the context exists and has not concluded yet
+  ``waiting_upstream``  the context does not exist, but its producing workflow
+                        run is still alive, so it can still appear — WAIT,
+                        never a merge blocker's fault
+  ``never_created``     the context does not exist and nothing on this commit
+                        can still create it: the producing run is finished, or
+                        a job the producing job depends on already concluded
+                        in a non-passing state. This is the #1691 trap.
+  ``no_run``            the producing workflow never started on this commit at
+                        all — the run has to be started before anything else
+                        can be said
+  ``unverified``        this module could not establish which of the above
+                        applies (no workflow file produces the context, the
+                        graph failed to parse, a gh call failed)
+
+``unverified`` is never collapsed into a pass and never into a fail. A guard
+that cannot see must say so — the same fail-loud contract
+``pre_merge_gate.check_ci_workflow`` already holds for SKIPPED_UNVERIFIED.
+
+The dependency graph comes from the workflow YAML in the checkout, not from
+GitHub: the ``needs:`` edges are what separate ``waiting_upstream`` from
+``never_created``, and there is no API that reports "this job has not been
+created yet, and here is why". A PR that itself edits ``.github/workflows``
+therefore gets classified against the graph in ``workflows_dir``; pass the
+PR's own checkout when that distinction matters.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# States
+# ---------------------------------------------------------------------------
+
+STATE_PASSED = "passed"
+STATE_FAILED = "failed"
+STATE_RUNNING = "running"
+STATE_WAITING_UPSTREAM = "waiting_upstream"
+STATE_NEVER_CREATED = "never_created"
+STATE_NO_RUN = "no_run"
+STATE_UNVERIFIED = "unverified"
+
+#: An allowlist, not a blocklist of failures: a state added later blocks until
+#: someone decides otherwise, never silently mergeable.
+NON_BLOCKING_STATES = frozenset({STATE_PASSED})
+
+#: "This commit can still produce the context if you wait." Distinct from
+#: blocking-ness: a waiting context blocks now, but the fix is time, not a re-run.
+TRANSIENT_STATES = frozenset({STATE_RUNNING, STATE_WAITING_UPSTREAM})
+
+#: Check-run conclusions that satisfy a required status check. ``skipped`` and
+#: ``neutral`` pass for branch protection — a path-filtered job that legitimately
+#: did not apply must not read as a failure.
+PASSING_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
+
+#: A workflow run or check run in any status other than this is still alive.
+COMPLETED_STATUS = "completed"
+
+
+@dataclass(frozen=True)
+class JobNode:
+    """One workflow job, keyed by the check-run context name it produces."""
+
+    context: str
+    job_key: str
+    workflow_name: str
+    workflow_file: str
+    needs: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class WorkflowGraph:
+    """Context name -> producing job, parsed from the checkout's workflows."""
+
+    by_context: Mapping[str, JobNode]
+    #: (workflow_file, job_key) -> JobNode, for resolving ``needs`` edges.
+    by_job: Mapping[tuple, JobNode]
+    #: Files that could not be parsed, with the reason. Never swallowed: a
+    #: context whose workflow failed to parse resolves to ``unverified``,
+    #: and this list says why.
+    parse_errors: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ContextState:
+    """The classification of one required branch-protection context."""
+
+    context: str
+    state: str
+    detail: str
+    conclusion: Optional[str] = None
+    workflow_name: Optional[str] = None
+    job_key: Optional[str] = None
+
+    @property
+    def blocking(self) -> bool:
+        return self.state not in NON_BLOCKING_STATES
+
+    @property
+    def transient(self) -> bool:
+        return self.state in TRANSIENT_STATES
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "context": self.context,
+            "state": self.state,
+            "detail": self.detail,
+            "conclusion": self.conclusion,
+            "workflow_name": self.workflow_name,
+            "job_key": self.job_key,
+            "blocking": self.blocking,
+            "transient": self.transient,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Workflow graph
+# ---------------------------------------------------------------------------
+
+
+def _normalise_needs(raw: Any) -> Sequence[str]:
+    """``needs:`` is a string, a list, or absent. Return it as a tuple."""
+    if isinstance(raw, str):
+        return (raw,)
+    if isinstance(raw, list):
+        return tuple(str(item) for item in raw if isinstance(item, (str, int)))
+    return ()
+
+
+def parse_workflow_graph(workflows_dir: Path) -> WorkflowGraph:
+    """Parse ``.github/workflows/*.y[a]ml`` into a context -> job mapping.
+
+    A job's context name is its ``name:`` when it declares one, and its job key
+    otherwise — the rule GitHub itself applies. Matrix jobs are NOT resolved:
+    their real context names carry the matrix values, so they never match a
+    plain required-context name and correctly land in ``unverified`` rather
+    than on a confidently wrong job.
+
+    A file that fails to parse is recorded in ``parse_errors`` and contributes
+    no jobs — never skipped silently, so a context a broken workflow would
+    have produced lands in ``unverified``, not in "nothing requires it".
+    """
+    by_context: Dict[str, JobNode] = {}
+    by_job: Dict[tuple, JobNode] = {}
+    errors: List[str] = []
+
+    if not workflows_dir.is_dir():
+        return WorkflowGraph(
+            by_context={},
+            by_job={},
+            parse_errors=(f"workflows directory not found: {workflows_dir}",),
+        )
+
+    paths = sorted(
+        [p for p in workflows_dir.iterdir() if p.suffix in (".yml", ".yaml") and p.is_file()]
+    )
+    for path in paths:
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            errors.append(f"{path.name}: {type(exc).__name__}: {exc}")
+            continue
+        if not isinstance(document, dict):
+            errors.append(f"{path.name}: top level is {type(document).__name__}, expected a mapping")
+            continue
+        workflow_name = document.get("name")
+        if not isinstance(workflow_name, str) or not workflow_name.strip():
+            workflow_name = path.stem
+        jobs = document.get("jobs")
+        if not isinstance(jobs, dict):
+            errors.append(f"{path.name}: no 'jobs' mapping")
+            continue
+        for job_key, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            declared = job.get("name")
+            context = declared if isinstance(declared, str) and declared.strip() else str(job_key)
+            node = JobNode(
+                context=context,
+                job_key=str(job_key),
+                workflow_name=workflow_name.strip(),
+                workflow_file=path.name,
+                needs=_normalise_needs(job.get("needs")),
+            )
+            by_job[(path.name, str(job_key))] = node
+            # First writer wins, and a genuine collision is an error rather
+            # than a silent overwrite: two jobs producing one context name
+            # makes the "which job is late" answer ambiguous.
+            if context in by_context:
+                errors.append(
+                    f"duplicate context {context!r}: "
+                    f"{by_context[context].workflow_file}:{by_context[context].job_key} "
+                    f"and {path.name}:{job_key}"
+                )
+                continue
+            by_context[context] = node
+
+    return WorkflowGraph(by_context=by_context, by_job=by_job, parse_errors=tuple(errors))
+
+
+def _upstream_chain(graph: WorkflowGraph, node: JobNode) -> List[JobNode]:
+    """All transitive ``needs`` ancestors of ``node``, nearest first.
+
+    Cycle-safe: a ``needs`` cycle is invalid on GitHub's side, but this walk
+    must terminate regardless of what the file says.
+    """
+    seen: Set[str] = {node.job_key}
+    ordered: List[JobNode] = []
+    frontier = list(node.needs)
+    while frontier:
+        job_key = str(frontier.pop(0))
+        if job_key in seen:
+            continue
+        seen.add(job_key)
+        parent = graph.by_job.get((node.workflow_file, job_key))
+        if parent is None:
+            continue
+        ordered.append(parent)
+        frontier.extend(parent.needs)
+    return ordered
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _index_check_runs(check_runs: Iterable[Mapping[str, Any]]) -> Dict[str, List[Mapping[str, Any]]]:
+    """Group check runs by name. One name can carry several runs — the same
+    workflow triggered by both ``push`` and ``pull_request`` produces two.
+    """
+    indexed: Dict[str, List[Mapping[str, Any]]] = {}
+    for run in check_runs:
+        name = run.get("name")
+        if isinstance(name, str) and name:
+            indexed.setdefault(name, []).append(run)
+    return indexed
+
+
+def _classify_present(context: str, runs: Sequence[Mapping[str, Any]], node: Optional[JobNode]) -> ContextState:
+    """Classify a context that HAS at least one check run on the commit.
+
+    Conservative on duplicates: any non-terminal run keeps the context
+    ``running``, and any terminal non-passing conclusion makes it ``failed``,
+    even when a sibling run of the same name passed. A merge gate resolving a
+    disagreement in favour of the passing copy is exactly the green-lie this
+    module exists to remove.
+    """
+    workflow_name = node.workflow_name if node else None
+    job_key = node.job_key if node else None
+
+    unfinished = [r for r in runs if (r.get("status") or "") != COMPLETED_STATUS]
+    if unfinished:
+        return ContextState(
+            context=context,
+            state=STATE_RUNNING,
+            detail=f"still running ({unfinished[0].get('status') or 'unknown status'})",
+            conclusion=None,
+            workflow_name=workflow_name,
+            job_key=job_key,
+        )
+
+    conclusions = [(r.get("conclusion") or "") for r in runs]
+    failing = [c for c in conclusions if c not in PASSING_CONCLUSIONS]
+    if failing:
+        return ContextState(
+            context=context,
+            state=STATE_FAILED,
+            detail=f"concluded {failing[0] or 'with no conclusion'}",
+            conclusion=failing[0] or None,
+            workflow_name=workflow_name,
+            job_key=job_key,
+        )
+    return ContextState(
+        context=context,
+        state=STATE_PASSED,
+        detail=f"concluded {conclusions[0]}",
+        conclusion=conclusions[0],
+        workflow_name=workflow_name,
+        job_key=job_key,
+    )
+
+
+def _pending_upstream(
+    graph: WorkflowGraph,
+    node: JobNode,
+    runs: Sequence[Mapping[str, Any]],
+    jobs_by_run_id: Mapping[Any, Sequence[Mapping[str, Any]]],
+) -> Set[str]:
+    """Ancestor context names that have not concluded yet, for the WAIT text.
+
+    An ancestor absent from a run's job list counts as pending: GitHub does
+    not list a job before it is created, and "not created yet" is precisely
+    the state that makes the child context wait.
+    """
+    pending: Set[str] = set()
+    for parent in _upstream_chain(graph, node):
+        for run in runs:
+            observed = next(
+                (j for j in jobs_by_run_id.get(run.get("id"), ()) if j.get("name") == parent.context),
+                None,
+            )
+            if observed is None or (observed.get("status") or "") != COMPLETED_STATUS:
+                pending.add(parent.context)
+    return pending
+
+
+def _failed_upstream(
+    graph: WorkflowGraph,
+    node: JobNode,
+    runs: Sequence[Mapping[str, Any]],
+    jobs_by_run_id: Mapping[Any, Sequence[Mapping[str, Any]]],
+) -> Optional[tuple]:
+    """First (ancestor, conclusion) that concluded in a non-passing state.
+
+    Returns None when every observed ancestor either passed or has not
+    concluded. An unobserved ancestor is never treated as failed — absence of
+    evidence stays absence of evidence here, and the caller falls through to
+    the wait/never-created decision that has real evidence behind it.
+    """
+    for run in runs:
+        job_states = {
+            j.get("name"): j
+            for j in jobs_by_run_id.get(run.get("id"), ())
+            if isinstance(j.get("name"), str)
+        }
+        for parent in _upstream_chain(graph, node):
+            observed = job_states.get(parent.context)
+            if observed is None:
+                continue
+            if (observed.get("status") or "") != COMPLETED_STATUS:
+                continue
+            conclusion = observed.get("conclusion") or ""
+            if conclusion not in PASSING_CONCLUSIONS:
+                return (parent, conclusion)
+    return None
+
+
+def _classify_absent(
+    context: str,
+    node: JobNode,
+    graph: WorkflowGraph,
+    workflow_runs: Sequence[Mapping[str, Any]],
+    jobs_by_run_id: Mapping[Any, Sequence[Mapping[str, Any]]],
+) -> ContextState:
+    """Classify a required context with NO check run on the commit.
+
+    This is the whole point of the module: separating "not created yet"
+    (#1701, Profile B/C behind ``needs: profile-a``) from "never created"
+    (#1691, five contexts lost to an Actions outage).
+    """
+    own_runs = [r for r in workflow_runs if r.get("name") == node.workflow_name]
+    if not own_runs:
+        return ContextState(
+            context=context,
+            state=STATE_NO_RUN,
+            detail=(
+                f"workflow {node.workflow_name!r} ({node.workflow_file}) has no run on this "
+                "commit — nothing is started that could produce this context"
+            ),
+            workflow_name=node.workflow_name,
+            job_key=node.job_key,
+        )
+
+    # An ancestor that already concluded in a non-passing state settles the
+    # question whether or not the run is still alive: the producing job will
+    # not execute, so waiting cannot help.
+    failed = _failed_upstream(graph, node, own_runs, jobs_by_run_id)
+    if failed is not None:
+        parent, conclusion = failed
+        return ContextState(
+            context=context,
+            state=STATE_NEVER_CREATED,
+            detail=(
+                f"job {node.job_key!r} needs {parent.job_key!r}, which concluded "
+                f"{conclusion or 'with no conclusion'} — this context can no longer be "
+                "produced on this commit"
+            ),
+            workflow_name=node.workflow_name,
+            job_key=node.job_key,
+        )
+
+    alive = [r for r in own_runs if (r.get("status") or "") != COMPLETED_STATUS]
+    if alive:
+        pending = _pending_upstream(graph, node, own_runs, jobs_by_run_id)
+        if pending:
+            reason = f"waiting on {', '.join(sorted(pending))}"
+        elif node.needs:
+            reason = f"declares needs: {', '.join(node.needs)}"
+        else:
+            reason = "the run has not created this job yet"
+        return ContextState(
+            context=context,
+            state=STATE_WAITING_UPSTREAM,
+            detail=(
+                f"workflow {node.workflow_name!r} is still running ({reason}) — "
+                "the context can still appear"
+            ),
+            workflow_name=node.workflow_name,
+            job_key=node.job_key,
+        )
+
+    conclusions = ", ".join(sorted({(r.get("conclusion") or "none") for r in own_runs}))
+    return ContextState(
+        context=context,
+        state=STATE_NEVER_CREATED,
+        detail=(
+            f"workflow {node.workflow_name!r} finished ({conclusions}) without ever creating "
+            "this context — re-run the workflow; this is the #1691 shape"
+        ),
+        workflow_name=node.workflow_name,
+        job_key=node.job_key,
+    )
+
+
+def classify_contexts(
+    required_contexts: Iterable[str],
+    check_runs: Iterable[Mapping[str, Any]],
+    workflow_runs: Iterable[Mapping[str, Any]],
+    graph: WorkflowGraph,
+    jobs_by_run_id: Optional[Mapping[Any, Sequence[Mapping[str, Any]]]] = None,
+) -> List[ContextState]:
+    """Classify every REQUIRED context against what exists on the commit.
+
+    Pure: every input is data, so the decision table is testable without a
+    network. ``jobs_by_run_id`` may be empty — the classification degrades to
+    "the run is alive, so wait" instead of naming which ancestor it waits on,
+    which is a weaker message but never a wrong verdict.
+
+    Contexts are iterated in the order given so the output is stable.
+    """
+    runs = list(workflow_runs)
+    jobs = dict(jobs_by_run_id or {})
+    indexed = _index_check_runs(check_runs)
+
+    states: List[ContextState] = []
+    for context in required_contexts:
+        node = graph.by_context.get(context)
+        present = indexed.get(context)
+        if present:
+            states.append(_classify_present(context, present, node))
+            continue
+        if node is None:
+            hint = (
+                f" (workflow parse errors: {'; '.join(graph.parse_errors)})"
+                if graph.parse_errors
+                else ""
+            )
+            states.append(
+                ContextState(
+                    context=context,
+                    state=STATE_UNVERIFIED,
+                    detail=(
+                        "no check run on this commit and no workflow job in the checkout "
+                        f"produces this context — cannot tell 'not yet' from 'never'{hint}"
+                    ),
+                )
+            )
+            continue
+        states.append(_classify_absent(context, node, graph, runs, jobs))
+    return states
+
+
+def summarise(states: Sequence[ContextState]) -> Dict[str, Any]:
+    """Counts + the blocking subset, for a caller that renders a verdict."""
+    blocking = [s for s in states if s.blocking]
+    return {
+        "total": len(states),
+        "passed": len([s for s in states if s.state == STATE_PASSED]),
+        "blocking": len(blocking),
+        "transient": len([s for s in states if s.transient]),
+        "never_created": len([s for s in states if s.state == STATE_NEVER_CREATED]),
+        "no_run": len([s for s in states if s.state == STATE_NO_RUN]),
+        "unverified": len([s for s in states if s.state == STATE_UNVERIFIED]),
+        "by_state": {s.context: s.state for s in states},
+        "blocking_contexts": [s.to_dict() for s in blocking],
+    }
+
+
+# ---------------------------------------------------------------------------
+# GitHub evidence collection
+# ---------------------------------------------------------------------------
+
+
+class CIContextsError(RuntimeError):
+    """A required piece of evidence could not be read.
+
+    Raised rather than returned as a degraded result: every caller in this
+    fabric turns an unreadable answer into a loud blocking state, and an
+    exception makes forgetting that impossible.
+    """
+
+
+def _gh_json(args: Sequence[str], project_root: Path, timeout: int) -> Any:
+    """Run ``gh`` and parse its JSON stdout, or raise :class:`CIContextsError`."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise CIContextsError(f"gh CLI not available: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CIContextsError(f"gh {' '.join(args)} timed out after {timeout}s") from exc
+    if proc.returncode != 0:
+        raise CIContextsError(
+            f"gh {' '.join(args)} failed (rc={proc.returncode}): {(proc.stderr or '').strip()[:300]}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise CIContextsError(f"gh {' '.join(args)} returned unparseable JSON: {exc}") from exc
+
+
+def fetch_required_contexts(project_root: Path, branch: str = "main", timeout: int = 20) -> List[str]:
+    """The branch-protection required contexts — what SHOULD exist.
+
+    Reads both shapes GitHub has shipped (``contexts`` and ``checks[].context``)
+    and returns their union, sorted. An empty result is returned as-is and is
+    NOT a pass: a caller that finds no required contexts on a branch it
+    believes is protected is looking at a misconfiguration, and this function
+    refuses to paper over it by inventing a default list.
+    """
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/branches/{branch}/protection"], project_root, timeout
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"branch protection payload is {type(payload).__name__}, expected a mapping")
+    required = payload.get("required_status_checks") or {}
+    contexts: Set[str] = set(required.get("contexts") or [])
+    for check in required.get("checks") or []:
+        if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
+            contexts.add(check["context"])
+    return sorted(contexts)
+
+
+def fetch_check_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
+    """The check runs that DO exist on ``head_sha``."""
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs?per_page=100", "--paginate"],
+        project_root,
+        timeout,
+    )
+    runs: List[Dict[str, Any]] = []
+    for page in payload if isinstance(payload, list) else [payload]:
+        if isinstance(page, dict):
+            runs.extend([r for r in (page.get("check_runs") or []) if isinstance(r, dict)])
+    return runs
+
+
+def fetch_workflow_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
+    """The workflow runs on ``head_sha``, with id/name/status/conclusion."""
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/actions/runs?head_sha={head_sha}&per_page=100"],
+        project_root,
+        timeout,
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"actions/runs payload is {type(payload).__name__}, expected a mapping")
+    return [r for r in (payload.get("workflow_runs") or []) if isinstance(r, dict)]
+
+
+def fetch_run_jobs(project_root: Path, run_id: Any, timeout: int = 20) -> List[Dict[str, Any]]:
+    """The jobs of one workflow run, with name/status/conclusion."""
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/jobs?per_page=100"],
+        project_root,
+        timeout,
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"actions/runs/{run_id}/jobs payload is {type(payload).__name__}")
+    return [j for j in (payload.get("jobs") or []) if isinstance(j, dict)]
+
+
+def evaluate_commit(
+    project_root: Path,
+    head_sha: str,
+    *,
+    branch: str = "main",
+    workflows_dir: Optional[Path] = None,
+    timeout: int = 20,
+    required_contexts: Optional[Sequence[str]] = None,
+) -> List[ContextState]:
+    """Classify the protected branch's required contexts against ``head_sha``.
+
+    Two-pass on purpose. The first pass runs with no per-run job data, which
+    costs zero extra API calls and is already conclusive for every context
+    that has a check run — the all-green case, i.e. most of them. Only when a
+    context is genuinely missing does the second pass fetch the jobs of the
+    runs that could still produce it, which is the only place the ``needs``
+    chain has to be resolved against live state.
+
+    Raises :class:`CIContextsError` when the branch-protection list, the check
+    runs, or the workflow runs cannot be read. Job-level detail is the one
+    piece allowed to degrade: a failure there costs the "waiting on X"
+    wording, never the verdict.
+    """
+    root = Path(project_root)
+    contexts = list(required_contexts) if required_contexts is not None else fetch_required_contexts(root, branch, timeout)
+    graph = parse_workflow_graph(workflows_dir or (root / ".github" / "workflows"))
+    check_runs = fetch_check_runs(root, head_sha, timeout)
+    workflow_runs = fetch_workflow_runs(root, head_sha, timeout)
+
+    first = classify_contexts(contexts, check_runs, workflow_runs, graph)
+    interesting = {
+        s.workflow_name
+        for s in first
+        if s.state in (STATE_WAITING_UPSTREAM, STATE_NEVER_CREATED) and s.workflow_name
+    }
+    if not interesting:
+        return first
+
+    jobs_by_run_id: Dict[Any, Sequence[Mapping[str, Any]]] = {}
+    for run in workflow_runs:
+        if run.get("name") not in interesting:
+            continue
+        try:
+            jobs_by_run_id[run.get("id")] = fetch_run_jobs(root, run.get("id"), timeout)
+        except CIContextsError as exc:
+            # Degrade the WORDING, never the verdict: without job data the
+            # classifier still separates alive-run from finished-run, which is
+            # the decision that blocks or releases a merge.
+            jobs_by_run_id[run.get("id")] = ()
+            graph = WorkflowGraph(
+                by_context=graph.by_context,
+                by_job=graph.by_job,
+                parse_errors=tuple(graph.parse_errors) + (f"jobs for run {run.get('id')}: {exc}",),
+            )
+    return classify_contexts(contexts, check_runs, workflow_runs, graph, jobs_by_run_id)

--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -54,7 +54,7 @@ import json
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set
 
 import yaml
 
@@ -85,6 +85,21 @@ PASSING_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
 
 #: A workflow run or check run in any status other than this is still alive.
 COMPLETED_STATUS = "completed"
+
+
+class RequiredCheck(NamedTuple):
+    """One required status check, with the app binding branch protection gave it.
+
+    GitHub's newer ``checks[]`` shape carries ``app_id``; the legacy
+    ``contexts[]`` list does not. When an ``app_id`` is present the requirement
+    is "a check with THIS name FROM THIS app" — matching on the name alone
+    would let a same-named check from any other app satisfy it. ``app_id`` is
+    None for a legacy entry, which means the name is genuinely all branch
+    protection asks for.
+    """
+
+    context: str
+    app_id: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -267,6 +282,26 @@ def _index_check_runs(check_runs: Iterable[Mapping[str, Any]]) -> Dict[str, List
     return indexed
 
 
+def _split_by_app(
+    runs: Sequence[Mapping[str, Any]], app_id: Optional[int]
+) -> tuple:
+    """Split check runs into those the requirement accepts and those it does not.
+
+    With no app binding every same-named run counts, which is exactly what the
+    legacy ``contexts[]`` shape asks for. With a binding, only runs whose
+    ``app.id`` matches count — a run missing the ``app`` object does NOT match,
+    since an unidentifiable producer cannot be shown to be the required one.
+    """
+    if app_id is None:
+        return list(runs), []
+    matching, foreign = [], []
+    for run in runs:
+        app = run.get("app")
+        observed = app.get("id") if isinstance(app, dict) else None
+        (matching if observed == app_id else foreign).append(run)
+    return matching, foreign
+
+
 def _classify_present(context: str, runs: Sequence[Mapping[str, Any]], node: Optional[JobNode]) -> ContextState:
     """Classify a context that HAS at least one check run on the commit.
 
@@ -444,7 +479,7 @@ def _classify_absent(
 
 
 def classify_contexts(
-    required_contexts: Iterable[str],
+    required_contexts: Iterable[Any],
     check_runs: Iterable[Mapping[str, Any]],
     workflow_runs: Iterable[Mapping[str, Any]],
     graph: WorkflowGraph,
@@ -464,9 +499,28 @@ def classify_contexts(
     indexed = _index_check_runs(check_runs)
 
     states: List[ContextState] = []
-    for context in required_contexts:
+    for required in required_contexts:
+        check = required if isinstance(required, RequiredCheck) else RequiredCheck(str(required))
+        context = check.context
         node = graph.by_context.get(context)
-        present = indexed.get(context)
+        named = indexed.get(context) or []
+        present, wrong_app = _split_by_app(named, check.app_id)
+        if wrong_app and not present:
+            states.append(
+                ContextState(
+                    context=context,
+                    state=STATE_UNVERIFIED,
+                    detail=(
+                        f"{len(wrong_app)} check run(s) named {context!r} exist on this commit "
+                        f"but none is from the required app (app_id={check.app_id}) — branch "
+                        "protection would not accept them, and matching on the name alone "
+                        "would turn a foreign check into a green light"
+                    ),
+                    workflow_name=node.workflow_name if node else None,
+                    job_key=node.job_key if node else None,
+                )
+            )
+            continue
         if present:
             states.append(_classify_present(context, present, node))
             continue
@@ -545,14 +599,19 @@ def _gh_json(args: Sequence[str], project_root: Path, timeout: int) -> Any:
         raise CIContextsError(f"gh {' '.join(args)} returned unparseable JSON: {exc}") from exc
 
 
-def fetch_required_contexts(project_root: Path, branch: str = "main", timeout: int = 20) -> List[str]:
-    """The branch-protection required contexts — what SHOULD exist.
+def fetch_required_checks(
+    project_root: Path, branch: str = "main", timeout: int = 20
+) -> List[RequiredCheck]:
+    """The branch-protection required checks — what SHOULD exist, with app bindings.
 
-    Reads both shapes GitHub has shipped (``contexts`` and ``checks[].context``)
-    and returns their union, sorted. An empty result is returned as-is and is
-    NOT a pass: a caller that finds no required contexts on a branch it
-    believes is protected is looking at a misconfiguration, and this function
-    refuses to paper over it by inventing a default list.
+    Reads both shapes GitHub has shipped. ``checks[]`` carries ``app_id`` and
+    wins over a same-named legacy ``contexts[]`` entry, because dropping the
+    app binding would widen the requirement rather than narrow it.
+
+    An empty result is returned as-is and is NOT a pass: a caller that finds no
+    required checks on a branch it believes is protected is looking at a
+    misconfiguration, and this function refuses to paper over it by inventing
+    a default list.
     """
     payload = _gh_json(
         ["api", f"repos/{{owner}}/{{repo}}/branches/{branch}/protection"], project_root, timeout
@@ -560,17 +619,36 @@ def fetch_required_contexts(project_root: Path, branch: str = "main", timeout: i
     if not isinstance(payload, dict):
         raise CIContextsError(f"branch protection payload is {type(payload).__name__}, expected a mapping")
     required = payload.get("required_status_checks") or {}
-    contexts: Set[str] = set(required.get("contexts") or [])
+
+    bound: Dict[str, Optional[int]] = {}
+    for name in required.get("contexts") or []:
+        if isinstance(name, str) and name:
+            bound.setdefault(name, None)
     for check in required.get("checks") or []:
-        if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
-            contexts.add(check["context"])
-    return sorted(contexts)
+        if not isinstance(check, dict):
+            continue
+        name = check.get("context")
+        if not isinstance(name, str) or not name:
+            continue
+        app_id = check.get("app_id")
+        bound[name] = app_id if isinstance(app_id, int) else None
+    return [RequiredCheck(name, bound[name]) for name in sorted(bound)]
 
 
 def fetch_check_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
     """The check runs that DO exist on ``head_sha``."""
+    # --slurp is required, not decorative: this endpoint returns an OBJECT, and
+    # `gh api --paginate` emits one document per page. Measured on a 16-run
+    # commit at per_page=5 — four pages, and json.loads fails with "Extra data"
+    # at char 15511. --slurp wraps the pages in an outer array instead, which is
+    # the shape the loop below already expects.
     payload = _gh_json(
-        ["api", f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs?per_page=100", "--paginate"],
+        [
+            "api",
+            f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs?per_page=100",
+            "--paginate",
+            "--slurp",
+        ],
         project_root,
         timeout,
     )
@@ -612,7 +690,7 @@ def evaluate_commit(
     branch: str = "main",
     workflows_dir: Optional[Path] = None,
     timeout: int = 20,
-    required_contexts: Optional[Sequence[str]] = None,
+    required_contexts: Optional[Sequence[Any]] = None,
 ) -> List[ContextState]:
     """Classify the protected branch's required contexts against ``head_sha``.
 
@@ -629,7 +707,11 @@ def evaluate_commit(
     wording, never the verdict.
     """
     root = Path(project_root)
-    contexts = list(required_contexts) if required_contexts is not None else fetch_required_contexts(root, branch, timeout)
+    contexts = (
+        list(required_contexts)
+        if required_contexts is not None
+        else fetch_required_checks(root, branch, timeout)
+    )
     graph = parse_workflow_graph(workflows_dir or (root / ".github" / "workflows"))
     check_runs = fetch_check_runs(root, head_sha, timeout)
     workflow_runs = fetch_workflow_runs(root, head_sha, timeout)

--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -673,6 +673,66 @@ def fetch_check_runs(project_root: Path, head_sha: str, timeout: int = 20) -> Li
     return runs
 
 
+#: Commit-status states mapped onto the check-run vocabulary the classifier
+#: already speaks. GitHub's two mechanisms are separate APIs but branch
+#: protection treats their contexts as one namespace, so the classifier must
+#: too — otherwise a required context satisfied by a STATUS reads as absent.
+_STATUS_STATE_TO_CONCLUSION = {
+    "success": ("completed", "success"),
+    "failure": ("completed", "failure"),
+    "error": ("completed", "failure"),
+    "pending": ("in_progress", None),
+}
+
+
+def fetch_commit_statuses(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
+    """Legacy commit statuses on ``head_sha``, in check-run shape.
+
+    Branch protection's legacy ``contexts[]`` can be satisfied by a commit
+    STATUS (the Statuses API) rather than a check run (the Checks API) — a
+    non-Actions CI, or anything posting through ``POST /statuses``. Reading
+    only check runs leaves such a context permanently unseen, so a PR whose
+    required context genuinely passed would be blocked forever on evidence
+    that was there all along.
+
+    Only the most recent status per context is returned: GitHub's combined
+    endpoint lists the history newest-first, and an older superseded state is
+    not what branch protection evaluates.
+
+    An unrecognised state maps to a non-terminal status rather than to a
+    conclusion, so a future state value holds the verdict at "running" instead
+    of silently passing or failing.
+    """
+    payload = _gh_json(
+        ["api", f"repos/{{owner}}/{{repo}}/commits/{head_sha}/status?per_page=100"],
+        project_root,
+        timeout,
+    )
+    if not isinstance(payload, dict):
+        raise CIContextsError(f"commit status payload is {type(payload).__name__}, expected a mapping")
+    seen: Set[str] = set()
+    out: List[Dict[str, Any]] = []
+    for status in payload.get("statuses") or []:
+        if not isinstance(status, dict):
+            continue
+        context = status.get("context")
+        if not isinstance(context, str) or not context or context in seen:
+            continue
+        seen.add(context)
+        state, conclusion = _STATUS_STATE_TO_CONCLUSION.get(
+            (status.get("state") or "").lower(), ("in_progress", None)
+        )
+        entry: Dict[str, Any] = {"name": context, "status": state, "conclusion": conclusion}
+        # A status has no Checks-API app object unless GitHub supplies one; an
+        # app-bound requirement is a `checks[]` entry, which only check runs
+        # satisfy, so leaving this absent is the correct answer rather than a
+        # gap.
+        if isinstance(status.get("app"), dict):
+            entry["app"] = status["app"]
+        out.append(entry)
+    return out
+
+
 def fetch_workflow_runs(project_root: Path, head_sha: str, timeout: int = 20) -> List[Dict[str, Any]]:
     """The workflow runs on ``head_sha``, with id/name/status/conclusion."""
     payload = _gh_json(
@@ -727,7 +787,9 @@ def evaluate_commit(
         else fetch_required_checks(root, branch, timeout)
     )
     graph = parse_workflow_graph(workflows_dir or (root / ".github" / "workflows"))
-    check_runs = fetch_check_runs(root, head_sha, timeout)
+    check_runs = fetch_check_runs(root, head_sha, timeout) + fetch_commit_statuses(
+        root, head_sha, timeout
+    )
     workflow_runs = fetch_workflow_runs(root, head_sha, timeout)
 
     first = classify_contexts(contexts, check_runs, workflow_runs, graph)

--- a/scripts/lib/ci_contexts.py
+++ b/scripts/lib/ci_contexts.py
@@ -87,14 +87,24 @@ PASSING_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
 COMPLETED_STATUS = "completed"
 
 
+#: GitHub's sentinel in ``checks[].app_id`` for "any app may set this status"
+#: (the branch-protection API's explicit allow-any value). It is an int, so a
+#: naive ``isinstance(app_id, int)`` keeps it as if it named a real producer —
+#: and then NO run matches it, turning every any-app required check into a
+#: false ``unverified``. It has to be normalised to "no binding" at the edge.
+ANY_APP_ID = -1
+
+
 class RequiredCheck(NamedTuple):
     """One required status check, with the app binding branch protection gave it.
 
     GitHub's newer ``checks[]`` shape carries ``app_id``; the legacy
-    ``contexts[]`` list does not. When an ``app_id`` is present the requirement
-    is "a check with THIS name FROM THIS app" — matching on the name alone
-    would let a same-named check from any other app satisfy it. ``app_id`` is
-    None for a legacy entry, which means the name is genuinely all branch
+    ``contexts[]`` list does not. When an ``app_id`` names a real app the
+    requirement is "a check with THIS name FROM THIS app" — matching on the
+    name alone would let a same-named check from any other app satisfy it.
+
+    ``app_id`` is None for a legacy entry AND for GitHub's explicit
+    :data:`ANY_APP_ID` sentinel: both mean the name is genuinely all branch
     protection asks for.
     """
 
@@ -631,7 +641,11 @@ def fetch_required_checks(
         if not isinstance(name, str) or not name:
             continue
         app_id = check.get("app_id")
-        bound[name] = app_id if isinstance(app_id, int) else None
+        # ANY_APP_ID is an int and would otherwise survive as a concrete
+        # producer that nothing can ever match.
+        bound[name] = (
+            app_id if isinstance(app_id, int) and app_id != ANY_APP_ID else None
+        )
     return [RequiredCheck(name, bound[name]) for name in sorted(bound)]
 
 

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -140,6 +140,56 @@ def pr_number_from_pr_id(pr_id: Optional[str]) -> Optional[int]:
         return None
 
 
+def normalise_pr_id(pr_id: str) -> str:
+    """Normalise an internal PR id for obligation matching.
+
+    "PR-879", "pr879" and "879" all normalise to "879"; "PR-HYG-1" to "HYG-1".
+    The door stores the raw spec pr_id on the obligation; every consumer joins
+    that against the GitHub PR number, which may differ in case, hyphen and the
+    "PR" prefix.
+
+    Promoted here from ``pr_merge._norm_pr_id`` so the merge gate and the
+    readiness report answer "which gate does this PR owe" from ONE
+    implementation — a second copy is exactly how the two would start
+    disagreeing about a PR's obligations.
+    """
+    s = (pr_id or "").strip().upper()
+    if s.startswith("PR-"):
+        return s[3:]
+    if len(s) > 2 and s.startswith("PR") and s[2].isdigit():
+        return s[2:]
+    return s
+
+
+def declared_gates_for_pr(state_dir: Path, pr_number: int) -> list:
+    """Every review gate declared for ``pr_number``, oldest obligation first.
+
+    Joins on the GitHub PR number the runner stamps on the obligation, falling
+    back to the normalised spec ``pr_id`` for records the runner never touched.
+    The ``__no_gate__`` sentinel and blank gates are excluded: they declare an
+    explicit absence, not an obligation.
+
+    Raises ValueError (via :func:`iter_obligations`) when an obligation file is
+    unreadable. That is deliberate — an obligation nobody can read is the
+    silent-evidence failure this whole mechanism exists to expose, so a caller
+    reports it rather than reading it as "this PR owes nothing".
+    """
+    num = str(pr_number)
+    num_forms = {normalise_pr_id(num), normalise_pr_id(f"PR-{num}")}
+    gates = []
+    for _path, record in iter_obligations(state_dir):
+        rec_num = record.get("pr_number")
+        matched = rec_num is not None and str(rec_num) == num
+        if not matched:
+            matched = normalise_pr_id(str(record.get("pr_id") or "")) in num_forms
+        if not matched:
+            continue
+        gate = (record.get("gate") or "").strip()
+        if gate and gate != NO_GATE_KEY:
+            gates.append(gate)
+    return gates
+
+
 def _utc_now_iso() -> str:
     # Stdlib-only on purpose: this module is imported by the dispatch door,
     # which must never fail on a transitive scripts/-side import chain.

--- a/scripts/lib/pr_readiness.py
+++ b/scripts/lib/pr_readiness.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""pr_readiness.py — what does this PR still need before it can merge?
+
+The question a human answered by hand fourteen times in one night: which of
+the fourteen branch-protection contexts are present, which review gates the
+obligation demands, whether each gate record sits on the CURRENT head, whether
+its report exists, and whether record and report contradict each other. Each
+pass took several ``gh`` calls plus a throwaway Python block.
+
+None of the underlying answers are new. This module deliberately reuses the
+implementations that already decide them, rather than growing a second
+opinion beside each one:
+
+  contexts        ``ci_contexts.evaluate_commit`` (required-vs-actual, with
+                  "not created yet" separated from "never created")
+  declared gates  ``gate_obligations.declared_gates_for_pr`` (the door's own
+                  obligation record, the same join ``pr_merge`` uses)
+  gate evidence   ``closure_verifier.check_review_gate_for_merge`` (record on
+                  this head, terminal, contract_hash + report_path non-empty,
+                  report on disk, verdict passes, report does not contradict
+                  the verdict)
+
+What is new is only the aggregation, the cost of closing each gap, and the
+refusal to round anything unmeasured up to green.
+
+Fail-loud is the whole point. Every section that cannot be measured yields
+:data:`VERDICT_UNMEASURABLE`, never ``READY``. "I could not look" and "I
+looked and it is fine" are the two answers this report exists to keep apart —
+counting only what is present is exactly how #1691 read as nine green passes
+while five required contexts had never been created.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys as _sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+_LIB_DIR = Path(__file__).resolve().parent
+_SCRIPTS_DIR = _LIB_DIR.parent
+for _p in (str(_LIB_DIR), str(_SCRIPTS_DIR)):
+    if _p not in _sys.path:
+        _sys.path.insert(0, _p)
+
+import ci_contexts  # noqa: E402
+from dispatch_spec import Gate  # noqa: E402
+
+VERDICT_READY = "READY"
+VERDICT_NOT_READY = "NOT READY"
+VERDICT_UNMEASURABLE = "UNMEASURABLE"
+
+#: PR fields the report needs. ``mergeable``/``mergeStateStatus`` are reported
+#: verbatim, including GitHub's "UNKNOWN" — that value means the background
+#: mergeability job has not finished, not that the PR is fine.
+_PR_FIELDS = (
+    "number,state,isDraft,title,headRefName,headRefOid,baseRefName,"
+    "mergeable,mergeStateStatus"
+)
+
+
+@dataclass(frozen=True)
+class GateCost:
+    """What closing one gate gap actually costs, in a runnable form."""
+
+    command: str
+    lane: str
+    usd: Optional[str] = None
+    note: str = ""
+
+    def describe(self, pr_number: int, head_sha: str) -> str:
+        price = self.usd or "no USD cost"
+        line = f"{self.command.format(pr=pr_number)} — {self.lane}, {price}"
+        if self.note:
+            line += f" ({self.note})"
+        return line
+
+
+#: Cost per gate, keyed on the CLOSED ``Gate`` enum. Every member has an entry
+#: and ``test_pr_readiness.py`` pins that: a gate added to the enum without a
+#: cost entry would otherwise be reported as "run it" with no idea what running
+#: it takes — which is the half of the question that made the manual count slow.
+#:
+#: The USD band on the OpenRouter lanes is the operator's measured range, not a
+#: list price: a gate run costs 1.3–2.8 USD, not the 0.4 an earlier estimate
+#: assumed.
+GATE_COST: Dict[str, GateCost] = {
+    Gate.GLM_GATE.value: GateCost(
+        command="python3 scripts/glm_gate.py --pr {pr}",
+        lane="glm-harness → litellm :4141 → OpenRouter",
+        usd="~1.3–2.8 USD",
+        note="source ~/.config/vnx/provider-usage.env in the same subshell; glm-5.2 only",
+    ),
+    Gate.KIMI_GATE.value: GateCost(
+        command="python3 scripts/kimi_gate.py --pr {pr}",
+        lane="kimi CLI (OAuth)",
+        usd="subscription",
+        note="kimi-via-cli-only: never the Moonshot API",
+    ),
+    Gate.CODEX_GATE.value: GateCost(
+        command="python3 scripts/review_gate_manager.py request-and-execute --gate codex_gate --pr {pr}",
+        lane="codex CLI",
+        usd="subscription",
+        note="rate-limited; operator policy A1 is to wait for the reset, not to fall back",
+    ),
+    Gate.GEMINI_REVIEW.value: GateCost(
+        command="python3 scripts/review_gate_manager.py request-and-execute --gate gemini_review --pr {pr}",
+        lane="gemini CLI",
+        usd="subscription",
+        note="no standalone runner script in this repo — goes through the manager",
+    ),
+    Gate.CI_GATE.value: GateCost(
+        command="python3 scripts/review_gate_manager.py request-and-execute --gate ci_gate --pr {pr}",
+        lane="gh CLI, inline (no provider)",
+        usd="free",
+        note="reads the checks that already ran; it does not start CI",
+    ),
+    Gate.WIRING_GATE.value: GateCost(
+        command="python3 scripts/review_gate_manager.py request-and-execute --gate wiring_gate --pr {pr}",
+        lane="local, deterministic",
+        usd="free",
+    ),
+    Gate.CLAUDE_GITHUB_OPTIONAL.value: GateCost(
+        command="python3 scripts/review_gate_manager.py request-and-execute --gate claude_github_optional --pr {pr}",
+        lane="GitHub app",
+        usd="subscription",
+        note="optional gate: an intentional absence is a legitimate end state",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class GateEvidence:
+    """One declared gate, and whether its evidence holds for THIS head."""
+
+    gate: str
+    verdict: str  # "GO" | "NO-GO" | "UNMEASURABLE"
+    message: str
+    record_sha: Optional[str] = None
+    report_path: Optional[str] = None
+    report_exists: Optional[bool] = None
+    #: False when no obligation declared this gate but a result record for it
+    #: exists anyway — a gate run by hand rather than through the door.
+    declared: bool = True
+
+    @property
+    def satisfied(self) -> bool:
+        return self.verdict == "GO"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "gate": self.gate,
+            "verdict": self.verdict,
+            "message": self.message,
+            "record_sha": self.record_sha,
+            "report_path": self.report_path,
+            "report_exists": self.report_exists,
+            "declared": self.declared,
+        }
+
+
+@dataclass
+class Readiness:
+    """The whole answer for one PR, renderable and serialisable."""
+
+    pr_number: int
+    facts: Dict[str, Any] = field(default_factory=dict)
+    contexts: List[Any] = field(default_factory=list)
+    contexts_error: Optional[str] = None
+    gates: List[GateEvidence] = field(default_factory=list)
+    gates_error: Optional[str] = None
+    declared_gates: List[str] = field(default_factory=list)
+    observed_gates: List[str] = field(default_factory=list)
+
+    @property
+    def head_sha(self) -> str:
+        return str(self.facts.get("headRefOid") or "")
+
+    @property
+    def unmeasurable_reasons(self) -> List[str]:
+        reasons = []
+        if self.contexts_error:
+            reasons.append(f"required contexts: {self.contexts_error}")
+        if self.gates_error:
+            reasons.append(f"review gates: {self.gates_error}")
+        reasons += [
+            f"{g.gate}: {g.message}" for g in self.gates if g.verdict == VERDICT_UNMEASURABLE
+        ]
+        return reasons
+
+    @property
+    def blockers(self) -> List[str]:
+        out = []
+        blocking = [c for c in self.contexts if c.blocking]
+        settled = [c for c in blocking if not c.transient]
+        in_flight = [c for c in blocking if c.transient]
+        if settled:
+            out.append(f"{len(settled)} required context(s) not satisfied")
+        if in_flight:
+            out.append(f"{len(in_flight)} required context(s) still in flight")
+        unsatisfied = [g for g in self.gates if g.verdict == "NO-GO"]
+        if unsatisfied:
+            out.append(f"{len(unsatisfied)} review gate(s) without evidence on this head")
+        if not self.declared_gates and not self.gates_error:
+            if self.observed_gates:
+                out.append(
+                    "no review-gate obligation declared — "
+                    f"{len(self.observed_gates)} gate result(s) exist off the door"
+                )
+            else:
+                out.append("no review-gate obligation declared for this PR")
+        state = str(self.facts.get("state") or "").upper()
+        if state and state != "OPEN":
+            out.append(f"PR state is {state}")
+        if self.facts.get("isDraft"):
+            out.append("PR is a draft")
+        return out
+
+    @property
+    def verdict(self) -> str:
+        if self.unmeasurable_reasons:
+            return VERDICT_UNMEASURABLE
+        return VERDICT_NOT_READY if self.blockers else VERDICT_READY
+
+    def costs(self) -> List[str]:
+        """What it takes to close each open gap, most actionable first."""
+        out = []
+        never = [c for c in self.contexts if c.state == ci_contexts.STATE_NEVER_CREATED]
+        no_run = [c for c in self.contexts if c.state == ci_contexts.STATE_NO_RUN]
+        for group, action in ((never, "re-run"), (no_run, "start")):
+            for c in group:
+                out.append(
+                    f"{action} {c.workflow_name or 'the producing workflow'} on {self.head_sha[:12]} "
+                    f"— gh run rerun (no flags, keeps the sha) — free, for {c.context}"
+                )
+        failed = [c for c in self.contexts if c.state == ci_contexts.STATE_FAILED]
+        for c in failed:
+            out.append(f"fix and re-push — {c.context} {c.detail}")
+        if not self.declared_gates and not self.gates_error and not self.observed_gates:
+            # An undeclared obligation has a cost too, and leaving it off the
+            # list was the one place this report said "nothing outstanding"
+            # about a PR it had just called NOT READY.
+            choices = " or ".join(
+                f"{name} ({GATE_COST[name].usd})"
+                for name in (Gate.GLM_GATE.value, Gate.CODEX_GATE.value)
+            )
+            out.append(
+                f"declare and run a review gate for #{self.pr_number} — {choices}; "
+                "the door writes the obligation, `vnx dispatch` is the entry"
+            )
+        for gate in self.gates:
+            if gate.satisfied:
+                continue
+            cost = GATE_COST.get(gate.gate)
+            if cost is None:
+                out.append(
+                    f"{gate.gate}: no cost entry — this gate is not in GATE_COST, so what it "
+                    "takes to run is UNKNOWN, not free"
+                )
+                continue
+            out.append(cost.describe(self.pr_number, self.head_sha))
+        return out
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "pr_number": self.pr_number,
+            "verdict": self.verdict,
+            "head_sha": self.head_sha,
+            "facts": self.facts,
+            "contexts": [c.to_dict() for c in self.contexts],
+            "contexts_error": self.contexts_error,
+            "contexts_summary": ci_contexts.summarise(self.contexts) if self.contexts else None,
+            "declared_gates": self.declared_gates,
+            "observed_gates": self.observed_gates,
+            "gates": [g.to_dict() for g in self.gates],
+            "gates_error": self.gates_error,
+            "blockers": self.blockers,
+            "unmeasurable": self.unmeasurable_reasons,
+            "costs": self.costs(),
+        }
+
+
+class PRReadinessError(RuntimeError):
+    """The PR itself could not be read — nothing downstream is meaningful."""
+
+
+def fetch_pr_facts(pr_number: int, project_root: Path, timeout: int = 20) -> Dict[str, Any]:
+    """``gh pr view`` for the fields the report needs, or raise."""
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", _PR_FIELDS],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise PRReadinessError(f"gh CLI not available: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise PRReadinessError(f"gh pr view #{pr_number} timed out after {timeout}s") from exc
+    if proc.returncode != 0:
+        raise PRReadinessError(
+            f"gh pr view #{pr_number} failed (rc={proc.returncode}): "
+            f"{(proc.stderr or '').strip()[:300]}"
+        )
+    try:
+        facts = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise PRReadinessError(f"gh pr view #{pr_number} returned unparseable JSON: {exc}") from exc
+    if not isinstance(facts, dict) or not facts.get("headRefOid"):
+        raise PRReadinessError(f"gh pr view #{pr_number} returned no head sha — cannot bind evidence")
+    return facts
+
+
+def observed_gates_for_pr(results_dir: Path, pr_number: int) -> List[str]:
+    """Gates that produced a result record for this PR, declared or not.
+
+    The obligation store is the door's record of what a PR OWES. It is empty
+    for a PR whose gate was run by hand rather than dispatched through the
+    door — measured on this fleet, #1701 merged with no obligation at all.
+    Reading only the obligations therefore misses gate evidence that is
+    sitting on disk, and reports "no gate verdict" about a PR that has one.
+
+    Offline ``test_run`` records are excluded here for the same reason
+    ``closure_verifier`` excludes them: a synthetic pr_id must never align
+    with a real PR.
+
+    An unreadable or malformed result file is skipped rather than raised on:
+    unlike an obligation, a result file is not a claim that something is
+    owed, so a corrupt one cannot hide an obligation. The declared list —
+    which CAN hide one — still fails loud.
+    """
+    gates: List[str] = []
+    if not results_dir.is_dir():
+        return gates
+    for path in sorted(results_dir.glob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        if str(record.get("pr_id") or "") != str(pr_number):
+            continue
+        if record.get("test_run") in (True, "1", "true", "yes"):
+            continue
+        gate = (record.get("gate") or "").strip()
+        if gate and gate not in gates:
+            gates.append(gate)
+    return gates
+
+
+def collect_gate_evidence(
+    pr_number: int,
+    declared_gates: Sequence[str],
+    state_dir: Path,
+    *,
+    branch: str,
+    head_sha: str,
+    declared: Optional[Sequence[str]] = None,
+) -> List[GateEvidence]:
+    """Evaluate each declared gate against ``head_sha``.
+
+    Delegates the verdict to ``closure_verifier.check_review_gate_for_merge`` —
+    the same five invariants the merge door enforces, never a weaker second
+    copy. On top of that it records WHERE the newest record for this gate sits
+    when it is not on this head, because "the gate ran, two commits ago" and
+    "the gate never ran" cost completely different things to fix and the merge
+    door's binary verdict cannot tell them apart.
+    """
+    from closure_verifier import _find_gate_result, check_review_gate_for_merge
+
+    results_dir = Path(state_dir) / "review_gates" / "results"
+    declared_set = set(declared_gates if declared is None else declared)
+    evidence: List[GateEvidence] = []
+    for gate in declared_gates:
+        try:
+            verdict = check_review_gate_for_merge(
+                str(pr_number), gate, results_dir, branch=branch, head_sha=head_sha,
+            )
+        except (OSError, ValueError) as exc:
+            evidence.append(
+                GateEvidence(
+                    gate=gate,
+                    verdict=VERDICT_UNMEASURABLE,
+                    message=f"gate evidence could not be read: {type(exc).__name__}: {exc}",
+                    declared=gate in declared_set,
+                )
+            )
+            continue
+
+        record_sha = None
+        report_path = None
+        report_exists = None
+        # Only interesting when the head-bound lookup found nothing: name the
+        # commit the newest record DOES sit on, so the reader sees "stale" and
+        # "absent" as the different problems they are.
+        anywhere = _find_gate_result(gate, str(pr_number), results_dir)
+        if anywhere:
+            record_sha = anywhere.get("commit_sha") or None
+            report_path = anywhere.get("report_path") or None
+            if report_path:
+                report_exists = Path(report_path).exists()
+        evidence.append(
+            GateEvidence(
+                gate=gate,
+                verdict=verdict.get("verdict", VERDICT_UNMEASURABLE),
+                message=verdict.get("message", ""),
+                record_sha=record_sha,
+                report_path=report_path,
+                report_exists=report_exists,
+                declared=gate in declared_set,
+            )
+        )
+    return evidence
+
+
+def assess(
+    pr_number: int,
+    project_root: Path,
+    state_dir: Path,
+    *,
+    protected_branch: str = "main",
+    timeout: int = 20,
+) -> Readiness:
+    """Build the full readiness answer for one PR.
+
+    Raises :class:`PRReadinessError` only when the PR itself is unreadable —
+    without a head sha there is nothing to bind evidence to. Every other
+    failure is captured into the report as an unmeasurable section, because a
+    report that dies on one unreadable input tells the reader less than one
+    that says exactly which part it could not see.
+    """
+    facts = fetch_pr_facts(pr_number, project_root, timeout)
+    report = Readiness(pr_number=pr_number, facts=facts)
+    head_sha = str(facts.get("headRefOid") or "")
+    branch = str(facts.get("headRefName") or "")
+
+    try:
+        report.contexts = ci_contexts.evaluate_commit(
+            project_root, head_sha, branch=protected_branch, timeout=timeout,
+        )
+    except ci_contexts.CIContextsError as exc:
+        report.contexts_error = str(exc)
+
+    try:
+        from gate_obligations import declared_gates_for_pr
+
+        report.declared_gates = list(dict.fromkeys(declared_gates_for_pr(state_dir, pr_number)))
+    except (ValueError, OSError) as exc:
+        report.gates_error = f"{type(exc).__name__}: {exc}"
+        return report
+
+    results_dir = Path(state_dir) / "review_gates" / "results"
+    observed = observed_gates_for_pr(results_dir, pr_number)
+    report.observed_gates = [g for g in observed if g not in report.declared_gates]
+    report.gates = collect_gate_evidence(
+        pr_number,
+        report.declared_gates + report.observed_gates,
+        state_dir,
+        branch=branch,
+        head_sha=head_sha,
+        declared=report.declared_gates,
+    )
+    return report

--- a/scripts/lib/pr_readiness.py
+++ b/scripts/lib/pr_readiness.py
@@ -195,6 +195,11 @@ class Readiness:
         if self.gates_error:
             reasons.append(f"review gates: {self.gates_error}")
         reasons += [
+            f"{c.context}: {c.detail}"
+            for c in self.contexts
+            if c.state == ci_contexts.STATE_UNVERIFIED
+        ]
+        reasons += [
             f"{g.gate}: {g.message}" for g in self.gates if g.verdict == VERDICT_UNMEASURABLE
         ]
         return reasons

--- a/scripts/lib/pr_readiness.py
+++ b/scripts/lib/pr_readiness.py
@@ -183,6 +183,15 @@ class Readiness:
         reasons = []
         if self.contexts_error:
             reasons.append(f"required contexts: {self.contexts_error}")
+        elif not self.contexts:
+            # An empty required-context set is a misconfiguration, not a pass.
+            # The renderer already said so; without this the verdict said READY
+            # and the command exited 0 on a set nobody measured — the report
+            # contradicting itself, which is the exact defect class this
+            # command exists to surface on other people's evidence.
+            reasons.append(
+                "required contexts: branch protection lists none, so nothing was verified"
+            )
         if self.gates_error:
             reasons.append(f"review gates: {self.gates_error}")
         reasons += [

--- a/scripts/lib/required_contexts_gate.py
+++ b/scripts/lib/required_contexts_gate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""required_contexts_gate.py — the merge-gate verdict for required CI contexts.
+
+``ci_contexts`` answers a factual question: for each context branch protection
+requires, does it exist on this commit, and if not, can it still appear?
+This module answers the gate's question: does that add up to permission to
+merge? The two are kept apart deliberately — the classifier has no opinion
+about merges, and the gate has no opinion about GitHub's job graph.
+
+It lives beside ``pre_merge_gate.py`` rather than inside it because that file
+is already 1522 lines on main, past the 1200-line hard ceiling
+``quality_advisory`` enforces. Growing it further to add a check would trade
+one governance finding for another.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path
+from typing import Any, Dict
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in _sys.path:
+    _sys.path.insert(0, str(_LIB_DIR))
+
+import ci_contexts  # noqa: E402
+
+#: Mirrors pre_merge_gate.SKIPPED_UNVERIFIED. Defined here rather than imported
+#: to keep the dependency one-way: pre_merge_gate imports this module, so an
+#: import back would be a cycle. The value is asserted equal in the tests.
+SKIPPED_UNVERIFIED = "SKIPPED_UNVERIFIED"
+
+CHECK_NAME = "required_contexts"
+
+
+def check_required_contexts(
+    project_root: Path,
+    *,
+    head_sha: str,
+    protected_branch: str = "main",
+    timeout: int = 20,
+) -> Dict[str, Any]:
+    """Check that every REQUIRED branch-protection context exists on the PR head.
+
+    ``pre_merge_gate.check_ci_workflow`` answers "did the configured CI
+    workflow run and succeed on this commit". That is a different question
+    from "is every check branch protection insists on actually present", and
+    #1691 is the case where the two answers disagreed: nine visible passes,
+    zero fails, and five of the fourteen required contexts never created at
+    all during an Actions outage. Counting what is present cannot see that.
+
+    The naive form of this check is worse than the gap it closes. #1701
+    measured that: twelve green, Profile B and Profile C absent because both
+    declare ``needs: profile-a`` and profile-a had not finished. A guard that
+    reads "absent" as "never created" blocks every PR in the first minutes of
+    its own CI. The verdict therefore keeps four outcomes apart:
+
+      - every context passed                      -> GO
+      - a context is missing for good, or failed  -> HOLD, named per context
+      - a context is still coming                 -> HOLD, reported as in
+        flight, so the reader knows the fix is time and not a re-run
+      - anything unmeasurable                     -> SKIPPED_UNVERIFIED
+
+    SKIPPED_UNVERIFIED, never GO, on an unreadable branch-protection list or
+    an unreachable gh: ``run_gate_checks`` treats it as blocking, and a merge
+    gate that could not look must not grant permission because it failed to
+    look (the OI-1140 contract, applied to this second question).
+    """
+    try:
+        states = ci_contexts.evaluate_commit(
+            project_root, head_sha, branch=protected_branch, timeout=timeout,
+        )
+    except ci_contexts.CIContextsError as exc:
+        return {
+            "check": CHECK_NAME,
+            "status": SKIPPED_UNVERIFIED,
+            "detail": f"required contexts could not be read: {exc}",
+            "contexts": [],
+            "summary": None,
+        }
+
+    summary = ci_contexts.summarise(states)
+    payload: Dict[str, Any] = {
+        "check": CHECK_NAME,
+        "contexts": [s.to_dict() for s in states],
+        "summary": summary,
+    }
+
+    if not states:
+        payload["status"] = SKIPPED_UNVERIFIED
+        payload["detail"] = (
+            f"branch protection on {protected_branch!r} lists no required contexts — "
+            "nothing to verify, which is a misconfiguration rather than a pass"
+        )
+        return payload
+
+    if summary["unverified"]:
+        unverified = [s.context for s in states if s.state == ci_contexts.STATE_UNVERIFIED]
+        payload["status"] = SKIPPED_UNVERIFIED
+        payload["detail"] = (
+            f"{len(unverified)} of {summary['total']} required contexts could not be "
+            f"classified: {', '.join(unverified)}"
+        )
+        return payload
+
+    blocking = [s for s in states if s.blocking]
+    if not blocking:
+        payload["status"] = "GO"
+        payload["detail"] = f"all {summary['total']} required contexts passed on {head_sha[:12]}"
+        return payload
+
+    payload["status"] = "HOLD"
+    payload["detail"] = _describe_blocking(blocking, summary["total"], head_sha)
+    return payload
+
+
+def _describe_blocking(blocking, total: int, head_sha: str) -> str:
+    """One line naming what blocks, with settled and in-flight kept apart."""
+    settled = [s for s in blocking if not s.transient]
+    in_flight = [s for s in blocking if s.transient]
+    parts = []
+    if settled:
+        parts.append(
+            "not satisfied: " + "; ".join(f"{s.context} [{s.state}] {s.detail}" for s in settled)
+        )
+    if in_flight:
+        parts.append("still in flight: " + ", ".join(f"{s.context} [{s.state}]" for s in in_flight))
+    return (
+        f"{len(blocking)} of {total} required contexts block the merge on "
+        f"{head_sha[:12]} — " + " | ".join(parts)
+    )

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -46,7 +46,7 @@ TIER_UNIVERSAL: FrozenSet[str] = frozenset({
 })
 
 TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
-    "staging-list", "promote", "queue-status", "gate-check", "suggest",
+    "staging-list", "promote", "queue-status", "gate-check", "pr-ready", "suggest",
     "cost-report", "analyze-sessions", "intelligence-export",
     "intelligence-import", "init-feature", "bootstrap-skills",
     "bootstrap-terminals", "bootstrap-hooks", "regen-settings", "regen-worker-permissions",

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -182,50 +182,28 @@ def _run_ci_gate(
 
 
 def _norm_pr_id(pr_id: str) -> str:
-    """Normalize an internal PR id for obligation matching.
+    """Deprecated alias for ``gate_obligations.normalise_pr_id``.
 
-    "PR-879", "pr879" and "879" all normalize to "879"; "PR-HYG-1" to "HYG-1".
-    The door stores the raw spec pr_id on the obligation; the merge gate joins
-    that against the GitHub PR number, which may differ in case, hyphen and the
-    "PR" prefix, so comparison goes through this normalization.
+    Kept as a name so existing imports and tests keep resolving; the logic
+    lives in gate_obligations, which the readiness report reads from too.
     """
-    s = (pr_id or "").strip().upper()
-    if s.startswith("PR-"):
-        return s[3:]
-    # Bare "PR<digits>" (e.g. "pr879") — strip the prefix only when it is
-    # followed by a digit, so alphanumeric labels like "PR-HYG-1" (handled
-    # above) and words that merely start with "PR" are never mangled.
-    if s.startswith("PR") and len(s) > 2 and s[2].isdigit():
-        return s[2:]
-    return s
+    from gate_obligations import normalise_pr_id
+
+    return normalise_pr_id(pr_id)
 
 
 def _resolve_declared_gate(pr_number: int, *, state_dir: Path) -> str:
     """Resolve a PR's declared review gate from its door obligation.
 
-    The obligation the dispatch door writes (``scripts/lib/gate_obligations.py``)
-    carries the declared gate. The merge-time join key is the GitHub PR number:
-    the runner stamps ``pr_number`` on the obligation it fulfils, and a numeric
-    pr_id ("PR-1584" / "1584" / "pr1584") normalizes to the same number.
-    Returns the gate name, or "" when no obligation declares one — the merge
-    gate treats "" as a refusal, never a pass.
+    Delegates the join to ``gate_obligations.declared_gates_for_pr`` and keeps
+    this function's own contract unchanged: the LAST declared gate wins, and
+    an unreadable obligation store degrades to "" (a refusal at the merge
+    gate) rather than raising into the merge path.
     """
     try:
-        from gate_obligations import NO_GATE_KEY, iter_obligations
+        from gate_obligations import declared_gates_for_pr
 
-        num = str(pr_number)
-        num_forms = {_norm_pr_id(num), _norm_pr_id(f"PR-{num}")}
-        matches = []
-        for _path, record in iter_obligations(state_dir):
-            rec_num = record.get("pr_number")
-            matched = rec_num is not None and str(rec_num) == num
-            if not matched:
-                matched = _norm_pr_id(str(record.get("pr_id") or "")) in num_forms
-            if not matched:
-                continue
-            gate = (record.get("gate") or "").strip()
-            if gate and gate != NO_GATE_KEY:
-                matches.append(gate)
+        matches = declared_gates_for_pr(state_dir, pr_number)
         if matches:
             return matches[-1]
     except (ValueError, OSError) as exc:

--- a/scripts/pr_ready.py
+++ b/scripts/pr_ready.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import List
@@ -61,6 +62,53 @@ _EXIT_BY_VERDICT = {
     VERDICT_NOT_READY: EXIT_NOT_READY,
     VERDICT_UNMEASURABLE: EXIT_UNMEASURABLE,
 }
+
+
+class StateDirMismatch(RuntimeError):
+    """The PR facts and the gate evidence would come from different projects."""
+
+
+def resolve_state_dir(project_root: Path, explicit: str | None) -> Path:
+    """Bind the gate-evidence store to the project the PR facts come from.
+
+    The PR facts, the required contexts and the CI runs are all resolved
+    against ``project_root``. The gate obligations and result records were
+    resolved against whatever the AMBIENT environment pointed at. Running from
+    a different directory, or with a VNX_* variable inherited from another
+    project, silently read one project's gate evidence into another project's
+    verdict — a wrong READY or NOT READY with nothing to show it happened.
+
+    An explicit ``--state-dir`` always wins; that is the operator's override
+    for a deliberate cross-project read. Otherwise the two must agree, and a
+    disagreement is refused rather than resolved: guessing which of the two
+    the operator meant is exactly the silent choice this check exists to stop.
+    """
+    if explicit:
+        return Path(explicit)
+    paths = ensure_env()
+    resolved_root = Path(paths["PROJECT_ROOT"]).resolve()
+    asked = _git_toplevel(project_root) or Path(project_root).resolve()
+    if resolved_root != asked:
+        raise StateDirMismatch(
+            f"the PR facts would come from {asked} but the gate evidence from the store "
+            f"of {resolved_root} ({paths['VNX_STATE_DIR']}). Run from the project, or pass "
+            "--state-dir to say which store you mean."
+        )
+    return Path(paths["VNX_STATE_DIR"])
+
+
+def _git_toplevel(path: Path) -> Path | None:
+    """The git root containing ``path``, or None when it is not a repository."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return Path(proc.stdout.strip()).resolve()
 
 
 def _context_line(report: Readiness) -> str:
@@ -160,6 +208,11 @@ def main(argv: List[str] | None = None) -> int:
         help="branch whose protection defines the required contexts (default: main)",
     )
     parser.add_argument("--project-root", default=None, help="project root (default: cwd)")
+    parser.add_argument(
+        "--state-dir", default=None,
+        help="explicit VNX state dir; required when --project-root names a project "
+             "other than the one the ambient environment resolves to",
+    )
     parser.add_argument("--timeout", type=int, default=20, help="per-gh-call timeout in seconds")
     args = parser.parse_args(argv)
 
@@ -170,7 +223,11 @@ def main(argv: List[str] | None = None) -> int:
         return EXIT_BAD_INPUT
 
     project_root = Path(args.project_root) if args.project_root else Path.cwd()
-    state_dir = Path(ensure_env()["VNX_STATE_DIR"])
+    try:
+        state_dir = resolve_state_dir(project_root, args.state_dir)
+    except StateDirMismatch as exc:
+        print(f"pr-ready: {exc}", file=sys.stderr)
+        return EXIT_BAD_INPUT
 
     reports = []
     worst = EXIT_READY

--- a/scripts/pr_ready.py
+++ b/scripts/pr_ready.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""pr_ready.py — `vnx pr-ready <N>`: what does this PR still need to merge?
+
+Five lines per PR: what is complete, what is missing, and what closing each
+gap costs. The manual version of this answer took several `gh` calls plus a
+throwaway Python block, fourteen times in one night.
+
+The measuring lives in ``scripts/lib/pr_readiness.py``, which reuses the
+implementations that already decide each sub-answer (``ci_contexts``,
+``gate_obligations``, ``closure_verifier``) rather than growing a second
+opinion beside them. This file only renders and exits.
+
+Exit codes:
+  0  - READY: every required context passed and every declared gate is evidenced
+  1  - NOT READY: measured, and something blocks
+  2  - UNMEASURABLE: at least one section could not be read (never 0)
+  10 - bad arguments / the PR itself could not be read
+
+The split between 1 and 2 is the point. A gate that could not look must not
+exit 0, and a script that treats "could not measure" as "not ready" hides the
+difference between a PR that needs another CI run and a machine that cannot
+reach GitHub.
+
+Usage:
+  python3 scripts/pr_ready.py 1703
+  python3 scripts/pr_ready.py 1703 --json
+  python3 scripts/pr_ready.py 1703 1704 --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+for _p in (str(SCRIPT_DIR / "lib"), str(SCRIPT_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import ci_contexts  # noqa: E402
+from pr_readiness import (  # noqa: E402
+    VERDICT_NOT_READY,
+    VERDICT_READY,
+    VERDICT_UNMEASURABLE,
+    PRReadinessError,
+    Readiness,
+    assess,
+)
+from vnx_paths import ensure_env  # noqa: E402
+
+EXIT_READY = 0
+EXIT_NOT_READY = 1
+EXIT_UNMEASURABLE = 2
+EXIT_BAD_INPUT = 10
+
+_EXIT_BY_VERDICT = {
+    VERDICT_READY: EXIT_READY,
+    VERDICT_NOT_READY: EXIT_NOT_READY,
+    VERDICT_UNMEASURABLE: EXIT_UNMEASURABLE,
+}
+
+
+def _context_line(report: Readiness) -> str:
+    if report.contexts_error:
+        return f"CI        UNMEASURABLE — {report.contexts_error}"
+    if not report.contexts:
+        return "CI        UNMEASURABLE — branch protection lists no required contexts"
+    summary = ci_contexts.summarise(report.contexts)
+    parts = [f"{summary['passed']}/{summary['total']} required contexts passed"]
+    in_flight = [c for c in report.contexts if c.transient]
+    if in_flight:
+        parts.append(f"{len(in_flight)} in flight ({', '.join(c.context for c in in_flight)})")
+    settled = [c for c in report.contexts if c.blocking and not c.transient]
+    if settled:
+        parts.append(
+            f"{len(settled)} NOT satisfied ("
+            + ", ".join(f"{c.context} [{c.state}]" for c in settled)
+            + ")"
+        )
+    return "CI        " + " · ".join(parts)
+
+
+def _gate_line(report: Readiness) -> str:
+    if report.gates_error:
+        return f"GATES     UNMEASURABLE — {report.gates_error}"
+    if not report.declared_gates and not report.observed_gates:
+        return (
+            "GATES     none declared — no obligation record joins this PR, so there is no "
+            "gate verdict to merge on"
+        )
+    parts = []
+    for gate in report.gates:
+        suffix = "" if gate.declared else " [off the door: no obligation]"
+        if gate.satisfied:
+            parts.append(f"{gate.gate} OK on head{suffix}")
+        elif gate.verdict == VERDICT_UNMEASURABLE:
+            parts.append(f"{gate.gate} UNMEASURABLE ({gate.message})")
+        elif gate.record_sha and gate.record_sha != report.head_sha:
+            parts.append(
+                f"{gate.gate} NOT on head (newest record on {gate.record_sha[:12]}){suffix}"
+            )
+        elif gate.record_sha:
+            parts.append(f"{gate.gate} incomplete ({gate.message}){suffix}")
+        else:
+            parts.append(f"{gate.gate} absent{suffix}")
+    return "GATES     " + " · ".join(parts)
+
+
+def render(report: Readiness, verbose: bool = False) -> str:
+    facts = report.facts
+    head = f"PR #{report.pr_number}  {facts.get('state', '?')}"
+    if facts.get("isDraft"):
+        head += " (DRAFT)"
+    head += (
+        f"  {facts.get('headRefName', '?')}  head {report.head_sha[:12]}"
+        f"  mergeable={facts.get('mergeable', '?')}/{facts.get('mergeStateStatus', '?')}"
+    )
+
+    lines = [head, _context_line(report), _gate_line(report)]
+
+    costs = report.costs()
+    if costs:
+        lines.append(f"COST      {costs[0]}")
+        lines += [f"          {c}" for c in costs[1:]]
+    else:
+        lines.append("COST      nothing outstanding")
+
+    verdict = report.verdict
+    if verdict == VERDICT_UNMEASURABLE:
+        reason = "; ".join(report.unmeasurable_reasons)
+        lines.append(f"VERDICT   {verdict} — {reason}")
+    elif verdict == VERDICT_NOT_READY:
+        lines.append(f"VERDICT   {verdict} — " + "; ".join(report.blockers))
+    else:
+        lines.append(f"VERDICT   {verdict} — every required context passed, every declared gate evidenced")
+
+    if verbose:
+        lines.append("")
+        for c in report.contexts:
+            lines.append(f"  [{c.state:16}] {c.context} — {c.detail}")
+        for g in report.gates:
+            lines.append(f"  [{g.verdict:16}] {g.gate} — {g.message}")
+    return "\n".join(lines)
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="vnx pr-ready",
+        description="Merge-readiness for one or more PRs: required contexts, review-gate "
+                    "evidence bound to the current head, and what closing each gap costs.",
+    )
+    parser.add_argument("pr", nargs="+", help="PR number(s)")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--verbose", action="store_true", help="one line per context and gate")
+    parser.add_argument(
+        "--protected-branch", default="main",
+        help="branch whose protection defines the required contexts (default: main)",
+    )
+    parser.add_argument("--project-root", default=None, help="project root (default: cwd)")
+    parser.add_argument("--timeout", type=int, default=20, help="per-gh-call timeout in seconds")
+    args = parser.parse_args(argv)
+
+    try:
+        numbers = [int(str(p).lstrip("#").upper().removeprefix("PR-")) for p in args.pr]
+    except ValueError:
+        print(f"pr-ready: PR arguments must be numbers, got {args.pr}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+
+    project_root = Path(args.project_root) if args.project_root else Path.cwd()
+    state_dir = Path(ensure_env()["VNX_STATE_DIR"])
+
+    reports = []
+    worst = EXIT_READY
+    for number in numbers:
+        try:
+            report = assess(
+                number, project_root, state_dir,
+                protected_branch=args.protected_branch, timeout=args.timeout,
+            )
+        except PRReadinessError as exc:
+            print(f"pr-ready: #{number} could not be read: {exc}", file=sys.stderr)
+            worst = max(worst, EXIT_BAD_INPUT)
+            continue
+        reports.append(report)
+        worst = max(worst, _EXIT_BY_VERDICT[report.verdict])
+
+    if args.json:
+        print(json.dumps([r.to_dict() for r in reports], indent=2))
+    else:
+        print("\n\n".join(render(r, verbose=args.verbose) for r in reports))
+    return worst
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre_merge_gate.py
+++ b/scripts/pre_merge_gate.py
@@ -48,6 +48,7 @@ from quality_advisory import (
 )
 from cqs_calculator import calculate_cqs
 from gate_findings_bridge import record_gate_finding, resolve_gate_finding
+from required_contexts_gate import check_required_contexts
 
 # CQS threshold: dispatches below this score get a HOLD
 CQS_THRESHOLD = 50.0
@@ -1322,6 +1323,14 @@ def run_gate_checks(
             ))
     else:
         checks.append(check_ci_workflow(project_root, workflow_name=ci_workflow_name))
+
+    # #1691/#1701: what EXISTS on the head is a different question from what
+    # branch protection REQUIRES, and only the second one can see a context
+    # that was never created. Meaningful only for a resolved PR head — a local
+    # working copy has no protected-branch contract to compare against, so the
+    # check is omitted rather than answered with a guess.
+    if pr_head is not None and pr_head.head_ref:
+        checks.append(check_required_contexts(project_root, head_sha=pr_head.head_ref))
 
     if not skip_pytest:
         checks.append(check_pytest(project_root))

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -471,3 +471,35 @@ def test_gh_failure_raises_rather_than_returning_an_empty_list(tmp_path):
     with pytest.raises(cc.CIContextsError) as excinfo:
         cc._gh_json(["api", "repos/{owner}/{repo}/nope"], tmp_path, timeout=10)
     assert "failed" in str(excinfo.value) or "not available" in str(excinfo.value)
+
+
+def test_the_any_app_sentinel_is_normalised_to_no_binding(monkeypatch, tmp_path):
+    """GitHub's branch-protection API uses app_id -1 for "any app may set this
+    status". It is an int, so a naive isinstance check keeps it as if it named
+    a real producer — and then NO run matches it, turning every any-app
+    required check into a false `unverified`.
+    """
+    payload = {
+        "required_status_checks": {
+            "contexts": [],
+            "checks": [
+                {"context": "any app", "app_id": cc.ANY_APP_ID},
+                {"context": "bound", "app_id": 15368},
+            ],
+        }
+    }
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
+    assert cc.fetch_required_checks(tmp_path) == [
+        cc.RequiredCheck("any app", None),
+        cc.RequiredCheck("bound", 15368),
+    ]
+
+
+def test_an_any_app_requirement_is_satisfied_by_any_producer(graph):
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", None)],
+        [_app_check("Profile A", 777)],
+        [_run()],
+        graph,
+    )
+    assert state.state == cc.STATE_PASSED

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -350,21 +350,121 @@ def test_summarise_counts_each_state_separately(graph):
     assert summary["by_state"]["Profile B"] == cc.STATE_NEVER_CREATED
 
 
-def test_required_contexts_unions_both_github_shapes(monkeypatch, tmp_path):
+def test_required_checks_unions_both_github_shapes(monkeypatch, tmp_path):
     payload = {
         "required_status_checks": {
             "contexts": ["legacy only", "shared"],
-            "checks": [{"context": "shared"}, {"context": "checks only"}, {"no_context": 1}],
+            "checks": [
+                {"context": "shared", "app_id": 15368},
+                {"context": "checks only", "app_id": 15368},
+                {"no_context": 1},
+            ],
         }
     }
     monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
-    assert cc.fetch_required_contexts(tmp_path) == ["checks only", "legacy only", "shared"]
+    assert cc.fetch_required_checks(tmp_path) == [
+        cc.RequiredCheck("checks only", 15368),
+        cc.RequiredCheck("legacy only", None),
+        cc.RequiredCheck("shared", 15368),
+    ]
 
 
-def test_required_contexts_refuses_a_non_mapping_payload(monkeypatch, tmp_path):
+def test_the_app_bound_shape_wins_over_the_legacy_name_only_entry(monkeypatch, tmp_path):
+    """Dropping the app binding would WIDEN the requirement, not narrow it."""
+    payload = {
+        "required_status_checks": {
+            "contexts": ["shared"],
+            "checks": [{"context": "shared", "app_id": 42}],
+        }
+    }
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
+    assert cc.fetch_required_checks(tmp_path) == [cc.RequiredCheck("shared", 42)]
+
+
+def test_required_checks_refuses_a_non_mapping_payload(monkeypatch, tmp_path):
     monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: ["not", "a", "mapping"])
     with pytest.raises(cc.CIContextsError):
-        cc.fetch_required_contexts(tmp_path)
+        cc.fetch_required_checks(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# The app binding branch protection actually enforces
+# ---------------------------------------------------------------------------
+
+
+def _app_check(name, app_id, conclusion="success"):
+    return {"name": name, "status": "completed", "conclusion": conclusion, "app": {"id": app_id}}
+
+
+def test_a_check_from_the_required_app_satisfies_the_requirement(graph):
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_app_check("Profile A", 15368)], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+def test_a_same_named_check_from_another_app_is_never_a_pass(graph):
+    """Branch protection would not accept it. Matching on the name alone turns
+    a foreign check into a green light."""
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_app_check("Profile A", 999)], [_run()], graph
+    )
+    assert state.state == cc.STATE_UNVERIFIED
+    assert state.blocking is True
+    assert "none is from the required app" in state.detail
+
+
+def test_a_check_run_with_no_app_object_does_not_satisfy_a_binding(graph):
+    """An unidentifiable producer cannot be shown to be the required one."""
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_check("Profile A")], [_run()], graph
+    )
+    assert state.state == cc.STATE_UNVERIFIED
+
+
+def test_without_a_binding_any_app_satisfies_the_legacy_requirement(graph):
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", None)], [_app_check("Profile A", 999)], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+def test_a_bound_context_with_only_foreign_runs_is_not_reported_as_never_created(graph):
+    """The distinction matters for the cost line: a foreign check is a
+    configuration problem, not a workflow that has to be re-run."""
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("Profile A", 15368)], [_app_check("Profile A", 999)], [], graph
+    )
+    assert state.state != cc.STATE_NEVER_CREATED
+
+
+def test_a_bare_string_requirement_still_works_as_an_unbound_check(graph):
+    [state] = cc.classify_contexts(["Profile A"], [_check("Profile A")], [_run()], graph)
+    assert state.state == cc.STATE_PASSED
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+def test_check_runs_are_fetched_with_slurp(monkeypatch, tmp_path):
+    """`gh api --paginate` emits one document per page for an OBJECT response.
+    Measured on a 16-run commit at per_page=5: four pages, and json.loads fails
+    with "Extra data" at char 15511. Without --slurp this check blocks every
+    PR whose commit has more than 100 check runs, for no real reason.
+    """
+    captured = {}
+
+    def fake(args, project_root, timeout):
+        captured["args"] = list(args)
+        return [{"check_runs": [{"name": "a"}]}, {"check_runs": [{"name": "b"}]}]
+
+    monkeypatch.setattr(cc, "_gh_json", fake)
+    runs = cc.fetch_check_runs(tmp_path, "a" * 40)
+    assert "--slurp" in captured["args"]
+    assert "--paginate" in captured["args"]
+    assert [r["name"] for r in runs] == ["a", "b"], "every page must be flattened, not just the first"
 
 
 def test_gh_failure_raises_rather_than_returning_an_empty_list(tmp_path):

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -503,3 +503,98 @@ def test_an_any_app_requirement_is_satisfied_by_any_producer(graph):
         graph,
     )
     assert state.state == cc.STATE_PASSED
+
+
+# ---------------------------------------------------------------------------
+# Legacy commit statuses — the other half of the namespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state,expected_status,expected_conclusion",
+    [
+        ("success", "completed", "success"),
+        ("failure", "completed", "failure"),
+        ("error", "completed", "failure"),
+        ("pending", "in_progress", None),
+    ],
+)
+def test_commit_statuses_map_onto_the_check_run_vocabulary(
+    monkeypatch, tmp_path, state, expected_status, expected_conclusion
+):
+    monkeypatch.setattr(
+        cc, "_gh_json", lambda *a, **k: {"statuses": [{"context": "legacy ci", "state": state}]}
+    )
+    [entry] = cc.fetch_commit_statuses(tmp_path, "a" * 40)
+    assert entry["name"] == "legacy ci"
+    assert entry["status"] == expected_status
+    assert entry["conclusion"] == expected_conclusion
+
+
+def test_an_unrecognised_status_state_holds_the_verdict_rather_than_deciding_it(
+    monkeypatch, tmp_path
+):
+    """A future state value must not silently pass or fail."""
+    monkeypatch.setattr(
+        cc, "_gh_json", lambda *a, **k: {"statuses": [{"context": "x", "state": "warped"}]}
+    )
+    [entry] = cc.fetch_commit_statuses(tmp_path, "a" * 40)
+    assert entry["status"] == "in_progress" and entry["conclusion"] is None
+
+
+def test_only_the_newest_status_per_context_counts(monkeypatch, tmp_path):
+    """GitHub lists the history newest-first; a superseded older state is not
+    what branch protection evaluates."""
+    monkeypatch.setattr(
+        cc, "_gh_json",
+        lambda *a, **k: {"statuses": [
+            {"context": "legacy ci", "state": "success"},
+            {"context": "legacy ci", "state": "failure"},
+        ]},
+    )
+    entries = cc.fetch_commit_statuses(tmp_path, "a" * 40)
+    assert len(entries) == 1 and entries[0]["conclusion"] == "success"
+
+
+def test_a_required_context_satisfied_by_a_status_is_not_reported_as_missing(graph):
+    """Branch protection's legacy `contexts[]` can be satisfied by a commit
+    STATUS rather than a check run. Reading only check runs left such a
+    context permanently unseen, blocking a PR on evidence that was there all
+    along. Found by codex_gate on this PR.
+    """
+    status_evidence = {"name": "legacy ci", "status": "completed", "conclusion": "success"}
+    [state] = cc.classify_contexts(
+        [cc.RequiredCheck("legacy ci", None)], [status_evidence], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+def test_commit_statuses_refuse_a_non_mapping_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: [1, 2, 3])
+    with pytest.raises(cc.CIContextsError):
+        cc.fetch_commit_statuses(tmp_path, "a" * 40)
+
+
+def test_evaluate_commit_consults_both_evidence_sources(monkeypatch, tmp_path):
+    """The wiring itself, not just the fetcher. A required context satisfied
+    only by a commit status must come back `passed` from the top-level entry
+    point — dropping the status source from evaluate_commit is a one-line
+    regression that every fetcher-level test would survive.
+    """
+    workflows = _write_workflow(tmp_path, "vnx-ci.yml", _GRAPH_BODY)
+    monkeypatch.setattr(
+        cc, "fetch_required_checks",
+        lambda *a, **k: [cc.RequiredCheck("Profile A", None), cc.RequiredCheck("legacy ci", None)],
+    )
+    monkeypatch.setattr(cc, "fetch_check_runs", lambda *a, **k: [_check("Profile A")])
+    monkeypatch.setattr(
+        cc, "fetch_commit_statuses",
+        lambda *a, **k: [{"name": "legacy ci", "status": "completed", "conclusion": "success"}],
+    )
+    monkeypatch.setattr(cc, "fetch_workflow_runs", lambda *a, **k: [_run()])
+
+    states = cc.evaluate_commit(tmp_path, "a" * 40, workflows_dir=workflows)
+    assert {s.context: s.state for s in states} == {
+        "Profile A": cc.STATE_PASSED,
+        "legacy ci": cc.STATE_PASSED,
+    }

--- a/tests/test_ci_contexts.py
+++ b/tests/test_ci_contexts.py
@@ -1,0 +1,373 @@
+"""Regression guards for scripts/lib/ci_contexts.py.
+
+Two measured cases anchor this file and they look identical from the outside:
+
+  #1691 — five of fourteen required contexts were never created during an
+          Actions outage. ``gh pr checks`` showed nine passes, zero fails.
+  #1701 — twelve of fourteen green, Profile B and Profile C absent because
+          both declare ``needs: profile-a`` and profile-a had not finished.
+
+The first must block loudly. The second must say "wait". A guard that
+collapses them is either useless or blocks every PR in its first minutes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import ci_contexts as cc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Graph parsing
+# ---------------------------------------------------------------------------
+
+
+def _write_workflow(tmp_path: Path, filename: str, body: str) -> Path:
+    workflows = tmp_path / "workflows"
+    workflows.mkdir(exist_ok=True)
+    (workflows / filename).write_text(body, encoding="utf-8")
+    return workflows
+
+
+def test_graph_uses_job_name_as_context_and_falls_back_to_job_key(tmp_path):
+    workflows = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+name: Demo CI
+on: [push]
+jobs:
+  named:
+    name: Profile A (doctor + core tests)
+    runs-on: ubuntu-latest
+  unnamed:
+    runs-on: ubuntu-latest
+""",
+    )
+    graph = cc.parse_workflow_graph(workflows)
+    assert "Profile A (doctor + core tests)" in graph.by_context
+    assert graph.by_context["Profile A (doctor + core tests)"].job_key == "named"
+    # No `name:` — GitHub uses the job key as the context, and so do we.
+    assert "unnamed" in graph.by_context
+    assert graph.parse_errors == ()
+
+
+@pytest.mark.parametrize(
+    "needs_literal,expected",
+    [("profile-a", ("profile-a",)), ("[profile-a, profile-d]", ("profile-a", "profile-d"))],
+)
+def test_graph_normalises_needs_string_and_list(tmp_path, needs_literal, expected):
+    workflows = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        f"""
+name: Demo CI
+on: [push]
+jobs:
+  profile-a:
+    name: A
+    runs-on: ubuntu-latest
+  profile-d:
+    name: D
+    runs-on: ubuntu-latest
+  profile-b:
+    name: B
+    needs: {needs_literal}
+    runs-on: ubuntu-latest
+""",
+    )
+    graph = cc.parse_workflow_graph(workflows)
+    assert tuple(graph.by_context["B"].needs) == expected
+
+
+def test_graph_records_unparseable_file_instead_of_skipping_it(tmp_path):
+    workflows = _write_workflow(tmp_path, "broken.yml", "name: [unclosed\njobs:\n")
+    graph = cc.parse_workflow_graph(workflows)
+    assert graph.by_context == {}
+    assert len(graph.parse_errors) == 1
+    assert "broken.yml" in graph.parse_errors[0]
+
+
+def test_graph_reports_duplicate_context_rather_than_overwriting(tmp_path):
+    workflows = _write_workflow(
+        tmp_path,
+        "ci.yml",
+        """
+name: Demo CI
+on: [push]
+jobs:
+  first:
+    name: Shared
+    runs-on: ubuntu-latest
+  second:
+    name: Shared
+    runs-on: ubuntu-latest
+""",
+    )
+    graph = cc.parse_workflow_graph(workflows)
+    assert graph.by_context["Shared"].job_key == "first"
+    assert any("duplicate context" in e for e in graph.parse_errors)
+
+
+def test_graph_on_missing_directory_is_an_error_not_an_empty_pass(tmp_path):
+    graph = cc.parse_workflow_graph(tmp_path / "does-not-exist")
+    assert graph.by_context == {}
+    assert graph.parse_errors and "not found" in graph.parse_errors[0]
+
+
+def test_real_vnx_ci_still_gates_profile_b_and_c_behind_profile_a():
+    """The #1701 fact this module is calibrated against, guarded in place.
+
+    If vnx-ci.yml ever drops ``needs: profile-a`` from Profile B/C, the
+    waiting_upstream classification stops describing this repo and the guard
+    silently changes meaning.
+    """
+    graph = cc.parse_workflow_graph(REPO_ROOT / ".github" / "workflows")
+    for context in ("Profile B (snapshot integration)", "Profile C (adoption smoke tests)"):
+        node = graph.by_context[context]
+        assert node.workflow_file == "vnx-ci.yml"
+        assert "profile-a" in node.needs
+
+
+# ---------------------------------------------------------------------------
+# Classification — contexts that exist
+# ---------------------------------------------------------------------------
+
+_GRAPH_BODY = """
+name: VNX CI
+on: [push]
+jobs:
+  profile-a:
+    name: Profile A
+    runs-on: ubuntu-latest
+  profile-b:
+    name: Profile B
+    needs: profile-a
+    runs-on: ubuntu-latest
+"""
+
+
+@pytest.fixture()
+def graph(tmp_path):
+    return cc.parse_workflow_graph(_write_workflow(tmp_path, "vnx-ci.yml", _GRAPH_BODY))
+
+
+def _run(status="completed", conclusion="success", name="VNX CI", run_id=1):
+    return {"id": run_id, "name": name, "status": status, "conclusion": conclusion}
+
+
+def _check(name, status="completed", conclusion="success"):
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+def test_present_and_successful_is_the_only_non_blocking_state(graph):
+    [state] = cc.classify_contexts(["Profile A"], [_check("Profile A")], [_run()], graph)
+    assert state.state == cc.STATE_PASSED
+    assert state.blocking is False
+
+
+@pytest.mark.parametrize("conclusion", ["skipped", "neutral"])
+def test_skipped_and_neutral_conclusions_count_as_passing(graph, conclusion):
+    [state] = cc.classify_contexts(
+        ["Profile A"], [_check("Profile A", conclusion=conclusion)], [_run()], graph
+    )
+    assert state.state == cc.STATE_PASSED
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "timed_out", "action_required", ""])
+def test_terminal_non_passing_conclusion_is_failed(graph, conclusion):
+    [state] = cc.classify_contexts(
+        ["Profile A"], [_check("Profile A", conclusion=conclusion)], [_run()], graph
+    )
+    assert state.state == cc.STATE_FAILED
+    assert state.blocking is True
+
+
+def test_unfinished_check_run_is_running_not_failed(graph):
+    [state] = cc.classify_contexts(
+        ["Profile A"],
+        [_check("Profile A", status="in_progress", conclusion=None)],
+        [_run(status="in_progress", conclusion=None)],
+        graph,
+    )
+    assert state.state == cc.STATE_RUNNING
+    assert state.blocking is True and state.transient is True
+
+
+def test_duplicate_check_runs_resolve_to_the_failing_one(graph):
+    """One context, two runs (push + pull_request). The passing copy must not
+    win: resolving a disagreement in favour of green is the green-lie itself.
+    """
+    [state] = cc.classify_contexts(
+        ["Profile A"],
+        [_check("Profile A"), _check("Profile A", conclusion="failure")],
+        [_run()],
+        graph,
+    )
+    assert state.state == cc.STATE_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Classification — contexts that do NOT exist (the whole point)
+# ---------------------------------------------------------------------------
+
+
+def test_1701_shape_absent_context_behind_a_running_dependency_says_wait(graph):
+    """Profile B absent, VNX CI alive, profile-a not finished — WAIT."""
+    jobs = {1: [{"name": "Profile A", "status": "in_progress", "conclusion": None}]}
+    [state] = cc.classify_contexts(
+        ["Profile B"],
+        [_check("Profile A", status="in_progress", conclusion=None)],
+        [_run(status="in_progress", conclusion=None)],
+        graph,
+        jobs,
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert state.transient is True
+    assert "Profile A" in state.detail
+
+
+def test_1691_shape_absent_context_on_a_finished_run_is_never_created(graph):
+    """VNX CI concluded, Profile B never appeared — the outage shape. Blocks."""
+    jobs = {1: [{"name": "Profile A", "status": "completed", "conclusion": "success"}]}
+    [state] = cc.classify_contexts(
+        ["Profile B"], [_check("Profile A")], [_run()], graph, jobs
+    )
+    assert state.state == cc.STATE_NEVER_CREATED
+    assert state.blocking is True and state.transient is False
+    assert "#1691" in state.detail
+
+
+def test_absent_context_whose_dependency_failed_can_never_be_created(graph):
+    """Run still alive, but profile-a already failed: waiting cannot help."""
+    jobs = {1: [{"name": "Profile A", "status": "completed", "conclusion": "failure"}]}
+    [state] = cc.classify_contexts(
+        ["Profile B"],
+        [_check("Profile A", conclusion="failure")],
+        [_run(status="in_progress", conclusion=None)],
+        graph,
+        jobs,
+    )
+    assert state.state == cc.STATE_NEVER_CREATED
+    assert "profile-a" in state.detail
+
+
+def test_absent_context_with_no_workflow_run_at_all_is_no_run(graph):
+    [state] = cc.classify_contexts(["Profile A"], [], [], graph)
+    assert state.state == cc.STATE_NO_RUN
+    assert state.blocking is True
+
+
+def test_absent_context_no_job_produces_it_is_unverified_never_green(graph):
+    [state] = cc.classify_contexts(["Some App Check"], [], [_run()], graph)
+    assert state.state == cc.STATE_UNVERIFIED
+    assert state.blocking is True
+    assert "cannot tell" in state.detail
+
+
+def test_waiting_names_the_dependency_even_without_job_data(graph):
+    """Job-level detail may fail to load. The verdict must survive that.
+
+    With no job list, an unobserved ancestor counts as pending — "not created
+    yet" is exactly the state that makes the child wait — so the message still
+    names Profile A instead of degrading to a bare "still running".
+    """
+    [state] = cc.classify_contexts(
+        ["Profile B"], [], [_run(status="queued", conclusion=None)], graph
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert "waiting on Profile A" in state.detail
+
+
+def test_waiting_falls_back_to_declared_needs_when_the_dependency_is_unresolvable(tmp_path):
+    """``needs:`` naming a job that does not exist in the file.
+
+    The ancestor cannot be resolved to a context name, so there is nothing to
+    report as pending — the message falls back to the raw declaration rather
+    than claiming the run simply has not got round to the job.
+    """
+    broken = cc.parse_workflow_graph(
+        _write_workflow(
+            tmp_path,
+            "vnx-ci.yml",
+            """
+name: VNX CI
+on: [push]
+jobs:
+  profile-b:
+    name: Profile B
+    needs: ghost-job
+    runs-on: ubuntu-latest
+""",
+        )
+    )
+    [state] = cc.classify_contexts(
+        ["Profile B"], [], [_run(status="queued", conclusion=None)], broken
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert "declares needs: ghost-job" in state.detail
+
+
+def test_missing_context_without_dependencies_on_a_live_run_still_waits(graph):
+    [state] = cc.classify_contexts(
+        ["Profile A"], [], [_run(status="queued", conclusion=None)], graph
+    )
+    assert state.state == cc.STATE_WAITING_UPSTREAM
+    assert "has not created this job yet" in state.detail
+
+
+# ---------------------------------------------------------------------------
+# Contract guards
+# ---------------------------------------------------------------------------
+
+
+def test_only_passed_is_non_blocking():
+    """An allowlist, so a state added later blocks until someone decides."""
+    assert cc.NON_BLOCKING_STATES == frozenset({cc.STATE_PASSED})
+
+
+def test_summarise_counts_each_state_separately(graph):
+    states = cc.classify_contexts(
+        ["Profile A", "Profile B", "Some App Check"],
+        [_check("Profile A")],
+        [_run()],
+        graph,
+        {1: [{"name": "Profile A", "status": "completed", "conclusion": "success"}]},
+    )
+    summary = cc.summarise(states)
+    assert summary["total"] == 3
+    assert summary["passed"] == 1
+    assert summary["never_created"] == 1
+    assert summary["unverified"] == 1
+    assert summary["blocking"] == 2
+    assert summary["by_state"]["Profile B"] == cc.STATE_NEVER_CREATED
+
+
+def test_required_contexts_unions_both_github_shapes(monkeypatch, tmp_path):
+    payload = {
+        "required_status_checks": {
+            "contexts": ["legacy only", "shared"],
+            "checks": [{"context": "shared"}, {"context": "checks only"}, {"no_context": 1}],
+        }
+    }
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: payload)
+    assert cc.fetch_required_contexts(tmp_path) == ["checks only", "legacy only", "shared"]
+
+
+def test_required_contexts_refuses_a_non_mapping_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(cc, "_gh_json", lambda *a, **k: ["not", "a", "mapping"])
+    with pytest.raises(cc.CIContextsError):
+        cc.fetch_required_contexts(tmp_path)
+
+
+def test_gh_failure_raises_rather_than_returning_an_empty_list(tmp_path):
+    with pytest.raises(cc.CIContextsError) as excinfo:
+        cc._gh_json(["api", "repos/{owner}/{repo}/nope"], tmp_path, timeout=10)
+    assert "failed" in str(excinfo.value) or "not available" in str(excinfo.value)

--- a/tests/test_pr_readiness.py
+++ b/tests/test_pr_readiness.py
@@ -339,3 +339,22 @@ def test_an_off_the_door_gate_removes_the_declare_and_run_cost():
         pr.GateEvidence(gate="glm_gate", verdict="GO", message="ok", declared=False)
     ]
     assert not any("declare and run a review gate" in c for c in report.costs())
+
+
+def test_an_empty_required_context_set_is_unmeasurable_not_ready():
+    """The renderer already called this UNMEASURABLE. The verdict said READY,
+    so the command exited 0 on a set nobody measured — the report
+    contradicting itself, which is the defect class this command exists to
+    surface on other people's evidence. Found by codex_gate on this PR.
+    """
+    report = _ready_report(contexts=[])
+    assert report.verdict == pr.VERDICT_UNMEASURABLE
+    assert any("lists none" in r for r in report.unmeasurable_reasons)
+    assert pr_ready._EXIT_BY_VERDICT[report.verdict] == pr_ready.EXIT_UNMEASURABLE
+
+
+def test_the_verdict_and_the_rendered_ci_line_never_disagree():
+    """Both halves must reach the same conclusion about an empty set."""
+    report = _ready_report(contexts=[])
+    assert "UNMEASURABLE" in pr_ready._context_line(report)
+    assert report.verdict == pr.VERDICT_UNMEASURABLE

--- a/tests/test_pr_readiness.py
+++ b/tests/test_pr_readiness.py
@@ -1,0 +1,341 @@
+"""Regression guards for the merge-readiness report (`vnx pr-ready`).
+
+The report exists because counting what is present is not the same as knowing
+what is required, and because "I could not look" is not "I looked and it is
+fine". Both distinctions are asserted here rather than assumed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+for _p in (REPO_ROOT / "scripts" / "lib", REPO_ROOT / "scripts"):
+    sys.path.insert(0, str(_p))
+
+import ci_contexts  # noqa: E402
+import pr_ready  # noqa: E402
+import pr_readiness as pr  # noqa: E402
+from pr_readiness import observed_gates_for_pr  # noqa: E402
+from dispatch_spec import Gate  # noqa: E402
+from gate_obligations import (  # noqa: E402
+    NO_GATE_KEY,
+    declared_gates_for_pr,
+    normalise_pr_id,
+    obligations_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# The cost half of the question
+# ---------------------------------------------------------------------------
+
+
+def test_every_gate_in_the_closed_enum_has_a_cost_entry():
+    """A gate with no cost entry is reported as "run it" with no idea what
+    running it takes — the half of the question that made the manual count
+    slow. The enum is closed (OI-845), so this is enforceable.
+    """
+    assert set(pr.GATE_COST) == {g.value for g in Gate}
+
+
+def test_a_gate_without_a_cost_entry_is_reported_as_unknown_not_free():
+    report = pr.Readiness(pr_number=7, facts={"headRefOid": "a" * 40})
+    report.declared_gates = ["invented_gate"]
+    report.gates = [pr.GateEvidence(gate="invented_gate", verdict="NO-GO", message="absent")]
+    costs = report.costs()
+    assert any("UNKNOWN, not free" in c for c in costs)
+
+
+def test_openrouter_cost_band_is_the_measured_range_not_the_old_estimate():
+    """1.3-2.8 USD per run, measured. An earlier 0.4 estimate under-read the
+    remaining balance by a factor of five.
+    """
+    assert "1.3" in pr.GATE_COST[Gate.GLM_GATE.value].usd
+    assert "2.8" in pr.GATE_COST[Gate.GLM_GATE.value].usd
+
+
+# ---------------------------------------------------------------------------
+# The PR -> declared-gate join, promoted out of pr_merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("PR-879", "879"), ("pr879", "879"), ("879", "879"), ("PR-HYG-1", "HYG-1"), ("", "")],
+)
+def test_normalise_pr_id(raw, expected):
+    assert normalise_pr_id(raw) == expected
+
+
+def _obligation(state_dir: Path, dispatch_id: str, **fields):
+    obligations_dir(state_dir).mkdir(parents=True, exist_ok=True)
+    record = {"schema_version": 1, "dispatch_id": dispatch_id, **fields}
+    (obligations_dir(state_dir) / f"{dispatch_id}.json").write_text(json.dumps(record))
+
+
+def test_declared_gates_joins_on_pr_number_and_on_pr_id(tmp_path):
+    _obligation(tmp_path, "d1", gate="codex_gate", pr_number=42, pr_id=None)
+    _obligation(tmp_path, "d2", gate="glm_gate", pr_number=None, pr_id="PR-42")
+    _obligation(tmp_path, "d3", gate="kimi_gate", pr_number=43, pr_id=None)
+    assert declared_gates_for_pr(tmp_path, 42) == ["codex_gate", "glm_gate"]
+
+
+def test_declared_gates_excludes_the_explicit_no_gate_sentinel(tmp_path):
+    """`__no_gate__` declares an absence, not an obligation."""
+    _obligation(tmp_path, "d1", gate=NO_GATE_KEY, pr_number=42)
+    _obligation(tmp_path, "d2", gate="", pr_number=42)
+    assert declared_gates_for_pr(tmp_path, 42) == []
+
+
+def test_declared_gates_raises_on_an_unreadable_obligation(tmp_path):
+    """An obligation nobody can read must never read as "this PR owes nothing"."""
+    obligations_dir(tmp_path).mkdir(parents=True, exist_ok=True)
+    (obligations_dir(tmp_path) / "broken.json").write_text("{not json")
+    with pytest.raises(ValueError):
+        declared_gates_for_pr(tmp_path, 42)
+
+
+def test_pr_merge_still_returns_the_last_declared_gate_after_delegation(tmp_path):
+    """Behaviour parity: pr_merge kept "last one wins" when the join moved."""
+    import pr_merge
+
+    _obligation(tmp_path, "d1", gate="codex_gate", pr_number=42)
+    _obligation(tmp_path, "d2", gate="glm_gate", pr_number=42)
+    assert pr_merge._resolve_declared_gate(42, state_dir=tmp_path) == "glm_gate"
+
+
+def test_pr_merge_degrades_an_unreadable_store_to_a_refusal_not_an_exception(tmp_path):
+    """The merge path must not crash on a corrupt obligation; "" is a refusal."""
+    import pr_merge
+
+    obligations_dir(tmp_path).mkdir(parents=True, exist_ok=True)
+    (obligations_dir(tmp_path) / "broken.json").write_text("{not json")
+    assert pr_merge._resolve_declared_gate(42, state_dir=tmp_path) == ""
+
+
+# ---------------------------------------------------------------------------
+# Verdict precedence — the distinction the whole report exists for
+# ---------------------------------------------------------------------------
+
+
+def _ctx(context, state):
+    return ci_contexts.ContextState(context=context, state=state, detail="d")
+
+
+def _ready_report(**overrides):
+    report = pr.Readiness(
+        pr_number=1,
+        facts={"headRefOid": "a" * 40, "state": "OPEN", "headRefName": "b", "isDraft": False},
+    )
+    report.contexts = [_ctx("Profile A", ci_contexts.STATE_PASSED)]
+    report.declared_gates = ["glm_gate"]
+    report.gates = [pr.GateEvidence(gate="glm_gate", verdict="GO", message="ok")]
+    for key, value in overrides.items():
+        setattr(report, key, value)
+    return report
+
+
+def test_a_fully_evidenced_open_pr_is_ready():
+    assert _ready_report().verdict == pr.VERDICT_READY
+
+
+def test_an_unmeasurable_section_beats_every_blocker_and_never_reads_as_ready():
+    report = _ready_report(contexts_error="gh api failed (rc=1)")
+    assert report.verdict == pr.VERDICT_UNMEASURABLE
+    assert "gh api failed" in report.unmeasurable_reasons[0]
+
+
+def test_an_unmeasurable_gate_is_not_a_passing_gate():
+    report = _ready_report(
+        gates=[pr.GateEvidence(gate="glm_gate", verdict=pr.VERDICT_UNMEASURABLE, message="boom")]
+    )
+    assert report.verdict == pr.VERDICT_UNMEASURABLE
+
+
+def test_a_context_still_in_flight_blocks_but_is_named_as_in_flight():
+    report = _ready_report(
+        contexts=[
+            _ctx("Profile A", ci_contexts.STATE_PASSED),
+            _ctx("Profile B", ci_contexts.STATE_WAITING_UPSTREAM),
+        ]
+    )
+    assert report.verdict == pr.VERDICT_NOT_READY
+    assert any("still in flight" in b for b in report.blockers)
+    assert not any("not satisfied" in b for b in report.blockers)
+
+
+def test_a_never_created_context_is_reported_as_not_satisfied():
+    report = _ready_report(contexts=[_ctx("Profile B", ci_contexts.STATE_NEVER_CREATED)])
+    assert any("not satisfied" in b for b in report.blockers)
+    assert any("gh run rerun" in c for c in report.costs())
+
+
+def test_a_pr_with_no_declared_obligation_blocks_and_names_the_choice():
+    """#1701 merged with no obligation record at all. That is a state, and it
+    must cost something rather than reading as "nothing outstanding".
+    """
+    report = _ready_report(declared_gates=[], gates=[])
+    assert report.verdict == pr.VERDICT_NOT_READY
+    assert any("no review-gate obligation declared" in b for b in report.blockers)
+    costs = report.costs()
+    assert any("declare and run a review gate" in c for c in costs)
+    assert any("glm_gate" in c and "codex_gate" in c for c in costs)
+
+
+@pytest.mark.parametrize("state,expected", [("MERGED", True), ("CLOSED", True), ("OPEN", False)])
+def test_a_non_open_pr_is_never_ready(state, expected):
+    report = _ready_report()
+    report.facts = dict(report.facts, state=state)
+    assert any("PR state is" in b for b in report.blockers) is expected
+
+
+def test_a_draft_pr_is_never_ready():
+    report = _ready_report()
+    report.facts = dict(report.facts, isDraft=True)
+    assert any("draft" in b for b in report.blockers)
+
+
+# ---------------------------------------------------------------------------
+# Reading the PR itself
+# ---------------------------------------------------------------------------
+
+
+class _Proc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_fetch_pr_facts_raises_on_a_failed_gh_call(monkeypatch, tmp_path):
+    monkeypatch.setattr(pr.subprocess, "run", lambda *a, **k: _Proc(1, "", "no such PR"))
+    with pytest.raises(pr.PRReadinessError) as excinfo:
+        pr.fetch_pr_facts(9999, tmp_path)
+    assert "no such PR" in str(excinfo.value)
+
+
+def test_fetch_pr_facts_raises_when_there_is_no_head_sha(monkeypatch, tmp_path):
+    """Without a head sha there is nothing to bind evidence to — refuse rather
+    than measure against whatever is checked out locally.
+    """
+    monkeypatch.setattr(pr.subprocess, "run", lambda *a, **k: _Proc(0, json.dumps({"number": 1})))
+    with pytest.raises(pr.PRReadinessError) as excinfo:
+        pr.fetch_pr_facts(1, tmp_path)
+    assert "no head sha" in str(excinfo.value)
+
+
+def test_fetch_pr_facts_raises_on_unparseable_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(pr.subprocess, "run", lambda *a, **k: _Proc(0, "{not json"))
+    with pytest.raises(pr.PRReadinessError):
+        pr.fetch_pr_facts(1, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Rendering and exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_render_is_five_lines_for_a_ready_pr():
+    """Five lines was the ask: what is complete, what is missing, what it costs."""
+    assert len(pr_ready.render(_ready_report()).splitlines()) == 5
+
+
+def test_render_names_a_stale_gate_record_by_its_commit():
+    report = _ready_report(
+        gates=[
+            pr.GateEvidence(
+                gate="glm_gate", verdict="NO-GO", message="geen resultaat",
+                record_sha="c" * 40,
+            )
+        ]
+    )
+    line = pr_ready._gate_line(report)
+    assert "NOT on head" in line and "cccccccccccc" in line
+
+
+def test_render_distinguishes_an_absent_gate_from_a_stale_one():
+    report = _ready_report(
+        gates=[pr.GateEvidence(gate="glm_gate", verdict="NO-GO", message="geen resultaat")]
+    )
+    assert "absent" in pr_ready._gate_line(report)
+
+
+def test_every_verdict_maps_to_a_distinct_exit_code():
+    """0 ready, 1 not ready, 2 unmeasurable. Collapsing 2 into 1 would hide
+    "the machine cannot reach GitHub" inside "this PR needs another run".
+    """
+    assert set(pr_ready._EXIT_BY_VERDICT) == {
+        pr.VERDICT_READY, pr.VERDICT_NOT_READY, pr.VERDICT_UNMEASURABLE,
+    }
+    assert len(set(pr_ready._EXIT_BY_VERDICT.values())) == 3
+    assert pr_ready._EXIT_BY_VERDICT[pr.VERDICT_READY] == 0
+
+
+def test_main_refuses_a_non_numeric_pr_argument(capsys):
+    assert pr_ready.main(["not-a-number"]) == pr_ready.EXIT_BAD_INPUT
+    assert "must be numbers" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Gates that ran off the door
+# ---------------------------------------------------------------------------
+
+
+def _result(results_dir: Path, name: str, **fields):
+    results_dir.mkdir(parents=True, exist_ok=True)
+    (results_dir / name).write_text(json.dumps(fields))
+
+
+def test_observed_gates_finds_a_result_the_obligation_store_never_declared(tmp_path):
+    """A gate run by hand leaves a result record and no obligation. Reading
+    only the obligations reports "no gate verdict" about a PR that has one —
+    measured on this fleet: #1701 merged with no obligation at all.
+    """
+    _result(tmp_path, "pr-42-glm_gate.json", pr_id="42", gate="glm_gate")
+    _result(tmp_path, "pr-42-ci_gate.json", pr_id="42", gate="ci_gate")
+    assert observed_gates_for_pr(tmp_path, 42) == ["ci_gate", "glm_gate"]
+
+
+def test_observed_gates_ignores_other_prs_and_offline_test_runs(tmp_path):
+    _result(tmp_path, "pr-43-glm_gate.json", pr_id="43", gate="glm_gate")
+    _result(tmp_path, "pr-42-kimi_gate.json", pr_id="42", gate="kimi_gate", test_run=True)
+    _result(tmp_path, "pr-42-str.json", pr_id="42", gate="codex_gate", test_run="true")
+    assert observed_gates_for_pr(tmp_path, 42) == []
+
+
+def test_observed_gates_skips_a_corrupt_result_file(tmp_path):
+    """A result file is not a claim that something is owed, so a corrupt one
+    cannot hide an obligation — unlike the obligation store, which raises.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "broken.json").write_text("{not json")
+    _result(tmp_path, "pr-42-glm_gate.json", pr_id="42", gate="glm_gate")
+    assert observed_gates_for_pr(tmp_path, 42) == ["glm_gate"]
+
+
+def test_observed_gates_on_a_missing_results_dir_is_empty_not_an_error(tmp_path):
+    assert observed_gates_for_pr(tmp_path / "nope", 42) == []
+
+
+def test_an_off_the_door_gate_is_reported_as_such():
+    report = _ready_report(declared_gates=[], observed_gates=["glm_gate"])
+    report.gates = [
+        pr.GateEvidence(gate="glm_gate", verdict="GO", message="ok", declared=False)
+    ]
+    line = pr_ready._gate_line(report)
+    assert "off the door" in line
+    assert any("gate result(s) exist off the door" in b for b in report.blockers)
+
+
+def test_an_off_the_door_gate_removes_the_declare_and_run_cost():
+    """The gate already ran; telling the reader to run one would be wrong."""
+    report = _ready_report(declared_gates=[], observed_gates=["glm_gate"])
+    report.gates = [
+        pr.GateEvidence(gate="glm_gate", verdict="GO", message="ok", declared=False)
+    ]
+    assert not any("declare and run a review gate" in c for c in report.costs())

--- a/tests/test_pr_readiness.py
+++ b/tests/test_pr_readiness.py
@@ -358,3 +358,70 @@ def test_the_verdict_and_the_rendered_ci_line_never_disagree():
     report = _ready_report(contexts=[])
     assert "UNMEASURABLE" in pr_ready._context_line(report)
     assert report.verdict == pr.VERDICT_UNMEASURABLE
+
+
+# ---------------------------------------------------------------------------
+# The two stores must be the same project's
+# ---------------------------------------------------------------------------
+
+
+def test_an_explicit_state_dir_always_wins(tmp_path):
+    """The operator's override for a deliberate cross-project read."""
+    assert pr_ready.resolve_state_dir(tmp_path, str(tmp_path / "s")) == tmp_path / "s"
+
+
+def test_a_state_dir_from_another_project_is_refused(monkeypatch, tmp_path):
+    """The PR facts, the required contexts and the CI runs resolve against
+    --project-root; the gate evidence resolved against whatever the ambient
+    environment pointed at. Reading one project's gate evidence into another
+    project's verdict is a wrong READY with nothing to show it happened.
+    Found by codex_gate on this PR.
+    """
+    monkeypatch.setattr(
+        pr_ready, "ensure_env",
+        lambda: {"PROJECT_ROOT": str(tmp_path / "project-a"), "VNX_STATE_DIR": str(tmp_path / "a")},
+    )
+    monkeypatch.setattr(pr_ready, "_git_toplevel", lambda p: tmp_path / "project-b")
+    with pytest.raises(pr_ready.StateDirMismatch) as excinfo:
+        pr_ready.resolve_state_dir(tmp_path / "project-b", None)
+    assert "project-a" in str(excinfo.value) and "project-b" in str(excinfo.value)
+
+
+def test_agreeing_roots_use_the_ambient_state_dir(monkeypatch, tmp_path):
+    root = tmp_path / "project"
+    monkeypatch.setattr(
+        pr_ready, "ensure_env",
+        lambda: {"PROJECT_ROOT": str(root), "VNX_STATE_DIR": str(tmp_path / "state")},
+    )
+    monkeypatch.setattr(pr_ready, "_git_toplevel", lambda p: root)
+    assert pr_ready.resolve_state_dir(root, None) == tmp_path / "state"
+
+
+def test_main_refuses_a_cross_project_invocation(monkeypatch, tmp_path, capsys):
+    def _boom(project_root, explicit):
+        raise pr_ready.StateDirMismatch("two different projects")
+
+    monkeypatch.setattr(pr_ready, "resolve_state_dir", _boom)
+    assert pr_ready.main(["1705"]) == pr_ready.EXIT_BAD_INPUT
+    assert "two different projects" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# An unverified context is unmeasurable, not merely blocking
+# ---------------------------------------------------------------------------
+
+
+def test_an_unverified_context_makes_the_verdict_unmeasurable():
+    """It fell through to blockers and reported NOT READY (exit 1). But
+    `unverified` is precisely "could not tell", which is exit 2 — the whole
+    reason the third bucket exists. Found by codex_gate on this PR.
+    """
+    report = _ready_report(
+        contexts=[
+            _ctx("Profile A", ci_contexts.STATE_PASSED),
+            _ctx("Some App Check", ci_contexts.STATE_UNVERIFIED),
+        ]
+    )
+    assert report.verdict == pr.VERDICT_UNMEASURABLE
+    assert any("Some App Check" in r for r in report.unmeasurable_reasons)
+    assert pr_ready._EXIT_BY_VERDICT[report.verdict] == pr_ready.EXIT_UNMEASURABLE

--- a/tests/test_pre_merge_gate_pr_ref.py
+++ b/tests/test_pre_merge_gate_pr_ref.py
@@ -211,6 +211,18 @@ class TestRunGateChecksPRHead:
                 "net_line_deletion_warn": False, "file_deletion_warn": False,
             },
         )
+        # required_contexts runs only for a resolved PR head, which the tests
+        # in this class supply. Stubbed so orchestration tests stay hermetic:
+        # the real check shells out to `gh api .../branches/main/protection`,
+        # and measuring this suite showed exactly one such live call escaping
+        # per run. Its own coverage is in test_pre_merge_gate_required_contexts.py.
+        monkeypatch.setattr(
+            pre_merge_gate, "check_required_contexts",
+            lambda project_root, **kw: {
+                "check": "required_contexts", "status": "GO", "detail": "stub",
+                "contexts": [], "summary": None,
+            },
+        )
 
     def test_without_pr_head_measures_head(self, state_dir, dispatch_dir, tmp_path, monkeypatch):
         captured = {}
@@ -274,6 +286,18 @@ class TestRunGateChecksCIHead:
                 "check": "net_deletion", "status": "GO", "detail": "stub",
                 "deleted_count": 0, "deleted_files": [], "net_line_deletion": 0,
                 "net_line_deletion_warn": False, "file_deletion_warn": False,
+            },
+        )
+        # required_contexts runs only for a resolved PR head, which the tests
+        # in this class supply. Stubbed so orchestration tests stay hermetic:
+        # the real check shells out to `gh api .../branches/main/protection`,
+        # and measuring this suite showed exactly one such live call escaping
+        # per run. Its own coverage is in test_pre_merge_gate_required_contexts.py.
+        monkeypatch.setattr(
+            pre_merge_gate, "check_required_contexts",
+            lambda project_root, **kw: {
+                "check": "required_contexts", "status": "GO", "detail": "stub",
+                "contexts": [], "summary": None,
             },
         )
 

--- a/tests/test_pre_merge_gate_required_contexts.py
+++ b/tests/test_pre_merge_gate_required_contexts.py
@@ -1,0 +1,185 @@
+"""pre_merge_gate.check_required_contexts — the merge-gate half of #1691/#1701.
+
+The classifier itself is covered in tests/test_ci_contexts.py. This file
+covers the translation from its states into a gate verdict, where the two
+mistakes that matter are opposite: reading an unmeasurable answer as GO, and
+reading "not created yet" as "never created".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import ci_contexts  # noqa: E402
+import pre_merge_gate  # noqa: E402
+from pre_merge_gate import SKIPPED_UNVERIFIED, run_gate_checks  # noqa: E402
+from required_contexts_gate import check_required_contexts  # noqa: E402
+import required_contexts_gate  # noqa: E402
+from pre_merge_gate import ResolvedPRRef  # noqa: E402
+
+HEAD = "a" * 40
+
+
+def test_the_mirrored_sentinel_matches_the_gate_it_mirrors():
+    """required_contexts_gate re-declares SKIPPED_UNVERIFIED to avoid an
+    import cycle. If the two ever drift, an unverifiable answer stops being
+    recognised as blocking by run_gate_checks and reads as an unknown status.
+    """
+    assert required_contexts_gate.SKIPPED_UNVERIFIED == SKIPPED_UNVERIFIED
+
+
+def _state(context, state, detail="d"):
+    return ci_contexts.ContextState(context=context, state=state, detail=detail)
+
+
+def _stub_states(monkeypatch, states):
+    monkeypatch.setattr(ci_contexts, "evaluate_commit", lambda *a, **k: states)
+
+
+def test_all_passed_is_go(monkeypatch, tmp_path):
+    _stub_states(monkeypatch, [_state("Profile A", ci_contexts.STATE_PASSED)])
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == "GO"
+    assert "all 1 required contexts passed" in result["detail"]
+
+
+def test_never_created_holds_and_names_the_context(monkeypatch, tmp_path):
+    """The #1691 shape: the gate must say WHICH context is missing."""
+    _stub_states(
+        monkeypatch,
+        [
+            _state("Profile A", ci_contexts.STATE_PASSED),
+            _state("Profile B", ci_contexts.STATE_NEVER_CREATED, "run finished without it"),
+        ],
+    )
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == "HOLD"
+    assert "Profile B" in result["detail"]
+    assert "not satisfied" in result["detail"]
+    assert result["summary"]["never_created"] == 1
+
+
+def test_waiting_holds_but_is_reported_as_in_flight(monkeypatch, tmp_path):
+    """The #1701 shape: still blocking, but the fix is time, not a re-run."""
+    _stub_states(
+        monkeypatch,
+        [
+            _state("Profile A", ci_contexts.STATE_PASSED),
+            _state("Profile B", ci_contexts.STATE_WAITING_UPSTREAM, "waiting on Profile A"),
+        ],
+    )
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == "HOLD"
+    assert "still in flight" in result["detail"]
+    assert "not satisfied" not in result["detail"]
+
+
+def test_unverified_context_is_skipped_unverified_never_go(monkeypatch, tmp_path):
+    _stub_states(
+        monkeypatch,
+        [
+            _state("Profile A", ci_contexts.STATE_PASSED),
+            _state("Some App Check", ci_contexts.STATE_UNVERIFIED),
+        ],
+    )
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == SKIPPED_UNVERIFIED
+    assert "Some App Check" in result["detail"]
+
+
+def test_unreadable_branch_protection_is_skipped_unverified(monkeypatch, tmp_path):
+    def _boom(*a, **k):
+        raise ci_contexts.CIContextsError("gh api failed (rc=1): not a git repository")
+
+    monkeypatch.setattr(ci_contexts, "evaluate_commit", _boom)
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == SKIPPED_UNVERIFIED
+    assert "not a git repository" in result["detail"]
+
+
+def test_empty_required_list_is_a_misconfiguration_not_a_pass(monkeypatch, tmp_path):
+    """Zero required contexts must never read as "everything required passed"."""
+    _stub_states(monkeypatch, [])
+    result = check_required_contexts(tmp_path, head_sha=HEAD)
+    assert result["status"] == SKIPPED_UNVERIFIED
+    assert "misconfiguration" in result["detail"]
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ci_contexts.STATE_FAILED,
+        ci_contexts.STATE_NO_RUN,
+        ci_contexts.STATE_NEVER_CREATED,
+        ci_contexts.STATE_RUNNING,
+        ci_contexts.STATE_WAITING_UPSTREAM,
+    ],
+)
+def test_no_non_passing_state_ever_yields_go(monkeypatch, tmp_path, state):
+    _stub_states(monkeypatch, [_state("Profile A", state)])
+    assert check_required_contexts(tmp_path, head_sha=HEAD)["status"] != "GO"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator wiring
+# ---------------------------------------------------------------------------
+
+
+def _quiet_orchestrator(monkeypatch):
+    for name, payload in (
+        ("check_pr_size", {"check": "pr_size", "status": "GO", "detail": "stub"}),
+        ("check_ci_workflow", {"check": "ci_workflow", "status": "GO", "detail": "stub"}),
+        ("check_net_deletion", {"check": "net_deletion", "status": "GO", "detail": "stub"}),
+    ):
+        monkeypatch.setattr(pre_merge_gate, name, lambda project_root, _p=payload, **kw: dict(_p))
+
+
+def test_orchestrator_omits_the_check_without_a_resolved_pr_head(monkeypatch, tmp_path):
+    """A local working copy has no protected-branch contract to compare to."""
+    _quiet_orchestrator(monkeypatch)
+    called = []
+    monkeypatch.setattr(
+        pre_merge_gate, "check_required_contexts",
+        lambda *a, **kw: called.append(kw) or {"check": "required_contexts", "status": "GO"},
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    dispatch_dir = tmp_path / "dispatches"
+    for sub in ("pending", "active", "completed", "staging"):
+        (dispatch_dir / sub).mkdir(parents=True)
+
+    result = run_gate_checks(
+        pr_id="PR-6", project_root=tmp_path, state_dir=state_dir,
+        dispatch_dir=dispatch_dir, skip_pytest=True,
+    )
+    assert called == []
+    assert not any(c["check"] == "required_contexts" for c in result["checks"])
+
+
+def test_orchestrator_binds_the_check_to_the_pr_head(monkeypatch, tmp_path):
+    """Never the local HEAD: the required contexts live on the PR's commit."""
+    _quiet_orchestrator(monkeypatch)
+    called = []
+    monkeypatch.setattr(
+        pre_merge_gate, "check_required_contexts",
+        lambda *a, **kw: called.append(kw) or {"check": "required_contexts", "status": "GO"},
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    dispatch_dir = tmp_path / "dispatches"
+    for sub in ("pending", "active", "completed", "staging"):
+        (dispatch_dir / sub).mkdir(parents=True)
+
+    run_gate_checks(
+        pr_id="1522", project_root=tmp_path, state_dir=state_dir,
+        dispatch_dir=dispatch_dir, skip_pytest=True,
+        pr_head=ResolvedPRRef("1522", "b" * 40, "feature/x", "c" * 40),
+    )
+    assert called and called[0]["head_sha"] == "b" * 40

--- a/tests/test_vnx_cli_pr_ready.py
+++ b/tests/test_vnx_cli_pr_ready.py
@@ -1,0 +1,136 @@
+"""tests/test_vnx_cli_pr_ready.py — pin `vnx pr-ready` on the pip CLI.
+
+Mirrors tests/test_vnx_cli_gate_check.py: the fabric repo's `bin/vnx` gets
+the command as a one-line delegation, and a consumer repo holds only the
+pip-installed vnx_cli. Without this wiring the pip CLI refuses the name with
+"invalid choice: 'pr-ready'" while the command is documented.
+
+Imports of new symbols happen inside each test so collection does not abort
+on a tree where the command module is absent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _build_parser():
+    import vnx_cli.main as m
+
+    parser = m._SuggestionArgumentParser(prog="vnx")
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+    m._register_pr_ready_subparser(subparsers)
+    return parser
+
+
+def test_subparser_parses_the_documented_form():
+    args = _build_parser().parse_args(["pr-ready", "1703"])
+    assert args.command == "pr-ready"
+    assert args.pr == ["1703"]
+
+
+def test_subparser_accepts_several_prs_in_one_call():
+    """The manual count was done PR by PR; the point is to ask once."""
+    args = _build_parser().parse_args(["pr-ready", "1703", "1704", "1705"])
+    assert args.pr == ["1703", "1704", "1705"]
+
+
+def test_subparser_requires_at_least_one_pr():
+    with pytest.raises(SystemExit):
+        _build_parser().parse_args(["pr-ready"])
+
+
+def test_build_argv_forwards_only_non_defaults():
+    from vnx_cli.commands.pr_ready import build_pr_ready_argv
+
+    ns = SimpleNamespace(pr=["1703"], json=False, verbose=False,
+                         protected_branch="main", project_root=None, timeout=20)
+    assert build_pr_ready_argv(ns) == ["1703"]
+
+
+def test_build_argv_forwards_the_full_flag_surface():
+    from vnx_cli.commands.pr_ready import build_pr_ready_argv
+
+    ns = SimpleNamespace(pr=["1703", "1704"], json=True, verbose=True,
+                         protected_branch="release", project_root="/tmp/x", timeout=45)
+    assert build_pr_ready_argv(ns) == [
+        "1703", "1704", "--json", "--verbose",
+        "--protected-branch", "release", "--project-root", "/tmp/x", "--timeout", "45",
+    ]
+
+
+def test_invokes_the_packaged_engine_script(tmp_path, monkeypatch):
+    import vnx_cli.commands.pr_ready as cmd
+
+    engine = tmp_path / "engine"
+    (engine / "scripts").mkdir(parents=True)
+    script = engine / "scripts" / "pr_ready.py"
+    script.write_text("# stand-in for the packaged script\n")
+    monkeypatch.setattr(cmd._engine, "engine_root", lambda: engine)
+
+    captured = {}
+
+    def fake_run(command, **_kwargs):
+        captured["cmd"] = command
+        return SimpleNamespace(returncode=2)  # UNMEASURABLE
+
+    monkeypatch.setattr(cmd.subprocess, "run", fake_run)
+    ns = SimpleNamespace(pr=["1703"], json=True, verbose=False,
+                         protected_branch="main", project_root=None, timeout=20)
+
+    assert cmd.vnx_pr_ready(ns) == 2, "the readiness exit code must propagate verbatim"
+    assert captured["cmd"][0] == sys.executable
+    assert captured["cmd"][1] == str(script)
+    assert captured["cmd"][2:] == ["1703", "--json"]
+
+
+def test_missing_script_fails_loudly_instead_of_reporting_ready(tmp_path, monkeypatch, capsys):
+    """An incomplete install must never exit 0 — that would read as READY."""
+    import vnx_cli.commands.pr_ready as cmd
+
+    monkeypatch.setattr(cmd._engine, "engine_root", lambda: tmp_path)
+    ns = SimpleNamespace(pr=["1703"], json=False, verbose=False,
+                         protected_branch="main", project_root=None, timeout=20)
+
+    rc = cmd.vnx_pr_ready(ns)
+    assert rc != 0
+    assert "pr_ready.py not found" in capsys.readouterr().err
+
+
+def test_main_registers_pr_ready_in_the_full_parser():
+    """Registering the helper but forgetting the call in main() would still
+    strand consumers, so the call site itself is pinned."""
+    import inspect
+
+    import vnx_cli.main as m
+
+    assert "_register_pr_ready_subparser(subparsers)" in inspect.getsource(m.main)
+
+
+def test_dispatch_command_routes_pr_ready(monkeypatch):
+    """Without the elif branch _dispatch_command falls through to print_help
+    and exit 0 — which would read as READY for every PR."""
+    import vnx_cli.commands.pr_ready as cmd
+    import vnx_cli.main as m
+
+    monkeypatch.setattr(cmd, "vnx_pr_ready", lambda args: 7)
+    ns = SimpleNamespace(command="pr-ready", pr=["1703"], json=False, verbose=False,
+                         protected_branch="main", project_root=None, timeout=20)
+    parser = argparse.ArgumentParser(prog="vnx")
+    with pytest.raises(SystemExit) as excinfo:
+        m._dispatch_command(ns, parser)
+    assert excinfo.value.code == 7
+
+
+def test_the_script_ships_where_bin_vnx_and_the_wheel_both_look():
+    assert (REPO_ROOT / "scripts" / "pr_ready.py").is_file()
+    assert "pr-ready)" in (REPO_ROOT / "bin" / "vnx").read_text()

--- a/vnx_cli/commands/pr_ready.py
+++ b/vnx_cli/commands/pr_ready.py
@@ -1,0 +1,81 @@
+"""vnx pr-ready — merge readiness for a PR, on the pip CLI.
+
+Mirrors ``vnx_cli/commands/gate_check.py`` exactly: the fabric repo's
+``bin/vnx pr-ready`` is a one-line delegation to ``scripts/pr_ready.py``, and
+consumer repos have no ``bin/`` — they hold the pip-installed ``vnx``. The
+script ships in the wheel (pyproject's ``[tool.setuptools.package-data]``
+carries ``scripts/**/*``), so the pip CLI runs the exact same machinery.
+
+Subprocess, not import: ``pr_ready.main()`` self-bootstraps ``scripts/lib``
+from its own location, so a child process keeps one launch path for both
+entrances and inherits the script's exit-code contract (0 ready, 1 not ready,
+2 unmeasurable, 10 bad input).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+from vnx_cli import _engine
+
+# Mirror of pr_ready.py's bad-input exit code — the closest failure class when
+# the engine install is missing the script.
+_EXIT_BAD_INPUT = 10
+
+
+def register_pr_ready_subparser(subparsers) -> None:
+    """Register the `vnx pr-ready` subparser (flag surface mirrors pr_ready.py)."""
+    parser = subparsers.add_parser(
+        "pr-ready",
+        help="merge readiness for a PR: required contexts + gate evidence on the current head",
+    )
+    parser.add_argument("pr", nargs="+", metavar="PR", help="PR number(s)")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--verbose", action="store_true", help="one line per context and gate")
+    parser.add_argument(
+        "--protected-branch", dest="protected_branch", default="main", metavar="BRANCH",
+        help="branch whose protection defines the required contexts (default: main)",
+    )
+    parser.add_argument(
+        "--project-root", dest="project_root", default=None, metavar="DIR",
+        help="project root (default: cwd)",
+    )
+    parser.add_argument("--timeout", type=int, default=20, metavar="SECONDS")
+
+
+def build_pr_ready_argv(args) -> List[str]:
+    """Translate the parsed namespace into pr_ready.py argv (non-defaults only)."""
+    argv = [str(p) for p in args.pr]
+    if getattr(args, "json", False):
+        argv.append("--json")
+    if getattr(args, "verbose", False):
+        argv.append("--verbose")
+    if getattr(args, "protected_branch", "main") != "main":
+        argv += ["--protected-branch", str(args.protected_branch)]
+    if getattr(args, "project_root", None):
+        argv += ["--project-root", str(args.project_root)]
+    if getattr(args, "timeout", 20) != 20:
+        argv += ["--timeout", str(args.timeout)]
+    return argv
+
+
+def resolve_pr_ready_script(root: Path | None = None) -> Path:
+    """Return the packaged pr_ready.py path for the resolved engine."""
+    root = root or _engine.engine_root()
+    return root / "scripts" / "pr_ready.py"
+
+
+def vnx_pr_ready(args) -> int:
+    """Run the readiness report via the packaged engine script."""
+    script = resolve_pr_ready_script()
+    if not script.is_file():
+        print(
+            f"vnx pr-ready: pr_ready.py not found at {script} — the installed engine is "
+            "incomplete (reinstall: pip install --force-reinstall vnx-orchestration)",
+            file=sys.stderr,
+        )
+        return _EXIT_BAD_INPUT
+    return subprocess.run([sys.executable, str(script), *build_pr_ready_argv(args)]).returncode

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -1454,6 +1454,13 @@ def _register_gate_check_subparser(subparsers: argparse.Action) -> None:
     register_gate_check_subparser(subparsers)
 
 
+def _register_pr_ready_subparser(subparsers: argparse.Action) -> None:
+    """`vnx pr-ready` — merge readiness (scripts/pr_ready.py), exposed on the
+    pip CLI so a consumer repo without `bin/` gets the same command."""
+    from vnx_cli.commands.pr_ready import register_pr_ready_subparser
+    register_pr_ready_subparser(subparsers)
+
+
 def _register_worktree_release_subparser(subparsers: argparse.Action) -> None:
     """`vnx worktree-release` — same engine as the fabric repo's `bin/vnx
     worktree-release` (scripts/lib/worktree_release.py), exposed on the pip
@@ -1548,6 +1555,9 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
     elif args.command == "gate-check":
         from vnx_cli.commands.gate_check import vnx_gate_check
         sys.exit(vnx_gate_check(args))
+    elif args.command == "pr-ready":
+        from vnx_cli.commands.pr_ready import vnx_pr_ready
+        sys.exit(vnx_pr_ready(args))
 
     elif args.command == "worktree-release":
         from vnx_cli.commands.worktree import vnx_worktree_release
@@ -1597,6 +1607,7 @@ def main() -> None:
     _register_objective_subparser(subparsers)
     _register_deliverable_subparser(subparsers)
     _register_gate_check_subparser(subparsers)
+    _register_pr_ready_subparser(subparsers)
     _register_worktree_release_subparser(subparsers)
 
     args = parser.parse_args()


### PR DESCRIPTION
> **Stacks on #1703.** It uses `scripts/lib/ci_contexts.py` from that PR, so its commit shows in this diff until #1703 merges. **Merge #1703 first.**

## What

Fourteen times in one night the same question got answered by hand: which of the fourteen branch-protection contexts are present, which review gates the obligation demands, whether each gate record sits on the **current** head, whether its report exists, and whether record and report contradict each other. Each pass cost several `gh` calls plus a throwaway Python block.

```
$ vnx pr-ready 1691
PR #1691  MERGED  dispatch/20260826-beta3-b-recovery-venster-drie-kanten  head 06291f637e7d  mergeable=UNKNOWN/UNKNOWN
CI        14/14 required contexts passed
GATES     glm_gate OK on head · ci_gate OK on head [off the door: no obligation] · codex_gate incomplete (codex_gate resultaat is niet terminaal (status=unavailable): bewijs onvolledig) [off the door: no obligation]
COST      python3 scripts/review_gate_manager.py request-and-execute --gate codex_gate --pr 1691 — codex CLI, subscription (rate-limited; operator policy A1 is to wait for the reset, not to fall back)
VERDICT   NOT READY — 1 review gate(s) without evidence on this head; PR state is MERGED
```

Takes several PRs at once (`vnx pr-ready 1703 1704 1705`), `--json` for machines, `--verbose` for one line per context and gate.

## Nothing here re-derives an answer that already exists

| sub-answer | existing implementation reused |
|---|---|
| required-vs-actual contexts | `ci_contexts.evaluate_commit` (#1703) |
| which gate does this PR owe | `gate_obligations.declared_gates_for_pr` |
| is the gate evidence good | `closure_verifier.check_review_gate_for_merge` — the same five invariants the merge door enforces |

New is only the aggregation, the cost, and the refusal to round anything unmeasured up to green.

## Three exit codes, not two

`0` READY · `1` NOT READY · `2` UNMEASURABLE. Collapsing 2 into 1 would hide "the machine cannot reach GitHub" inside "this PR needs another run", and collapsing it into 0 is the failure this whole cluster is about.

## Two things the measurement changed while building it

**The join moved, so there is one implementation.** `pr_merge._resolve_declared_gate` held the PR→obligation join; the report needed the same join, and a second copy is how the merge gate and the report would start disagreeing about a PR's obligations. It now lives in `gate_obligations.declared_gates_for_pr`. `pr_merge` keeps its exact contract — last gate wins, an unreadable store degrades to `""` (a refusal) rather than raising into the merge path — and both halves are pinned by test.

**Reading only the obligation store was wrong for how gates are actually run here.** #1701 merged with **no obligation record at all**, and a gate run by hand leaves a result and no obligation. Reading only obligations reports "no gate verdict" about a PR that has one. `observed_gates_for_pr` therefore also finds result records off the door and marks them `[off the door: no obligation]`.

## Verification

- `tests/test_pr_readiness.py` — 37 tests. `tests/test_vnx_cli_pr_ready.py` — 10 tests mirroring `test_vnx_cli_gate_check.py` (both entrances: `bin/vnx` and the pip CLI).
- **Mutation-checked**, three branches, each caught by a distinct test:
  - `unmeasurable` folded into not-ready → 2 tests fail
  - undeclared obligation not a blocker → 1 test fails
  - `__no_gate__` sentinel counted as an obligation → 1 test fails
- **Live**: #1696 → 14/14 contexts, `codex_gate` + `glm_gate` OK on head. #1691 → surfaces a `codex_gate` record with `status=unavailable`, a provider outage correctly **not** counted as a pass, and names what re-running it costs. #1703 (open, mid-CI) → 11/14 with Profile A/B/C in flight.
- `pytest tests/test_pr_readiness.py tests/test_vnx_cli_pr_ready.py tests/test_pr_merge_review_gate.py tests/test_gate_obligations.py tests/test_gate_obligation_runner.py tests/test_closure_verifier.py tests/test_vnx_cli_gate_check.py tests/test_ci_contexts.py` → **229 passed**.
- `scripts/ci_lint_patterns.py --scan-stdin` over the added lines → clean. `bash -n bin/vnx` → clean.

## Two things worth an operator decision

1. **`GATE_COST` is pinned to the closed `Gate` enum by test** — a gate added to the enum without a cost entry fails loudly rather than being reported as "run it" with no idea what running it takes. The USD band on the OpenRouter lane is the operator's measured 1.3–2.8, not the older 0.4 estimate.
2. **#1696 declared three obligations** (`codex_gate`, `codex_gate`, `glm_gate`) and `pr_merge` only verifies the **last** one at merge time. That behaviour is unchanged here — this PR only makes it visible, since `pr-ready` reports all of them.

## Known, not introduced here

`vnx_cli/main.py` exceeds the 1200-line hard ceiling on `main` (1607 → 1618); `quality_advisory` books that as the one blocking finding for any PR touching it. My addition is 11 lines. Splitting it is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018u28zASUuaqYqLWbRpe3XN