### PR TITLE
feat(router): record every routing decision, including the declined ones (OI-1494)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1354,6 +1354,12 @@ def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[DoorRouteResul
     Fail-open for the classifier and other unexpected errors — but fail-loud for
     registry drift (ADR-036 §2): a RegistryLookupError (unknown provider/model)
     propagates so the door rejects instead of silently falling back to CLAUDE.
+
+    ``dispatch_id`` is passed through so the router's decision ledger (OI-1494)
+    can tie a record back to the dispatch it describes, and so the staging
+    canary buckets on the dispatch's stable identity rather than on its content.
+    This is the router's only production call site: a decision made here that is
+    not written down is not observable anywhere else.
     """
     try:
         from providers.smart_router.door_routing import resolve_door_route  # noqa: PLC0415
@@ -1371,6 +1377,7 @@ def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[DoorRouteResul
             target_slot=spec.target_slot,
             instruction_text=instruction_text,
             file_paths=file_paths,
+            dispatch_id=spec.dispatch_id,
         )
     except RegistryLookupError:
         # ADR-036 §2: unknown provider/model is drift, not a routing bug — the

--- a/scripts/lib/providers/smart_router/decision_log.py
+++ b/scripts/lib/providers/smart_router/decision_log.py
@@ -1,0 +1,129 @@
+"""decision_log.py — Observation ledger for every smart-router decision (OI-1494).
+
+The router has been default-on since 2026-08-02 — no kill-switch is set anywhere — while
+every per-tier enable flag and the canary sat at 0. ``staging.staging_verdict`` declines
+before ``tier_routing.resolve_tier_route`` is ever reached, so the route the router WOULD
+have chosen was not merely unused: it was never computed, and nothing about the decision
+was written down.
+
+That is a rollout with no observation layer. The staging design ramps a tier up on
+evidence, but no evidence can accumulate while the declined half of the split records
+nothing — so the flags stay at 0 because there is nothing to justify raising them, and
+there is nothing to justify raising them because the flags are at 0.
+
+This module breaks that loop. Every decision the door makes is appended here: the applied
+ones AND the declined ones, each carrying the provider, model and lane the router settled
+on. The dispatch is unaffected — a declined dispatch still follows the legacy lane, byte
+for byte as before. The router observes; it does not act.
+
+Recording is ON by default, with ``VNX_ROUTER_DECISION_LOG_DISABLE`` as the kill-switch.
+That direction is deliberate: an observation layer behind an opt-in flag that nobody sets
+observes nothing, which is the exact shape of the bug this closes.
+
+Writing is fail-open throughout — a broken ledger must never block a dispatch. The append
+follows the fcntl-locked NDJSON contract of ``decision_shadow._atomic_append`` (exclusive
+flock on a sentinel, then a plain append under a second flock). Deliberately NOT the
+fixed-name ``<path>.tmp`` + ``os.replace`` form: two writers sharing one tmp name lose
+records (OI-1486). There is no shared NDJSON-append helper in scripts/lib — some twenty
+modules each carry their own copy of this primitive — so this follows the decision_shadow
+copy verbatim to keep a later consolidation a grep rather than a search.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+ROUTER_DECISION_LEDGER = "router_decisions.ndjson"
+
+# Kill-switch, not an opt-in: see the module docstring on why the direction matters.
+DISABLE_FLAG = "VNX_ROUTER_DECISION_LOG_DISABLE"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def recording_enabled(env: Optional[dict] = None) -> bool:
+    """True unless the kill-switch is set. Default ON."""
+    _env = os.environ if env is None else env
+    return str(_env.get(DISABLE_FLAG, "")).strip().lower() not in _TRUTHY
+
+
+def _state_dir(state_dir: "str | Path | None") -> Path:
+    if state_dir is not None:
+        return Path(state_dir)
+    from vnx_paths import resolve_state_dir  # noqa: PLC0415
+
+    return resolve_state_dir()
+
+
+def ledger_path(state_dir: "str | Path | None" = None) -> Path:
+    """Absolute path of the router-decision ledger for this project's state dir."""
+    return _state_dir(state_dir) / ROUTER_DECISION_LEDGER
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_append(path: Path, record: Dict[str, Any], lock_name: str) -> None:
+    """fcntl-locked NDJSON append (same contract as decision_shadow/append_receipt)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sentinel = path.parent / lock_name
+    with sentinel.open("a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        with path.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(json.dumps(record, separators=(",", ":"), sort_keys=False) + "\n")
+
+
+def record_router_decision(
+    *,
+    tier: Optional[str],
+    applied: bool,
+    decline_reason: Optional[str],
+    would_route: Optional[Dict[str, Any]],
+    target_slot: str,
+    dispatch_id: Optional[str] = None,
+    compute_error: Optional[str] = None,
+    state_dir: "str | Path | None" = None,
+    env: Optional[dict] = None,
+    ts: Optional[str] = None,
+) -> bool:
+    """Append one router decision to the ledger. Returns whether a record was written.
+
+    ``applied`` separates the two halves of the trail: True means the door acted on
+    ``would_route``, False means it computed the route and followed the legacy lane
+    anyway. ``compute_error`` is set when the route could not be computed at all — an
+    observation failure, which is recorded rather than raised.
+
+    Never raises. A ledger that cannot be written is an observability problem; a dispatch
+    that dies because of one is an outage.
+    """
+    if not recording_enabled(env):
+        return False
+    try:
+        record = {
+            "event": "router_decision",
+            "ts": ts or _now_iso(),
+            "dispatch_id": dispatch_id,
+            "target_slot": target_slot,
+            "tier": tier,
+            "applied": applied,
+            "decline_reason": decline_reason,
+            "would_route": would_route,
+            "compute_error": compute_error,
+            "note": (
+                "OBSERVED — the router computed this route and acted on it"
+                if applied
+                else "OBSERVED — the router computed this route and did NOT act on it"
+            ),
+        }
+        _atomic_append(
+            ledger_path(state_dir), record, ROUTER_DECISION_LEDGER + ".lock"
+        )
+        return True
+    except Exception:  # noqa: BLE001 — observation must never break the decision path
+        return False

--- a/scripts/lib/providers/smart_router/decision_log.py
+++ b/scripts/lib/providers/smart_router/decision_log.py
@@ -88,6 +88,7 @@ def record_router_decision(
     target_slot: str,
     dispatch_id: Optional[str] = None,
     compute_error: Optional[str] = None,
+    raised: bool = False,
     state_dir: "str | Path | None" = None,
     env: Optional[dict] = None,
     ts: Optional[str] = None,
@@ -98,6 +99,11 @@ def record_router_decision(
     ``would_route``, False means it computed the route and followed the legacy lane
     anyway. ``compute_error`` is set when the route could not be computed at all — an
     observation failure, which is recorded rather than raised.
+
+    ``raised`` marks the third outcome: the door refused the dispatch outright
+    (ADR-036 §2 registry drift). That is fail-loud by design and stays fail-loud, but
+    it is still a decision and belongs in the trail — otherwise the one outcome that
+    actually stops a dispatch is the one the ledger cannot show.
 
     Never raises. A ledger that cannot be written is an observability problem; a dispatch
     that dies because of one is an outage.
@@ -115,8 +121,11 @@ def record_router_decision(
             "decline_reason": decline_reason,
             "would_route": would_route,
             "compute_error": compute_error,
+            "raised": raised,
             "note": (
-                "OBSERVED — the router computed this route and acted on it"
+                "OBSERVED — the door refused the dispatch (fail-loud registry drift)"
+                if raised
+                else "OBSERVED — the router computed this route and acted on it"
                 if applied
                 else "OBSERVED — the router computed this route and did NOT act on it"
             ),

--- a/scripts/lib/providers/smart_router/door_routing.py
+++ b/scripts/lib/providers/smart_router/door_routing.py
@@ -155,9 +155,11 @@ def resolve_door_route(
     the computed provider/model/lane even when the route is not applied.
 
     Every outcome is appended to the router-decision ledger (OI-1494) before it
-    is returned. The decision itself is made by ``_decide`` — this wrapper is the
+    leaves this function — the applied ones, the declined ones, and the refusals
+    that raise. The decision itself is made by ``_decide``; this wrapper is the
     single exit point, so a branch added to ``_decide`` later cannot skip the
-    ledger. Recording is fail-open and never changes the returned result.
+    ledger. Recording is fail-open and never changes the returned result, nor the
+    exception raised.
 
     Raises RegistryLookupError when the classifier succeeded but produced a
     provider/model the registry does not know (ADR-036 §2 fail-loud) — the
@@ -177,19 +179,37 @@ def resolve_door_route(
         state_dir: Project state dir, used for the availability/cooldown read and
             for the ledger. Defaults to the resolved project state dir.
     """
-    result, compute_error = _decide(
-        spec_provider=spec_provider,
-        spec_model=spec_model,
-        target_slot=target_slot,
-        instruction_text=instruction_text,
-        file_paths=file_paths,
-        loc_estimate=loc_estimate,
-        env=env,
-        dispatch_id=dispatch_id,
-        state_dir=state_dir,
-    )
-
     from .decision_log import record_router_decision  # noqa: PLC0415
+
+    try:
+        result, compute_error = _decide(
+            spec_provider=spec_provider,
+            spec_model=spec_model,
+            target_slot=target_slot,
+            instruction_text=instruction_text,
+            file_paths=file_paths,
+            loc_estimate=loc_estimate,
+            env=env,
+            dispatch_id=dispatch_id,
+            state_dir=state_dir,
+        )
+    except Exception as exc:
+        # Registry drift raises here and must keep raising (ADR-036 §2) — but a
+        # refusal is the one outcome that actually stops a dispatch, so it is the
+        # last thing the ledger may be blind to. Record, then re-raise unchanged.
+        record_router_decision(
+            tier=None,
+            applied=False,
+            decline_reason=None,
+            would_route=None,
+            target_slot=target_slot,
+            dispatch_id=dispatch_id,
+            compute_error=f"{type(exc).__name__}: {exc}",
+            raised=True,
+            state_dir=state_dir,
+            env=env,
+        )
+        raise
 
     record_router_decision(
         tier=result.tier,

--- a/scripts/lib/providers/smart_router/door_routing.py
+++ b/scripts/lib/providers/smart_router/door_routing.py
@@ -22,6 +22,14 @@ distinguishable in the dry-run output and receipt. Before this, a T0 skip, an
 explicit provider, the kill-switch, the enum gap and a classifier crash all
 returned a bare None and were indistinguishable in the audit trail.
 
+Every decision — applied or declined — is appended to the router-decision ledger
+(``.decision_log``, OI-1494). A declined dispatch still has its provider, model
+and lane computed and written down; it simply is not acted on. Before this the
+staging gate returned before ``resolve_tier_route`` was reached, so a switched-off
+tier produced no observation at all and the rollout had no evidence to ramp on.
+Recording happens at the single exit point of ``resolve_door_route`` so a decline
+branch added later cannot silently skip the ledger.
+
 Constraints:
 - No imports from dispatch_cli or dispatch_plan (avoid circular deps).
 - No I/O beyond what the smart_router submodules already do.
@@ -33,6 +41,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
+from pathlib import Path
 from typing import Optional, Tuple
 
 from dispatch_spec import Provider, ValidatedSpec  # noqa: PLC0415 — sibling package, no cycle
@@ -79,11 +88,50 @@ class DoorRouteResult:
     tier-aware fallback when a route cannot be applied after a successful
     classification (OI-1187): a tier-high decline must never silently land on
     the sonnet default.
+
+    ``would_route`` is the provider/model/lane the router settled on, present
+    whenever it could be computed — including on a decline, where it is the
+    route that was deliberately NOT taken (OI-1494). It lets the dry-run output
+    show what the router would have done without the router doing it.
     """
 
     route: Optional[Tuple[Provider, str, str]] = None
     decline_reason: Optional[str] = None
     tier: Optional[str] = None
+    would_route: Optional[dict] = None
+
+
+def _compute_would_route(
+    tier: str,
+    env: dict,
+    state_dir: Optional["Path"] = None,
+) -> Tuple[Optional[dict], Optional[str]]:
+    """Compute the route the router WOULD take for a tier, without acting on it.
+
+    Total and fail-open by contract, because this runs on the DECLINE path: the
+    dispatch is already following the legacy lane, so a registry drift or a
+    broken availability read here is an observation failure and is returned as
+    one. Raising would turn a previously harmless decline into a hard dispatch
+    failure — the observation layer would become an outage.
+
+    On the APPLY path the same drift still raises through ``_provider_enum``,
+    where fail-loud is correct (ADR-036 §2) because the route is actually used.
+    """
+    try:
+        from .tier_routing import resolve_tier_route  # noqa: PLC0415
+
+        route = resolve_tier_route(tier, env, state_dir=state_dir)
+        return (
+            {
+                "provider": route.provider,
+                "model": route.model,
+                "lane": route.lane,
+                "reason": route.reason,
+            },
+            None,
+        )
+    except Exception as exc:  # noqa: BLE001 — see the contract above
+        return None, f"{type(exc).__name__}: {exc}"
 
 
 def resolve_door_route(
@@ -95,6 +143,7 @@ def resolve_door_route(
     loc_estimate: int = 0,
     env: Optional[dict] = None,
     dispatch_id: Optional[str] = None,
+    state_dir: Optional["Path"] = None,
 ) -> DoorRouteResult:
     """Resolve a concrete provider + model for a dispatch without an explicit one.
 
@@ -102,7 +151,13 @@ def resolve_door_route(
     when the router has a recommendation, or a ``decline_reason`` naming why
     routing was skipped (T0, explicit provider, router disabled, or a
     classifier error). ``tier`` is populated whenever the classifier ran so the
-    door can fall back tier-aware instead of blindly.
+    door can fall back tier-aware instead of blindly, and ``would_route`` carries
+    the computed provider/model/lane even when the route is not applied.
+
+    Every outcome is appended to the router-decision ledger (OI-1494) before it
+    is returned. The decision itself is made by ``_decide`` — this wrapper is the
+    single exit point, so a branch added to ``_decide`` later cannot skip the
+    ledger. Recording is fail-open and never changes the returned result.
 
     Raises RegistryLookupError when the classifier succeeded but produced a
     provider/model the registry does not know (ADR-036 §2 fail-loud) — the
@@ -116,30 +171,77 @@ def resolve_door_route(
         file_paths: List of dispatch file paths (for LOC-aware classification).
         loc_estimate: Estimated LOC of the change.
         env: Process environment dict (defaults to os.environ).
-        dispatch_id: The dispatch's stable id, used to seed the deterministic
-            canary bucket when provided; the door call site does not pass it
-            yet, so the fallback is the dispatch's own content (target slot +
-            instruction + paths).
+        dispatch_id: The dispatch's stable id. Seeds the deterministic canary
+            bucket and identifies the decision in the ledger; without it a record
+            cannot be tied back to the dispatch it describes.
+        state_dir: Project state dir, used for the availability/cooldown read and
+            for the ledger. Defaults to the resolved project state dir.
+    """
+    result, compute_error = _decide(
+        spec_provider=spec_provider,
+        spec_model=spec_model,
+        target_slot=target_slot,
+        instruction_text=instruction_text,
+        file_paths=file_paths,
+        loc_estimate=loc_estimate,
+        env=env,
+        dispatch_id=dispatch_id,
+        state_dir=state_dir,
+    )
+
+    from .decision_log import record_router_decision  # noqa: PLC0415
+
+    record_router_decision(
+        tier=result.tier,
+        applied=result.route is not None,
+        decline_reason=result.decline_reason,
+        would_route=result.would_route,
+        target_slot=target_slot,
+        dispatch_id=dispatch_id,
+        compute_error=compute_error,
+        state_dir=state_dir,
+        env=env,
+    )
+    return result
+
+
+def _decide(
+    *,
+    spec_provider: Provider,
+    spec_model: Optional[str],
+    target_slot: str,
+    instruction_text: str,
+    file_paths: Optional[list[str]],
+    loc_estimate: int,
+    env: Optional[dict],
+    dispatch_id: Optional[str],
+    state_dir: Optional["Path"],
+) -> Tuple[DoorRouteResult, Optional[str]]:
+    """The routing decision itself — pure, never writes.
+
+    Returns the result plus an optional compute-error string describing why
+    ``would_route`` could not be filled in. Kept separate from
+    ``resolve_door_route`` so the ledger append has exactly one call site.
     """
     # Gate 1: T0 never routes. t0-opus-only is a floor, not an advisory.
     if target_slot == "T0":
-        return DoorRouteResult(decline_reason=DECLINE_T0_NEVER_ROUTES)
+        return DoorRouteResult(decline_reason=DECLINE_T0_NEVER_ROUTES), None
 
     # Gate 2: Only fill in when the spec is silent. An explicit provider wins
     # undiminished (worker-provider-free-choice, pin_semantics=default).
     if spec_provider != Provider.AUTO:
-        return DoorRouteResult(decline_reason=DECLINE_EXPLICIT_PROVIDER)
+        return DoorRouteResult(decline_reason=DECLINE_EXPLICIT_PROVIDER), None
 
     _env = env if env is not None else dict(os.environ)
 
     # Gate 3: VNX_SMART_ROUTER_DISABLE=1 disables the router entirely.
     if _env.get("VNX_SMART_ROUTER_DISABLE", "").strip().lower() in ("1", "true", "yes", "on"):
-        return DoorRouteResult(decline_reason=DECLINE_ROUTER_DISABLED)
+        return DoorRouteResult(decline_reason=DECLINE_ROUTER_DISABLED), None
 
     # Backward compat: VNX_AUTO_ROUTE=0/false/off also disables.
     auto_route = _env.get("VNX_AUTO_ROUTE", "").strip().lower()
     if auto_route in ("0", "false", "no", "off"):
-        return DoorRouteResult(decline_reason=DECLINE_ROUTER_DISABLED)
+        return DoorRouteResult(decline_reason=DECLINE_ROUTER_DISABLED), None
 
     # Classifier — fail-open (ADR-036 §2). A routing bug (a stale loc_estimate,
     # an import error, a classifier crash) must never block a dispatch.
@@ -155,7 +257,7 @@ def resolve_door_route(
             exc,
             exc_info=True,
         )
-        return DoorRouteResult(decline_reason=DECLINE_CLASSIFIER_ERROR)
+        return DoorRouteResult(decline_reason=DECLINE_CLASSIFIER_ERROR), None
 
     # Staging gate — UNDER the kill-switch (checked above), so a kill-switch
     # always wins. The rollout is per-tier + a deterministic canary fraction:
@@ -168,22 +270,40 @@ def resolve_door_route(
     group_key = dispatch_group_key(dispatch_id, target_slot, instruction_text, file_paths)
     staging_decline = staging_verdict(tier, group_key, staging_config)
     if staging_decline is not None:
-        return DoorRouteResult(decline_reason=staging_decline, tier=tier)
+        # OI-1494: the dispatch follows the legacy lane, but the route it would
+        # have taken is computed anyway so the declined half of the split is
+        # observable. Computation is fail-open here — see _compute_would_route.
+        would_route, compute_error = _compute_would_route(tier, _env, state_dir)
+        return (
+            DoorRouteResult(
+                decline_reason=staging_decline, tier=tier, would_route=would_route,
+            ),
+            compute_error,
+        )
 
     # Tier routing + provider enum — fail-loud (ADR-036 §2). The classifier
     # worked; an unknown provider/model is registry drift and must surface, not
     # vanish as a silent None. RegistryLookupError propagates to the door.
     from .tier_routing import resolve_tier_route  # noqa: PLC0415
 
-    route = resolve_tier_route(tier, _env)
+    route = resolve_tier_route(tier, _env, state_dir=state_dir)
     provider_enum = _provider_enum(route.provider)
 
     route_reason = f"smart-router:tier={tier},provider={route.provider},model={route.model},lane={route.lane}"
     if route.reason:
         route_reason += f";{route.reason}"
-    return DoorRouteResult(
-        route=(provider_enum, route.model, route_reason),
-        tier=tier,
+    return (
+        DoorRouteResult(
+            route=(provider_enum, route.model, route_reason),
+            tier=tier,
+            would_route={
+                "provider": route.provider,
+                "model": route.model,
+                "lane": route.lane,
+                "reason": route.reason,
+            },
+        ),
+        None,
     )
 
 
@@ -193,12 +313,21 @@ def apply_door_route(
 ) -> Tuple[ValidatedSpec, Optional[str]]:
     """Apply smart routing to a validated spec when provider is AUTO.
 
-    Single call site for dispatch_cli.run_dispatch(). Returns (vspec, route_reason)
-    where vspec is either the original (router skipped/disabled/failed) or a new
-    ValidatedSpec with the resolved provider + model. route_reason is a
-    human-readable string for the dry-run output and receipt: the router's
-    recommendation when routed, or the decline reason (prefixed "smart-router:")
-    when the router skipped — never a bare None for a decline (OI-1187).
+    Returns (vspec, route_reason) where vspec is either the original (router
+    skipped/disabled/failed) or a new ValidatedSpec with the resolved provider +
+    model. route_reason is a human-readable string for the dry-run output and
+    receipt: the router's recommendation when routed, or the decline reason
+    (prefixed "smart-router:") when the router skipped — never a bare None for a
+    decline (OI-1187).
+
+    NOTE ON CALLERS: this function has no production caller. The door resolves
+    the router BEFORE validate() (OI-962), so ``dispatch_cli._resolve_router_pre_validate``
+    calls ``resolve_door_route`` on the raw DispatchSpec and applies the result
+    itself; this ValidatedSpec-shaped wrapper is exercised only by tests. It used
+    to claim to be "the single call site for dispatch_cli.run_dispatch()", which
+    has not been true since the pre-validate move — a docstring naming a caller
+    that does not exist sends the next reader to the wrong seam, which is exactly
+    how an observability fix ends up somewhere it never runs (OI-1494).
 
     Fail-open for a broken classifier (returns the original vspec unchanged
     with a decline reason); fail-loud for registry drift (RegistryLookupError

--- a/tests/smart_router/test_router_decision_log.py
+++ b/tests/smart_router/test_router_decision_log.py
@@ -1,0 +1,267 @@
+"""Tests for smart_router.decision_log — the router writes down what it decided (OI-1494).
+
+The smart router has been default-on since 2026-08-02: no kill-switch is set, yet every
+tier flag and the canary sit at 0. ``staging_verdict`` therefore declines before
+``resolve_tier_route`` is ever reached, so the route the router WOULD have chosen was
+never computed, let alone recorded. A rollout with no observation layer has nothing to
+ramp from — the operator cannot see what the router would have done, so no evidence ever
+accumulates on which to switch a tier on.
+
+These tests pin the fix: a dispatch whose tier is switched off still computes provider,
+model and lane and appends a record, and its decline is exactly what it was before. The
+router observes; it does not act.
+
+Every test in this file fails on main 17de88de: ``decision_log`` does not exist there and
+the decline path computes nothing.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from providers.smart_router import decision_log as dl
+from providers.smart_router import door_routing as dr
+from providers.smart_router import staging as st
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_state(monkeypatch):
+    """Neutralise config-registry global state (same contract as test_staging): operator
+    config wiring from another test must not leak into the staging resolution here."""
+    import config_registry as cr
+    import config_runtime as crt
+
+    cr.set_db_resolver(None)
+    cr.set_default_project_id(None)
+    crt._wired_for.clear()
+    for key in list(st.TIER_FLAGS.values()) + [st.CANARY_PCT_KEY]:
+        monkeypatch.delenv(key, raising=False)
+        monkeypatch.delenv(f"VNX_OVERRIDE_{key[len('VNX_'):]}", raising=False)
+    monkeypatch.delenv(dl.DISABLE_FLAG, raising=False)
+    yield
+
+
+def _records(state_dir: Path) -> list[dict]:
+    path = dl.ledger_path(state_dir)
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _route_once(
+    state_dir: Path,
+    *,
+    slot: str = "T1",
+    instruction: str = "fix a typo",
+    env: dict | None = None,
+):
+    """Route one dispatch. ``env`` defaults to an empty dict so the ambient process
+    environment cannot decide the outcome of a test."""
+    from dispatch_spec import Provider
+
+    return dr.resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot=slot,
+        instruction_text=instruction,
+        file_paths=["scripts/lib/example.py"],
+        env={} if env is None else env,
+        dispatch_id="20260829-beta-c1-observe",
+        state_dir=state_dir,
+    )
+
+
+def _enable_every_tier(monkeypatch):
+    for key in st.TIER_FLAGS.values():
+        monkeypatch.setenv(key, "1")
+    monkeypatch.setenv(st.CANARY_PCT_KEY, "100")
+
+
+# ---------------------------------------------------------------------------
+# The core of OI-1494: a switched-off tier still produces an observation
+# ---------------------------------------------------------------------------
+
+def test_disabled_tier_still_records_provider_model_and_lane(tmp_path):
+    """The bug: every tier off => nothing computed, nothing written. The fix: the route
+    is computed and recorded anyway, and NOT acted on."""
+    result = _route_once(tmp_path)
+
+    # unchanged behaviour: the dispatch is still declined
+    assert result.route is None
+    assert result.decline_reason.startswith(st.DECLINE_TIER_DISABLED)
+
+    records = _records(tmp_path)
+    assert len(records) == 1, "a declined decision must still leave exactly one record"
+    rec = records[0]
+    assert rec["event"] == "router_decision"
+    assert rec["applied"] is False
+    assert rec["decline_reason"] == result.decline_reason
+    assert rec["tier"] == result.tier
+
+    would = rec["would_route"]
+    assert would["provider"], "provider must be computed even though the tier is off"
+    assert would["model"], "model must be computed even though the tier is off"
+    assert would["lane"], "lane must be computed even though the tier is off"
+
+
+def test_would_route_is_also_exposed_on_the_result(tmp_path):
+    """The computed-but-not-applied route is readable by the caller, not only by the
+    ledger — the dry-run output must be able to show it."""
+    result = _route_once(tmp_path)
+    assert result.route is None
+    assert result.would_route is not None
+    assert result.would_route["provider"]
+    assert result.would_route["model"]
+    assert result.would_route["lane"]
+
+
+def test_decline_reason_and_tier_are_byte_for_byte_unchanged(tmp_path):
+    """Observation must not move the decision. The decline this returns is exactly the
+    one staging_verdict produces for the same tier."""
+    result = _route_once(tmp_path)
+    expected = st.staging_verdict(
+        result.tier,
+        st.dispatch_group_key(
+            "20260829-beta-c1-observe", "T1", "fix a typo", ["scripts/lib/example.py"]
+        ),
+        st.load_staging_config(),
+    )
+    assert result.decline_reason == expected
+    assert result.route is None
+
+
+# ---------------------------------------------------------------------------
+# Applied routes are recorded too — one ledger, both halves of the canary
+# ---------------------------------------------------------------------------
+
+def test_applied_route_is_recorded_as_applied(tmp_path, monkeypatch):
+    _enable_every_tier(monkeypatch)
+    result = _route_once(tmp_path)
+
+    assert result.route is not None, "every tier on + canary 100 must route"
+    records = _records(tmp_path)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["applied"] is True
+    assert rec["decline_reason"] is None
+    provider_enum, model, _reason = result.route
+    assert rec["would_route"]["model"] == model
+    assert rec["would_route"]["provider"] == provider_enum.value
+
+
+def test_each_decision_appends_one_line(tmp_path):
+    _route_once(tmp_path)
+    _route_once(tmp_path)
+    _route_once(tmp_path)
+    assert len(_records(tmp_path)) == 3
+
+
+def test_t0_decline_is_recorded_without_a_computed_route(tmp_path):
+    """T0 declines before classification, so there is no tier and nothing to compute —
+    but the decision itself is still written down."""
+    result = _route_once(tmp_path, slot="T0")
+    assert result.decline_reason == dr.DECLINE_T0_NEVER_ROUTES
+
+    records = _records(tmp_path)
+    assert len(records) == 1
+    assert records[0]["applied"] is False
+    assert records[0]["decline_reason"] == dr.DECLINE_T0_NEVER_ROUTES
+    assert records[0]["tier"] is None
+    assert records[0]["would_route"] is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: the ledger must never be able to block a dispatch
+# ---------------------------------------------------------------------------
+
+def test_kill_switch_stops_recording_but_not_the_decision(tmp_path):
+    """The switch is read from the env the door was handed, exactly like the router's
+    own VNX_SMART_ROUTER_DISABLE — one env source for every router switch."""
+    result = _route_once(tmp_path, env={dl.DISABLE_FLAG: "1"})
+    assert result.decline_reason.startswith(st.DECLINE_TIER_DISABLED)
+    assert _records(tmp_path) == []
+
+
+def test_kill_switch_is_read_from_the_process_env_when_none_is_passed(tmp_path, monkeypatch):
+    """The production call site passes no env, so the switch must also work from
+    os.environ — otherwise the kill-switch would be unreachable in production."""
+    from dispatch_spec import Provider
+
+    monkeypatch.setenv(dl.DISABLE_FLAG, "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_DISABLE", "1")  # keep the decision cheap
+
+    result = dr.resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="fix a typo",
+        file_paths=["scripts/lib/example.py"],
+        dispatch_id="20260829-beta-c1-observe",
+        state_dir=tmp_path,
+    )
+    assert result.decline_reason == dr.DECLINE_ROUTER_DISABLED
+    assert _records(tmp_path) == []
+
+
+def test_recording_is_on_by_default(tmp_path):
+    """The bug this closes is an observation layer nobody switched on. Recording is
+    therefore ON unless explicitly disabled — the flag is a kill-switch, not an opt-in."""
+    assert dl.recording_enabled({}) is True
+    assert dl.recording_enabled({dl.DISABLE_FLAG: "1"}) is False
+
+
+def test_unwritable_ledger_does_not_break_the_decision(tmp_path):
+    """state_dir is a regular file, so mkdir/append cannot succeed. The dispatch must
+    still get its decline."""
+    blocked = tmp_path / "not-a-dir"
+    blocked.write_text("i am a file", encoding="utf-8")
+
+    result = _route_once(blocked)
+    assert result.route is None
+    assert result.decline_reason.startswith(st.DECLINE_TIER_DISABLED)
+
+
+def test_record_router_decision_returns_false_instead_of_raising(tmp_path):
+    blocked = tmp_path / "blocked"
+    blocked.write_text("file", encoding="utf-8")
+    assert (
+        dl.record_router_decision(
+            tier="tier-zero",
+            applied=False,
+            decline_reason="staging-tier-disabled:tier-zero",
+            would_route={"provider": "deepseek", "model": "m", "lane": "l", "reason": None},
+            target_slot="T1",
+            dispatch_id="d",
+            state_dir=blocked,
+        )
+        is False
+    )
+
+
+def test_shadow_computation_failure_still_records_and_still_declines(tmp_path, monkeypatch):
+    """A broken tier-route computation is an observation problem, never a dispatch
+    problem: the decline stands and the failure is visible in the record."""
+    import providers.smart_router.tier_routing as tr
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("registry drift in the shadow path")
+
+    monkeypatch.setattr(tr, "resolve_tier_route", _boom)
+
+    result = _route_once(tmp_path)
+    assert result.route is None
+    assert result.decline_reason.startswith(st.DECLINE_TIER_DISABLED)
+
+    records = _records(tmp_path)
+    assert len(records) == 1
+    assert records[0]["would_route"] is None
+    assert "registry drift in the shadow path" in records[0]["compute_error"]

--- a/tests/smart_router/test_router_decision_log.py
+++ b/tests/smart_router/test_router_decision_log.py
@@ -265,3 +265,43 @@ def test_shadow_computation_failure_still_records_and_still_declines(tmp_path, m
     assert len(records) == 1
     assert records[0]["would_route"] is None
     assert "registry drift in the shadow path" in records[0]["compute_error"]
+
+
+# ---------------------------------------------------------------------------
+# The third outcome: a refusal that raises is still a decision
+# ---------------------------------------------------------------------------
+
+def test_registry_drift_is_recorded_and_still_raises(tmp_path, monkeypatch):
+    """ADR-036 §2 drift must keep failing loud — and must not be the one outcome the
+    ledger cannot show. It is the only outcome that actually stops a dispatch."""
+    import providers.smart_router.tier_routing as tr
+    from providers.provider_registry import RegistryLookupError
+
+    _enable_every_tier(monkeypatch)
+
+    def _drifted(tier, env=None, **_kw):
+        return tr.TierRoute(
+            tier=tier,
+            provider="a-provider-the-enum-never-heard-of",
+            model="some-model",
+            lane="some-lane",
+        )
+
+    monkeypatch.setattr(tr, "resolve_tier_route", _drifted)
+
+    with pytest.raises(RegistryLookupError):
+        _route_once(tmp_path)
+
+    records = _records(tmp_path)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["raised"] is True
+    assert rec["applied"] is False
+    assert rec["would_route"] is None
+    assert "a-provider-the-enum-never-heard-of" in rec["compute_error"]
+
+
+def test_a_normal_decline_is_not_marked_as_raised(tmp_path):
+    """Guard against the raised flag becoming decorative."""
+    _route_once(tmp_path)
+    assert _records(tmp_path)[0]["raised"] is False


### PR DESCRIPTION
## Wat er mis was

De smart router staat default-on sinds 2026-08-02. De kill-switch is nergens gezet. Toch stonden alle vier de per-tier vlaggen en de canary op 0.

`staging_verdict` declineert in `door_routing.py` **voordat** `resolve_tier_route` wordt bereikt. De route die de router zou kiezen werd dus niet ongebruikt gelaten: hij werd nooit berekend, en over de beslissing werd niets vastgelegd.

Dat is een uitrol zonder waarnemingslaag. Een tier blijft uit omdat niets rechtvaardigt hem aan te zetten, en niets kan dat rechtvaardigen omdat de tier uit staat en niets waarneemt.

### Meting op main `17de88de`, opnieuw gedraaid

```
staging.py treffers voor ndjson/emit/log : 0   (controle-grep in dezelfde scope: 88 treffers)
VNX_SMART_ROUTER_TIER_ZERO/LOW/MID/HIGH  : False, False, False, False  (raw '0')
VNX_SMART_ROUTER_CANARY_PCT              : '0'
VNX_SMART_ROUTER_DISABLE / VNX_AUTO_ROUTE: None / None
door_routing.py:169-171 returnt voor regel 178 (resolve_tier_route)
```

## Wat er nu gebeurt

Elke beslissing landt in `state/router_decisions.ndjson`, de toegepaste en de gedeclineerde, elk met de provider, het model en de lane waar de router op uitkwam. Een gedeclineerde dispatch volgt onveranderd de legacy-lane. De route wordt berekend en vastgelegd, niet uitgevoerd.

### Bewijs: run met geschreven records

Echte staging-config (`enabled_tiers=(geen) canary_pct=0`), vier dispatches, verse ledger:

```
T1 -> DECLINED  staging-tier-disabled:tier-zero
T1 -> DECLINED  staging-tier-disabled:tier-mid
T2 -> DECLINED  staging-tier-disabled:tier-zero
T0 -> DECLINED  t0-never-routes

20260829-demo-t1  tier=tier-zero  applied=False  zou-kiezen: deepseek-harness/deepseek-v4-flash lane=claude_harness_keyed
20260829-demo-t1  tier=tier-mid   applied=False  zou-kiezen: claude/sonnet-5              lane=tmux_interactive
20260829-demo-t2  tier=tier-zero  applied=False  zou-kiezen: deepseek-harness/deepseek-v4-flash lane=claude_harness_keyed
20260829-demo-t0  tier=None       applied=False  zou-kiezen: (niets te berekenen)
```

Vier beslissingen, vier records, provider/model/lane berekend terwijl elke tier uit staat.

## Ontwerpkeuzes

**Opname staat AAN, met een kill-switch.** `VNX_ROUTER_DECISION_LOG_DISABLE` zet hem uit. Die richting is bewust: een waarnemingslaag achter een opt-in die niemand zet neemt niets waar, en dat is precies de fout die hier dichtgaat.

**Eén uitgang.** `resolve_door_route` is opgesplitst in `_decide` (puur, beslist) en een wrapper die opneemt. Zo kan een decline-tak die er later bij komt het grootboek niet stil overslaan.

**Fail-open op de decline-weg, fail-loud op de apply-weg.** Drift tijdens het berekenen van een niet-gebruikte route is een waarnemingsprobleem en wordt als `compute_error` vastgelegd. Diezelfde drift op de apply-weg gooit nog steeds via `_provider_enum` (ADR-036 §2), want daar wordt de route echt gebruikt.

**Append-vorm.** `decision_log._atomic_append` volgt `decision_shadow._atomic_append` letterlijk: flock op een sentinel, dan een gewone append onder een tweede flock. Bewust **niet** de vaste-naam `<path>.tmp` + `os.replace`-vorm, die records verliest bij twee schrijvers (OI-1486).

## Twee stale plekken meegenomen

`dispatch_cli._resolve_router_pre_validate` geeft nu `dispatch_id` door. Dat is de enige productie-aanroeper van de router; zonder die doorgifte is elk record anoniem en niet aan een dispatch te koppelen.

`apply_door_route` claimde in zijn docstring "Single call site for dispatch_cli.run_dispatch()". Dat is onwaar sinds de pre-validate-verplaatsing (OI-962): nul productie-aanroepers. Gecorrigeerd, want een docstring die een niet-bestaande aanroeper noemt is precies hoe een observability-fix belandt op een plek waar hij nooit draait.

## Tests

`tests/smart_router/test_router_decision_log.py`, 12 tests. Allemaal rood op main (de module bestaat daar niet, en de decline-weg berekent niets).

Buren groen: **448 passed** over `tests/smart_router/`, `test_dispatch_cli.py`, `test_smart_router.py`, `test_smart_router_wiring.py`, `test_smart_router_e2e.py`.

## Niet aangeraakt

`governance_emit.py` leunt op de tmp+os.replace-vorm en wordt door `provider_dispatch.py` geimporteerd. Buiten deze boom, gemeld aan T0 als uitbreiding van OI-1486.

Er bestaat geen gedeelde NDJSON-append-helper: ~20 modules in `scripts/lib` dragen elk hun eigen kopie. Gemeld als kandidaat-OI; hoort niet in een routerings-PR.