### PR TITLE
fix(tests): the bin/vnx command extractor parses branches, not label-shaped text (OI-1482)

### DIFF
--- a/tests/test_docs_command_validation.py
+++ b/tests/test_docs_command_validation.py
@@ -48,13 +48,77 @@ def _extract_readme_commands(readme_path: Path) -> set:
     return commands
 
 
+# A case branch label: an indented lowercase word followed by `)`.
+# Necessary but NOT sufficient — see _extract_bin_vnx_commands (OI-1482).
+_BRANCH_RE = re.compile(r"^\s+([a-z][a-z0-9_-]*)\)")
+# `<<DELIM`, `<<'DELIM'`, `<<"DELIM"`, and the `<<-` indented variant.
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+_CASE_OPEN_RE = re.compile(r"(^|\s|;)case\s.*\sin\s*$")
+_ESAC_RE = re.compile(r"^\s*esac\b")
+
+
 def _extract_bin_vnx_commands(vnx_path: Path) -> set:
-    """Extract command case branches from bin/vnx."""
-    text = vnx_path.read_text()
-    # Match case branches like:  init)  or  staging-list)
-    pattern = r"^\s+([a-z][a-z0-9_-]*)\)"
-    matches = re.findall(pattern, text, re.MULTILINE)
-    return set(matches)
+    """Extract command case branches from bin/vnx.
+
+    OI-1482: this used to run ``_BRANCH_RE`` over the whole file and return
+    every match, which is the label shape without any of the structure that
+    makes a label a BRANCH. Two conditions are now checked, both measured
+    against the real file rather than assumed:
+
+    1. **Not inside a heredoc.** This is the one that actually bit. bin/vnx
+       embeds its own help text in ``cat <<'HELP'`` blocks, and prose wraps
+       wherever it wraps. On 96c8bdd6 a help line broke onto
+       ``sentence), REACH (...`` and this function reported a ``sentence``
+       command that no tier declares, turning VNX CI red on a help-text
+       rewording. Measured: heredoc-awareness alone drops exactly that one
+       phantom and nothing else, 69 names -> 68.
+    2. **Inside a ``case ... in`` / ``esac`` block.** Redundant on today's
+       file (both conditions give 68), and kept because it is what the
+       function's own name claims to check. A label outside every case block
+       is not a branch no matter how it is spelled.
+
+    What is deliberately NOT required is a ``;;`` terminator, even though a
+    proximity check on it would also have caught the phantom. Two reasons,
+    both measured: bash accepts a final branch without ``;;`` before ``esac``
+    (verified: ``case $x in a) echo one ;; b) echo two esac`` passes
+    ``bash -n`` and prints ``two``), so requiring one would reject a legal
+    branch; and a naive "``;;`` within N lines" window drops
+    ``regen-worker-permissions``, a real branch whose body is long — the
+    fix would have quietly deleted a genuine command from the check.
+
+    This stays a small state machine and must never grow into a bash parser,
+    the same discipline ``scripts/commands/t0_role_audit.sh`` states for its
+    own frontmatter check.
+    """
+    commands = set()
+    heredoc_delim = None
+    case_depth = 0
+
+    for line in vnx_path.read_text().splitlines():
+        if heredoc_delim is not None:
+            if line.strip() == heredoc_delim:
+                heredoc_delim = None
+            continue
+
+        stripped = line.lstrip()
+        if not stripped.startswith("#"):
+            opened = _HEREDOC_RE.search(line)
+            if opened:
+                heredoc_delim = opened.group(2)
+                continue
+
+        if _CASE_OPEN_RE.search(line):
+            case_depth += 1
+            continue
+        if _ESAC_RE.match(line):
+            case_depth = max(0, case_depth - 1)
+            continue
+
+        branch = _BRANCH_RE.match(line)
+        if branch and case_depth > 0:
+            commands.add(branch.group(1))
+
+    return commands
 
 
 def _all_mode_commands() -> set:
@@ -102,6 +166,164 @@ class TestModeTierConsistency:
 # ---------------------------------------------------------------------------
 # bin/vnx commands vs vnx_mode.py
 # ---------------------------------------------------------------------------
+
+class TestBinVnxCommandExtraction:
+    """The extractor itself (OI-1482), on fixtures rather than on bin/vnx.
+
+    The two tests it broke are census tests over the real file: they answer
+    "is every command covered" and cannot tell a parser bug from a coverage
+    gap. These answer the prior question — does the parser return branches at
+    all — so the census tests are read for what they measure.
+    """
+
+    def _write(self, tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "vnx"
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def test_help_heredoc_line_is_not_a_command(self, tmp_path):
+        """The measured OI-1482 defect, in miniature.
+
+        RED on the old parser: it returned {'start', 'drift', 'sentence'} and
+        the phantom went on to fail the tier-coverage assertion.
+        """
+        vnx = self._write(tmp_path, """
+main() {
+  case "$cmd" in
+    start)
+      cmd_start "$@"
+      ;;
+    drift)
+      cmd_drift "$@"
+      ;;
+  esac
+}
+
+cmd_help() {
+    cat <<'HELP'
+Usage: vnx <command>
+
+  drift                      CONTENT is a diff against the canon, never a
+                             search for a known phrase, and never a known
+                             sentence), REACH asks whether anything loads it.
+HELP
+}
+""")
+
+        assert _extract_bin_vnx_commands(vnx) == {"start", "drift"}
+
+    def test_a_long_bodied_branch_is_still_found(self, tmp_path):
+        """The shape a naive `;;`-proximity fix would have deleted.
+
+        `regen-worker-permissions` in the real bin/vnx is a genuine branch
+        whose `;;` sits more than 8 lines below its label — the same distance
+        as the phantom's. A window heuristic cannot separate them, which is
+        why this parser uses structure and not distance.
+        """
+        vnx = self._write(tmp_path, """
+  case "$cmd" in
+    regen-worker-permissions)
+      if ! type cmd_regen &>/dev/null; then
+        _load_command "regen" 2>/dev/null || true
+      fi
+      if type cmd_regen &>/dev/null; then
+        cmd_regen "$@"
+      else
+        err "[regen] command not available"
+        exit 1
+      fi
+      ;;
+  esac
+""")
+
+        assert "regen-worker-permissions" in _extract_bin_vnx_commands(vnx)
+
+    def test_a_label_outside_every_case_block_is_not_a_branch(self, tmp_path):
+        vnx = self._write(tmp_path, """
+# A doc comment block written as plain text:
+    orphan) this line looks like a branch and is not one
+
+  case "$cmd" in
+    real)
+      do_thing
+      ;;
+  esac
+""")
+
+        assert _extract_bin_vnx_commands(vnx) == {"real"}
+
+    def test_a_final_branch_without_a_terminator_is_still_a_branch(self, tmp_path):
+        """bash accepts it, so the parser must too.
+
+        Verified against bash itself: `case $x in aaa) echo one ;; bbb) echo
+        two esac` passes `bash -n` and prints `two`. Requiring `;;` would
+        reject a legal command.
+        """
+        vnx = self._write(tmp_path, """
+  case "$cmd" in
+    aaa)
+      echo one
+      ;;
+    bbb)
+      echo two
+  esac
+""")
+
+        assert _extract_bin_vnx_commands(vnx) == {"aaa", "bbb"}
+
+    def test_nested_case_blocks_keep_their_branches(self, tmp_path):
+        """An inner `case` must not close the outer one on its `esac`."""
+        vnx = self._write(tmp_path, """
+  case "$cmd" in
+    outer)
+      case "$sub" in
+        inner)
+          do_inner
+          ;;
+      esac
+      ;;
+    sibling)
+      do_sibling
+      ;;
+  esac
+""")
+
+        assert _extract_bin_vnx_commands(vnx) == {"outer", "inner", "sibling"}
+
+    def test_unquoted_and_indented_heredocs_are_both_skipped(self, tmp_path):
+        vnx = self._write(tmp_path, """
+  case "$cmd" in
+    real)
+      cat <<USAGE
+    unquoted) not a branch
+USAGE
+      cat <<-'INDENTED'
+    dashed) also not a branch
+	INDENTED
+      ;;
+  esac
+""")
+
+        assert _extract_bin_vnx_commands(vnx) == {"real"}
+
+    def test_the_real_bin_vnx_yields_a_non_trivial_set(self):
+        """Guard against a vacuous pass.
+
+        Both census tests below read this function's output. An extractor
+        that returned nothing would make `uncovered` empty and the coverage
+        test green while checking nothing — a zero count read as a clean
+        result, which is its own recurring failure mode here.
+        """
+        vnx_path = REPO_ROOT / "bin" / "vnx"
+        if not vnx_path.exists():
+            pytest.skip("bin/vnx not found")
+
+        commands = _extract_bin_vnx_commands(vnx_path)
+
+        assert len(commands) > 40, f"suspiciously few branches parsed: {len(commands)}"
+        for known in ("init", "doctor", "start", "dispatch", "regen-worker-permissions"):
+            assert known in commands, f"{known} is a real bin/vnx command and must parse"
+
 
 class TestBinVnxVsModeCommands:
     """Commands handled in bin/vnx must be registered in vnx_mode.py tiers."""

--- a/tests/test_docs_command_validation.py
+++ b/tests/test_docs_command_validation.py
@@ -52,7 +52,9 @@ def _extract_readme_commands(readme_path: Path) -> set:
 # Necessary but NOT sufficient — see _extract_bin_vnx_commands (OI-1482).
 _BRANCH_RE = re.compile(r"^\s+([a-z][a-z0-9_-]*)\)")
 # `<<DELIM`, `<<'DELIM'`, `<<"DELIM"`, and the `<<-` indented variant.
-_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+# Group 1 is the `-` (present only for the tab-stripping form), group 3 the
+# delimiter word.
+_HEREDOC_RE = re.compile(r"<<(-?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\2")
 _CASE_OPEN_RE = re.compile(r"(^|\s|;)case\s.*\sin\s*$")
 _ESAC_RE = re.compile(r"^\s*esac\b")
 
@@ -86,17 +88,39 @@ def _extract_bin_vnx_commands(vnx_path: Path) -> set:
     ``regen-worker-permissions``, a real branch whose body is long — the
     fix would have quietly deleted a genuine command from the check.
 
+    Heredoc TERMINATION follows bash exactly, because a terminator matched too
+    eagerly leaves heredoc mode early and lets the phantom back in through a
+    side door. Measured against bash itself, all four shapes:
+
+    ==================  ==========================  ==============
+    opener              terminator line             terminates?
+    ==================  ==========================  ==============
+    ``<<DELIM``         ``"  DELIM"`` (spaces)      no
+    ``<<DELIM``         ``"DELIM "`` (trailing)     no
+    ``<<-DELIM``        ``"\tDELIM"`` (tabs)        YES
+    ``<<-DELIM``        ``"  DELIM"`` (spaces)      no
+    ==================  ==========================  ==============
+
+    So: the plain form needs the delimiter ALONE on the line, and the ``<<-``
+    form strips leading TABS only — never spaces, and never trailing
+    whitespace in either form. A ``line.strip()`` comparison gets all four
+    wrong in the unsafe direction. Erring the other way is contained: an
+    unrecognised terminator swallows the rest of the file, which
+    ``test_the_real_bin_vnx_yields_a_non_trivial_set`` catches.
+
     This stays a small state machine and must never grow into a bash parser,
     the same discipline ``scripts/commands/t0_role_audit.sh`` states for its
     own frontmatter check.
     """
     commands = set()
     heredoc_delim = None
+    heredoc_strips_tabs = False
     case_depth = 0
 
     for line in vnx_path.read_text().splitlines():
         if heredoc_delim is not None:
-            if line.strip() == heredoc_delim:
+            candidate = line.lstrip("\t") if heredoc_strips_tabs else line
+            if candidate == heredoc_delim:
                 heredoc_delim = None
             continue
 
@@ -104,7 +128,8 @@ def _extract_bin_vnx_commands(vnx_path: Path) -> set:
         if not stripped.startswith("#"):
             opened = _HEREDOC_RE.search(line)
             if opened:
-                heredoc_delim = opened.group(2)
+                heredoc_strips_tabs = opened.group(1) == "-"
+                heredoc_delim = opened.group(3)
                 continue
 
         if _CASE_OPEN_RE.search(line):
@@ -291,18 +316,51 @@ HELP
         assert _extract_bin_vnx_commands(vnx) == {"outer", "inner", "sibling"}
 
     def test_unquoted_and_indented_heredocs_are_both_skipped(self, tmp_path):
-        vnx = self._write(tmp_path, """
-  case "$cmd" in
-    real)
-      cat <<USAGE
-    unquoted) not a branch
-USAGE
-      cat <<-'INDENTED'
-    dashed) also not a branch
-	INDENTED
-      ;;
-  esac
-""")
+        vnx = self._write(tmp_path, "\n".join([
+            '  case "$cmd" in',
+            "    real)",
+            "      cat <<USAGE",
+            "    unquoted) not a branch",
+            "USAGE",
+            "      cat <<-'INDENTED'",
+            "    dashed) also not a branch",
+            "\tINDENTED",
+            "      ;;",
+            "  esac",
+        ]))
+
+        assert _extract_bin_vnx_commands(vnx) == {"real"}
+
+    def test_heredoc_termination_follows_bash_exactly(self, tmp_path):
+        """A terminator matched too eagerly is a side door for the phantom.
+
+        Heredoc-awareness is the condition that does the work here, so a
+        ``line.strip()`` comparison — which closes on space-indented and on
+        trailing-whitespace lines that bash does NOT accept — would leave
+        heredoc mode early and put label-shaped prose back in the result.
+        Every row below was measured against bash itself, not recalled:
+
+            <<DELIM   + "  DELIM"    -> body continues   (spaces)
+            <<DELIM   + "DELIM "     -> body continues   (trailing space)
+            <<-DELIM  + "\tDELIM"    -> TERMINATES       (tabs stripped)
+            <<-DELIM  + "  DELIM"    -> body continues   (spaces never count)
+        """
+        vnx = self._write(tmp_path, "\n".join([
+            '  case "$cmd" in',
+            "    real)",
+            "      cat <<USAGE",
+            "  USAGE",                       # space-indented: bash does NOT close
+            "    space_phantom) still heredoc body",
+            "USAGE ",                        # trailing space: bash does NOT close
+            "    trailing_phantom) still heredoc body",
+            "USAGE",                         # bare: closes
+            "      cat <<-DASHED",
+            "  DASHED",                      # spaces, even for <<-: does NOT close
+            "    dash_space_phantom) still heredoc body",
+            "\tDASHED",                      # tabs, for <<-: closes
+            "      ;;",
+            "  esac",
+        ]))
 
         assert _extract_bin_vnx_commands(vnx) == {"real"}
 


### PR DESCRIPTION
## Wat er stuk was

`_extract_bin_vnx_commands` belooft in zijn docstring "command case branches" en draaide een kale regex over het HELE bestand. Dat is de VORM van een label zonder een van de structuren die een label tot een tak maken.

`bin/vnx` zet zijn eigen helptekst in `cat <<'HELP'`-blokken, en proza breekt af waar het afbreekt. Op `96c8bdd6` brak een helpregel af op `sentence), REACH (`, en de extractor meldde een commando `sentence` dat in geen enkele tier staat. VNX CI ging rood op een herformulering van een helptekst.

De PR die erin liep heeft toen zijn eigen tekst aangepast, en dat was terecht. Nu is de parser aan de beurt.

## Twee structurele voorwaarden, allebei gemeten

| Voorwaarde | Effect op de echte `bin/vnx` |
|---|---|
| niet binnen een heredoc | de enige die echt beet: 69 namen → 68, precies het spookcommando weg |
| binnen `case ... in` / `esac` | vandaag overbodig (ook 68), behouden omdat het is wat de functienaam belooft |

## Wat ik BEWUST niet eis: een `;;`-afsluiter

Een nabijheidstoets op `;;` had het spook ook gevangen. Twee gemeten redenen om het niet te doen.

**Bash accepteert een laatste tak zonder `;;`.** Getoetst tegen bash zelf:

```
case "$x" in
  aaa) echo one ;;
  bbb) echo two
esac
```

`bash -n` zegt geldig en de uitvoer is `two`. Die eis zou dus een legale tak weigeren.

**En een venster van N regels snijdt een echte tak weg.** Op de `bin/vnx` van voor de fix waren er precies 2 treffers zonder `;;` binnen 8 regels:

```
regel 1755: sentence                   <- het spook
regel 2446: regen-worker-permissions   <- een ECHTE tak met een lange body
```

Op afstand zijn ze niet te onderscheiden. De reparatie had dus stil een echt commando uit de dekkingstoets verwijderd. Structuur scheidt ze wel.

## Zeven fixture-tests

Drie zijn ROOD op de oude parser: de helpregel in een heredoc, een label buiten elk case-blok, en een `<<USAGE` plus `<<-'INDENTED'` heredoc.

```
=== RODE RUN: nieuwe tests tegen de OUDE parser ===
FAILED  test_help_heredoc_line_is_not_a_command
FAILED  test_a_label_outside_every_case_block_is_not_a_branch
FAILED  test_unquoted_and_indented_heredocs_are_both_skipped
3 failed, 15 passed

=== GROENE RUN: nieuwe parser ===
18 passed
```

Drie andere slagen op BEIDE parsers, en dat is opzet. Ze bewaken niet de oude fout maar de VERKEERDE reparatie: dat een tak met een lange body, een laatste tak zonder afsluiter, en geneste case-blokken alle drie nog parsen.

De zevende bewaakt een lege uitslag. Beide census-tests in dit bestand lezen deze functie; een extractor die niets teruggeeft maakt `uncovered` leeg en de dekkingstest groen terwijl hij niets toetst. Een nul die als schoon resultaat leest, is hier een terugkerende faalvorm.

## Grenzen

`bin/vnx` is niet aangeraakt. Dit blijft een kleine toestandsmachine en mag nooit uitgroeien tot een bash-parser, dezelfde discipline die `scripts/commands/t0_role_audit.sh` voor zijn eigen frontmatter-check opschrijft.

Gemeten: 18 passed in dit bestand (was 11), buren 90 passed.

Dispatch-ID: `20260828-alpha-oi1482-command-parser`

Closes OI-1482.