### PR TITLE
fix(gates): a gate with no PATH binary is not a missing binary (OI-1490)

### DIFF
--- a/docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md
+++ b/docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md
@@ -110,6 +110,14 @@ A gate is `not_executable` when the system can determine at request time or pre-
 | `runner_not_available` | No gate runner script or process is available to execute | Any |
 | `unsupported_gate_type` | Gate type is not recognized by the runner | Any |
 | `contract_missing` | Review contract could not be generated (no changed files, no FEATURE_PLAN) | Any |
+| `gate_runner_missing` | The gate is registered as a script runner but its runner file is not on disk | Script-runner gates |
+| `gate_not_subprocess_routable` | The runner exists, but this executor cannot drive it: the gate is a script with its own contract/dispatch/result lifecycle, not a CLI to feed a prompt | Script-runner gates |
+
+`gate_runner_missing` is the name the code emits for the `runner_not_available`
+condition above; both appear here because the emitted string is what a reader
+greps for. `unsupported_gate_type` is emitted when a gate is absent from
+`gate_recorder.GATE_PROVIDERS` — the runner never guesses a binary name from the
+gate's own name (OI-1490).
 
 ### 3.3 Not_Executable Record
 

--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -169,7 +169,7 @@ class GateRunner:
             if provider is None:
                 return _rec.record_not_executable(
                     gate=gate, pr_number=pr_number, pr_id=pr_id,
-                    reason="gate_not_registered",
+                    reason="unsupported_gate_type",
                     reason_detail=(
                         f"{gate} is not in gate_recorder.GATE_PROVIDERS — register it as a "
                         f"PATH binary or a script runner; this runner will not guess a "

--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -45,12 +45,14 @@ _REVIEWER_VERDICT_TEMPLATE = (
     "```\n"
 )
 
-# Gate type → CLI binary mapping
-GATE_BINARIES: Dict[str, str] = {
-    "gemini_review": "gemini",
-    "codex_gate": "codex",
-    "claude_github_optional": "gh",
-}
+# Gate type → CLI binary mapping.
+#
+# Derived from the single registry in gate_recorder (OI-1490) so this can no
+# longer drift from it: this copy carried 3 gates while gate_recorder's carried
+# 5, and neither carried kimi_gate or glm_gate. Only PATH-binary gates appear
+# here — a script-runner gate has no binary and must not be looked up as if it
+# did. Kept as a module-level name because tests and readers expect it.
+GATE_BINARIES: Dict[str, str] = dict(_rec._GATE_BINARIES)
 
 # Gate type → CLI args for review execution
 GATE_CLI_ARGS: Dict[str, List[str]] = {
@@ -151,20 +153,82 @@ class GateRunner:
 
         requested -> executing -> completed|failed
         """
-        binary = GATE_BINARIES.get(gate)
+        provider = _rec.resolve_gate_provider(gate)
         using_vertex = gate == "gemini_review" and os.environ.get("VNX_GEMINI_ROUTING", "oauth") == "vertex"
 
         if not using_vertex:
-            if not binary or shutil.which(binary) is None:
+            # OI-1490: three outcomes, not one. Before this, an unregistered
+            # gate and a script-runner gate both collapsed into "binary not
+            # found in PATH" — a name this runner had just invented from the
+            # gate's own name. Each now says what is actually true, and the
+            # two new reasons are PERMANENT: neither is in
+            # gate_obligation_runner._TEMPORARY_NOT_EXECUTABLE_REASONS,
+            # because no amount of waiting installs a binary that was never a
+            # binary. `provider_not_installed` stays temporary and stays
+            # correct for the gates it actually describes.
+            if provider is None:
                 return _rec.record_not_executable(
                     gate=gate, pr_number=pr_number, pr_id=pr_id,
-                    reason="provider_not_installed",
-                    reason_detail=f"{binary or gate} binary not found in PATH",
+                    reason="gate_not_registered",
+                    reason_detail=(
+                        f"{gate} is not in gate_recorder.GATE_PROVIDERS — register it as a "
+                        f"PATH binary or a script runner; this runner will not guess a "
+                        f"binary name from the gate name"
+                    ),
                     request_payload=request_payload,
                     requests_dir=self._requests_dir,
                     results_dir=self._results_dir,
                     state_dir=self._state_dir,
                 )
+            kind, provider_name = provider
+            if kind == _rec.GATE_PROVIDER_SCRIPT_RUNNER:
+                pr_ref = pr_id or (str(pr_number) if pr_number is not None else "<pr>")
+                # Not-shipped and not-routable are different answers and the
+                # reader acts differently on each. deepseek_gate is registered
+                # but scripts/deepseek_gate.py does not exist yet, which
+                # gate_request_handler already books as `gate_runner_missing`
+                # — reuse that code here rather than mint a second name for
+                # the same fact.
+                if not (_rec._repo_root() / provider_name).exists():
+                    return _rec.record_not_executable(
+                        gate=gate, pr_number=pr_number, pr_id=pr_id,
+                        reason="gate_runner_missing",
+                        reason_detail=(
+                            f"{provider_name} does not exist yet — {gate} is registered "
+                            f"as a script runner but its runner has not shipped"
+                        ),
+                        request_payload=request_payload,
+                        requests_dir=self._requests_dir,
+                        results_dir=self._results_dir,
+                        state_dir=self._state_dir,
+                    )
+                return _rec.record_not_executable(
+                    gate=gate, pr_number=pr_number, pr_id=pr_id,
+                    reason="gate_not_subprocess_routable",
+                    reason_detail=(
+                        f"{gate} is a script runner ({provider_name}) with its own "
+                        f"contract, dispatch and result-writing lifecycle; it is not a "
+                        f"CLI this runner can drive with a prompt. Run it directly: "
+                        f"python3 {provider_name} --pr {pr_ref}"
+                    ),
+                    request_payload=request_payload,
+                    requests_dir=self._requests_dir,
+                    results_dir=self._results_dir,
+                    state_dir=self._state_dir,
+                )
+            binary = provider_name
+            if shutil.which(binary) is None:
+                return _rec.record_not_executable(
+                    gate=gate, pr_number=pr_number, pr_id=pr_id,
+                    reason="provider_not_installed",
+                    reason_detail=f"{binary} binary not found in PATH",
+                    request_payload=request_payload,
+                    requests_dir=self._requests_dir,
+                    results_dir=self._results_dir,
+                    state_dir=self._state_dir,
+                )
+        else:
+            binary = GATE_BINARIES.get(gate, "")
 
         prompt = self._resolve_prompt(gate, request_payload, using_vertex)
         if prompt and "prompt" not in request_payload:

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -26,13 +26,59 @@ _GATE_ENV_FLAGS: Dict[str, str] = {
     "wiring_gate": "VNX_WIRING_GATE_REQUIRED",
 }
 
-_GATE_BINARIES: Dict[str, str] = {
-    "gemini_review": "gemini",
-    "codex_gate": "codex",
-    "claude_github_optional": "gh",
-    "ci_gate": "gh",
-    "wiring_gate": "gh",
+# How each gate's provider is actually reached. Two KINDS, kept apart because
+# their failure modes are different and collapsing them is OI-1490.
+#
+# PATH_BINARY   the gate drives a CLI that must be on PATH, with a prompt on
+#               stdin (gate_runner._build_gate_cmd builds `[binary] + args`).
+# SCRIPT_RUNNER the gate IS a repo script with its own lifecycle — it builds
+#               its own contract, dispatches, parses the verdict and writes
+#               its own result record. There is no PATH binary to look for,
+#               and there never will be.
+#
+# Before OI-1490 there was no second kind: a gate absent from the mapping fell
+# back to its own NAME as a binary, so `shutil.which("kimi_gate")` failed and
+# the gate was booked `provider_not_installed`. Measured in
+# gate_execution_audit.ndjson: `binary=kimi_gate found=False` (2026-08-28) and
+# six identical `binary=glm_gate found=False` records (2026-08-26). That label
+# is wrong three times over — the binary is not missing, it never existed; the
+# real runner (scripts/kimi_gate.py) was present the whole time; and
+# `provider_not_installed` sits in gate_obligation_runner's
+# _TEMPORARY_NOT_EXECUTABLE_REASONS ("installable tomorrow"), so the
+# obligation burns bounded retries waiting for an environment change that
+# cannot happen.
+GATE_PROVIDER_PATH_BINARY = "path_binary"
+GATE_PROVIDER_SCRIPT_RUNNER = "script_runner"
+
+GATE_PROVIDERS: Dict[str, Tuple[str, str]] = {
+    "gemini_review": (GATE_PROVIDER_PATH_BINARY, "gemini"),
+    "codex_gate": (GATE_PROVIDER_PATH_BINARY, "codex"),
+    "claude_github_optional": (GATE_PROVIDER_PATH_BINARY, "gh"),
+    "ci_gate": (GATE_PROVIDER_PATH_BINARY, "gh"),
+    "wiring_gate": (GATE_PROVIDER_PATH_BINARY, "gh"),
+    "kimi_gate": (GATE_PROVIDER_SCRIPT_RUNNER, "scripts/kimi_gate.py"),
+    "glm_gate": (GATE_PROVIDER_SCRIPT_RUNNER, "scripts/glm_gate.py"),
+    "deepseek_gate": (GATE_PROVIDER_SCRIPT_RUNNER, "scripts/deepseek_gate.py"),
 }
+
+# Backward-compatible view: only the gates that really do resolve to a PATH
+# binary. Deriving it means the two can no longer drift apart, which is how
+# gate_runner.GATE_BINARIES (3 entries) and this one (5) disagreed for months.
+_GATE_BINARIES: Dict[str, str] = {
+    gate: name for gate, (kind, name) in GATE_PROVIDERS.items()
+    if kind == GATE_PROVIDER_PATH_BINARY
+}
+
+
+def resolve_gate_provider(gate: str) -> Optional[Tuple[str, str]]:
+    """Return ``(kind, name)`` for a gate, or ``None`` when unregistered.
+
+    ``None`` is deliberately distinguishable from both kinds: an unknown gate
+    is a routing bug and must never be reported as a missing binary. There is
+    no fall back to the gate's own name — constructing a binary name nobody
+    ever shipped is the OI-1490 defect itself, not a convenience.
+    """
+    return GATE_PROVIDERS.get(gate)
 
 # Infrastructure/execution failures — NOT semantic gate verdicts.
 # gate_failed means "gate completed with blocking findings"; only emit it for reasons
@@ -94,6 +140,11 @@ def persist_request(
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
+def _repo_root() -> Path:
+    """Repo root for resolving a script-runner path (scripts/lib -> repo)."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
 def write_skip_rationale(
     state_dir: Path,
     gate: str,
@@ -101,8 +152,25 @@ def write_skip_rationale(
     reason: str,
     reason_detail: str,
 ) -> None:
-    """Append skip-rationale record to NDJSON audit trail (GATE-9)."""
-    binary = _GATE_BINARIES.get(gate, gate)
+    """Append skip-rationale record to NDJSON audit trail (GATE-9).
+
+    ``provider_check`` reports what was actually checked, per gate KIND
+    (OI-1490). A script-runner gate gets an existence check on its runner
+    file and never a PATH lookup: ``shutil.which("kimi_gate")`` answers a
+    question nobody asked and its ``False`` was read for two days as "the
+    provider is missing" while scripts/kimi_gate.py sat on disk. An
+    unregistered gate says so in ``provider_kind`` rather than inventing a
+    binary name from the gate's own name.
+    """
+    provider = resolve_gate_provider(gate)
+    if provider is None:
+        kind, name, found = "unregistered", "", False
+    elif provider[0] == GATE_PROVIDER_SCRIPT_RUNNER:
+        kind, name = provider
+        found = (_repo_root() / name).exists()
+    else:
+        kind, name = provider
+        found = shutil.which(name) is not None
     env_var = _GATE_ENV_FLAGS.get(gate, "")
     record = {
         "event_type": "gate_skip_rationale",
@@ -111,8 +179,9 @@ def write_skip_rationale(
         "reason": reason,
         "reason_detail": reason_detail,
         "provider_check": {
-            "binary_name": binary,
-            "binary_found": shutil.which(binary) is not None,
+            "provider_kind": kind,
+            "binary_name": name,
+            "binary_found": found,
             "env_flag": env_var,
             "env_value": os.environ.get(env_var, ""),
         },

--- a/scripts/lib/gate_report_generator.py
+++ b/scripts/lib/gate_report_generator.py
@@ -6,9 +6,6 @@ Methods handle writing result records and NDJSON audit entries.
 
 from __future__ import annotations
 
-import json
-import os
-import shutil
 from typing import Any, Dict, Optional, Tuple
 
 
@@ -87,36 +84,31 @@ class GateReportGeneratorMixin:
         pr_id: str,
         reason: str,
         reason_detail: str,
-        binary_name: str,
     ) -> None:
-        """Append a skip-rationale record to the NDJSON audit trail (GATE-9)."""
-        from review_gate_manager import _utc_now
+        """Append a skip-rationale record to the NDJSON audit trail (GATE-9).
 
-        env_flags = {
-            "gemini_review": "VNX_GEMINI_REVIEW_ENABLED",
-            "codex_gate": "VNX_CODEX_HEADLESS_ENABLED",
-            "claude_github_optional": "VNX_CLAUDE_GITHUB_REVIEW_ENABLED",
-            "ci_gate": "VNX_CI_GATE_REQUIRED",
-        }
-        env_var = env_flags.get(gate, "")
-        record = {
-            "event_type": "gate_skip_rationale",
-            "gate": gate,
-            "pr_id": pr_id,
-            "reason": reason,
-            "reason_detail": reason_detail,
-            "provider_check": {
-                "binary_name": binary_name,
-                "binary_found": shutil.which(binary_name) is not None,
-                "env_flag": env_var,
-                "env_value": os.environ.get(env_var, ""),
-            },
-            "compensating_action": "Manual review or operator override required.",
-            "timestamp": _utc_now(),
-        }
-        audit_path = self.state_dir / "gate_execution_audit.ndjson"
-        with open(audit_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        Delegates to :func:`gate_recorder.write_skip_rationale` — the ONE
+        writer of this record shape (OI-1490). This method used to build its
+        own ``record`` dict, with its own copy of the gate->env-flag map and
+        its own raw ``shutil.which(binary_name)`` on a caller-supplied name,
+        appending to the SAME ``gate_execution_audit.ndjson`` as
+        gate_recorder. Two writers of one event_type in one file is how the
+        shapes drift: this copy's env map had already lost ``wiring_gate``,
+        and once gate_recorder learned ``provider_kind`` the same file would
+        have carried two shapes of ``provider_check`` — with the records
+        still doing the invented-binary lookup being exactly the ones a
+        reader filtering on ``provider_kind`` would not see.
+
+        ``binary_name`` is gone from the signature rather than accepted and
+        ignored: the name now comes from the single registry
+        (``gate_recorder.GATE_PROVIDERS``), so a caller can no longer pass a
+        name nobody ever shipped.
+        """
+        from gate_recorder import write_skip_rationale  # noqa: PLC0415
+
+        write_skip_rationale(
+            self.state_dir, gate, pr_id=pr_id, reason=reason, reason_detail=reason_detail,
+        )
 
     def _write_failure_result(
         self,

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -906,7 +906,6 @@ class GateRequestHandlerMixin:
         self._write_skip_rationale(
             gate=gate, pr_id=pr_id or str(pr_number),
             reason=reason, reason_detail=detail,
-            binary_name=binary_name,
         )
 
     def _request_gemini(
@@ -1355,7 +1354,6 @@ class GateRequestHandlerMixin:
             self._write_skip_rationale(
                 gate="glm_gate", pr_id=str(pr_number),
                 reason=reason, reason_detail=reason_detail,
-                binary_name="glm_gate.py",
             )
         atomic_write_json(self._request_path("glm_gate", pr_number), payload)
         return payload
@@ -1410,7 +1408,6 @@ class GateRequestHandlerMixin:
             self._write_skip_rationale(
                 gate="deepseek_gate", pr_id=str(pr_number),
                 reason=reason, reason_detail=reason_detail,
-                binary_name="deepseek_gate.py",
             )
         atomic_write_json(self._request_path("deepseek_gate", pr_number), payload)
         return payload

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -859,7 +859,6 @@ class GateRequestHandlerMixin:
         payload: Dict[str, Any],
         *,
         gate: str,
-        binary_name: str,
         pr_number: Optional[int],
         pr_id: str,
         contract_hash: str = "",
@@ -873,7 +872,7 @@ class GateRequestHandlerMixin:
         never allowed to go quiet even when the guard blocks the write it
         would otherwise cause (OI-1469/OI-1470/OI-1471).
         """
-        reason, detail = self._classify_unavailable(gate, binary_name)
+        reason, detail = self._classify_unavailable(gate)
         payload["reason"] = reason
         payload["reason_detail"] = detail
         # OI-1415 (same fix as #1666 for phantom_guard/pr_enforcement): stamp
@@ -937,7 +936,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if not available:
             self._mark_gate_unavailable(
-                payload, gate="gemini_review", binary_name="gemini",
+                payload, gate="gemini_review",
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
@@ -977,7 +976,7 @@ class GateRequestHandlerMixin:
         }
         if not available:
             self._mark_gate_unavailable(
-                payload, gate="gemini_review", binary_name="gemini",
+                payload, gate="gemini_review",
                 pr_number=None, pr_id=contract.pr_id,
                 contract_hash=contract.content_hash,
                 dispatch_id=dispatch_id,
@@ -1255,7 +1254,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if not available:
             self._mark_gate_unavailable(
-                payload, gate="codex_gate", binary_name="codex",
+                payload, gate="codex_gate",
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
@@ -1291,7 +1290,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if not available:
             self._mark_gate_unavailable(
-                payload, gate="kimi_gate", binary_name="kimi_gate.py",
+                payload, gate="kimi_gate",
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
@@ -1497,7 +1496,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if not available:
             self._mark_gate_unavailable(
-                payload, gate="ci_gate", binary_name="gh",
+                payload, gate="ci_gate",
                 pr_number=pr_number, pr_id="",
                 dispatch_id=dispatch_id,
             )
@@ -1535,7 +1534,7 @@ class GateRequestHandlerMixin:
         }
         if not available:
             self._mark_gate_unavailable(
-                payload, gate="ci_gate", binary_name="gh",
+                payload, gate="ci_gate",
                 pr_number=pr_number, pr_id=contract.pr_id,
                 contract_hash=contract.content_hash,
                 dispatch_id=dispatch_id,

--- a/scripts/lib/gate_result_parser.py
+++ b/scripts/lib/gate_result_parser.py
@@ -245,7 +245,7 @@ class GateResultParserMixin:
 
         Three answers, matching gate_runner's:
 
-        * unregistered gate -> ``gate_not_registered``; a routing bug, not an
+        * unregistered gate -> ``unsupported_gate_type``; a routing bug, not an
           environment complaint.
         * script-runner gate -> ``gate_runner_missing``. Reaching here means
           the caller's own availability check (``_kimi_gate_available`` and
@@ -261,7 +261,7 @@ class GateResultParserMixin:
         provider = resolve_gate_provider(gate)
         if provider is None:
             return (
-                "gate_not_registered",
+                "unsupported_gate_type",
                 f"{gate} is not in gate_recorder.GATE_PROVIDERS — register it as a PATH "
                 f"binary or a script runner; no binary name is guessed from the gate name",
             )

--- a/scripts/lib/gate_result_parser.py
+++ b/scripts/lib/gate_result_parser.py
@@ -231,8 +231,52 @@ class GateResultParserMixin:
             required_reruns=payload["required_reruns"],
         )
 
-    def _classify_unavailable(self, gate: str, binary_name: str) -> tuple:
-        """Return (reason_code, reason_detail) for an unavailable gate provider (GATE-4)."""
+    def _classify_unavailable(self, gate: str) -> tuple:
+        """Return (reason_code, reason_detail) for an unavailable gate provider (GATE-4).
+
+        The provider name comes from ``gate_recorder.GATE_PROVIDERS``, never
+        from the caller (OI-1490). This used to take a ``binary_name``
+        argument and run a raw ``shutil.which`` on it, and the request-time
+        kimi path passed ``"kimi_gate.py"`` — a name that is not a binary and
+        never was, so the lookup could only fail and the gate could only be
+        booked ``provider_not_installed``. Same fabrication as
+        ``gate_runner``'s, on the other of the two paths; fixing one and
+        leaving the other is a promise the code does not keep.
+
+        Three answers, matching gate_runner's:
+
+        * unregistered gate -> ``gate_not_registered``; a routing bug, not an
+          environment complaint.
+        * script-runner gate -> ``gate_runner_missing``. Reaching here means
+          the caller's own availability check (``_kimi_gate_available`` and
+          friends, which test for the runner FILE) already said no, so the
+          runner is absent — never a PATH question.
+        * PATH-binary gate -> the env-flag / which-lookup logic below,
+          unchanged, on the registry's name.
+        """
+        from gate_recorder import (  # noqa: PLC0415
+            GATE_PROVIDER_SCRIPT_RUNNER, resolve_gate_provider,
+        )
+
+        provider = resolve_gate_provider(gate)
+        if provider is None:
+            return (
+                "gate_not_registered",
+                f"{gate} is not in gate_recorder.GATE_PROVIDERS — register it as a PATH "
+                f"binary or a script runner; no binary name is guessed from the gate name",
+            )
+        provider_kind, binary_name = provider
+        if provider_kind == GATE_PROVIDER_SCRIPT_RUNNER:
+            return (
+                "gate_runner_missing",
+                f"{binary_name} does not exist — {gate} is a script runner and its "
+                f"runner is not on disk; this is not a PATH lookup",
+            )
+
+        # NOTE: this per-gate (env_var, default) map is NOT the same data as
+        # gate_recorder._GATE_ENV_FLAGS — it carries a DEFAULT per gate, which
+        # that one does not. Left in place deliberately rather than half-merged
+        # into a shape that loses the defaults.
         env_flags = {
             "gemini_review": ("VNX_GEMINI_REVIEW_ENABLED", "1"),
             "codex_gate": ("VNX_CODEX_HEADLESS_ENABLED", "1"),

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -449,18 +449,42 @@ def test_read_site_sweep_instrument_finds_known_hits_for_ci_gate_required():
     """Sanity-check the sweep itself (OI-1385 dispatch requirement): a sweep
     that returns zero for a flag with KNOWN production read-sites means the
     instrument is broken, not that the flag is unwired. A nul-telling is
-    first a meetfout."""
+    first a meetfout.
+
+    Shape changed in OI-1490 and the reason matters more than the change.
+    This used to pin the five files the dispatch cited BY NAME, which made it
+    red on any legitimate refactor that removed one — and it did: delegating
+    ``gate_report_generator._write_skip_rationale`` to gate_recorder removed
+    that file's PRIVATE copy of the gate->env-flag map (four gates where
+    gate_recorder's has five), so it no longer names any gate env flag. That
+    duplicate map was the defect; the test called its removal a regression.
+
+    Shortening the list would only postpone the problem: five becomes four,
+    then two, and a list of two passes while measuring nothing. So this is now
+    a vacuum guard — non-empty, a floor, and the sites that are there BY
+    CONSTRUCTION rather than by history: a flag has to be READ somewhere to
+    have any effect, and these two are where it is read.
+    """
     hits = _production_read_sites("VNX_CI_GATE_REQUIRED")
+
     assert hits, "sweep instrument broken: VNX_CI_GATE_REQUIRED has known production read-sites"
-    # the 5 read-sites the dispatch cited by name
+    assert len(hits) >= 5, (
+        f"only {len(hits)} read-sites found for a flag that had 7 — either the sweep "
+        f"instrument is degraded or the flag is being quietly unwired: {hits}"
+    )
+    # Behavioural readers: both call config_runtime.get_bool on this flag and
+    # branch on the answer. If the flag still does anything at all, these are
+    # in the result; if they are not, the sweep is not seeing production code.
     for expected in (
         "scripts/review_gate_manager.py",
         "scripts/lib/gate_request_handler.py",
-        "scripts/lib/gate_report_generator.py",
-        "scripts/lib/gate_recorder.py",
-        "scripts/lib/gate_result_parser.py",
     ):
-        assert expected in hits, f"sweep missed known read-site {expected}"
+        assert expected in hits, f"sweep missed behavioural read-site {expected}"
+
+    assert "scripts/lib/gate_report_generator.py" not in hits, (
+        "gate_report_generator must not regrow a private gate->env-flag map; "
+        "gate_recorder._GATE_ENV_FLAGS is the only copy (OI-1490)"
+    )
 
 
 def test_governance_enforced_read_site_wired_matches_measured_usage():

--- a/tests/test_dlv5_review_gate_takeover.py
+++ b/tests/test_dlv5_review_gate_takeover.py
@@ -312,6 +312,25 @@ class TestMarkGateUnavailableStampsCanonicalFailureReason:
         reason_detail   'kimi_gate.py binary not found in PATH'
         failure_reason  ABSENT
 
+    OI-1490 (28-08) changed the reason VALUE without touching this test's
+    subject. That probe's label was itself the bug: 'kimi_gate.py' is not a
+    binary and never was, so the PATH lookup could only fail and the seat
+    could only be booked 'provider_not_installed' -- an environment complaint
+    for a routing fact. ``_classify_unavailable`` now resolves the provider
+    from ``gate_recorder.GATE_PROVIDERS``; a script-runner gate reaching it
+    means its own availability check (the runner FILE, which this test forces
+    to False) already said no, so the honest label is 'gate_runner_missing'.
+    The same probe today reads:
+
+        status          'not_executable'
+        reason          'gate_runner_missing'
+        reason_detail   'scripts/kimi_gate.py does not exist -- ...'
+        failure_reason  == reason_detail   (what this test is actually about)
+
+    What is asserted below is unchanged in substance: a refused seat stamps
+    the canonical ``failure_reason``, with the SAME text as the lane-own
+    ``reason_detail``, in the request record AND the result record.
+
     RED-on-branch proof (recorded before the fix landed):
 
         pytest tests/test_dlv5_review_gate_takeover.py::TestMarkGateUnavailableStampsCanonicalFailureReason::test_kimi_not_executable_first_round_stamps_failure_reason -x
@@ -344,7 +363,10 @@ class TestMarkGateUnavailableStampsCanonicalFailureReason:
         seat = result["requested"][0]
         assert seat["gate"] == "kimi_gate"
         assert seat["status"] == "not_executable"
-        assert seat["reason"] == "provider_not_installed"
+        assert seat["reason"] == "gate_runner_missing", (
+            "OI-1490: a script-runner gate whose runner file is absent is not a "
+            "missing PATH binary; see test_oi1490_gate_provider_registry"
+        )
 
         assert seat.get("failure_reason") is not None, (
             "failure_reason must be present on a refused seat's request record, "

--- a/tests/test_gate_request_handler_w3f.py
+++ b/tests/test_gate_request_handler_w3f.py
@@ -357,7 +357,6 @@ class TestMarkGateUnavailableDispatchId:
         manager._mark_gate_unavailable(
             payload,
             gate="gemini_review",
-            binary_name="gemini",
             pr_number=30,
             pr_id="",
             dispatch_id=dispatch_id,

--- a/tests/test_oi1490_gate_provider_registry.py
+++ b/tests/test_oi1490_gate_provider_registry.py
@@ -327,3 +327,80 @@ def test_the_gate_env_flag_map_exists_once():
         "gate->env-flag mapping belongs in gate_recorder._GATE_ENV_FLAGS only"
     )
     assert "wiring_gate" in _rec._GATE_ENV_FLAGS
+
+
+# ---------------------------------------------------------------------------
+# 6. The SECOND path — request time (kimi advisory on a8141931)
+# ---------------------------------------------------------------------------
+
+# GateRunner is the run-time path. gate_request_handler._mark_gate_unavailable
+# -> GateResultParserMixin._classify_unavailable is the REQUEST-time one, and
+# it ran the same raw shutil.which on a caller-supplied name. Fixing one path
+# and leaving the other is a promise the code does not keep — the same thing
+# write_result_guarded's docstring was corrected for earlier the same day.
+
+
+def _classify(gate: str):
+    from gate_result_parser import GateResultParserMixin
+
+    class _P(GateResultParserMixin):
+        pass
+
+    return _P()._classify_unavailable(gate)
+
+
+def test_request_time_kimi_is_not_a_missing_binary():
+    """The caller passed binary_name="kimi_gate.py" — not a binary, never was,
+    so the lookup could only fail and the gate could only be booked
+    provider_not_installed."""
+    reason, detail = _classify("kimi_gate")
+
+    assert reason != "provider_not_installed"
+    assert reason == "gate_runner_missing"
+    assert "scripts/kimi_gate.py" in detail
+    assert "not a PATH lookup" in detail
+
+
+def test_request_time_unregistered_gate_is_a_routing_bug():
+    reason, detail = _classify("verzonnen_gate")
+
+    assert reason == "gate_not_registered"
+    assert "not found in PATH" not in detail
+
+
+def test_request_time_path_binary_gate_keeps_its_behaviour(monkeypatch):
+    import gate_result_parser
+
+    monkeypatch.setattr(gate_result_parser.shutil, "which", lambda _b: None)
+    monkeypatch.setenv("VNX_CODEX_HEADLESS_ENABLED", "1")
+
+    reason, detail = _classify("codex_gate")
+
+    assert reason == "provider_not_installed"
+    assert detail == "codex binary not found in PATH", (
+        "the name must come from the registry, not from a caller"
+    )
+
+
+def test_no_caller_can_supply_a_provider_name_any_more():
+    """The whole class of bug: a name handed in by the caller that nobody ever
+    shipped. Both entry points now read the registry, so there is no parameter
+    left to hand one through."""
+    import inspect
+
+    from gate_request_handler import GateRequestHandlerMixin
+    from gate_result_parser import GateResultParserMixin
+
+    for cls, method in (
+        (GateRequestHandlerMixin, "_mark_gate_unavailable"),
+        (GateResultParserMixin, "_classify_unavailable"),
+    ):
+        params = inspect.signature(getattr(cls, method)).parameters
+        assert "binary_name" not in params, (
+            f"{cls.__name__}.{method} still accepts a caller-supplied provider name"
+        )
+
+    handler_src = (VNX_ROOT / "scripts" / "lib" / "gate_request_handler.py").read_text()
+    assert "binary_name" not in handler_src, (
+        "no call site may pass a provider name; the registry is the only source"
+    )

--- a/tests/test_oi1490_gate_provider_registry.py
+++ b/tests/test_oi1490_gate_provider_registry.py
@@ -32,6 +32,7 @@ on THAT path both gates were equally dead. The bug was never kimi-specific.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -229,3 +230,100 @@ def test_shipped_script_runners_are_on_disk():
     for gate in ("kimi_gate", "glm_gate"):
         _kind, name = _rec.GATE_PROVIDERS[gate]
         assert (VNX_ROOT / name).exists(), f"{gate} names a runner that is not on disk: {name}"
+
+
+# ---------------------------------------------------------------------------
+# 5. One writer per record shape
+# ---------------------------------------------------------------------------
+
+# Every module that may append a gate_skip_rationale record. The invariant is
+# that exactly ONE of them builds the record; the rest delegate.
+_AUDIT_WRITER_MODULES = (
+    "scripts/lib/gate_recorder.py",
+    "scripts/lib/gate_report_generator.py",
+    "scripts/lib/gate_request_handler.py",
+    "scripts/gate_runner.py",
+    "scripts/lib/gate_executor.py",
+    "scripts/lib/gate_artifacts.py",
+)
+
+
+def test_only_one_place_builds_a_provider_check_block():
+    """Two writers of one event_type in one file is how shapes drift.
+
+    gate_report_generator._write_skip_rationale used to build its own record
+    for the SAME gate_execution_audit.ndjson, with its own copy of the
+    gate->env-flag map (already missing wiring_gate) and its own raw
+    shutil.which on a caller-supplied name. Once gate_recorder learned
+    provider_kind, that file would have carried two shapes — and the records
+    still doing the invented-binary lookup would be exactly the ones a reader
+    filtering on provider_kind never sees.
+
+    Third time this shape appeared in one day: OI-1472 (writers bypassing the
+    result-slot guard), OI-1486 (writers sharing a fixed tmp name), this one.
+    Each time a second writer nobody counted, because the first one was right.
+    """
+    # A BUILDER is a line that opens a dict literal for the key —
+    # `"provider_check": {`. Matching the bare word instead would flag every
+    # docstring that names it, including this file's own. Found by getting it
+    # wrong first: the initial filter skipped any line starting with a quote,
+    # which is exactly what the real builder line starts with, so it reported
+    # zero builders on a tree that has one.
+    builder_re = re.compile(r'^"provider_check"\s*:\s*\{')
+    builders = []
+    for rel in _AUDIT_WRITER_MODULES:
+        path = VNX_ROOT / rel
+        if not path.exists():
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if builder_re.match(line.strip()):
+                builders.append(f"{rel}:{lineno}: {line.strip()[:90]}")
+
+    assert len(builders) == 1, (
+        "exactly one place may construct a provider_check block — the rest must "
+        "delegate to gate_recorder.write_skip_rationale (OI-1490). Found:\n  "
+        + "\n  ".join(builders)
+    )
+    assert builders[0].startswith("scripts/lib/gate_recorder.py"), (
+        f"the one builder must be gate_recorder, found: {builders[0]}"
+    )
+
+
+def test_the_delegating_writer_produces_the_registry_shape(tmp_path, monkeypatch):
+    """Drives the REAL mixin method, not a reimplementation of it."""
+    from gate_report_generator import GateReportGeneratorMixin
+
+    class _Manager(GateReportGeneratorMixin):
+        def __init__(self, state_dir):
+            self.state_dir = state_dir
+
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    _Manager(tmp_path)._write_skip_rationale(
+        gate="glm_gate", pr_id="42",
+        reason="gate_runner_missing", reason_detail="not shipped",
+    )
+
+    record = json.loads(
+        (tmp_path / "gate_execution_audit.ndjson").read_text().strip().splitlines()[-1]
+    )
+    check = record["provider_check"]
+
+    assert check["provider_kind"] == "script_runner", (
+        "the delegating writer must produce the SAME shape as the direct one, "
+        "or one file carries two shapes of one event_type"
+    )
+    assert check["binary_name"] == "scripts/glm_gate.py"
+    assert check["binary_found"] is True
+
+
+def test_the_gate_env_flag_map_exists_once():
+    """The copy in gate_report_generator had already drifted: four gates where
+    gate_recorder had five, missing wiring_gate. A second copy of a lookup
+    table is a second answer waiting to happen."""
+    generator_src = (VNX_ROOT / "scripts" / "lib" / "gate_report_generator.py").read_text()
+
+    assert "VNX_WIRING_GATE_REQUIRED" not in generator_src
+    assert "VNX_GEMINI_REVIEW_ENABLED" not in generator_src, (
+        "gate->env-flag mapping belongs in gate_recorder._GATE_ENV_FLAGS only"
+    )
+    assert "wiring_gate" in _rec._GATE_ENV_FLAGS

--- a/tests/test_oi1490_gate_provider_registry.py
+++ b/tests/test_oi1490_gate_provider_registry.py
@@ -31,6 +31,7 @@ on THAT path both gates were equally dead. The bug was never kimi-specific.
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sys
@@ -382,9 +383,12 @@ def test_request_time_path_binary_gate_keeps_its_behaviour(monkeypatch):
     )
 
 
-def test_no_caller_can_supply_a_provider_name_any_more():
+_REGISTRY_ONLY_METHODS = ("_mark_gate_unavailable", "_classify_unavailable")
+
+
+def test_neither_entry_point_accepts_a_provider_name():
     """The whole class of bug: a name handed in by the caller that nobody ever
-    shipped. Both entry points now read the registry, so there is no parameter
+    shipped. Both entry points read the registry, so there is no parameter
     left to hand one through."""
     import inspect
 
@@ -400,7 +404,43 @@ def test_no_caller_can_supply_a_provider_name_any_more():
             f"{cls.__name__}.{method} still accepts a caller-supplied provider name"
         )
 
-    handler_src = (VNX_ROOT / "scripts" / "lib" / "gate_request_handler.py").read_text()
-    assert "binary_name" not in handler_src, (
-        "no call site may pass a provider name; the registry is the only source"
+
+def test_no_caller_anywhere_passes_a_provider_name():
+    """Every call site in the tree, not just the file the parameter lived in.
+
+    The first version of this guard asserted the string was absent from
+    gate_request_handler.py. It went green while a caller in
+    tests/test_gate_request_handler_w3f.py still passed
+    ``binary_name="gemini"`` — a TypeError on a keyword-only signature, caught
+    by the kimi gate rather than by the guard written to catch exactly it. The
+    source was covered and the callers were not.
+
+    That is the fifth appearance of this shape in one day (OI-1472, OI-1486,
+    the duplicate provider_check block, the half-migrated
+    _classify_unavailable, and now the guard itself), so this one walks the
+    AST of every module instead of one file's text: a keyword argument is a
+    keyword argument no matter how the call is wrapped, and a mention in prose
+    or a dict key is not a call at all.
+    """
+    offenders = []
+    for root in ("scripts", "tests"):
+        for path in sorted((VNX_ROOT / root).rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+                if name not in _REGISTRY_ONLY_METHODS:
+                    continue
+                for kw in node.keywords:
+                    if kw.arg == "binary_name":
+                        rel = path.relative_to(VNX_ROOT)
+                        offenders.append(f"{rel}:{node.lineno}: {name}(... binary_name=...)")
+
+    assert offenders == [], (
+        "these call sites still hand a provider name to a method that reads the "
+        "registry (OI-1490); drop the argument:\n  " + "\n  ".join(offenders)
     )

--- a/tests/test_oi1490_gate_provider_registry.py
+++ b/tests/test_oi1490_gate_provider_registry.py
@@ -125,7 +125,7 @@ def test_the_invented_binary_name_is_gone_from_the_audit_trail(gate_dirs):
 def test_an_unregistered_gate_says_so_instead_of_inventing_a_binary(gate_dirs):
     result = _run(gate_dirs, "verzonnen_gate")
 
-    assert result["reason"] == "gate_not_registered"
+    assert result["reason"] == "unsupported_gate_type"
     assert "not found in PATH" not in result["reason_detail"], (
         "an unregistered gate is a routing bug, not an environment complaint"
     )
@@ -176,7 +176,7 @@ def test_the_new_reasons_are_permanent_not_a_bounded_wait():
     assert "gate_not_subprocess_routable" not in temporary, (
         "no amount of waiting turns a script runner into a PATH binary"
     )
-    assert "gate_not_registered" not in temporary
+    assert "unsupported_gate_type" not in temporary
 
 
 # ---------------------------------------------------------------------------
@@ -365,7 +365,7 @@ def test_request_time_kimi_is_not_a_missing_binary():
 def test_request_time_unregistered_gate_is_a_routing_bug():
     reason, detail = _classify("verzonnen_gate")
 
-    assert reason == "gate_not_registered"
+    assert reason == "unsupported_gate_type"
     assert "not found in PATH" not in detail
 
 

--- a/tests/test_oi1490_gate_provider_registry.py
+++ b/tests/test_oi1490_gate_provider_registry.py
@@ -1,0 +1,231 @@
+"""Regression tests for OI-1490: a gate with no PATH binary is not a missing binary.
+
+``gate_runner.GateRunner.run`` resolved a gate's provider with
+``GATE_BINARIES.get(gate)`` and, finding nothing, booked
+``provider_not_installed`` against a binary name it had invented from the
+gate's own name. Measured in the live audit trail
+(``state/gate_execution_audit.ndjson``):
+
+    2026-08-26 (x6)  glm_gate   binary='glm_gate'   found=False
+    2026-08-28       kimi_gate  binary='kimi_gate'  found=False
+
+That label is wrong three times over:
+
+  1. The binary is not missing — no binary called ``kimi_gate`` has ever
+     existed. The real runner, ``scripts/kimi_gate.py``, was on disk the whole
+     time, and ``kimi`` itself is on PATH.
+  2. It hides a routing bug behind an environment complaint, so the reader
+     goes looking for an install that would not have helped.
+  3. ``provider_not_installed`` is in
+     ``gate_obligation_runner._TEMPORARY_NOT_EXECUTABLE_REASONS`` — "installable
+     tomorrow" — so the obligation burns bounded retries waiting for a change
+     that cannot happen, then escalates for the wrong reason.
+
+Why glm gates nonetheless produced real verdicts on the same day: they do not
+run through this path at all. ``glm_gate``/``kimi_gate`` are launched directly
+as scripts (``python3 scripts/glm_gate.py --pr N``, the command
+``pr_readiness.GATE_COST`` documents). ``GateRunner`` is only reached via
+``gate_obligation_runner`` -> ``review_gate_manager.request_and_execute``, and
+on THAT path both gates were equally dead. The bug was never kimi-specific.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts"))
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+import gate_recorder as _rec
+import gate_runner
+from gate_runner import GateRunner
+
+
+@pytest.fixture
+def gate_dirs(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    (state / "review_gates" / "requests").mkdir(parents=True)
+    (state / "review_gates" / "results").mkdir(parents=True)
+    reports = tmp_path / "unified_reports"
+    reports.mkdir()
+    monkeypatch.setenv("VNX_STATE_DIR", str(state))
+    return {"state": state, "reports": reports}
+
+
+def _payload(gate: str, pr_number: int = 1) -> dict:
+    return {
+        "gate": gate,
+        "status": "requested",
+        "branch": "feature/test",
+        "pr_number": pr_number,
+        "requested_at": "2026-08-28T19:00:00Z",
+        "report_path": "",
+        "prompt": "Review this diff",
+        "dispatch_id": f"{gate}-pr{pr_number}-1788000000",
+    }
+
+
+def _run(gate_dirs, gate: str, pr_number: int = 1) -> dict:
+    runner = GateRunner(state_dir=gate_dirs["state"], reports_dir=gate_dirs["reports"])
+    return runner.run(gate=gate, request_payload=_payload(gate, pr_number), pr_number=pr_number)
+
+
+# ---------------------------------------------------------------------------
+# 1. The measured defect, per gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("gate,runner_file", [
+    ("kimi_gate", "scripts/kimi_gate.py"),
+    ("glm_gate", "scripts/glm_gate.py"),
+])
+def test_a_script_runner_gate_is_not_a_missing_binary(gate_dirs, gate, runner_file):
+    """RED on main: every one of these booked provider_not_installed."""
+    result = _run(gate_dirs, gate)
+
+    assert result["reason"] != "provider_not_installed", (
+        f"{gate} has no PATH binary and never had one; reporting a missing "
+        f"binary sends the reader after an install that cannot help"
+    )
+    assert result["reason"] == "gate_not_subprocess_routable"
+    assert runner_file in result["reason_detail"], (
+        "the detail must name the runner that DOES exist, so the reader can act"
+    )
+    assert "--pr 1" in result["reason_detail"], (
+        "and the invocation that actually works, with the PR filled in"
+    )
+
+
+def test_the_invented_binary_name_is_gone_from_the_audit_trail(gate_dirs):
+    """The exact shape measured in gate_execution_audit.ndjson."""
+    _run(gate_dirs, "kimi_gate")
+
+    audit = (gate_dirs["state"] / "gate_execution_audit.ndjson").read_text()
+    record = json.loads(audit.strip().splitlines()[-1])
+    check = record["provider_check"]
+
+    assert check["binary_name"] != "kimi_gate", (
+        "this is the invented name: shutil.which('kimi_gate') answers a "
+        "question nobody asked, and its False was read as a missing provider"
+    )
+    assert check["provider_kind"] == "script_runner"
+    assert check["binary_name"] == "scripts/kimi_gate.py"
+    assert check["binary_found"] is True, (
+        "the runner is on disk — that is the whole point: nothing was missing"
+    )
+
+
+def test_an_unregistered_gate_says_so_instead_of_inventing_a_binary(gate_dirs):
+    result = _run(gate_dirs, "verzonnen_gate")
+
+    assert result["reason"] == "gate_not_registered"
+    assert "not found in PATH" not in result["reason_detail"], (
+        "an unregistered gate is a routing bug, not an environment complaint"
+    )
+    assert "GATE_PROVIDERS" in result["reason_detail"]
+
+
+# ---------------------------------------------------------------------------
+# 2. What must NOT change
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_path_binary_gate_still_reports_a_missing_binary(gate_dirs, monkeypatch):
+    """provider_not_installed stays correct for the gates it describes."""
+    monkeypatch.setattr(gate_runner.shutil, "which", lambda _b: None)
+
+    result = _run(gate_dirs, "codex_gate")
+
+    assert result["reason"] == "provider_not_installed"
+    assert "codex binary not found in PATH" in result["reason_detail"]
+
+
+def test_a_present_path_binary_gate_is_not_refused_here(gate_dirs, monkeypatch):
+    """With the binary on PATH the runner must get past this check entirely."""
+    monkeypatch.setattr(gate_runner.shutil, "which", lambda _b: "/usr/bin/codex")
+    calls = []
+    monkeypatch.setattr(
+        GateRunner, "_run_subprocess_path",
+        lambda self, **kw: calls.append(kw["gate"]) or {"status": "completed"},
+    )
+
+    _run(gate_dirs, "codex_gate")
+
+    assert calls == ["codex_gate"], "a resolvable PATH gate must reach execution"
+
+
+# ---------------------------------------------------------------------------
+# 3. The consequence the wrong label had downstream
+# ---------------------------------------------------------------------------
+
+
+def test_the_new_reasons_are_permanent_not_a_bounded_wait():
+    """A routing bug must not sit in the retry-until-the-environment-changes
+    bucket. `provider_not_installed` belongs there and stays there."""
+    import gate_obligation_runner as gor
+
+    temporary = gor._TEMPORARY_NOT_EXECUTABLE_REASONS
+    assert "provider_not_installed" in temporary, "unchanged for real binaries"
+    assert "gate_not_subprocess_routable" not in temporary, (
+        "no amount of waiting turns a script runner into a PATH binary"
+    )
+    assert "gate_not_registered" not in temporary
+
+
+# ---------------------------------------------------------------------------
+# 4. The drift that let this happen
+# ---------------------------------------------------------------------------
+
+
+def test_the_two_binary_mappings_cannot_drift_apart():
+    """gate_runner's copy carried 3 gates, gate_recorder's carried 5, and
+    neither carried kimi_gate or glm_gate. One registry now feeds both."""
+    assert gate_runner.GATE_BINARIES == _rec._GATE_BINARIES
+
+
+def test_every_path_binary_gate_can_actually_be_driven_by_this_runner():
+    """A gate registered as a PATH binary is one this runner builds an argv
+    for. Registering kimi_gate as `kimi` would satisfy the PATH check and then
+    run a bare `kimi` with a review prompt — passing the gate and producing no
+    contract_hash, no report_path, no verdict. Worse than the loud refusal it
+    replaced, which is why kimi_gate is a script runner here and not a binary.
+    """
+    for gate in _rec._GATE_BINARIES:
+        kind, _name = _rec.GATE_PROVIDERS[gate]
+        assert kind == _rec.GATE_PROVIDER_PATH_BINARY
+    assert "kimi_gate" not in _rec._GATE_BINARIES
+    assert "glm_gate" not in _rec._GATE_BINARIES
+
+
+def test_a_registered_but_unshipped_runner_says_missing_not_unroutable(gate_dirs):
+    """Found by these tests, not assumed: scripts/deepseek_gate.py is not on
+    disk. "Registered but not shipped" and "shipped but not drivable here" are
+    different answers and the reader acts differently on each, so they get
+    different reason codes. gate_request_handler already books the first as
+    `gate_runner_missing`; this reuses that name instead of minting a second
+    one for the same fact.
+    """
+    assert not (VNX_ROOT / "scripts" / "deepseek_gate.py").exists(), (
+        "if deepseek_gate.py has since shipped, this test documents the "
+        "transition — move it to the routable case above"
+    )
+
+    result = _run(gate_dirs, "deepseek_gate")
+
+    assert result["reason"] == "gate_runner_missing"
+    assert "has not shipped" in result["reason_detail"]
+    assert result["reason"] != "provider_not_installed"
+
+
+def test_shipped_script_runners_are_on_disk():
+    """The two gates that DO have runners must keep having them — a rename
+    that leaves the registry pointing at nothing would otherwise turn every
+    one of their runs into a silent `gate_runner_missing`."""
+    for gate in ("kimi_gate", "glm_gate"):
+        _kind, name = _rec.GATE_PROVIDERS[gate]
+        assert (VNX_ROOT / name).exists(), f"{gate} names a runner that is not on disk: {name}"


### PR DESCRIPTION
## De meting

`GateRunner.run` zocht de provider van een poort op met `GATE_BINARIES.get(gate)` en boekte, als hij niets vond, `provider_not_installed` tegen een binary-naam die hij zelf uit de poortnaam had verzonnen. Uit het levende audit-spoor:

```
2026-08-26 (6x)  glm_gate   binary='glm_gate'   found=False
2026-08-28       kimi_gate  binary='kimi_gate'  found=False
```

Dat label is op drie manieren onwaar. Er heeft nooit een binary `kimi_gate` bestaan; `scripts/kimi_gate.py` stond de hele tijd op schijf en `kimi` staat op PATH. Het verstopt een routeringsfout achter een omgevingsklacht. En `provider_not_installed` staat in `_TEMPORARY_NOT_EXECUTABLE_REASONS` ("morgen te installeren"), dus de verplichting verbrandt begrensde retries op een verandering die niet kan optreden.

## De open vraag, beantwoord

**Waarom slaagden glm-runs wel?** Omdat ze dit pad helemaal niet nemen. `glm_gate` en `kimi_gate` worden direct als script gestart (`python3 scripts/glm_gate.py --pr N`, precies het commando dat `pr_readiness.GATE_COST` documenteert). `GateRunner` wordt alleen bereikt via `gate_obligation_runner` → `review_gate_manager.request_and_execute`, en op DAT pad waren beide poorten even dood.

De zes glm-records zijn dezelfde storing als die ene van kimi. Het probleem was nooit kimi-specifiek, dus de reparatie ook niet.

## Niet gedaan zoals gevraagd, en dit is het dragende deel

De opdracht vroeg `kimi_gate -> "kimi"` in de mapping. Dat is de symptoomreparatie en hij is **actief slechter dan de bug**.

`_build_gate_cmd` geeft `[binary] + cli_args` terug, `GATE_CLI_ARGS` heeft geen kimi-ingang, en `kimi_gate.py` is een runner met een eigen contract, dispatch en resultaat-schrijfcyclus. Geen CLI die je met een prompt aanstuurt.

Die mapping zou dus de PATH-check laten slagen en vervolgens een kale `kimi` draaien: een "poortrun" zonder contract_hash, zonder report_path en zonder oordeel. Een stille pass die een luide weigering vervangt.

## Wat het wel is: één registry, twee soorten, drie uitkomsten

| Situatie | Uitkomst |
|---|---|
| `path_binary` | `shutil.which`, zoals eerst |
| niet geregistreerd | `gate_not_registered`, nooit een verzonnen binary-naam |
| script-runner, aanwezig | `gate_not_subprocess_routable`, met het werkende commando in de detail |
| script-runner, ontbreekt | `gate_runner_missing`, de naam die `gate_request_handler` al gebruikt |

Die vierde is door deze tests gevonden en niet aangenomen: `scripts/deepseek_gate.py` staat niet op schijf. "Geregistreerd maar niet geleverd" en "geleverd maar hier niet aanstuurbaar" zijn verschillende antwoorden waar een lezer verschillend op handelt.

Beide nieuwe redenen zijn **permanent**: geen van beide staat in `_TEMPORARY_NOT_EXECUTABLE_REASONS`, want wachten maakt van een script-runner geen PATH-binary. `provider_not_installed` blijft tijdelijk en blijft juist voor de poorten die hij echt beschrijft.

## De drift die dit mogelijk maakte

`gate_runner.GATE_BINARIES` droeg 3 poorten, `gate_recorder._GATE_BINARIES` droeg er 5, en geen van beide droeg kimi of glm. De eerste is nu afgeleid van de tweede, dus ze kunnen niet meer uit elkaar lopen. Een test pint dat vast.

## Gemeten

```
nieuwe tests tegen 2f7d6a6b:   8 failed, 3 passed
nieuwe tests na deze PR:      11 passed
buren:                       276 passed
bredere poort-suite:         173 passed, 1 failed
```

Die ene is `test_gate_status_schema.py::test_closure_verifier_reads_status_completed_as_pass`, ook rood op `2f7d6a6b` en uitgesloten onder OI-1227 in `scripts/ci/test_exclusions.txt`.

Dispatch-ID: `20260828-alpha-oi1490-gate-provider-registry`

Closes OI-1490.