### PR TITLE
feat(gate-reanchor): move a gate verdict instead of buying it again (OI-1471)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -352,6 +352,9 @@ Gate commands (pre-merge verification):
   pr-ready <N> [<N>..]  Merge readiness: required contexts + gate evidence on the
                         current head, and what closing each gap costs
                         (exit 0 ready, 1 not ready, 2 unmeasurable)
+  gate-reanchor --pr <N> --gate <G>
+                        Move an existing gate verdict onto the PR's current head when
+                        the reviewed input is provably identical (read-only; --apply writes)
   roadmap <sub>       Roadmap orchestration and auto-next feature loading
 
 Planning commands (strategic-layer read surface):
@@ -2571,6 +2574,9 @@ main() {
       ;;
     pr-ready)
       "$VNX_PYTHON" "$VNX_HOME/scripts/pr_ready.py" "$@"
+      ;;
+    gate-reanchor)
+      "$VNX_PYTHON" "$VNX_HOME/scripts/gate_reanchor_cli.py" "$@"
       ;;
     dispatch)
       cmd_dispatch "$@"

--- a/scripts/gate_reanchor_cli.py
+++ b/scripts/gate_reanchor_cli.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""gate_reanchor_cli.py — re-anchor a gate verdict instead of buying it again.
+
+OI-1471. A rebase moves a PR onto a new commit; the fabric's rule is "gate
+AFTER a rebase, never before", so the verdict has to sit on the commit that
+merges. On a busy day main moved four times, and each shift forced a fresh
+model call on PRs whose diff had not changed at all — PR #1691 was gated three
+times against the identical ``contract_hash`` ``dd5ac45f7e84535e``.
+
+This command moves the existing verdict onto the new commit when, and only
+when, both halves of the condition hold. ``scripts/lib/gate_reanchor`` decides;
+this file resolves the inputs, writes through the guarded recorder, and stamps
+provenance so nobody can later mistake a re-anchored verdict for a fresh one.
+
+Read-only by default. ``--apply`` writes.
+
+Exit codes:
+  0  - re-anchored (with --apply), or allowed (without)
+  1  - refused: a condition does not hold, so the gate must actually run
+  10 - bad arguments, or the existing record cannot be read
+  20 - the write itself failed
+
+Usage:
+  python3 scripts/gate_reanchor_cli.py --pr 1691 --gate glm_gate
+  python3 scripts/gate_reanchor_cli.py --pr 1691 --gate glm_gate --apply
+  python3 scripts/gate_reanchor_cli.py --pr 1691 --gate glm_gate --depth full
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+for _p in (str(SCRIPT_DIR / "lib"), str(SCRIPT_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import gate_reanchor  # noqa: E402
+from gate_artifacts import _compute_contract_hash  # noqa: E402  canonical hasher, never a second one
+from gate_status import has_complete_evidence, is_terminal  # noqa: E402
+from vnx_paths import ensure_env  # noqa: E402
+
+EXIT_OK = 0
+EXIT_REFUSED = 1
+EXIT_BAD_INPUT = 10
+EXIT_WRITE_FAILED = 20
+
+#: Gates whose ``contract_hash`` is ``sha256(prompt)[:16]`` with the full diff
+#: inside the prompt — the ONLY gates for which hash equality proves the input
+#: was byte-identical.
+#:
+#: This restriction is load-bearing, not caution. ``_compute_contract_hash``
+#: falls back to ``sha256({gate, branch, sorted(changed_files)})`` when the
+#: request carries no prompt, and that fallback is stable across content
+#: changes: edit a file's contents without adding or removing files and the
+#: hash does not move. Re-anchoring on such a hash would carry a verdict onto
+#: a diff nobody reviewed — the exact failure this whole mechanism exists to
+#: avoid. Every other gate refuses, loudly.
+DIFF_DERIVED_HASH_GATES = ("glm_gate", "kimi_gate")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _gh(args, timeout: int = 30) -> str:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {(proc.stderr or '').strip()[:200]}")
+    return proc.stdout
+
+
+def load_existing_result(results_dir: Path, gate: str, pr_number: int) -> Dict[str, Any]:
+    """The record whose verdict is a candidate for re-anchoring.
+
+    Requires a terminal, fully-evidenced record. A ``not_executable`` or an
+    ``unavailable`` outage record carries no verdict to move, and moving one
+    would manufacture evidence rather than relocate it.
+    """
+    path = results_dir / f"pr-{pr_number}-{gate}.json"
+    if not path.is_file():
+        raise FileNotFoundError(f"no existing {gate} result for PR #{pr_number} at {path}")
+    record = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(record, dict):
+        raise ValueError(f"{path} is not a JSON object")
+    if not is_terminal(record):
+        raise ValueError(
+            f"{gate} result for #{pr_number} is not terminal (status="
+            f"{record.get('status')!r}) — there is no verdict to re-anchor"
+        )
+    if not has_complete_evidence(record):
+        raise ValueError(
+            f"{gate} result for #{pr_number} lacks contract_hash and/or report_path — "
+            "an unevidenced record cannot be relocated onto a new commit"
+        )
+    return record
+
+
+def current_contract_hash(gate: str, pr_number: int) -> str:
+    """Recompute the hash the gate WOULD produce for the PR head, offline.
+
+    No model call: ``_build_prompt`` is deterministic and the diff comes from
+    ``gh``. Verified against PR #1691, whose recorded hash
+    ``dd5ac45f7e84535e`` this reproduces exactly.
+    """
+    diff = _gh(["pr", "diff", str(pr_number)])
+    if gate == "glm_gate":
+        import glm_gate as gate_module
+    elif gate == "kimi_gate":
+        import kimi_gate as gate_module
+    else:  # pragma: no cover — guarded by DIFF_DERIVED_HASH_GATES at the call site
+        raise ValueError(f"{gate} has no diff-derived contract hash")
+    prompt = gate_module._build_prompt(diff, str(pr_number))
+    return _compute_contract_hash({"prompt": prompt}, gate)
+
+
+def build_reanchored_payload(
+    record: Dict[str, Any], *, new_sha: str, new_branch: str, decision,
+) -> Dict[str, Any]:
+    """The old verdict, on the new commit, marked as relocated.
+
+    Everything that makes the verdict evidence is carried over unchanged:
+    status, findings, ``contract_hash``, ``report_path`` (the report reviewed a
+    byte-identical diff, so it is still the right report) and ``dispatch_id``
+    (the producer identity is the run that actually reviewed it — claiming a
+    new one would be the lie).
+
+    What is added is provenance. ``evidence_source: "reanchored"`` sits beside
+    the existing ``"live"``/``"reprocessed"`` vocabulary, and
+    ``reanchored_from_commit_sha`` plus ``reanchor_basis`` record which commit
+    the verdict came from and on what grounds. An audit that cannot tell a
+    relocated verdict from a freshly bought one is worse than paying twice.
+    """
+    payload = dict(record)
+    payload["commit_sha"] = new_sha
+    payload["branch"] = new_branch
+    payload["evidence_source"] = "reanchored"
+    payload["reanchored_from_commit_sha"] = record.get("commit_sha", "")
+    payload["reanchored_at"] = _utc_now_iso()
+    payload["reanchor_basis"] = decision.to_dict()
+    return payload
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="gate_reanchor_cli.py",
+        description="Re-anchor an existing gate verdict onto the PR's current head "
+                    "when the reviewed input is provably identical (OI-1471).",
+    )
+    parser.add_argument("--pr", required=True, type=int, help="PR number")
+    parser.add_argument("--gate", required=True, help=f"one of {', '.join(DIFF_DERIVED_HASH_GATES)}")
+    parser.add_argument("--apply", action="store_true", help="write the re-anchored record")
+    parser.add_argument(
+        "--depth", default="direct", choices=("direct", "full"),
+        help="import-graph depth for the symbol analysis (default: direct — see "
+             "gate_reanchor.DEPTH_DEFAULT for why)",
+    )
+    parser.add_argument("--project-root", default=None)
+    parser.add_argument("--base-ref", default="origin/main")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.gate not in DIFF_DERIVED_HASH_GATES:
+        print(
+            f"gate-reanchor: {args.gate} has no diff-derived contract hash. Only "
+            f"{', '.join(DIFF_DERIVED_HASH_GATES)} hash the full diff; every other gate's "
+            "hash is stable across content changes, so equality would prove nothing.",
+            file=sys.stderr,
+        )
+        return EXIT_BAD_INPUT
+
+    project_root = Path(args.project_root) if args.project_root else Path.cwd()
+    results_dir = Path(ensure_env()["VNX_STATE_DIR"]) / "review_gates" / "results"
+
+    try:
+        record = load_existing_result(results_dir, args.gate, args.pr)
+        pr_view = json.loads(_gh(["pr", "view", str(args.pr), "--json", "headRefOid,headRefName,files"]))
+        new_sha = pr_view.get("headRefOid") or ""
+        new_branch = pr_view.get("headRefName") or ""
+        pr_files = [f["path"] for f in (pr_view.get("files") or []) if f.get("path")]
+        new_hash = current_contract_hash(args.gate, args.pr)
+    except (OSError, ValueError, RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        print(f"gate-reanchor: cannot establish the inputs: {exc}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+
+    decision = gate_reanchor.can_reanchor(
+        project_root,
+        old_sha=record.get("commit_sha", ""),
+        new_sha=new_sha,
+        pr_files=pr_files,
+        old_contract_hash=record.get("contract_hash", ""),
+        new_contract_hash=new_hash,
+        base_ref=args.base_ref,
+        depth=gate_reanchor.DEPTH_FULL if args.depth == "full" else gate_reanchor.DEPTH_DIRECT,
+    )
+
+    payload_out: Dict[str, Any] = {
+        "pr": args.pr, "gate": args.gate, "applied": False, "decision": decision.to_dict(),
+    }
+
+    if not decision.allowed:
+        if args.json:
+            print(json.dumps(payload_out, indent=2))
+        else:
+            print(f"REFUSED  #{args.pr} {args.gate}: {decision.reason}")
+            print(f"         the gate has to run — this is not a saving that was available")
+        return EXIT_REFUSED
+
+    if not args.apply:
+        if args.json:
+            print(json.dumps(payload_out, indent=2))
+        else:
+            print(f"ALLOWED  #{args.pr} {args.gate}: {decision.reason}")
+            print(f"         old {decision.old_sha[:12]} -> new {decision.new_sha[:12]}; "
+                  f"re-run with --apply to write it")
+        return EXIT_OK
+
+    from gate_recorder import ResultOverwriteRefused, record_terminal_result  # noqa: PLC0415
+
+    payload = build_reanchored_payload(
+        record, new_sha=new_sha, new_branch=new_branch, decision=decision,
+    )
+    try:
+        written = record_terminal_result(
+            gate=args.gate,
+            pr_id=str(args.pr),
+            result_path=results_dir / f"pr-{args.pr}-{args.gate}.json",
+            payload=payload,
+        )
+    except (OSError, ValueError, ResultOverwriteRefused) as exc:
+        print(f"gate-reanchor: the guarded write refused: {exc}", file=sys.stderr)
+        return EXIT_WRITE_FAILED
+
+    payload_out["applied"] = True
+    payload_out["result_path"] = str(written)
+    if args.json:
+        print(json.dumps(payload_out, indent=2))
+    else:
+        print(f"RE-ANCHORED  #{args.pr} {args.gate} onto {new_sha[:12]} "
+              f"(from {decision.old_sha[:12]}) -> {written}")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gate_reanchor_cli.py
+++ b/scripts/gate_reanchor_cli.py
@@ -43,7 +43,9 @@ for _p in (str(SCRIPT_DIR / "lib"), str(SCRIPT_DIR)):
 
 import gate_reanchor  # noqa: E402
 from gate_artifacts import _compute_contract_hash  # noqa: E402  canonical hasher, never a second one
+from gate_register_emit import register_path  # noqa: E402  one resolver, not a second copy
 from gate_status import has_complete_evidence, is_terminal  # noqa: E402
+import state_writer  # noqa: E402
 from vnx_paths import ensure_env  # noqa: E402
 
 EXIT_OK = 0
@@ -147,6 +149,42 @@ def build_reanchored_payload(
     return payload
 
 
+def emit_reanchor_event(
+    *, gate: str, pr_number: int, record: Dict[str, Any], new_sha: str, decision,
+) -> Path:
+    """Append the re-anchor to dispatch_register.ndjson (ADR-005).
+
+    A re-anchor is a gate outcome — one of the ledger's named classes — and it
+    is the one gate outcome nobody paid a model for. Writing the result record
+    without a register line would leave a state mutation with no line in the
+    ledger, which is the whole defect this cluster is about.
+
+    Reuses ``gate_register_emit.register_path`` and ``state_writer.append_locked``:
+    the same resolver and the same locked append every other gate line goes
+    through, never a second ledger invented for this one writer.
+
+    Raises on failure rather than swallowing it. The result record is already
+    on disk and carries its own provenance, so the state is not corrupt — but
+    a missing ledger line has to be said out loud, not logged and forgotten.
+    """
+    path = register_path()
+    state_writer.append_locked(path, {
+        "timestamp": _utc_now_iso(),
+        "event": "gate_reanchored",
+        "gate": gate,
+        "pr_number": pr_number,
+        "dispatch_id": record.get("dispatch_id", ""),
+        "status": record.get("status", ""),
+        "contract_hash": record.get("contract_hash", ""),
+        "from_commit_sha": record.get("commit_sha", ""),
+        "to_commit_sha": new_sha,
+        "commits_in_range": decision.commits_in_range,
+        "depth": decision.depth,
+        "reason": decision.reason,
+    })
+    return path
+
+
 def main(argv: Optional[list] = None) -> int:
     parser = argparse.ArgumentParser(
         prog="gate_reanchor_cli.py",
@@ -237,8 +275,23 @@ def main(argv: Optional[list] = None) -> int:
         print(f"gate-reanchor: the guarded write refused: {exc}", file=sys.stderr)
         return EXIT_WRITE_FAILED
 
+    try:
+        register = emit_reanchor_event(
+            gate=args.gate, pr_number=args.pr, record=record,
+            new_sha=new_sha, decision=decision,
+        )
+    except (OSError, ValueError) as exc:
+        print(
+            f"gate-reanchor: the record was written to {written} but the register line "
+            f"failed: {exc}. The verdict carries its own provenance, so the state is "
+            "sound — the LEDGER is now incomplete and needs the line adding by hand.",
+            file=sys.stderr,
+        )
+        return EXIT_WRITE_FAILED
+
     payload_out["applied"] = True
     payload_out["result_path"] = str(written)
+    payload_out["register_path"] = str(register)
     if args.json:
         print(json.dumps(payload_out, indent=2))
     else:

--- a/scripts/gate_reanchor_cli.py
+++ b/scripts/gate_reanchor_cli.py
@@ -209,7 +209,7 @@ def main(argv: Optional[list] = None) -> int:
             print(json.dumps(payload_out, indent=2))
         else:
             print(f"REFUSED  #{args.pr} {args.gate}: {decision.reason}")
-            print(f"         the gate has to run — this is not a saving that was available")
+            print("         the gate has to run — this is not a saving that was available")
         return EXIT_REFUSED
 
     if not args.apply:

--- a/scripts/gate_reanchor_cli.py
+++ b/scripts/gate_reanchor_cli.py
@@ -29,9 +29,11 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import subprocess
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -149,6 +151,55 @@ def build_reanchored_payload(
     return payload
 
 
+@contextmanager
+def exclusive_result_lock(result_path: Path):
+    """Hold an exclusive lock over one result slot for a whole read-check-write.
+
+    ``gate_recorder`` has no lock anywhere: ``_write_result_atomic`` is atomic
+    per WRITE (tmp + replace), but the read in ``_check_overwrite_guard`` and
+    the write that follows are two separate operations with a window between
+    them. Measured with two threads that both read the record on the old sha
+    before either wrote: both cleared the overwrite guard.
+
+    Everything the re-anchor decides — is this record terminal, is its hash
+    still equal, has the head moved — is read BEFORE the write. Without this
+    lock two concurrent ``--apply`` runs both decide against the same old sha
+    and both act on it.
+    """
+    lock_path = result_path.with_suffix(".reanchor.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def compare_and_swap_guard(result_path: Path, expected_old_sha: str) -> None:
+    """Refuse when the record moved between the decision and the write.
+
+    The lock above keeps two of THIS command apart. This check keeps it honest
+    against every other writer of the same slot — the live gate, --reprocess,
+    the obligation runner — none of which take that lock. Re-reading under the
+    lock and confirming the record still sits on the commit the decision was
+    made against turns the write into a compare-and-swap instead of a
+    last-writer-wins.
+    """
+    if not result_path.is_file():
+        raise ValueError(
+            f"{result_path} disappeared between the decision and the write — refusing"
+        )
+    current = json.loads(result_path.read_text(encoding="utf-8"))
+    observed = (current or {}).get("commit_sha", "")
+    if observed != expected_old_sha:
+        raise ValueError(
+            f"{result_path} moved from {expected_old_sha[:12]} to {observed[:12] or '(none)'} "
+            "while this re-anchor was deciding — another writer got there first, so the "
+            "decision was made against a record that no longer exists"
+        )
+
+
 def emit_reanchor_event(
     *, gate: str, pr_number: int, record: Dict[str, Any], new_sha: str, decision,
 ) -> Path:
@@ -264,13 +315,16 @@ def main(argv: Optional[list] = None) -> int:
     payload = build_reanchored_payload(
         record, new_sha=new_sha, new_branch=new_branch, decision=decision,
     )
+    result_path = results_dir / f"pr-{args.pr}-{args.gate}.json"
     try:
-        written = record_terminal_result(
-            gate=args.gate,
-            pr_id=str(args.pr),
-            result_path=results_dir / f"pr-{args.pr}-{args.gate}.json",
-            payload=payload,
-        )
+        with exclusive_result_lock(result_path):
+            compare_and_swap_guard(result_path, record.get("commit_sha", ""))
+            written = record_terminal_result(
+                gate=args.gate,
+                pr_id=str(args.pr),
+                result_path=result_path,
+                payload=payload,
+            )
     except (OSError, ValueError, ResultOverwriteRefused) as exc:
         print(f"gate-reanchor: the guarded write refused: {exc}", file=sys.stderr)
         return EXIT_WRITE_FAILED

--- a/scripts/lib/gate_reanchor.py
+++ b/scripts/lib/gate_reanchor.py
@@ -233,21 +233,54 @@ def referenced_symbols(project_root: Path, ref: str, files: Iterable[str]) -> Se
     for path in files:
         if not path.endswith(".py"):
             continue
+        # Absent at this ref is a legitimate, complete answer: the PR DELETED
+        # the file, so it contributes no references. Distinguished from
+        # unreadable by asking git directly rather than by reading stderr —
+        # `pr_files` comes from `gh pr view --json files`, which lists deleted
+        # paths too, so collapsing the two would refuse every PR that removes
+        # a file.
         try:
-            source = _git(project_root, "show", f"{ref}:{path}")
+            _git(project_root, "cat-file", "-e", f"{ref}:{path}")
         except ReanchorError:
             continue
+        # Present but unreadable is the opposite case, and fail-CLOSED:
+        # skipping it under-approximates the reference set and then treats the
+        # remainder as complete, producing an ALLOW on evidence nobody
+        # gathered — the one direction this module must never fail in.
+        try:
+            source = _git(project_root, "show", f"{ref}:{path}")
+        except ReanchorError as exc:
+            raise ReanchorError(
+                f"{path} exists at {ref[:12]} but could not be read, so the PR's reference "
+                f"set is incomplete and nothing can be proven: {exc}"
+            ) from exc
         try:
             tree = ast.parse(source)
-        except SyntaxError:
-            continue
+        except SyntaxError as exc:
+            raise ReanchorError(
+                f"{path} does not parse at {ref[:12]}, so its references are unknown: {exc}"
+            ) from exc
+
         alias_to_module: Dict[str, str] = {}
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module:
                 module = node.module.split(".")[-1]
                 out.add((module, MODULE_LEVEL))
                 for alias in node.names:
+                    if alias.name == "*":
+                        # A star-import binds the PR to EVERY name in the
+                        # module, so nothing narrower than the whole module
+                        # can be claimed about what it uses.
+                        out.add((module, WHOLE_MODULE))
+                        continue
                     out.add((module, alias.name))
+                    # `from pkg import mod` followed by `mod.fn()`: the
+                    # imported name may itself be a module. Mapping it to
+                    # itself makes `mod.fn` resolve to ("mod", "fn") below.
+                    # Over-approximation is the safe direction — a class
+                    # imported the same way yields a (Class, method) pair that
+                    # matches no module, which is noise, never a false ALLOW.
+                    alias_to_module.setdefault(alias.asname or alias.name, alias.name)
             elif isinstance(node, ast.Import):
                 for alias in node.names:
                     module = alias.name.split(".")[-1]
@@ -327,10 +360,11 @@ def find_blocking_symbols(
          table or decorator (``<module>``), or a module that is gone or
          unparseable (``*``), changes behaviour for everyone importing it,
          whichever symbol they use. Blocks.
-      3. **Reached only indirectly.** ``indirect_modules`` are modules the PR
-         does not import but can reach through the import graph. Which symbol
-         of those the PR actually depends on is not knowable from its own
-         source, so ANY change in one of them blocks.
+      3. **Reached only indirectly, or star-imported.** ``indirect_modules``
+         are modules the PR does not import but can reach through the import
+         graph; a ``from x import *`` adds ``x`` to the same set. In neither
+         case is it knowable from the PR's own source WHICH symbol it depends
+         on, so ANY change in one of them blocks.
 
     Keeping 1 apart from 3 is what makes the direct-depth rule symbol-precise.
     Folding them together — as an earlier draft of this function did, by
@@ -340,8 +374,14 @@ def find_blocking_symbols(
     the exact-overlap line changed no test result, because nothing could
     reach it.
     """
-    indirect = indirect_modules or set()
+    indirect = set(indirect_modules or set())
     referenced_modules = {m for m, _ in referenced}
+    # A star-import is recorded as (module, "*") on the REFERENCED side. It
+    # says "this PR may use any name in that module", which is the same
+    # information-free position as an indirectly-reached module — so it gets
+    # the same coarse treatment rather than falling through the exact-symbol
+    # match and matching nothing.
+    indirect |= {m for m, s in referenced if s == WHOLE_MODULE}
     blocking: Set[Symbol] = set(changed & referenced)
     for module, symbol in changed:
         if module in indirect:

--- a/scripts/lib/gate_reanchor.py
+++ b/scripts/lib/gate_reanchor.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""gate_reanchor.py — may a gate verdict be re-anchored instead of re-bought?
+
+OI-1471, measured 2026-08-26: PR #1691's ``contract_hash`` was
+``dd5ac45f7e84535e`` on three separate glm-gate runs, across two rebases and
+three main shifts. For ``glm_gate``/``kimi_gate`` that hash is
+``sha256(prompt)[:16]`` and the prompt carries the full diff
+(``gate_artifacts._compute_contract_hash``), so an identical hash means the
+gate judged a byte-identical input. The same review was bought three times.
+
+Re-anchoring on the hash ALONE is unsafe, and the counterexample is from the
+same day: #1688 tightened ``gate_status.has_complete_evidence``; #1692 imports
+and calls it. #1692's diff was byte-identical across that shift — and its
+meaning was not. A diff hash cannot see that.
+
+So the condition has two halves, and BOTH must hold:
+
+  (a) the contract hash the gate would compute for the new head equals the
+      hash on the existing terminal record, and
+  (b) no commit between the old and the new merge-base touches a symbol this
+      PR's own files reach.
+
+(b) is what this module computes. Measured with THIS code over 120 ordered PR
+pairs from 2026-08-26, the busiest measured day on this repo:
+
+  import depth        allowed   refused
+  direct (default)        87%       13%
+  +1 hop                  74%       26%
+  +2 hops                 69%       31%
+  full closure            58%       42%
+
+The whole sweep took 8.1 seconds including building the 713-module import
+graph from scratch, so (b) is affordable — the outcome the OI left open.
+
+Which row to stand on is a real decision, and the measurement settles it in
+an unobvious direction: see :data:`DEPTH_DEFAULT`.
+
+Every failure to establish an answer refuses. A re-anchor that cannot prove
+both halves is a re-buy, never a shrug.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+#: (module_stem, symbol). ``"<module>"`` is the module's own top level —
+#: constants, dispatch tables, decorators — which a diff can change without
+#: touching any def. ``"*"`` means the whole module is suspect (deleted, or
+#: unparseable at that commit).
+Symbol = Tuple[str, str]
+
+MODULE_LEVEL = "<module>"
+WHOLE_MODULE = "*"
+
+#: Import-graph expansion depth. DEPTH_DIRECT looks only at the modules the
+#: PR's own files import; DEPTH_FULL follows the whole closure.
+DEPTH_DIRECT = 0
+DEPTH_FULL = -1
+
+#: The default is DEPTH_DIRECT, and that choice is measured rather than
+#: convenient. Running the analysis at DEPTH_FULL against #1691 — the PR
+#: OI-1471 was written about — REFUSES it: glm_gate transitively reaches
+#: gate_status, so the #1688 change lands in its closure. The conservative
+#: setting would therefore have saved nothing for the case that motivated
+#: this at all, while still refusing #1692 for a reason no one can act on.
+#:
+#: The substantive argument is what the gate itself can see. A review gate
+#: judges the DIFF. The #1688/#1692 failure was catchable precisely because
+#: #1692's diff CALLS has_complete_evidence — a reviewer reading that diff
+#: has the changed symbol in front of it. A change two import hops away is
+#: not visible in the diff either, so re-running the gate would not catch it
+#: any better than re-anchoring does. Guarding at the depth the gate can
+#: actually reason about is the honest boundary; guarding deeper buys a
+#: refusal rate, not a caught bug.
+#:
+#: Callers who want the paranoid setting pass ``depth=DEPTH_FULL``.
+DEPTH_DEFAULT = DEPTH_DIRECT
+
+
+class ReanchorError(RuntimeError):
+    """A git fact needed for the decision could not be established."""
+
+
+@dataclass(frozen=True)
+class ReanchorDecision:
+    allowed: bool
+    reason: str
+    contract_hash_matches: bool = False
+    old_sha: str = ""
+    new_sha: str = ""
+    old_merge_base: str = ""
+    new_merge_base: str = ""
+    commits_in_range: int = 0
+    blocking_symbols: Sequence[Symbol] = field(default_factory=tuple)
+    depth: int = DEPTH_DEFAULT
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "contract_hash_matches": self.contract_hash_matches,
+            "old_sha": self.old_sha,
+            "new_sha": self.new_sha,
+            "old_merge_base": self.old_merge_base,
+            "new_merge_base": self.new_merge_base,
+            "commits_in_range": self.commits_in_range,
+            "blocking_symbols": [list(s) for s in self.blocking_symbols],
+            "depth": self.depth,
+        }
+
+
+def _git(project_root: Path, *args: str, timeout: int = 30) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise ReanchorError(
+            f"git {' '.join(args)} failed (rc={proc.returncode}): "
+            f"{(proc.stderr or '').strip()[:200]}"
+        )
+    return proc.stdout
+
+
+def merge_base(project_root: Path, base_ref: str, commit: str) -> str:
+    """Where ``commit`` branched off ``base_ref``. Raises when unresolvable.
+
+    A rebased-away commit whose objects are gone is exactly such a case, and
+    it must refuse: without the old merge-base there is no range to inspect,
+    so condition (b) cannot be established at all.
+    """
+    return _git(project_root, "merge-base", base_ref, commit).strip()
+
+
+def _changed_line_numbers(project_root: Path, commit: str, path: str) -> Set[int]:
+    """Post-image line numbers ``commit`` touched in ``path``."""
+    out = _git(project_root, "diff", "--unified=0", f"{commit}^", commit, "--", path)
+    lines: Set[int] = set()
+    for line in out.splitlines():
+        if not line.startswith("@@"):
+            continue
+        try:
+            plus = line.split("+", 1)[1].split("@@", 1)[0].strip()
+            start_text, _, count_text = plus.partition(",")
+            start = int(start_text)
+            count = int(count_text or 1)
+        except (IndexError, ValueError):
+            # An unparseable hunk header must not silently narrow the range.
+            raise ReanchorError(f"unparseable diff hunk header in {commit[:12]} {path}: {line!r}")
+        lines.update(range(start, start + count))
+    return lines
+
+
+def changed_symbols(project_root: Path, old_base: str, new_base: str) -> Set[Symbol]:
+    """Qualified symbols changed by any commit in ``old_base..new_base``.
+
+    Test files are excluded: a change under ``tests/`` cannot alter the
+    runtime meaning of a symbol the PR calls.
+
+    A file that is deleted or does not parse at its commit yields
+    ``(module, "*")`` — the whole module is suspect. That is the fail-closed
+    direction: unknown becomes blocking, never invisible.
+    """
+    out: Set[Symbol] = set()
+    revs = _git(project_root, "rev-list", f"{old_base}..{new_base}").split()
+    for commit in revs:
+        names = _git(project_root, "diff", "--name-only", f"{commit}^..{commit}").split()
+        for path in names:
+            if not path.endswith(".py") or path.startswith("tests/"):
+                continue
+            module = Path(path).stem
+            try:
+                source = _git(project_root, "show", f"{commit}:{path}")
+            except ReanchorError:
+                out.add((module, WHOLE_MODULE))
+                continue
+            if not source.strip():
+                out.add((module, WHOLE_MODULE))
+                continue
+            try:
+                tree = ast.parse(source)
+            except SyntaxError:
+                out.add((module, WHOLE_MODULE))
+                continue
+            touched = _changed_line_numbers(project_root, commit, path)
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    lo = node.lineno
+                    hi = getattr(node, "end_lineno", node.lineno)
+                    if any(lo <= n <= hi for n in touched):
+                        out.add((module, node.name))
+            spans: List[Tuple[int, int]] = [
+                (n.lineno, getattr(n, "end_lineno", n.lineno))
+                for n in tree.body
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+            ]
+            if any(not any(lo <= n <= hi for lo, hi in spans) for n in touched):
+                out.add((module, MODULE_LEVEL))
+    return out
+
+
+def referenced_symbols(project_root: Path, ref: str, files: Iterable[str]) -> Set[Symbol]:
+    """Qualified symbols the PR's own files import or reach through.
+
+    ``from x import a`` yields ``("x", "a")`` and ``("x", "<module>")`` — the
+    second because importing from a module also binds you to its top level.
+    ``import x`` plus ``x.y`` yields ``("x", "y")``.
+
+    Bare-name matching was measured and rejected: it refused 40% of the same
+    120 pairs, and most of those refusals were the name ``main``, which nearly
+    every script in this repo both defines and calls. Qualifying by module
+    took the refusal rate to 13% without losing the #1688/#1692 counterexample.
+    """
+    out: Set[Symbol] = set()
+    for path in files:
+        if not path.endswith(".py"):
+            continue
+        try:
+            source = _git(project_root, "show", f"{ref}:{path}")
+        except ReanchorError:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        alias_to_module: Dict[str, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                module = node.module.split(".")[-1]
+                out.add((module, MODULE_LEVEL))
+                for alias in node.names:
+                    out.add((module, alias.name))
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    module = alias.name.split(".")[-1]
+                    alias_to_module[alias.asname or module] = module
+                    out.add((module, MODULE_LEVEL))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                module = alias_to_module.get(node.value.id)
+                if module:
+                    out.add((module, node.attr))
+    return out
+
+
+def build_import_graph(project_root: Path, ref: str) -> Dict[str, Set[str]]:
+    """module_stem -> directly imported module_stems, over the repo at ``ref``.
+
+    Only modules that exist in the tree are edges: a stdlib or third-party
+    import is not something a commit in this range can have changed.
+    """
+    paths = [
+        p for p in _git(project_root, "ls-tree", "-r", "--name-only", ref).split()
+        if p.endswith(".py") and not p.startswith("tests/")
+    ]
+    known = {Path(p).stem for p in paths}
+    graph: Dict[str, Set[str]] = {}
+    for path in paths:
+        try:
+            source = _git(project_root, "show", f"{ref}:{path}")
+            tree = ast.parse(source)
+        except (ReanchorError, SyntaxError):
+            continue
+        deps: Set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                module = node.module.split(".")[-1]
+                if module in known:
+                    deps.add(module)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    module = alias.name.split(".")[-1]
+                    if module in known:
+                        deps.add(module)
+        graph.setdefault(Path(path).stem, set()).update(deps)
+    return graph
+
+
+def reachable_modules(
+    modules: Iterable[str], graph: Dict[str, Set[str]], depth: int = DEPTH_DEFAULT
+) -> Set[str]:
+    """Modules reachable from ``modules`` within ``depth`` import hops."""
+    seen = set(modules)
+    frontier = set(seen)
+    hops = 0
+    while frontier and (depth == DEPTH_FULL or hops < depth):
+        nxt: Set[str] = set()
+        for module in frontier:
+            nxt |= graph.get(module, set()) - seen
+        seen |= nxt
+        frontier = nxt
+        hops += 1
+    return seen
+
+
+def find_blocking_symbols(
+    changed: Set[Symbol],
+    referenced: Set[Symbol],
+    indirect_modules: Optional[Set[str]] = None,
+) -> List[Symbol]:
+    """Changed symbols this PR reaches — the reason a re-anchor is refused.
+
+    Precision differs by how the PR reaches the module, and that difference is
+    the point:
+
+      1. **Directly imported, exact symbol.** The PR imports that
+         ``(module, symbol)`` — it uses the thing that changed. Blocks.
+      2. **Directly imported, module top level.** A changed constant, dispatch
+         table or decorator (``<module>``), or a module that is gone or
+         unparseable (``*``), changes behaviour for everyone importing it,
+         whichever symbol they use. Blocks.
+      3. **Reached only indirectly.** ``indirect_modules`` are modules the PR
+         does not import but can reach through the import graph. Which symbol
+         of those the PR actually depends on is not knowable from its own
+         source, so ANY change in one of them blocks.
+
+    Keeping 1 apart from 3 is what makes the direct-depth rule symbol-precise.
+    Folding them together — as an earlier draft of this function did, by
+    letting the reachable set carry the directly-imported modules too — silently
+    turns the whole thing into rule 3, blocking on a changed sibling function
+    the PR never calls. It was caught by mutation-testing this file: deleting
+    the exact-overlap line changed no test result, because nothing could
+    reach it.
+    """
+    indirect = indirect_modules or set()
+    referenced_modules = {m for m, _ in referenced}
+    blocking: Set[Symbol] = set(changed & referenced)
+    for module, symbol in changed:
+        if module in indirect:
+            blocking.add((module, symbol))
+        elif symbol in (MODULE_LEVEL, WHOLE_MODULE) and module in referenced_modules:
+            blocking.add((module, symbol))
+    return sorted(blocking)
+
+
+def can_reanchor(
+    project_root: Path,
+    *,
+    old_sha: str,
+    new_sha: str,
+    pr_files: Sequence[str],
+    old_contract_hash: str,
+    new_contract_hash: str,
+    base_ref: str = "origin/main",
+    depth: int = DEPTH_DEFAULT,
+) -> ReanchorDecision:
+    """May the verdict recorded for ``old_sha`` be re-anchored on ``new_sha``?
+
+    Both halves of the OI-1471 condition, in the order that costs least: the
+    hash comparison is free and settles most refusals, so the import analysis
+    only runs when the hashes already agree.
+
+    Refuses on every unestablished fact — an empty hash on either side, an
+    unresolvable merge-base (a rebased-away commit whose objects are gone), an
+    unparseable diff hunk. Absence of evidence is a re-buy.
+    """
+    if not old_contract_hash or not new_contract_hash:
+        return ReanchorDecision(
+            allowed=False,
+            reason=(
+                "one of the contract hashes is empty — an unevidenced record cannot be "
+                "the basis for re-anchoring anything"
+            ),
+            old_sha=old_sha, new_sha=new_sha, depth=depth,
+        )
+    if old_contract_hash != new_contract_hash:
+        return ReanchorDecision(
+            allowed=False,
+            reason=(
+                f"contract hash changed ({old_contract_hash} -> {new_contract_hash}): the gate "
+                "would be judging a different input, so the old verdict does not apply"
+            ),
+            old_sha=old_sha, new_sha=new_sha, depth=depth,
+        )
+    if old_sha == new_sha:
+        return ReanchorDecision(
+            allowed=False,
+            reason="old and new commit are the same — there is nothing to re-anchor",
+            contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha, depth=depth,
+        )
+
+    try:
+        old_base = merge_base(project_root, base_ref, old_sha)
+        new_base = merge_base(project_root, base_ref, new_sha)
+    except (ReanchorError, subprocess.TimeoutExpired) as exc:
+        return ReanchorDecision(
+            allowed=False,
+            reason=f"merge-base could not be resolved, so the range is unknown: {exc}",
+            contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha, depth=depth,
+        )
+
+    if old_base == new_base:
+        return ReanchorDecision(
+            allowed=True,
+            reason="identical contract hash and the merge-base did not move — nothing came between",
+            contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha,
+            old_merge_base=old_base, new_merge_base=new_base, depth=depth,
+        )
+
+    try:
+        changed = changed_symbols(project_root, old_base, new_base)
+        referenced = referenced_symbols(project_root, new_sha, pr_files)
+        # At DEPTH_DIRECT the closure is the input set, so the graph is never
+        # consulted. Building it anyway cost 6.8s of a 7.3s decision — measured
+        # on the #1691 replay — for a value that is discarded.
+        graph = (
+            {} if depth == DEPTH_DIRECT else build_import_graph(project_root, new_sha)
+        )
+        commits = len(_git(project_root, "rev-list", f"{old_base}..{new_base}").split())
+    except (ReanchorError, subprocess.TimeoutExpired) as exc:
+        return ReanchorDecision(
+            allowed=False,
+            reason=f"the range could not be analysed, so nothing is proven: {exc}",
+            contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha,
+            old_merge_base=old_base, new_merge_base=new_base, depth=depth,
+        )
+
+    direct_modules = {m for m, _ in referenced}
+    # Only the modules reached BEYOND the direct imports get the coarse
+    # treatment; the direct ones stay symbol-precise. At DEPTH_DIRECT this set
+    # is empty by construction.
+    indirect_modules = reachable_modules(direct_modules, graph, depth) - direct_modules
+    blocking = find_blocking_symbols(changed, referenced, indirect_modules)
+    if blocking:
+        named = ", ".join(f"{m}.{s}" for m, s in blocking[:5])
+        more = f" (+{len(blocking) - 5} more)" if len(blocking) > 5 else ""
+        return ReanchorDecision(
+            allowed=False,
+            reason=(
+                f"{commits} commit(s) between the merge-bases changed {len(blocking)} symbol(s) "
+                f"this PR reaches: {named}{more} — the diff is identical but its meaning may "
+                "not be (the #1688/#1692 shape)"
+            ),
+            contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha,
+            old_merge_base=old_base, new_merge_base=new_base,
+            commits_in_range=commits, blocking_symbols=tuple(blocking), depth=depth,
+        )
+    return ReanchorDecision(
+        allowed=True,
+        reason=(
+            f"identical contract hash, and none of the {commits} commit(s) between the "
+            "merge-bases touches a symbol this PR reaches"
+        ),
+        contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha,
+        old_merge_base=old_base, new_merge_base=new_base,
+        commits_in_range=commits, depth=depth,
+    )

--- a/scripts/lib/gate_reanchor.py
+++ b/scripts/lib/gate_reanchor.py
@@ -20,21 +20,26 @@ So the condition has two halves, and BOTH must hold:
   (b) no commit between the old and the new merge-base touches a symbol this
       PR's own files reach.
 
-(b) is what this module computes. Measured with THIS code over 153 ordered PR
-pairs from 2026-08-26/28, both columns from one run over identical rows:
+(b) is what this module computes. Measured with THIS code over 171 ordered PR
+pairs from 2026-08-26/28, both columns from ONE run over identical rows —
+comparing two semantics across two row sets would show a difference that is
+partly just the row choice:
 
   import depth        allowed         allowed
                       (permissive)    (fail-closed, shipped)
-  direct (default)        88%             76%
-  +1 hop                  76%             68%
-  +2 hops                 71%             64%
-  full closure            63%             57%
+  direct (default)        87%             75%
+  +1 hop                  77%             70%
+  +2 hops                 73%             66%
+  full closure            65%             60%
 
 The right-hand column is what ships. Refusing everything the analysis cannot
 model costs 12 points at the default depth and still re-anchors three quarters
-of the re-gates that were actually paid for. Every one of those refusals came
-from a dynamic import or ``getattr`` in the PR's own files — five of eighteen
-PRs, seven occurrences.
+of the re-gates that were actually paid for. Every refusal it adds comes from
+a dynamic import or ``getattr`` in the PR's own files.
+
+The answer to OI-1471 is therefore neither "it cannot be done" nor "it is
+free": three quarters can be re-anchored, one quarter has to be re-bought,
+and which is which is decided by evidence rather than by a rule of thumb.
 
 The whole sweep took 8.1 seconds including building the 713-module import
 graph from scratch, so (b) is affordable — the outcome the OI left open.
@@ -347,6 +352,16 @@ def referenced_symbols(project_root: Path, ref: str, files: Iterable[str]) -> Re
         except SyntaxError as exc:
             unmodelled.append(f"{path} does not parse at {ref[:12]}: {exc}")
             continue
+
+        # The file's OWN module is reached in full. A PR file that calls a
+        # helper defined beside it referenced nothing at all under an
+        # import-only analysis, so an intervening commit changing that same
+        # helper produced an empty-but-provable reference set and an ALLOW on a
+        # stale verdict. Enumerating which subset of its own file a file "uses"
+        # buys no safety here: the PR is EDITING that module, so a commit in
+        # the range touching it is exactly what must block.
+        out.add((Path(path).stem, WHOLE_MODULE))
+        referenced_modules.add(Path(path).stem)
 
         alias_to_module: Dict[str, str] = {}
         for node in ast.walk(tree):

--- a/scripts/lib/gate_reanchor.py
+++ b/scripts/lib/gate_reanchor.py
@@ -340,26 +340,14 @@ def find_blocking_symbols(
     return sorted(blocking)
 
 
-def can_reanchor(
-    project_root: Path,
-    *,
-    old_sha: str,
-    new_sha: str,
-    pr_files: Sequence[str],
-    old_contract_hash: str,
-    new_contract_hash: str,
-    base_ref: str = "origin/main",
-    depth: int = DEPTH_DEFAULT,
-) -> ReanchorDecision:
-    """May the verdict recorded for ``old_sha`` be re-anchored on ``new_sha``?
+def _check_hash_precondition(
+    *, old_sha: str, new_sha: str,
+    old_contract_hash: str, new_contract_hash: str, depth: int,
+) -> Optional[ReanchorDecision]:
+    """Condition (a) plus the trivial no-op case, or None to carry on.
 
-    Both halves of the OI-1471 condition, in the order that costs least: the
-    hash comparison is free and settles most refusals, so the import analysis
-    only runs when the hashes already agree.
-
-    Refuses on every unestablished fact — an empty hash on either side, an
-    unresolvable merge-base (a rebased-away commit whose objects are gone), an
-    unparseable diff hunk. Absence of evidence is a re-buy.
+    Split out because it is free — no git, no parsing — and settles most
+    refusals, so :func:`can_reanchor` runs it before touching the repository.
     """
     if not old_contract_hash or not new_contract_hash:
         return ReanchorDecision(
@@ -385,6 +373,37 @@ def can_reanchor(
             reason="old and new commit are the same — there is nothing to re-anchor",
             contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha, depth=depth,
         )
+    return None
+
+
+def can_reanchor(
+    project_root: Path,
+    *,
+    old_sha: str,
+    new_sha: str,
+    pr_files: Sequence[str],
+    old_contract_hash: str,
+    new_contract_hash: str,
+    base_ref: str = "origin/main",
+    depth: int = DEPTH_DEFAULT,
+) -> ReanchorDecision:
+    """May the verdict recorded for ``old_sha`` be re-anchored on ``new_sha``?
+
+    Both halves of the OI-1471 condition, in the order that costs least: the
+    hash comparison is free and settles most refusals, so the import analysis
+    only runs when the hashes already agree.
+
+    Refuses on every unestablished fact — an empty hash on either side, an
+    unresolvable merge-base (a rebased-away commit whose objects are gone), an
+    unparseable diff hunk. Absence of evidence is a re-buy.
+    """
+    refusal = _check_hash_precondition(
+        old_sha=old_sha, new_sha=new_sha,
+        old_contract_hash=old_contract_hash, new_contract_hash=new_contract_hash,
+        depth=depth,
+    )
+    if refusal is not None:
+        return refusal
 
     try:
         old_base = merge_base(project_root, base_ref, old_sha)

--- a/scripts/lib/gate_reanchor.py
+++ b/scripts/lib/gate_reanchor.py
@@ -20,14 +20,21 @@ So the condition has two halves, and BOTH must hold:
   (b) no commit between the old and the new merge-base touches a symbol this
       PR's own files reach.
 
-(b) is what this module computes. Measured with THIS code over 120 ordered PR
-pairs from 2026-08-26, the busiest measured day on this repo:
+(b) is what this module computes. Measured with THIS code over 153 ordered PR
+pairs from 2026-08-26/28, both columns from one run over identical rows:
 
-  import depth        allowed   refused
-  direct (default)        87%       13%
-  +1 hop                  74%       26%
-  +2 hops                 69%       31%
-  full closure            58%       42%
+  import depth        allowed         allowed
+                      (permissive)    (fail-closed, shipped)
+  direct (default)        88%             76%
+  +1 hop                  76%             68%
+  +2 hops                 71%             64%
+  full closure            63%             57%
+
+The right-hand column is what ships. Refusing everything the analysis cannot
+model costs 12 points at the default depth and still re-anchors three quarters
+of the re-gates that were actually paid for. Every one of those refusals came
+from a dynamic import or ``getattr`` in the PR's own files — five of eighteen
+PRs, seven occurrences.
 
 The whole sweep took 8.1 seconds including building the 713-module import
 graph from scratch, so (b) is affordable — the outcome the OI left open.
@@ -35,8 +42,21 @@ graph from scratch, so (b) is affordable — the outcome the OI left open.
 Which row to stand on is a real decision, and the measurement settles it in
 an unobvious direction: see :data:`DEPTH_DEFAULT`.
 
-Every failure to establish an answer refuses. A re-anchor that cannot prove
-both halves is a re-buy, never a shrug.
+ONE PRINCIPLE RUNS THROUGH ALL OF IT. Condition (b) is a PROOF: *no* commit in
+the range touches *any* symbol this PR reaches. A proof cannot rest on an
+incomplete analysis, and a static Python import analysis is never complete —
+star-imports, ``importlib``, ``getattr``, re-exports, unreadable files. Working
+that list down one entry at a time only ever produces the next entry.
+
+So every construct the analysis does not model yields ``cannot_prove``, and
+``cannot_prove`` refuses. Never "no reference found". The difference is the
+whole safety argument: "I did not find a reference" and "I could not tell"
+are the same output from a silent ``except: continue``, and only one of them
+is a proof.
+
+The price is refusing more often, and so re-buying a gate more often. That is
+the correct direction to fail in: paying twice costs money, re-anchoring
+wrongly costs the validity of the audit trail.
 """
 
 from __future__ import annotations
@@ -45,7 +65,7 @@ import ast
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Dict, FrozenSet, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 
 #: (module_stem, symbol). ``"<module>"`` is the module's own top level —
 #: constants, dispatch tables, decorators — which a diff can change without
@@ -83,6 +103,30 @@ DEPTH_DEFAULT = DEPTH_DIRECT
 
 class ReanchorError(RuntimeError):
     """A git fact needed for the decision could not be established."""
+
+
+#: Python constructs this analysis deliberately does not model. Each one is
+#: detected and reported as ``cannot_prove`` rather than resolved: a partial
+#: resolution would be indistinguishable from a complete one at the call site.
+_DYNAMIC_IMPORT_NAMES = frozenset({"import_module", "__import__", "getattr"})
+
+
+@dataclass(frozen=True)
+class ReferenceSet:
+    """What a PR reaches, plus what could not be established about it.
+
+    ``unmodelled`` is the whole point. A reference analysis that returns only
+    the symbols it found is indistinguishable from one that found nothing
+    because it could not look, and :func:`can_reanchor` needs to tell those
+    apart to make its refusal honest.
+    """
+
+    symbols: Set[Symbol] = field(default_factory=set)
+    unmodelled: Sequence[str] = field(default_factory=tuple)
+
+    @property
+    def provable(self) -> bool:
+        return not self.unmodelled
 
 
 @dataclass(frozen=True)
@@ -217,88 +261,164 @@ def changed_symbols(project_root: Path, old_base: str, new_base: str) -> Set[Sym
     return out
 
 
-def referenced_symbols(project_root: Path, ref: str, files: Iterable[str]) -> Set[Symbol]:
-    """Qualified symbols the PR's own files import or reach through.
+def _module_source(project_root: Path, ref: str, module: str, tree_files: Dict[str, str]) -> Optional[str]:
+    """Source of ``module`` at ``ref``, or None when this repo has no such module."""
+    path = tree_files.get(module)
+    if path is None:
+        return None
+    return _git(project_root, "show", f"{ref}:{path}")
+
+
+def _tree_modules(project_root: Path, ref: str) -> Dict[str, str]:
+    """module_stem -> path, for the non-test Python files in the tree at ``ref``."""
+    out: Dict[str, str] = {}
+    for path in _git(project_root, "ls-tree", "-r", "--name-only", ref).split():
+        if path.endswith(".py") and not path.startswith("tests/"):
+            out.setdefault(Path(path).stem, path)
+    return out
+
+
+def _scan_module_bindings(source: str) -> Dict[str, str]:
+    """name -> origin module, for names a module RE-EXPORTS via ``from x import name``.
+
+    A re-export is the quietest hole in this whole analysis. The PR writes
+    ``from vnx_paths import ensure_env``; the function actually lives in
+    another module and is merely re-bound there. A commit changing the real
+    definition records ``(origin, ensure_env)``, the PR references
+    ``(vnx_paths, ensure_env)``, and nothing matches — a silent ALLOW on a
+    changed symbol the PR calls. One level of resolution closes it.
+    """
+    bindings: Dict[str, str] = {}
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return bindings
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            origin = node.module.split(".")[-1]
+            for alias in node.names:
+                if alias.name != "*":
+                    bindings.setdefault(alias.asname or alias.name, origin)
+    return bindings
+
+
+def referenced_symbols(project_root: Path, ref: str, files: Iterable[str]) -> ReferenceSet:
+    """Qualified symbols the PR's own files reach, plus what could not be modelled.
 
     ``from x import a`` yields ``("x", "a")`` and ``("x", "<module>")`` — the
     second because importing from a module also binds you to its top level.
-    ``import x`` plus ``x.y`` yields ``("x", "y")``.
+    ``import x`` plus ``x.y`` yields ``("x", "y")``. ``from x import *`` yields
+    ``("x", "*")``, which :func:`find_blocking_symbols` treats as "any change
+    in x blocks" — the honest position, since a star-import says nothing about
+    which name is used.
 
-    Bare-name matching was measured and rejected: it refused 40% of the same
-    120 pairs, and most of those refusals were the name ``main``, which nearly
-    every script in this repo both defines and calls. Qualifying by module
-    took the refusal rate to 13% without losing the #1688/#1692 counterexample.
+    Bare-name matching was measured and rejected: it refused 40% of 120 real
+    PR pairs, and most of those were the name ``main``, which nearly every
+    script here both defines and calls. Qualifying by module took the refusal
+    rate to 13% without losing the #1688/#1692 counterexample.
+
+    Three things produce ``cannot_prove`` rather than a smaller symbol set:
+    a PR file that is present but unreadable or unparseable, a dynamic import
+    or ``getattr`` (which can reach a name no static walk will see), and a
+    module whose own source cannot be read while resolving its re-exports.
+    A file the PR DELETED is not one of them — absence at this ref is a
+    complete answer, and refusing on it would refuse every PR that removes a
+    file.
     """
     out: Set[Symbol] = set()
+    unmodelled: List[str] = []
+    tree_files = _tree_modules(project_root, ref)
+    referenced_modules: Set[str] = set()
+
     for path in files:
         if not path.endswith(".py"):
             continue
-        # Absent at this ref is a legitimate, complete answer: the PR DELETED
-        # the file, so it contributes no references. Distinguished from
-        # unreadable by asking git directly rather than by reading stderr —
-        # `pr_files` comes from `gh pr view --json files`, which lists deleted
-        # paths too, so collapsing the two would refuse every PR that removes
-        # a file.
         try:
             _git(project_root, "cat-file", "-e", f"{ref}:{path}")
         except ReanchorError:
-            continue
-        # Present but unreadable is the opposite case, and fail-CLOSED:
-        # skipping it under-approximates the reference set and then treats the
-        # remainder as complete, producing an ALLOW on evidence nobody
-        # gathered — the one direction this module must never fail in.
+            continue  # deleted by this PR: no references to gather
         try:
             source = _git(project_root, "show", f"{ref}:{path}")
         except ReanchorError as exc:
-            raise ReanchorError(
-                f"{path} exists at {ref[:12]} but could not be read, so the PR's reference "
-                f"set is incomplete and nothing can be proven: {exc}"
-            ) from exc
+            unmodelled.append(f"{path} exists at {ref[:12]} but could not be read: {exc}")
+            continue
         try:
             tree = ast.parse(source)
         except SyntaxError as exc:
-            raise ReanchorError(
-                f"{path} does not parse at {ref[:12]}, so its references are unknown: {exc}"
-            ) from exc
+            unmodelled.append(f"{path} does not parse at {ref[:12]}: {exc}")
+            continue
 
         alias_to_module: Dict[str, str] = {}
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module:
                 module = node.module.split(".")[-1]
                 out.add((module, MODULE_LEVEL))
+                referenced_modules.add(module)
                 for alias in node.names:
                     if alias.name == "*":
-                        # A star-import binds the PR to EVERY name in the
-                        # module, so nothing narrower than the whole module
-                        # can be claimed about what it uses.
                         out.add((module, WHOLE_MODULE))
                         continue
                     out.add((module, alias.name))
-                    # `from pkg import mod` followed by `mod.fn()`: the
-                    # imported name may itself be a module. Mapping it to
-                    # itself makes `mod.fn` resolve to ("mod", "fn") below.
-                    # Over-approximation is the safe direction — a class
-                    # imported the same way yields a (Class, method) pair that
-                    # matches no module, which is noise, never a false ALLOW.
                     alias_to_module.setdefault(alias.asname or alias.name, alias.name)
             elif isinstance(node, ast.Import):
                 for alias in node.names:
                     module = alias.name.split(".")[-1]
                     alias_to_module[alias.asname or module] = module
+                    referenced_modules.add(module)
                     out.add((module, MODULE_LEVEL))
+            elif isinstance(node, ast.Name) and node.id in _DYNAMIC_IMPORT_NAMES:
+                unmodelled.append(
+                    f"{path} uses {node.id!r}: a dynamic import or attribute lookup can reach "
+                    "a symbol no static walk sees, so this PR's references cannot be enumerated"
+                )
+            elif isinstance(node, ast.Attribute) and node.attr in _DYNAMIC_IMPORT_NAMES:
+                unmodelled.append(
+                    f"{path} uses {node.attr!r}: a dynamic import or attribute lookup can reach "
+                    "a symbol no static walk sees, so this PR's references cannot be enumerated"
+                )
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
                 module = alias_to_module.get(node.value.id)
                 if module:
                     out.add((module, node.attr))
-    return out
+                    referenced_modules.add(module)
+
+    # Resolve one level of re-export for every module the PR imports from.
+    for module in sorted(referenced_modules):
+        try:
+            source = _module_source(project_root, ref, module, tree_files)
+        except ReanchorError as exc:
+            unmodelled.append(f"module {module!r} could not be read at {ref[:12]}: {exc}")
+            continue
+        if source is None:
+            continue  # stdlib or third-party: no commit in this range changed it
+        bindings = _scan_module_bindings(source)
+        for name, origin in bindings.items():
+            if (module, name) in out:
+                out.add((origin, name))
+                out.add((origin, MODULE_LEVEL))
+
+    return ReferenceSet(symbols=out, unmodelled=tuple(dict.fromkeys(unmodelled)))
 
 
-def build_import_graph(project_root: Path, ref: str) -> Dict[str, Set[str]]:
+@dataclass(frozen=True)
+class ImportGraph:
+    """The repo's import edges, plus the modules whose edges are UNKNOWN."""
+
+    edges: Mapping[str, Set[str]] = field(default_factory=dict)
+    unresolved: FrozenSet[str] = frozenset()
+
+
+def build_import_graph(project_root: Path, ref: str) -> ImportGraph:
     """module_stem -> directly imported module_stems, over the repo at ``ref``.
 
-    Only modules that exist in the tree are edges: a stdlib or third-party
+    Only modules that exist in the tree become edges: a stdlib or third-party
     import is not something a commit in this range can have changed.
+
+    A module that cannot be read or parsed goes into ``unresolved`` rather
+    than being skipped. Its edges are unknown, not absent, and a caller
+    walking the closure has to know the difference.
     """
     paths = [
         p for p in _git(project_root, "ls-tree", "-r", "--name-only", ref).split()
@@ -306,11 +426,18 @@ def build_import_graph(project_root: Path, ref: str) -> Dict[str, Set[str]]:
     ]
     known = {Path(p).stem for p in paths}
     graph: Dict[str, Set[str]] = {}
+    unresolved: Set[str] = set()
     for path in paths:
         try:
             source = _git(project_root, "show", f"{ref}:{path}")
             tree = ast.parse(source)
         except (ReanchorError, SyntaxError):
+            # Its edges are UNKNOWN, not absent. Dropping it silently truncated
+            # the closure, so a DEPTH_FULL run could allow a re-anchor without
+            # having proved condition (b) at all — the same fail-open shape as
+            # the deletion-only hunk and the swallowed PR-file read.
+            unresolved.add(Path(path).stem)
+            graph.setdefault(Path(path).stem, set())
             continue
         deps: Set[str] = set()
         for node in ast.walk(tree):
@@ -324,11 +451,11 @@ def build_import_graph(project_root: Path, ref: str) -> Dict[str, Set[str]]:
                     if module in known:
                         deps.add(module)
         graph.setdefault(Path(path).stem, set()).update(deps)
-    return graph
+    return ImportGraph(edges=graph, unresolved=frozenset(unresolved))
 
 
 def reachable_modules(
-    modules: Iterable[str], graph: Dict[str, Set[str]], depth: int = DEPTH_DEFAULT
+    modules: Iterable[str], graph: ImportGraph, depth: int = DEPTH_DEFAULT
 ) -> Set[str]:
     """Modules reachable from ``modules`` within ``depth`` import hops."""
     seen = set(modules)
@@ -337,7 +464,7 @@ def reachable_modules(
     while frontier and (depth == DEPTH_FULL or hops < depth):
         nxt: Set[str] = set()
         for module in frontier:
-            nxt |= graph.get(module, set()) - seen
+            nxt |= set(graph.edges.get(module, set())) - seen
         seen |= nxt
         frontier = nxt
         hops += 1
@@ -346,7 +473,7 @@ def reachable_modules(
 
 def find_blocking_symbols(
     changed: Set[Symbol],
-    referenced: Set[Symbol],
+    referenced,
     indirect_modules: Optional[Set[str]] = None,
 ) -> List[Symbol]:
     """Changed symbols this PR reaches — the reason a re-anchor is refused.
@@ -374,6 +501,7 @@ def find_blocking_symbols(
     the exact-overlap line changed no test result, because nothing could
     reach it.
     """
+    referenced = referenced.symbols if isinstance(referenced, ReferenceSet) else referenced
     indirect = set(indirect_modules or set())
     referenced_modules = {m for m, _ in referenced}
     # A star-import is recorded as (module, "*") on the REFERENCED side. It
@@ -476,12 +604,14 @@ def can_reanchor(
 
     try:
         changed = changed_symbols(project_root, old_base, new_base)
-        referenced = referenced_symbols(project_root, new_sha, pr_files)
+        reference_set = referenced_symbols(project_root, new_sha, pr_files)
         # At DEPTH_DIRECT the closure is the input set, so the graph is never
         # consulted. Building it anyway cost 6.8s of a 7.3s decision — measured
         # on the #1691 replay — for a value that is discarded.
         graph = (
-            {} if depth == DEPTH_DIRECT else build_import_graph(project_root, new_sha)
+            ImportGraph()
+            if depth == DEPTH_DIRECT
+            else build_import_graph(project_root, new_sha)
         )
         commits = len(_git(project_root, "rev-list", f"{old_base}..{new_base}").split())
     except (ReanchorError, subprocess.TimeoutExpired) as exc:
@@ -492,12 +622,38 @@ def can_reanchor(
             old_merge_base=old_base, new_merge_base=new_base, depth=depth,
         )
 
-    direct_modules = {m for m, _ in referenced}
+    direct_modules = {m for m, _ in reference_set.symbols}
     # Only the modules reached BEYOND the direct imports get the coarse
     # treatment; the direct ones stay symbol-precise. At DEPTH_DIRECT this set
     # is empty by construction.
-    indirect_modules = reachable_modules(direct_modules, graph, depth) - direct_modules
-    blocking = find_blocking_symbols(changed, referenced, indirect_modules)
+    reachable = reachable_modules(direct_modules, graph, depth)
+    indirect_modules = reachable - direct_modules
+
+    # cannot_prove, in both its forms. Either the PR's own references could not
+    # be enumerated, or a module inside the closure has unknown edges — and a
+    # closure with a hole in it proves nothing about what lies beyond the hole.
+    unprovable = list(reference_set.unmodelled)
+    blind = sorted(reachable & set(graph.unresolved))
+    if blind:
+        unprovable.append(
+            "the import closure passes through "
+            + ", ".join(blind[:5])
+            + ", whose own imports could not be read — everything beyond them is unknown"
+        )
+    if unprovable:
+        return ReanchorDecision(
+            allowed=False,
+            reason=(
+                "cannot prove condition (b): "
+                + "; ".join(unprovable[:3])
+                + (f" (+{len(unprovable) - 3} more)" if len(unprovable) > 3 else "")
+            ),
+            contract_hash_matches=True, old_sha=old_sha, new_sha=new_sha,
+            old_merge_base=old_base, new_merge_base=new_base,
+            commits_in_range=commits, depth=depth,
+        )
+
+    blocking = find_blocking_symbols(changed, reference_set.symbols, indirect_modules)
     if blocking:
         named = ", ".join(f"{m}.{s}" for m, s in blocking[:5])
         more = f" (+{len(blocking) - 5} more)" if len(blocking) > 5 else ""

--- a/scripts/lib/gate_reanchor.py
+++ b/scripts/lib/gate_reanchor.py
@@ -154,6 +154,17 @@ def _changed_line_numbers(project_root: Path, commit: str, path: str) -> Set[int
         except (IndexError, ValueError):
             # An unparseable hunk header must not silently narrow the range.
             raise ReanchorError(f"unparseable diff hunk header in {commit[:12]} {path}: {line!r}")
+        if count == 0:
+            # A deletion-only hunk has a `+N,0` post-image span, so
+            # range(N, N+0) is EMPTY and the change would register as touching
+            # nothing at all — a commit that deletes a guard out of a function
+            # this PR calls would then read as "nothing changed" and allow a
+            # re-anchor that must be refused. Git's convention for `+N,0` is
+            # that the removed content sat after post-image line N, so both N
+            # and N+1 are marked: whichever scope enclosed the deletion
+            # contains one of them.
+            lines.update({max(start, 1), start + 1})
+            continue
         lines.update(range(start, start + count))
     return lines
 

--- a/scripts/lib/gate_register_emit.py
+++ b/scripts/lib/gate_register_emit.py
@@ -19,14 +19,25 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 logger = logging.getLogger(__name__)
 
 
-def _resolve_register_path() -> Path:
-    """Resolve dispatch_register.ndjson path using env vars only (no git subprocess)."""
+def register_path() -> Path:
+    """Resolve dispatch_register.ndjson path using env vars only (no git subprocess).
+
+    Public because it is not codex-specific: any writer that has to append a
+    gate-lifecycle line to the register needs the same resolution, and a
+    second copy of this fallback chain is how two writers start disagreeing
+    about which ledger they are appending to.
+    """
     state_dir_env = os.environ.get("VNX_STATE_DIR")
     if state_dir_env:
         return Path(state_dir_env) / "dispatch_register.ndjson"
     if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
         return Path(os.environ["VNX_DATA_DIR"]) / "state" / "dispatch_register.ndjson"
     return _REPO_ROOT / ".vnx-data" / "state" / "dispatch_register.ndjson"
+
+
+def _resolve_register_path() -> Path:
+    """Deprecated alias for :func:`register_path`, kept for existing callers."""
+    return register_path()
 
 
 def emit_codex_gate_to_register(

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -63,7 +63,7 @@ TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "worktree-refresh", "worktree-status", "worktree-release", "merge-preflight",
     "dispatch-cleanup",
     "smoke", "package-check", "fabric-audit", "subsystems",
-    "dispatch", "gate", "dream",
+    "dispatch", "gate", "gate-reanchor", "dream",
     "snapshot", "restore", "quiesce-check", "pause", "resume",
     "pool", "permission",
 })

--- a/tests/test_gate_reanchor.py
+++ b/tests/test_gate_reanchor.py
@@ -698,3 +698,40 @@ def test_the_lock_actually_serialises_two_holders(tmp_path):
         t.join()
     assert overlapped == [], "the lock let two holders into the critical section"
     assert sorted(order) == ["A", "B"], "both holders must eventually run"
+
+
+def test_a_pr_file_reaches_its_own_module_in_full(repo):
+    """A PR file that calls a helper defined beside it referenced nothing at
+    all under an import-only analysis: an empty-but-provable reference set, and
+    an ALLOW on a stale verdict when an intervening commit changed that helper.
+    Found by codex_gate on this PR.
+    """
+    root, base = repo
+    (root / "scripts" / "selfref.py").write_text(
+        "def helper(x):\n    return x + 1\n\n\ndef run(x):\n    return helper(x)\n"
+    )
+    head = _commit(root, "a file that only calls itself")
+    result = gr.referenced_symbols(root, head, ["scripts/selfref.py"])
+    assert result.provable
+    assert ("selfref", gr.WHOLE_MODULE) in result.symbols
+    assert gr.find_blocking_symbols({("selfref", "helper")}, result) == [("selfref", "helper")]
+
+
+def test_a_commit_changing_the_same_file_the_pr_edits_refuses(repo):
+    """End-to-end: the PR edits scripts/consumer.py and so does main."""
+    root, base = repo
+    _git(root, "checkout", "-q", "-b", "feature", base)
+    old_head = base
+    _git(root, "checkout", "-q", "main")
+    path = root / "scripts" / "consumer.py"
+    path.write_text(path.read_text().replace("return helper(x)", "return helper(x) * 2"))
+    _commit(root, "main touches the same file")
+    _git(root, "checkout", "-q", "-B", "feature2", "main")
+    tip = _git(root, "rev-parse", "HEAD").strip()
+
+    decision = gr.can_reanchor(
+        root, old_sha=old_head, new_sha=tip, pr_files=["scripts/consumer.py"],
+        old_contract_hash="h1", new_contract_hash="h1", base_ref="main",
+    )
+    assert not decision.allowed
+    assert ("consumer", "run") in decision.blocking_symbols

--- a/tests/test_gate_reanchor.py
+++ b/tests/test_gate_reanchor.py
@@ -368,3 +368,61 @@ def test_the_reanchored_payload_does_not_mutate_the_record_it_came_from():
     cli.build_reanchored_payload(record, new_sha="b" * 40, new_branch="n", decision=decision)
     assert record["commit_sha"] == "a" * 40
     assert record["evidence_source"] == "live"
+
+
+# ---------------------------------------------------------------------------
+# Deletion-only hunks
+# ---------------------------------------------------------------------------
+
+
+def test_a_deletion_only_hunk_still_marks_the_function_as_changed(repo):
+    """`@@ -a,b +c,0 @@` has an EMPTY post-image span.
+
+    Reading it literally records no touched line, so a commit that deletes a
+    guard out of a function this PR calls would register as "nothing changed"
+    and allow a re-anchor that must be refused. Found by codex_gate on this
+    very PR.
+    """
+    root, base = repo
+    path = root / "scripts" / "lib" / "lib_a.py"
+    path.write_text(
+        "CONSTANT = 1\n\n\ndef helper(x):\n    if x < 0:\n        raise ValueError(x)\n"
+        "    return x + 1\n\n\ndef untouched(x):\n    return x\n"
+    )
+    with_guard = _commit(root, "add a guard to helper")
+    path.write_text(
+        "CONSTANT = 1\n\n\ndef helper(x):\n    return x + 1\n\n\ndef untouched(x):\n    return x\n"
+    )
+    without_guard = _commit(root, "delete the guard")
+
+    raw = _git(root, "diff", "--unified=0", with_guard, without_guard)
+    assert "+4,0" in raw or ",0 @@" in raw, f"expected a deletion-only hunk, got:\n{raw}"
+
+    assert gr.changed_symbols(root, with_guard, without_guard) == {("lib_a", "helper")}
+
+
+def test_a_deletion_only_change_refuses_the_re_anchor_end_to_end(repo):
+    """The same case through can_reanchor: identical hash, deleted guard."""
+    root, base = repo
+    path = root / "scripts" / "lib" / "lib_a.py"
+    path.write_text(
+        "CONSTANT = 1\n\n\ndef helper(x):\n    if x < 0:\n        raise ValueError(x)\n"
+        "    return x + 1\n\n\ndef untouched(x):\n    return x\n"
+    )
+    guarded = _commit(root, "add a guard")
+    _git(root, "checkout", "-q", "-b", "feature", guarded)
+    old_head = guarded
+    _git(root, "checkout", "-q", "main")
+    path.write_text(
+        "CONSTANT = 1\n\n\ndef helper(x):\n    return x + 1\n\n\ndef untouched(x):\n    return x\n"
+    )
+    _commit(root, "delete the guard")
+    _git(root, "checkout", "-q", "-B", "feature2", "main")
+    tip = _git(root, "rev-parse", "HEAD").strip()
+
+    decision = gr.can_reanchor(
+        root, old_sha=old_head, new_sha=tip, pr_files=["scripts/consumer.py"],
+        old_contract_hash="h1", new_contract_hash="h1", base_ref="main",
+    )
+    assert not decision.allowed
+    assert ("lib_a", "helper") in decision.blocking_symbols

--- a/tests/test_gate_reanchor.py
+++ b/tests/test_gate_reanchor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -631,3 +632,69 @@ def test_cannot_prove_beats_a_clean_symbol_analysis():
     reference = gr.ReferenceSet(symbols=set(), unmodelled=("importlib in x.py",))
     assert not reference.provable
     assert gr.find_blocking_symbols({("lib_a", "helper")}, reference) == []
+
+
+# ---------------------------------------------------------------------------
+# The read-check-write window
+# ---------------------------------------------------------------------------
+
+
+def _seed_result(tmp_path: Path, sha: str) -> Path:
+    path = tmp_path / "pr-9-glm_gate.json"
+    path.write_text(json.dumps({
+        "gate": "glm_gate", "pr_id": "9", "status": "pass", "contract_hash": "h1",
+        "report_path": "/r.md", "dispatch_id": "glm-gate-pr9-1", "commit_sha": sha,
+    }))
+    return path
+
+
+def test_the_swap_guard_passes_when_the_record_has_not_moved(tmp_path):
+    path = _seed_result(tmp_path, "a" * 40)
+    cli.compare_and_swap_guard(path, "a" * 40)  # must not raise
+
+
+def test_the_swap_guard_refuses_when_another_writer_got_there_first(tmp_path):
+    """gate_recorder takes no lock anywhere: the read in _check_overwrite_guard
+    and the write that follows are two operations with a window between them.
+    Measured with two threads that both read the record on the old sha before
+    either wrote — both cleared the overwrite guard. Re-reading under the lock
+    turns the write into a compare-and-swap.
+    """
+    path = _seed_result(tmp_path, "b" * 40)
+    with pytest.raises(ValueError) as excinfo:
+        cli.compare_and_swap_guard(path, "a" * 40)
+    assert "while this re-anchor was deciding" in str(excinfo.value)
+
+
+def test_the_swap_guard_refuses_a_record_that_vanished(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        cli.compare_and_swap_guard(tmp_path / "gone.json", "a" * 40)
+    assert "disappeared" in str(excinfo.value)
+
+
+def test_the_lock_actually_serialises_two_holders(tmp_path):
+    """Two threads entering the same lock must not overlap. Without the lock
+    both decide against the same old sha and both act on it."""
+    import threading
+
+    path = _seed_result(tmp_path, "a" * 40)
+    order = []
+    inside = threading.Lock()
+    overlapped = []
+
+    def hold(tag):
+        with cli.exclusive_result_lock(path):
+            if not inside.acquire(blocking=False):
+                overlapped.append(tag)
+            else:
+                order.append(tag)
+                time.sleep(0.05)
+                inside.release()
+
+    threads = [threading.Thread(target=hold, args=(t,)) for t in ("A", "B")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert overlapped == [], "the lock let two holders into the critical section"
+    assert sorted(order) == ["A", "B"], "both holders must eventually run"

--- a/tests/test_gate_reanchor.py
+++ b/tests/test_gate_reanchor.py
@@ -134,9 +134,51 @@ def test_referenced_symbols_captures_module_attribute_access(repo):
     assert ("lib_a", "helper") in referenced
 
 
-def test_referenced_symbols_skips_a_file_that_is_not_in_the_tree(repo):
+def test_a_file_the_pr_deleted_contributes_no_references(repo):
+    """`gh pr view --json files` lists deleted paths too. Absent at this ref is
+    a complete answer, not a gap — refusing on it would refuse every PR that
+    removes a file."""
     root, base = repo
     assert gr.referenced_symbols(root, base, ["scripts/does_not_exist.py"]) == set()
+
+
+def test_an_unparseable_file_refuses_instead_of_shrinking_the_reference_set(repo):
+    """Present but unreadable is the opposite case. Skipping it silently
+    under-approximates what the PR reaches and then treats the remainder as
+    complete — an ALLOW on evidence nobody gathered. Found by codex_gate."""
+    root, base = repo
+    (root / "scripts" / "broken.py").write_text("def f(:\n    pass\n")
+    head = _commit(root, "add an unparseable file")
+    with pytest.raises(gr.ReanchorError) as excinfo:
+        gr.referenced_symbols(root, head, ["scripts/broken.py"])
+    assert "does not parse" in str(excinfo.value)
+
+
+def test_a_star_import_binds_the_pr_to_the_whole_module(repo):
+    """`from x import *` says "any name in x". Recording it as the literal
+    symbol `*` matched nothing on the changed side, so a changed symbol in a
+    star-imported module slipped through. Found by codex_gate."""
+    root, base = repo
+    (root / "scripts" / "star.py").write_text("from lib_a import *\n\n\ndef run(x):\n    return helper(x)\n")
+    head = _commit(root, "add a star importer")
+    referenced = gr.referenced_symbols(root, head, ["scripts/star.py"])
+    assert ("lib_a", gr.WHOLE_MODULE) in referenced
+    assert gr.find_blocking_symbols({("lib_a", "untouched")}, referenced) == [
+        ("lib_a", "untouched")
+    ]
+
+
+def test_a_module_imported_by_name_still_resolves_its_attributes(repo):
+    """`from pkg import mod; mod.fn()` recorded (pkg, mod) and never mapped
+    `mod` to its own module, so changes to mod.fn were invisible. Found by
+    codex_gate."""
+    root, base = repo
+    (root / "scripts" / "pkgstyle.py").write_text(
+        "from lib import lib_a\n\n\ndef run(x):\n    return lib_a.helper(x)\n"
+    )
+    head = _commit(root, "add a package-style importer")
+    referenced = gr.referenced_symbols(root, head, ["scripts/pkgstyle.py"])
+    assert ("lib_a", "helper") in referenced
 
 
 # ---------------------------------------------------------------------------
@@ -426,3 +468,65 @@ def test_a_deletion_only_change_refuses_the_re_anchor_end_to_end(repo):
     )
     assert not decision.allowed
     assert ("lib_a", "helper") in decision.blocking_symbols
+
+
+# ---------------------------------------------------------------------------
+# The ADR-005 ledger line
+# ---------------------------------------------------------------------------
+
+
+def test_a_reanchor_appends_a_register_line(tmp_path, monkeypatch):
+    """A re-anchor is a gate outcome — one of ADR-005's named ledger classes —
+    and it is the one gate outcome nobody paid a model for. Writing the result
+    record with no register line would leave a state mutation with no trace,
+    which is the defect this whole cluster is about.
+    """
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    record = {
+        "gate": "glm_gate", "status": "pass", "contract_hash": "h1",
+        "report_path": "/r.md", "dispatch_id": "glm-gate-pr9-1", "commit_sha": "a" * 40,
+    }
+    decision = gr.ReanchorDecision(
+        allowed=True, reason="identical hash", contract_hash_matches=True,
+        commits_in_range=3, depth=gr.DEPTH_DIRECT,
+    )
+    path = cli.emit_reanchor_event(
+        gate="glm_gate", pr_number=9, record=record, new_sha="b" * 40, decision=decision,
+    )
+    assert path == tmp_path / "dispatch_register.ndjson"
+    lines = [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+    assert len(lines) == 1
+    entry = lines[0]
+    assert entry["event"] == "gate_reanchored"
+    assert entry["gate"] == "glm_gate"
+    assert entry["pr_number"] == 9
+    assert entry["dispatch_id"] == "glm-gate-pr9-1"
+    assert entry["from_commit_sha"] == "a" * 40
+    assert entry["to_commit_sha"] == "b" * 40
+    assert entry["commits_in_range"] == 3
+    assert entry["reason"] == "identical hash"
+
+
+def test_the_register_line_goes_to_the_same_resolver_every_other_gate_line_uses(tmp_path, monkeypatch):
+    """One resolver, not a second ledger invented for this writer."""
+    import gate_register_emit
+
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    assert gate_register_emit.register_path() == tmp_path / "dispatch_register.ndjson"
+    assert gate_register_emit._resolve_register_path() == gate_register_emit.register_path()
+
+
+def test_a_failing_register_write_is_reported_not_swallowed(tmp_path, monkeypatch):
+    """The result is already on disk and carries its own provenance, so the
+    state is sound — but a missing ledger line has to be said out loud."""
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+
+    def _boom(path, record):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cli.state_writer, "append_locked", _boom)
+    with pytest.raises(OSError):
+        cli.emit_reanchor_event(
+            gate="glm_gate", pr_number=9, record={}, new_sha="b" * 40,
+            decision=gr.ReanchorDecision(allowed=True, reason="r"),
+        )

--- a/tests/test_gate_reanchor.py
+++ b/tests/test_gate_reanchor.py
@@ -119,7 +119,7 @@ def test_a_deleted_module_makes_the_whole_module_suspect(repo):
 
 def test_referenced_symbols_captures_a_from_import_and_its_module(repo):
     root, base = repo
-    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"]).symbols
     assert ("lib_a", "helper") in referenced
     assert ("lib_a", gr.MODULE_LEVEL) in referenced
 
@@ -130,7 +130,7 @@ def test_referenced_symbols_captures_module_attribute_access(repo):
         "import lib_a\n\n\ndef run(x):\n    return lib_a.helper(x)\n"
     )
     head = _commit(root, "switch to module import")
-    referenced = gr.referenced_symbols(root, head, ["scripts/consumer.py"])
+    referenced = gr.referenced_symbols(root, head, ["scripts/consumer.py"]).symbols
     assert ("lib_a", "helper") in referenced
 
 
@@ -139,19 +139,21 @@ def test_a_file_the_pr_deleted_contributes_no_references(repo):
     a complete answer, not a gap — refusing on it would refuse every PR that
     removes a file."""
     root, base = repo
-    assert gr.referenced_symbols(root, base, ["scripts/does_not_exist.py"]) == set()
+    result = gr.referenced_symbols(root, base, ["scripts/does_not_exist.py"])
+    assert result.symbols == set()
+    assert result.provable, "a deleted file is a complete answer, not a gap"
 
 
-def test_an_unparseable_file_refuses_instead_of_shrinking_the_reference_set(repo):
-    """Present but unreadable is the opposite case. Skipping it silently
+def test_an_unparseable_file_is_cannot_prove_not_an_empty_reference_set(repo):
+    """Present but unreadable is the opposite of deleted. Skipping it silently
     under-approximates what the PR reaches and then treats the remainder as
     complete — an ALLOW on evidence nobody gathered. Found by codex_gate."""
     root, base = repo
     (root / "scripts" / "broken.py").write_text("def f(:\n    pass\n")
     head = _commit(root, "add an unparseable file")
-    with pytest.raises(gr.ReanchorError) as excinfo:
-        gr.referenced_symbols(root, head, ["scripts/broken.py"])
-    assert "does not parse" in str(excinfo.value)
+    result = gr.referenced_symbols(root, head, ["scripts/broken.py"])
+    assert not result.provable
+    assert "does not parse" in result.unmodelled[0]
 
 
 def test_a_star_import_binds_the_pr_to_the_whole_module(repo):
@@ -161,7 +163,7 @@ def test_a_star_import_binds_the_pr_to_the_whole_module(repo):
     root, base = repo
     (root / "scripts" / "star.py").write_text("from lib_a import *\n\n\ndef run(x):\n    return helper(x)\n")
     head = _commit(root, "add a star importer")
-    referenced = gr.referenced_symbols(root, head, ["scripts/star.py"])
+    referenced = gr.referenced_symbols(root, head, ["scripts/star.py"]).symbols
     assert ("lib_a", gr.WHOLE_MODULE) in referenced
     assert gr.find_blocking_symbols({("lib_a", "untouched")}, referenced) == [
         ("lib_a", "untouched")
@@ -177,7 +179,7 @@ def test_a_module_imported_by_name_still_resolves_its_attributes(repo):
         "from lib import lib_a\n\n\ndef run(x):\n    return lib_a.helper(x)\n"
     )
     head = _commit(root, "add a package-style importer")
-    referenced = gr.referenced_symbols(root, head, ["scripts/pkgstyle.py"])
+    referenced = gr.referenced_symbols(root, head, ["scripts/pkgstyle.py"]).symbols
     assert ("lib_a", "helper") in referenced
 
 
@@ -190,7 +192,7 @@ def test_a_directly_imported_changed_symbol_blocks(repo):
     """The #1688/#1692 shape, in miniature. No indirect modules involved."""
     root, base = repo
     changed = {("lib_a", "helper")}
-    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"]).symbols
     assert gr.find_blocking_symbols(changed, referenced) == [("lib_a", "helper")]
 
 
@@ -201,7 +203,7 @@ def test_a_changed_sibling_in_an_imported_module_does_not_block(repo):
     branch load-bearing."""
     root, base = repo
     changed = {("lib_a", "untouched")}
-    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"]).symbols
     assert gr.find_blocking_symbols(changed, referenced) == []
 
 
@@ -210,21 +212,21 @@ def test_the_same_sibling_blocks_once_the_module_is_only_reached_indirectly(repo
     knowable from its own source, so any change there blocks."""
     root, base = repo
     changed = {("lib_a", "untouched")}
-    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"]).symbols
     assert gr.find_blocking_symbols(changed, referenced, {"lib_a"}) == [("lib_a", "untouched")]
 
 
 def test_a_changed_symbol_the_pr_does_not_reach_does_not_block(repo):
     root, base = repo
     changed = {("lib_a", "helper")}
-    referenced = gr.referenced_symbols(root, base, ["scripts/unrelated.py"])
+    referenced = gr.referenced_symbols(root, base, ["scripts/unrelated.py"]).symbols
     assert gr.find_blocking_symbols(changed, referenced) == []
 
 
 def test_a_module_level_change_blocks_anyone_importing_that_module(repo):
     root, base = repo
     changed = {("lib_a", gr.MODULE_LEVEL)}
-    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"]).symbols
     assert gr.find_blocking_symbols(changed, referenced) == [("lib_a", gr.MODULE_LEVEL)]
 
 
@@ -232,7 +234,8 @@ def test_reachability_is_what_separates_direct_from_transitive(repo):
     """lib_b imports lib_a; a PR touching only lib_b reaches lib_a at depth 1."""
     root, base = repo
     graph = gr.build_import_graph(root, base)
-    assert graph["lib_b"] == {"lib_a"}
+    assert graph.edges["lib_b"] == {"lib_a"}
+    assert graph.unresolved == frozenset()
     direct = gr.reachable_modules({"lib_b"}, graph, gr.DEPTH_DIRECT)
     full = gr.reachable_modules({"lib_b"}, graph, gr.DEPTH_FULL)
     assert direct == {"lib_b"}
@@ -530,3 +533,101 @@ def test_a_failing_register_write_is_reported_not_swallowed(tmp_path, monkeypatc
             gate="glm_gate", pr_number=9, record={}, new_sha="b" * 40,
             decision=gr.ReanchorDecision(allowed=True, reason="r"),
         )
+
+
+# ---------------------------------------------------------------------------
+# cannot_prove — one principle, every unmodelled construct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "import importlib\n\n\ndef run(n):\n    return importlib.import_module(n)\n",
+        "def run(m, n):\n    return getattr(m, n)\n",
+        "def run(n):\n    return __import__(n)\n",
+    ],
+)
+def test_a_dynamic_import_or_lookup_is_cannot_prove(repo, body):
+    """A dynamic import or getattr can reach a name no static walk sees, so
+    the reference set cannot be enumerated. Reporting the smaller set would be
+    indistinguishable from having enumerated it completely."""
+    root, base = repo
+    (root / "scripts" / "dyn.py").write_text(body)
+    head = _commit(root, "add a dynamic reference")
+    result = gr.referenced_symbols(root, head, ["scripts/dyn.py"])
+    assert not result.provable
+    assert "dynamic import" in result.unmodelled[0]
+
+
+def test_a_re_export_resolves_to_the_module_that_really_defines_it(repo):
+    """The quietest hole: the PR writes `from lib_b import helper`, the symbol
+    really lives in lib_a. A commit changing lib_a.helper records
+    (lib_a, helper); without resolution the PR only references
+    (lib_b, helper) and nothing matches — a silent ALLOW on a changed symbol
+    the PR calls.
+    """
+    root, base = repo
+    (root / "scripts" / "reexport.py").write_text(
+        "from lib_b import helper\n\n\ndef run(x):\n    return helper(x)\n"
+    )
+    head = _commit(root, "import a re-exported symbol")
+    result = gr.referenced_symbols(root, head, ["scripts/reexport.py"])
+    assert ("lib_b", "helper") in result.symbols
+    assert ("lib_a", "helper") in result.symbols, "the re-export must resolve one level"
+    assert gr.find_blocking_symbols({("lib_a", "helper")}, result) == [("lib_a", "helper")]
+
+
+def test_an_unresolvable_module_in_the_closure_refuses_the_re_anchor(repo, monkeypatch):
+    """A closure with a hole in it proves nothing about what lies beyond the
+    hole. Dropping such a module silently truncated the closure, so a
+    DEPTH_FULL run could allow without having proved condition (b) at all."""
+    root, base = repo
+    _git(root, "checkout", "-q", "-b", "feature", base)
+    old_head = base
+    _git(root, "checkout", "-q", "main")
+    _change_helper(root)
+    _git(root, "checkout", "-q", "-B", "feature2", "main")
+    tip = _git(root, "rev-parse", "HEAD").strip()
+
+    real = gr.build_import_graph
+
+    def _blind(project_root, ref):
+        graph = real(project_root, ref)
+        return gr.ImportGraph(edges=graph.edges, unresolved=frozenset({"lib_a"}))
+
+    monkeypatch.setattr(gr, "build_import_graph", _blind)
+    decision = gr.can_reanchor(
+        root, old_sha=old_head, new_sha=tip, pr_files=["scripts/consumer.py"],
+        old_contract_hash="h1", new_contract_hash="h1", base_ref="main",
+        depth=gr.DEPTH_FULL,
+    )
+    assert not decision.allowed
+    assert "cannot prove condition (b)" in decision.reason
+    assert "lib_a" in decision.reason
+
+
+def test_an_unparseable_pr_file_refuses_the_re_anchor_end_to_end(repo):
+    root, base = repo
+    _git(root, "checkout", "-q", "-b", "feature", base)
+    old_head = base
+    _git(root, "checkout", "-q", "main")
+    (root / "scripts" / "broken.py").write_text("def f(:\n    pass\n")
+    _commit(root, "unparseable file on main")
+    _git(root, "checkout", "-q", "-B", "feature2", "main")
+    tip = _git(root, "rev-parse", "HEAD").strip()
+
+    decision = gr.can_reanchor(
+        root, old_sha=old_head, new_sha=tip, pr_files=["scripts/broken.py"],
+        old_contract_hash="h1", new_contract_hash="h1", base_ref="main",
+    )
+    assert not decision.allowed
+    assert "cannot prove condition (b)" in decision.reason
+
+
+def test_cannot_prove_beats_a_clean_symbol_analysis():
+    """The ordering matters: an unprovable reference set must refuse even when
+    the symbols it DID find happen not to overlap."""
+    reference = gr.ReferenceSet(symbols=set(), unmodelled=("importlib in x.py",))
+    assert not reference.provable
+    assert gr.find_blocking_symbols({("lib_a", "helper")}, reference) == []

--- a/tests/test_gate_reanchor.py
+++ b/tests/test_gate_reanchor.py
@@ -1,0 +1,370 @@
+"""Regression guards for the OI-1471 re-anchor condition.
+
+Everything here runs against a real git repository built in tmp_path — the
+analysis reads git and parses real source, so a test that faked either would
+pass while the thing itself was broken.
+
+The measured case this is calibrated against: #1688 tightened
+gate_status.has_complete_evidence; #1692 imports and calls it. #1692's diff was
+byte-identical across that shift and its meaning was not. Condition (a) alone
+cannot see that, which is why (b) exists.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+for _p in (REPO_ROOT / "scripts" / "lib", REPO_ROOT / "scripts"):
+    sys.path.insert(0, str(_p))
+
+import gate_reanchor as gr  # noqa: E402
+import gate_reanchor_cli as cli  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# A real repository to measure against
+# ---------------------------------------------------------------------------
+
+
+def _git(root: Path, *args: str) -> str:
+    proc = subprocess.run(["git", *args], cwd=str(root), capture_output=True, text=True)
+    assert proc.returncode == 0, f"git {' '.join(args)} -> {proc.stderr}"
+    return proc.stdout
+
+
+def _commit(root: Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", message)
+    return _git(root, "rev-parse", "HEAD").strip()
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A repo shaped like the real case: a library, a consumer, a branch."""
+    root = tmp_path / "repo"
+    (root / "scripts" / "lib").mkdir(parents=True)
+    (root / "tests").mkdir()
+    _git(root.parent, "init", "-q", "-b", "main", str(root))
+
+    (root / "scripts" / "lib" / "lib_a.py").write_text(
+        "CONSTANT = 1\n\n\ndef helper(x):\n    return x + 1\n\n\ndef untouched(x):\n    return x\n"
+    )
+    (root / "scripts" / "lib" / "lib_b.py").write_text(
+        "from lib_a import helper\n\n\ndef middle(x):\n    return helper(x)\n"
+    )
+    (root / "scripts" / "consumer.py").write_text(
+        "from lib_a import helper\n\n\ndef run(x):\n    return helper(x)\n"
+    )
+    (root / "scripts" / "unrelated.py").write_text("def run(x):\n    return x\n")
+    (root / "tests" / "test_lib_a.py").write_text("def test_x():\n    assert True\n")
+    base = _commit(root, "base")
+    return root, base
+
+
+def _change_helper(root: Path) -> str:
+    path = root / "scripts" / "lib" / "lib_a.py"
+    path.write_text(path.read_text().replace("return x + 1", "return x + 2"))
+    return _commit(root, "tighten helper")
+
+
+# ---------------------------------------------------------------------------
+# changed_symbols
+# ---------------------------------------------------------------------------
+
+
+def test_changed_symbols_names_the_function_a_commit_touched(repo):
+    root, base = repo
+    head = _change_helper(root)
+    assert gr.changed_symbols(root, base, head) == {("lib_a", "helper")}
+
+
+def test_changed_symbols_reports_a_module_level_edit_separately(repo):
+    """A changed constant or dispatch table touches no def, and still changes
+    behaviour for everyone importing the module."""
+    root, base = repo
+    path = root / "scripts" / "lib" / "lib_a.py"
+    path.write_text(path.read_text().replace("CONSTANT = 1", "CONSTANT = 99"))
+    head = _commit(root, "bump constant")
+    assert gr.changed_symbols(root, base, head) == {("lib_a", gr.MODULE_LEVEL)}
+
+
+def test_changed_symbols_ignores_test_files(repo):
+    """A change under tests/ cannot alter the runtime meaning of a call."""
+    root, base = repo
+    (root / "tests" / "test_lib_a.py").write_text("def test_x():\n    assert 1 == 1\n")
+    head = _commit(root, "touch a test")
+    assert gr.changed_symbols(root, base, head) == set()
+
+
+def test_a_deleted_module_makes_the_whole_module_suspect(repo):
+    """Fail-closed: unknown becomes blocking, never invisible."""
+    root, base = repo
+    (root / "scripts" / "lib" / "lib_a.py").unlink()
+    (root / "scripts" / "consumer.py").write_text("def run(x):\n    return x\n")
+    (root / "scripts" / "lib" / "lib_b.py").write_text("def middle(x):\n    return x\n")
+    head = _commit(root, "delete lib_a")
+    assert ("lib_a", gr.WHOLE_MODULE) in gr.changed_symbols(root, base, head)
+
+
+# ---------------------------------------------------------------------------
+# referenced_symbols
+# ---------------------------------------------------------------------------
+
+
+def test_referenced_symbols_captures_a_from_import_and_its_module(repo):
+    root, base = repo
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    assert ("lib_a", "helper") in referenced
+    assert ("lib_a", gr.MODULE_LEVEL) in referenced
+
+
+def test_referenced_symbols_captures_module_attribute_access(repo):
+    root, base = repo
+    (root / "scripts" / "consumer.py").write_text(
+        "import lib_a\n\n\ndef run(x):\n    return lib_a.helper(x)\n"
+    )
+    head = _commit(root, "switch to module import")
+    referenced = gr.referenced_symbols(root, head, ["scripts/consumer.py"])
+    assert ("lib_a", "helper") in referenced
+
+
+def test_referenced_symbols_skips_a_file_that_is_not_in_the_tree(repo):
+    root, base = repo
+    assert gr.referenced_symbols(root, base, ["scripts/does_not_exist.py"]) == set()
+
+
+# ---------------------------------------------------------------------------
+# The blocking decision
+# ---------------------------------------------------------------------------
+
+
+def test_a_directly_imported_changed_symbol_blocks(repo):
+    """The #1688/#1692 shape, in miniature. No indirect modules involved."""
+    root, base = repo
+    changed = {("lib_a", "helper")}
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    assert gr.find_blocking_symbols(changed, referenced) == [("lib_a", "helper")]
+
+
+def test_a_changed_sibling_in_an_imported_module_does_not_block(repo):
+    """`untouched` lives in lib_a, which the PR imports, but the PR does not
+    use it. This is what makes the direct rule symbol-precise rather than
+    module-precise — and it is the assertion that keeps the exact-overlap
+    branch load-bearing."""
+    root, base = repo
+    changed = {("lib_a", "untouched")}
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    assert gr.find_blocking_symbols(changed, referenced) == []
+
+
+def test_the_same_sibling_blocks_once_the_module_is_only_reached_indirectly(repo):
+    """Which symbol of an indirectly-reached module the PR depends on is not
+    knowable from its own source, so any change there blocks."""
+    root, base = repo
+    changed = {("lib_a", "untouched")}
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    assert gr.find_blocking_symbols(changed, referenced, {"lib_a"}) == [("lib_a", "untouched")]
+
+
+def test_a_changed_symbol_the_pr_does_not_reach_does_not_block(repo):
+    root, base = repo
+    changed = {("lib_a", "helper")}
+    referenced = gr.referenced_symbols(root, base, ["scripts/unrelated.py"])
+    assert gr.find_blocking_symbols(changed, referenced) == []
+
+
+def test_a_module_level_change_blocks_anyone_importing_that_module(repo):
+    root, base = repo
+    changed = {("lib_a", gr.MODULE_LEVEL)}
+    referenced = gr.referenced_symbols(root, base, ["scripts/consumer.py"])
+    assert gr.find_blocking_symbols(changed, referenced) == [("lib_a", gr.MODULE_LEVEL)]
+
+
+def test_reachability_is_what_separates_direct_from_transitive(repo):
+    """lib_b imports lib_a; a PR touching only lib_b reaches lib_a at depth 1."""
+    root, base = repo
+    graph = gr.build_import_graph(root, base)
+    assert graph["lib_b"] == {"lib_a"}
+    direct = gr.reachable_modules({"lib_b"}, graph, gr.DEPTH_DIRECT)
+    full = gr.reachable_modules({"lib_b"}, graph, gr.DEPTH_FULL)
+    assert direct == {"lib_b"}
+    assert full == {"lib_a", "lib_b"}
+
+
+def test_the_default_depth_is_direct_and_that_choice_is_deliberate():
+    """Measured: at DEPTH_FULL the analysis refuses #1691 — the PR OI-1471 was
+    written about — because glm_gate transitively reaches gate_status. The
+    default is the depth a diff-reading gate can itself reason about."""
+    assert gr.DEPTH_DEFAULT == gr.DEPTH_DIRECT
+
+
+# ---------------------------------------------------------------------------
+# can_reanchor: both halves, and every unestablished fact refuses
+# ---------------------------------------------------------------------------
+
+
+def _decide(root, old, new, files, old_hash="h1", new_hash="h1", **kw):
+    return gr.can_reanchor(
+        root, old_sha=old, new_sha=new, pr_files=files,
+        old_contract_hash=old_hash, new_contract_hash=new_hash,
+        base_ref="main", **kw,
+    )
+
+
+@pytest.mark.parametrize("old_hash,new_hash", [("", "h1"), ("h1", ""), ("", "")])
+def test_an_empty_contract_hash_refuses(repo, old_hash, new_hash):
+    root, base = repo
+    d = _decide(root, base, base, [], old_hash=old_hash, new_hash=new_hash)
+    assert not d.allowed and "empty" in d.reason
+
+
+def test_a_changed_contract_hash_refuses_without_touching_git(repo):
+    """Condition (a) is free and settles most refusals, so it runs first."""
+    root, base = repo
+    d = _decide(root, "old", "new", [], old_hash="h1", new_hash="h2")
+    assert not d.allowed and "contract hash changed" in d.reason
+    assert d.commits_in_range == 0
+
+
+def test_the_same_commit_has_nothing_to_re_anchor(repo):
+    root, base = repo
+    d = _decide(root, base, base, [])
+    assert not d.allowed and "nothing to re-anchor" in d.reason
+
+
+def test_an_unresolvable_merge_base_refuses(repo):
+    """A rebased-away commit whose objects are gone: without the old
+    merge-base there is no range, so nothing can be proven."""
+    root, base = repo
+    d = _decide(root, "0" * 40, base, [])
+    assert not d.allowed and "merge-base could not be resolved" in d.reason
+
+
+def test_a_moved_base_with_no_overlap_is_allowed(repo):
+    root, base = repo
+    _change_helper(root)
+    _git(root, "checkout", "-q", "-b", "feature", base)
+    (root / "scripts" / "unrelated.py").write_text("def run(x):\n    return x * 3\n")
+    head = _commit(root, "unrelated work")
+    _git(root, "checkout", "-q", "main")
+    _git(root, "checkout", "-q", "-B", "feature2", "main")
+    tip = _git(root, "rev-parse", "HEAD").strip()
+    d = _decide(root, head, tip, ["scripts/unrelated.py"])
+    assert d.allowed, d.reason
+    assert d.commits_in_range == 1
+
+
+def test_a_moved_base_that_changed_a_reached_symbol_refuses(repo):
+    """The whole point: identical diff, changed meaning."""
+    root, base = repo
+    _git(root, "checkout", "-q", "-b", "feature", base)
+    old_head = base
+    _git(root, "checkout", "-q", "main")
+    _change_helper(root)
+    _git(root, "checkout", "-q", "-B", "feature2", "main")
+    tip = _git(root, "rev-parse", "HEAD").strip()
+    d = _decide(root, old_head, tip, ["scripts/consumer.py"])
+    assert not d.allowed
+    assert ("lib_a", "helper") in d.blocking_symbols
+    assert "meaning may" in d.reason
+
+
+def test_an_unmoved_merge_base_is_allowed_without_any_analysis(repo):
+    root, base = repo
+    _git(root, "checkout", "-q", "-b", "feature", base)
+    (root / "scripts" / "unrelated.py").write_text("def run(x):\n    return x * 5\n")
+    head = _commit(root, "branch work")
+    (root / "scripts" / "unrelated.py").write_text("def run(x):\n    return x * 5  # note\n")
+    head2 = _commit(root, "more branch work")
+    d = _decide(root, head, head2, ["scripts/unrelated.py"])
+    assert d.allowed and "merge-base did not move" in d.reason
+
+
+# ---------------------------------------------------------------------------
+# The CLI's own refusals
+# ---------------------------------------------------------------------------
+
+
+def test_only_diff_derived_hash_gates_may_be_re_anchored(capsys):
+    """_compute_contract_hash's fallback is stable across content changes, so
+    hash equality would prove nothing for any other gate."""
+    assert cli.main(["--pr", "1", "--gate", "codex_gate"]) == cli.EXIT_BAD_INPUT
+    err = capsys.readouterr().err
+    assert "no diff-derived contract hash" in err
+
+
+def test_the_diff_derived_gate_list_is_exactly_the_prompt_hashing_gates():
+    assert set(cli.DIFF_DERIVED_HASH_GATES) == {"glm_gate", "kimi_gate"}
+
+
+def test_a_non_terminal_record_has_no_verdict_to_move(tmp_path):
+    results = tmp_path / "results"
+    results.mkdir()
+    (results / "pr-5-glm_gate.json").write_text(json.dumps({
+        "status": "unavailable", "contract_hash": "h", "report_path": "/x",
+    }))
+    with pytest.raises(ValueError) as excinfo:
+        cli.load_existing_result(results, "glm_gate", 5)
+    assert "not terminal" in str(excinfo.value)
+
+
+def test_an_evidence_less_record_cannot_be_relocated(tmp_path):
+    results = tmp_path / "results"
+    results.mkdir()
+    (results / "pr-5-glm_gate.json").write_text(json.dumps({
+        "status": "pass", "contract_hash": "", "report_path": "",
+    }))
+    with pytest.raises(ValueError) as excinfo:
+        cli.load_existing_result(results, "glm_gate", 5)
+    assert "contract_hash" in str(excinfo.value)
+
+
+def test_a_missing_record_is_a_loud_absence(tmp_path):
+    results = tmp_path / "results"
+    results.mkdir()
+    with pytest.raises(FileNotFoundError):
+        cli.load_existing_result(results, "glm_gate", 5)
+
+
+# ---------------------------------------------------------------------------
+# Provenance on the written record
+# ---------------------------------------------------------------------------
+
+
+def test_the_reanchored_payload_keeps_the_evidence_and_stamps_where_it_came_from():
+    record = {
+        "gate": "glm_gate", "status": "pass", "contract_hash": "h1",
+        "report_path": "/reports/r.md", "dispatch_id": "glm-gate-pr1-123",
+        "commit_sha": "a" * 40, "branch": "old", "evidence_source": "live",
+        "blocking_findings": [],
+    }
+    decision = gr.ReanchorDecision(allowed=True, reason="ok", contract_hash_matches=True)
+    payload = cli.build_reanchored_payload(
+        record, new_sha="b" * 40, new_branch="new", decision=decision,
+    )
+    # Evidence carried over verbatim — including the producer that really ran it.
+    assert payload["contract_hash"] == "h1"
+    assert payload["report_path"] == "/reports/r.md"
+    assert payload["dispatch_id"] == "glm-gate-pr1-123"
+    assert payload["status"] == "pass"
+    # Relocated, and impossible to mistake for a fresh purchase.
+    assert payload["commit_sha"] == "b" * 40
+    assert payload["branch"] == "new"
+    assert payload["evidence_source"] == "reanchored"
+    assert payload["reanchored_from_commit_sha"] == "a" * 40
+    assert payload["reanchor_basis"]["allowed"] is True
+    assert payload["reanchored_at"]
+
+
+def test_the_reanchored_payload_does_not_mutate_the_record_it_came_from():
+    record = {"status": "pass", "commit_sha": "a" * 40, "evidence_source": "live"}
+    decision = gr.ReanchorDecision(allowed=True, reason="ok")
+    cli.build_reanchored_payload(record, new_sha="b" * 40, new_branch="n", decision=decision)
+    assert record["commit_sha"] == "a" * 40
+    assert record["evidence_source"] == "live"


### PR DESCRIPTION
Independent of #1703 and #1705 — branches from `main`, merges in any order.

## The measured problem

PR #1691 was gated three times against the identical `contract_hash` `dd5ac45f7e84535e`, across two rebases and three main shifts. For `glm_gate`/`kimi_gate` that hash is `sha256(prompt)[:16]` with the full diff inside the prompt, so an identical hash means the gate judged a byte-identical input. The same review was bought three times.

## Why the hash alone is not enough

The counterexample is from the same day. #1688 tightened `gate_status.has_complete_evidence`; #1692 imports and calls it. #1692's diff was byte-identical across that shift and its meaning was not. So both halves must hold:

- **(a)** the hash the gate would compute for the new head equals the hash on the record
- **(b)** no commit between the old and the new merge-base touches a symbol this PR reaches

## OI-1471 left open whether (b) is affordable. It is.

**(a) is reproducible offline.** Recomputing #1691's prompt hash from `gh pr diff` returns `dd5ac45f7e84535e` exactly. No model call.

**(b) costs 0.20s at the default depth.** The historical decision replays end to end: merge-base `7f93f681` → `f79f9916`, three commits (#1689/#1690/#1688), and the analysis **allows #1691** while **refusing #1692** by name (`gate_status.has_complete_evidence`).

**Over 120 ordered PR pairs from 2026-08-26**, the busiest measured day:

| import depth | allowed | refused |
|---|---|---|
| direct (default) | **87%** | 13% |
| +1 hop | 74% | 26% |
| +2 hops | 69% | 31% |
| full closure | 58% | 42% |

Against a gate run at 1.3–2.8 USD and several minutes, a 0.20s check that clears 87% of them is not a close call.

## The default depth is a measured choice, and it went the unobvious way

At **full closure the analysis refuses #1691 itself** — `glm_gate` transitively reaches `gate_status` — so the conservative setting would have saved nothing for the case that motivated this, while still refusing #1692 for a reason nobody can act on.

The substantive argument: **a review gate judges the diff.** The #1692 failure was catchable precisely because #1692's diff *calls* the changed symbol; a reviewer reading that diff has it in front of them. A change two import hops away is invisible to the gate too, so re-running would not catch it any better than re-anchoring does. Guarding at the depth the gate can reason about is the honest boundary. `--depth full` is there for the paranoid run.

## Only two gates may be re-anchored

`_compute_contract_hash` falls back to `sha256({gate, branch, sorted(changed_files)})` when the request carries no prompt, and **that fallback does not move when file contents change**. Re-anchoring on it would carry a verdict onto a diff nobody reviewed — the exact failure this exists to prevent. Only `glm_gate` and `kimi_gate` hash the diff; every other gate refuses loudly, pinned by test.

## Provenance, not laundering

The write goes through `gate_recorder.record_terminal_result`, so the OI-1469/OI-1470 anti-downgrade guard applies unchanged. The relocated record keeps `status`, `contract_hash`, `report_path` and `dispatch_id` (the producer identity is the run that actually reviewed it — claiming a new one would be the lie) and adds `evidence_source: "reanchored"`, `reanchored_from_commit_sha`, `reanchored_at` and the full decision as `reanchor_basis`. An audit that cannot tell a relocated verdict from a freshly bought one is worse than paying twice.

Read-only by default; `--apply` writes. `vnx gate-reanchor --pr N --gate glm_gate`.

## A defect mutation testing found in this very file

`find_blocking_symbols` had an exact-symbol-overlap branch that **nothing could reach**: `reachable_modules` always contains the directly-imported modules, so the coarse branch subsumed it. The shipped rule was module-precise while the docstring claimed symbol-precision — it would have blocked on a changed *sibling* function the PR never calls. Direct imports are now matched by symbol; only indirectly-reached modules get the coarse treatment. Deleting that line now fails two tests.

## Verification

- `tests/test_gate_reanchor.py` — 30 tests, all against a **real git repository** built in `tmp_path`. The analysis reads git and parses real source; a test that faked either would pass while the thing was broken.
- **Mutation-checked**, three branches: ignore exact symbol overlap → 2 tests fail; stop excluding `tests/` → 1 fails; skip the hash comparison → 1 fails.
- `pytest tests/test_gate_reanchor.py tests/test_gate_recorder_overwrite_guard.py tests/test_gate_obligations.py` → **117 passed**.
- `scripts/ci_lint_patterns.py --scan-stdin` clean; `bash -n bin/vnx` clean; quality advisory `approve_with_followup`, 0 blocking.

## For the operator

The OI's own cost line says "0,4 tot 0,6 per run". The operator's measured band is 1.3–2.8, so the saving this buys is roughly three to five times what the OI estimated. **OI-1471 now has an answer and can be closed** — I have deliberately not touched the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018u28zASUuaqYqLWbRpe3XN