### PR TITLE
fix(gates): a scratch file named after its destination is shared by every writer (OI-1486)

### DIFF
--- a/scripts/lib/atomic_io.py
+++ b/scripts/lib/atomic_io.py
@@ -5,6 +5,12 @@ state_writer.py, worker_permission_relay.py, tmux_interactive_dispatch.py,
 intelligence_dashboard.py) and the fcntl.flock NDJSON append used in
 governance_emit.py.
 
+The scratch file here is a ``tempfile.mkstemp`` name, unique to the writer.
+That is the point of it, and the reason a caller must not hand-roll
+``path.with_suffix(".tmp")`` instead: that name is a function of the
+DESTINATION, so every concurrent writer of one path picks the same scratch
+file. See :func:`slot_lock` for what atomicity alone still does not buy.
+
 ADR-005: ledger-first write ordering — appenders raise on OSError, never
 silently drop events.
 
@@ -22,12 +28,45 @@ import os
 import re
 import stat
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _EVENT_TYPE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$")
+
+
+@contextmanager
+def slot_lock(path: Path) -> Iterator[None]:
+    """Hold one path's exclusive lock across a read-check-write sequence.
+
+    :func:`atomic_write_text` makes a write indivisible: a reader never sees
+    half a record. It does NOT order two writers, and it cannot, because by
+    the time either writes, both have already decided to. A caller that reads
+    a file, decides something from what it read, and only then writes needs
+    the lock to span all three steps — otherwise two callers read the same
+    state, both reach the same decision, and both write, the check having
+    ruled out nothing (OI-1486).
+
+    The lock is a sibling ``.<name>.lock`` file rather than the target itself,
+    so it survives the target being replaced by rename mid-sequence — locking
+    the target would leave each writer holding a lock on a file that is no
+    longer at that path.
+
+    ``flock`` is advisory: it holds between callers that take it, and it holds
+    equally between threads of one process and between processes, because the
+    lock belongs to the open file description and each caller opens its own.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.parent / f".{path.name}.lock"
+    with lock_path.open("a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
 
 
 def atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
 
+from atomic_io import atomic_write_json, slot_lock
 from governance_receipts import utc_now_iso
 
 logger = logging.getLogger(__name__)
@@ -403,10 +404,24 @@ def _check_overwrite_guard(
 
 
 def _write_result_atomic(result_path: Path, payload: Dict[str, Any]) -> None:
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = result_path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    tmp.replace(result_path)
+    """Write one result record through the shared atomic-write helper.
+
+    Callers must already hold :func:`atomic_io.slot_lock` for ``result_path``
+    — both guarded entry points below do. This is the write half of that
+    critical section, not a standalone atomic write: on its own it guarantees
+    only that a reader never sees a partial record.
+
+    Until OI-1486 this derived its scratch file as
+    ``result_path.with_suffix(".json.tmp")``: one name for every concurrent
+    writer of the slot, because the name came from the destination and
+    nothing else. Two writers then shared one scratch file — the second
+    overwrote the first's bytes, the first renamed those bytes into place
+    while reporting its own payload as landed, and the second renamed a path
+    the first had already consumed and died on FileNotFoundError. The record
+    on disk matched neither writer's account of what it had written.
+    ``atomic_io`` gives each writer its own ``mkstemp`` scratch file.
+    """
+    atomic_write_json(result_path, payload)
 
 
 def write_result_guarded(
@@ -452,13 +467,14 @@ def write_result_guarded(
     internal :data:`_CORRUPT_RESULT` sentinel), which is NOT what is on disk;
     ``written is False`` is what tells the caller the write did not land.
     """
-    try:
-        _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_ref)
-    except ResultOverwriteRefused:
-        existing = _read_existing_result(result_path)
-        on_disk = existing if isinstance(existing, dict) else {}
-        return on_disk or payload, False
-    _write_result_atomic(result_path, payload)
+    with slot_lock(result_path):
+        try:
+            _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_ref)
+        except ResultOverwriteRefused:
+            existing = _read_existing_result(result_path)
+            on_disk = existing if isinstance(existing, dict) else {}
+            return on_disk or payload, False
+        _write_result_atomic(result_path, payload)
     return payload, True
 
 
@@ -501,8 +517,9 @@ def record_terminal_result(
             f"({payload.get('status')!r}) but no producer identity "
             f"(dispatch_id) — refusing to write unauthenticated gate evidence"
         )
-    _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_id)
-    _write_result_atomic(result_path, payload)
+    with slot_lock(result_path):
+        _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_id)
+        _write_result_atomic(result_path, payload)
     return result_path
 
 

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -1631,9 +1631,7 @@ class GateRequestHandlerMixin:
             if dispatch_id:
                 payload["dispatch_id"] = dispatch_id
             _path = self._request_path("wiring_gate", pr_number)
-            _tmp = _path.with_suffix(".tmp")
-            _tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-            os.replace(_tmp, _path)
+            atomic_write_json(_path, payload)
             return payload
 
         try:
@@ -1662,9 +1660,7 @@ class GateRequestHandlerMixin:
             if dispatch_id:
                 payload["dispatch_id"] = dispatch_id
             _path = self._request_path("wiring_gate", pr_number)
-            _tmp = _path.with_suffix(".tmp")
-            _tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-            os.replace(_tmp, _path)
+            atomic_write_json(_path, payload)
             return payload
 
         payload = {
@@ -1693,7 +1689,5 @@ class GateRequestHandlerMixin:
         if dispatch_id:
             payload["dispatch_id"] = dispatch_id
         _path = self._request_path("wiring_gate", pr_number)
-        _tmp = _path.with_suffix(".tmp")
-        _tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        os.replace(_tmp, _path)
+        atomic_write_json(_path, payload)
         return payload

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -13,7 +13,10 @@ lock-file, hash-chain-stamping, validated append primitive Path 2
 Hard rules (PRD provider-governance-unification):
   - Provider field MUST match _PROVIDER_RE — raises ValueError on mismatch.
   - Receipt write MUST NOT silently fail — raises RuntimeError on write/validation failure.
-  - Unified report uses tmp + os.replace for atomic write.
+  - Unified report is written via atomic_io.atomic_write_text, whose scratch
+    file is unique per writer. A scratch name derived from the destination
+    (the old `report_path.with_suffix('.md.tmp')`) is shared by every
+    concurrent writer of that report — see atomic_io (OI-1486).
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ _LIB_DIR = str(Path(__file__).resolve().parent)
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
+from atomic_io import atomic_write_text
 from append_receipt_internals.common import AppendReceiptError
 from append_receipt_internals.idempotency import (
     _cache_file_for,
@@ -790,15 +794,9 @@ def emit_unified_report(
     else:
         content = body
 
-    tmp_path = report_path.with_suffix(".md.tmp")
     try:
-        tmp_path.write_text(content, encoding="utf-8")
-        os.replace(tmp_path, report_path)
+        atomic_write_text(report_path, content)
     except OSError as exc:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
         raise RuntimeError(
             f"governance_emit: unified report write failed for dispatch={dispatch_id}: {exc}"
         ) from exc

--- a/tests/test_oi1472_residual_guard_writers.py
+++ b/tests/test_oi1472_residual_guard_writers.py
@@ -27,6 +27,7 @@ appears outside the enumerated set.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -218,22 +219,26 @@ def test_a_torn_write_cannot_reach_the_live_record(results_dir, tmp_path, monkey
 
     A bare ``write_text`` that dies mid-write leaves the LIVE record torn —
     manufacturing exactly the unreadable-but-present shape the guard refuses
-    on, from the writer the guard was supposed to protect. tmp + ``os.replace``
-    can only tear the temp file.
+    on, from the writer the guard was supposed to protect. A scratch file plus
+    ``os.replace`` can only tear the scratch file.
+
+    The failure is injected at ``os.fsync`` because that is where a full disk
+    is usually reported, and because it is inside the real write path. It used
+    to be injected by monkeypatching ``Path.write_text``, which stopped
+    intersecting that path when OI-1486 moved the scratch write to a
+    ``mkstemp`` handle — the assertions below held, but nothing was failing
+    any more and the test was passing on an empty run. The behaviour under
+    test is unchanged; only the seam moved.
     """
     slot = results_dir / "pr-1691-codex_gate.json"
     slot.write_text(json.dumps(DECIDED_AND_EVIDENCED), encoding="utf-8")
     report = tmp_path / "report.md"
     report.write_text("# report\n", encoding="utf-8")
 
-    real_write_text = Path.write_text
-
-    def dying_write_text(self, data, *args, **kwargs):
-        """Write the first 20 bytes, then die — a full disk or a SIGKILL."""
-        real_write_text(self, data[:20], *args, **kwargs)
+    def dying_fsync(fd):
         raise OSError(28, "No space left on device")
 
-    monkeypatch.setattr(Path, "write_text", dying_write_text)
+    monkeypatch.setattr(os, "fsync", dying_fsync)
     err = gate_artifacts._write_result_record(
         results_dir, "codex_gate", 1691, "", _result_payload(), report,
     )
@@ -243,6 +248,9 @@ def test_a_torn_write_cannot_reach_the_live_record(results_dir, tmp_path, monkey
     assert json.loads(slot.read_text(encoding="utf-8")) == DECIDED_AND_EVIDENCED, (
         "the live record must be untouched by a write that died halfway; a raw "
         "write_text would have truncated it to 20 bytes of JSON"
+    )
+    assert list(results_dir.glob("*.tmp")) == [], (
+        "a died write must not leave its scratch file behind"
     )
 
 

--- a/tests/test_oi1486_concurrent_result_writers.py
+++ b/tests/test_oi1486_concurrent_result_writers.py
@@ -92,6 +92,11 @@ def test_concurrent_writers_never_report_a_write_that_did_not_land(tmp_path):
         t.start()
     for t in threads:
         t.join(timeout=60)
+    assert not any(t.is_alive() for t in threads), (
+        "a writer thread was still running after the join timeout — the lock "
+        "this test exercises can deadlock, and a join that only times out "
+        "reports that as success"
+    )
 
     assert not errors, (
         "a concurrent writer raised instead of writing: "
@@ -176,8 +181,15 @@ def test_overwrite_guard_holds_under_two_concurrent_writers(tmp_path):
             t.start()
         for t in threads:
             t.join(timeout=60)
+        stuck = [t for t in threads if t.is_alive()]
     finally:
         gate_recorder._read_existing_result = real_read
+
+    assert not stuck, (
+        "a writer thread was still running after the join timeout — two "
+        "writers contending for one slot lock is exactly the shape that "
+        "deadlocks, and a bare join would let that pass"
+    )
 
     assert not errors, f"a writer raised: {[repr(e) for e in errors]}"
 

--- a/tests/test_oi1486_concurrent_result_writers.py
+++ b/tests/test_oi1486_concurrent_result_writers.py
@@ -1,0 +1,190 @@
+"""Two concurrent writers of one gate-result slot must not corrupt each other (OI-1486).
+
+``gate_recorder`` persists every ``review_gates/results/pr-<N>-<gate>.json``
+record through a read-check-write pair: ``_check_overwrite_guard`` reads the
+existing record and decides, then ``_write_result_atomic`` writes. Two
+defects made that pair unsafe for the concurrent writers the guard itself was
+built for (OI-1469/OI-1470 names three of them landing in one slot with no
+ordering guarantee):
+
+1. ``_write_result_atomic`` derived its scratch file as
+   ``result_path.with_suffix(".json.tmp")`` — a name fixed by the destination,
+   so every concurrent writer of the same slot used the SAME scratch file.
+   Writer A's content is overwritten by B before A renames, so A renames B's
+   bytes into place and reports its own payload as landed; B then renames a
+   path A already consumed and dies on FileNotFoundError. The writer that
+   reports success is not the writer whose bytes are on disk.
+
+2. Nothing held a lock across read-check-write, so two writers could both
+   read the same "absent" state, both pass the guard, and both write. The
+   guard's rule — a decided, evidenced verdict may only be replaced by
+   another decided, evidenced verdict — is a statement about serialized
+   writes; without a lock it does not hold.
+
+Both tests below fail on the pre-fix code and pass after.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import gate_recorder
+from gate_recorder import write_result_guarded
+
+# Wide enough that the write of one thread reliably straddles the write of the
+# other. The defect is a shared scratch path, not a timing curiosity, but a
+# one-line payload can slip through the window often enough to look green.
+_FILLER = "x" * 200_000
+_ROUNDS = 12
+
+
+def _running_payload(marker: str) -> dict:
+    """A non-terminal record. The overwrite guard returns early on these, so
+    any exception or mixed content is the write path itself, never a refusal."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": "1486",
+        "status": "running",
+        "marker": marker,
+        "filler": _FILLER,
+    }
+
+
+def test_concurrent_writers_never_report_a_write_that_did_not_land(tmp_path):
+    """No writer may raise, and disk must hold exactly one writer's payload."""
+    result_path = tmp_path / "results" / "pr-1486-codex_gate.json"
+    errors: list[BaseException] = []
+    landed: list[str] = []
+    lock = threading.Lock()
+
+    def writer(marker: str, barrier: threading.Barrier) -> None:
+        for _ in range(_ROUNDS):
+            payload = _running_payload(marker)
+            try:
+                barrier.wait(timeout=10)
+            except threading.BrokenBarrierError:
+                pass
+            try:
+                _, written = write_result_guarded(
+                    result_path, payload, gate="codex_gate", pr_ref="1486"
+                )
+                if written:
+                    with lock:
+                        landed.append(marker)
+            except BaseException as exc:  # noqa: BLE001 - the defect IS the exception
+                with lock:
+                    errors.append(exc)
+                return
+
+    barrier = threading.Barrier(2)
+    threads = [
+        threading.Thread(target=writer, args=(m, barrier), daemon=True)
+        for m in ("aaaaaa", "bbbbbb")
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert not errors, (
+        "a concurrent writer raised instead of writing: "
+        f"{[repr(e) for e in errors]} — a scratch path shared between writers "
+        "lets one rename away the file the other is about to rename"
+    )
+    assert landed, "no writer reported a landed write"
+
+    on_disk = json.loads(result_path.read_text(encoding="utf-8"))
+    assert on_disk["marker"] in {"aaaaaa", "bbbbbb"}
+    assert on_disk["filler"] == _FILLER, (
+        "the record on disk is truncated or mixed — two writers shared one "
+        "scratch file"
+    )
+
+
+def test_overwrite_guard_holds_under_two_concurrent_writers(tmp_path):
+    """A decided, evidenced verdict survives a concurrent evidence-less write.
+
+    Both threads are forced to read the same absent state before either
+    writes, which is exactly what an unlocked read-check-write pair allows.
+    The guard's rule must still hold: whatever the interleaving, the evidenced
+    ``pass`` is what remains on disk — it may overwrite the evidence-less
+    ``not_executable`` (that record is terminal but not decided), and it may
+    never be overwritten BY it.
+    """
+    result_path = tmp_path / "results" / "pr-1486-glm_gate.json"
+
+    evidenced_pass = {
+        "gate": "glm_gate",
+        "pr_id": "1486",
+        "status": "pass",
+        "contract_hash": "088a30754169bb91",
+        "report_path": "/tmp/glm-report.md",
+        "dispatch_id": "glm-gate-pr1486-1787999000",
+    }
+    evidence_less = {
+        "gate": "glm_gate",
+        "pr_id": "1486",
+        "status": "not_executable",
+        "reason": "provider_unavailable",
+    }
+
+    # Force both threads to complete their read of the slot before either
+    # writes. Under a lock held across read-check-write the second thread
+    # cannot reach this point until the first has finished, so the barrier
+    # times out instead of syncing — that is the passing shape, not a failure.
+    stale_read_barrier = threading.Barrier(2)
+    synced: set[int] = set()
+    sync_lock = threading.Lock()
+    real_read = gate_recorder._read_existing_result
+
+    def read_then_sync_once(path: Path):
+        value = real_read(path)
+        tid = threading.get_ident()
+        with sync_lock:
+            first_time = tid not in synced
+            synced.add(tid)
+        if first_time:
+            try:
+                stale_read_barrier.wait(timeout=2)
+            except threading.BrokenBarrierError:
+                pass
+        return value
+
+    gate_recorder._read_existing_result = read_then_sync_once
+    errors: list[BaseException] = []
+    try:
+        def writer(payload: dict) -> None:
+            try:
+                write_result_guarded(
+                    result_path, payload, gate="glm_gate", pr_ref="1486"
+                )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, args=(p,), daemon=True)
+            for p in (evidenced_pass, evidence_less)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+    finally:
+        gate_recorder._read_existing_result = real_read
+
+    assert not errors, f"a writer raised: {[repr(e) for e in errors]}"
+
+    on_disk = json.loads(result_path.read_text(encoding="utf-8"))
+    assert on_disk["status"] == "pass", (
+        "an evidence-less not_executable erased a decided, evidenced verdict — "
+        "the overwrite guard read the slot outside the lock that protects the "
+        "write, so both writers passed it against the same stale state"
+    )
+    assert on_disk.get("contract_hash") == "088a30754169bb91"

--- a/tests/test_oi1486_scratch_name_sweep.py
+++ b/tests/test_oi1486_scratch_name_sweep.py
@@ -1,0 +1,155 @@
+"""No new writer may derive its scratch file from the destination alone (OI-1486).
+
+``atomic_io.atomic_write_text`` exists because this pattern was already
+consolidated once::
+
+    tmp = target.with_suffix(".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, target)
+
+The consolidation added the helper and left the inline copies in place, so the
+form kept spreading. It is not a style preference: the scratch name is a pure
+function of the DESTINATION, so every concurrent writer of one path picks the
+same scratch file. They overwrite each other's bytes, the first to rename
+lands somebody else's content under its own name, and the second renames a
+path that is already gone. OI-1486 measured that on the gate-result slot: two
+threads, and the writer that reported success was not the writer whose bytes
+were on disk.
+
+This test pins the TREE, not the five call sites OI-1486 repaired. A new
+occurrence in any ``scripts/lib`` module fails it, and so does an extra
+occurrence in a module that still carries known ones. The allowlist below is
+the backlog, counted rather than hidden — shrink an entry when you convert
+one, and delete the entry at zero.
+
+Not flagged: a scratch name that already carries a per-writer discriminator
+(``mkstemp``, ``os.getpid()``, a uuid). ``getpid`` is the weaker form — it
+separates processes but not two threads of one process — and six sites in this
+tree use it. That is a narrower defect than the one measured here and it is
+not what this guard is for.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+
+# A scratch name containing any of these is discriminated per writer.
+_DISCRIMINATORS = ("mkstemp", "getpid", "uuid", "tempfile", "NamedTemporary")
+
+# path relative to scripts/lib -> occurrences still carrying the form.
+# Converting one of these means decrementing its number in the same commit.
+_KNOWN_BACKLOG: dict[str, int] = {
+    "context_rotation.py": 2,
+    "dispatch_broker.py": 1,
+    "dispatch_cli.py": 1,
+    "event_store.py": 1,
+    "headless_dispatch_writer.py": 1,
+    "health_beacon.py": 1,
+    "injection_effectiveness_probe.py": 1,
+    "intelligence_aggregator.py": 1,
+    "objective_reconcile.py": 2,
+    "provider_spawns/kimi_spawn.py": 1,
+    "receipt_classifier.py": 2,
+    "skill_refinement.py": 1,
+    "smart_router.py": 1,
+    "state_rebuild_trigger.py": 1,
+    "tmux_interactive_dispatch.py": 1,
+}
+
+
+def _scratch_sites(module: Path) -> list[tuple[int, str]]:
+    """Assignments whose value builds a ``.tmp`` path with no writer identity.
+
+    Parsed rather than grepped: every docstring in this tree that explains the
+    defect contains the defective text, and a grep counts those as instances
+    of it. Only real assignment expressions reach this list.
+    """
+    try:
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    sites: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
+            continue
+        expr = ast.unparse(node.value)
+        if ".tmp'" not in expr:
+            continue
+        if any(d in expr for d in _DISCRIMINATORS):
+            continue
+        sites.append((node.lineno, expr))
+    return sites
+
+
+def _sweep() -> dict[str, list[tuple[int, str]]]:
+    found: dict[str, list[tuple[int, str]]] = {}
+    for module in sorted(LIB_DIR.rglob("*.py")):
+        sites = _scratch_sites(module)
+        if sites:
+            found[module.relative_to(LIB_DIR).as_posix()] = sites
+    return found
+
+
+def test_the_sweep_finds_a_case_that_is_known_to_exist():
+    """The detector must be able to see the thing before its count means anything.
+
+    A sweep that silently matches nothing reports a clean tree in exactly the
+    same words as a sweep that works. This asserts against a backlog entry
+    that is known to be present.
+    """
+    found = _sweep()
+    assert "smart_router.py" in found, (
+        "the sweep found no scratch-name site in smart_router.py, which is "
+        "known to carry one — the detector is broken, not the tree clean"
+    )
+
+
+def test_the_repaired_call_sites_stay_repaired():
+    """The five OI-1486 conversions, named so a revert cannot pass quietly."""
+    found = _sweep()
+    for repaired in (
+        "gate_recorder.py",
+        "gate_request_handler.py",
+        "governance_emit.py",
+    ):
+        assert repaired not in found, (
+            f"{repaired} carries a destination-derived scratch name again: "
+            f"{found.get(repaired)} — use atomic_io.atomic_write_text/_json, "
+            "and atomic_io.slot_lock when a read decides the write"
+        )
+
+
+def test_no_module_gains_a_destination_derived_scratch_name():
+    found = _sweep()
+    offenders: list[str] = []
+    for module, sites in found.items():
+        allowed = _KNOWN_BACKLOG.get(module, 0)
+        if len(sites) > allowed:
+            rendered = ", ".join(f"line {ln}: {src}" for ln, src in sites)
+            offenders.append(
+                f"{module}: {len(sites)} site(s), {allowed} allowed — {rendered}"
+            )
+    assert not offenders, (
+        "a scratch file whose name comes from the destination alone is shared "
+        "by every concurrent writer of that destination (OI-1486). Use "
+        "atomic_io.atomic_write_text / atomic_write_json, which take a "
+        "per-writer mkstemp name; add atomic_io.slot_lock when the write "
+        "depends on something the caller just read.\n" + "\n".join(offenders)
+    )
+
+
+def test_backlog_entries_that_are_gone_are_deleted_from_the_list():
+    """An allowlist that outlives what it lists stops describing the tree."""
+    found = _sweep()
+    stale = {
+        module: allowed
+        for module, allowed in _KNOWN_BACKLOG.items()
+        if len(found.get(module, [])) < allowed
+    }
+    assert not stale, (
+        "these entries claim more remaining sites than the tree has — the "
+        "conversion landed without shrinking the number, so the backlog now "
+        "over-reports: " + repr(stale)
+    )


### PR DESCRIPTION
## What was wrong

`gate_recorder._write_result_atomic` derived its scratch file as
`result_path.with_suffix(".json.tmp")`. That name is a pure function of the
destination, so every concurrent writer of one gate-result slot picked the same
scratch file — on a slot that `_check_overwrite_guard`'s own docstring
describes as having three independent writers with no ordering guarantee.

Two defects, not one:

1. **Shared scratch file.** Writer B overwrites A's bytes; A renames B's bytes
   into place and reports its own payload as landed; B renames a path A has
   already consumed and dies on `FileNotFoundError`. The record on disk belongs
   to neither writer's account of what happened.
2. **No lock across read-check-write.** `_check_overwrite_guard` reads the slot,
   decides, and only then writes. Both writers could read the same absent state,
   both conclude the write was permitted, and both write. The guard's rule — a
   decided, evidenced verdict may only be replaced by another decided, evidenced
   one — is a statement about serialized writers. Without a lock it did not hold.

## Red before, green after

`tests/test_oi1486_concurrent_result_writers.py`, on `main` 17de88de:

```
FAILED test_concurrent_writers_never_report_a_write_that_did_not_land
E  AssertionError: a concurrent writer raised instead of writing:
   ["FileNotFoundError(2, 'No such file or directory')"]
FAILED test_overwrite_guard_holds_under_two_concurrent_writers
2 failed in 10.28s
```

After: `2 passed`. Full targeted run over the four changed modules and their
neighbours: **196 passed**.

## No new atomic-write implementation

`atomic_io.py` already consolidated this pattern — its header names the four
inline copies it replaced. The consolidation added the helper and left the
copies in place, so the form kept spreading. `gate_request_handler.py` had
already imported `atomic_write_json` and hand-rolled the defective form three
times next to that import.

So this PR adds only what was genuinely missing: **`atomic_io.slot_lock`**, an
exclusive lock over a sibling `.<name>.lock`, held across a read-check-write
sequence. Atomic writes make a write indivisible; they cannot order two writers,
because by the time either writes, both have already decided to.

## Sweep: the form, not the file

Measured across all of `scripts/lib`, parsing rather than grepping (every
docstring explaining this defect contains the defective text):

| | sites |
|---|---|
| before (17de88de) | 23 |
| repaired here | 5 |
| remaining | 18 |

Repaired: `gate_recorder.py` (1), `gate_request_handler.py` (3),
`governance_emit.py` (1 — its module header stated the defective form as the
atomicity guarantee).

`tests/test_oi1486_scratch_name_sweep.py` pins the **tree**: a new occurrence in
any `scripts/lib` module fails it, and the remaining 18 are an allowlist with
per-file counts, so the backlog is recorded rather than hidden. A fourth test
fails when an entry over-reports, so the list cannot outlive what it lists.

Proven able to fail — reintroducing the form into `gate_recorder.py`:

```
FAILED test_the_repaired_call_sites_stay_repaired
FAILED test_no_module_gains_a_destination_derived_scratch_name
E  gate_recorder.py: 1 site(s), 0 allowed — line 424: result_path.with_suffix('.json.tmp')
```

## A neighbour test that had stopped failing

`test_oi1472_residual_guard_writers::test_a_torn_write_cannot_reach_the_live_record`
injected its mid-write failure by monkeypatching `Path.write_text`. Once the
scratch write moved to a `mkstemp` handle that patch no longer intersected the
write path: the assertions still held, but nothing was failing and the test was
passing on an empty run. The seam moved to `os.fsync`, which is where a full
disk is usually reported. The behaviour under test is unchanged.

## Out of scope

Six sites in this tree discriminate their scratch name with `os.getpid()`. That
separates processes but not two threads of one process — a narrower defect,
deliberately not addressed here and not flagged by the sweep.

`scripts/lib/providers/**`, `provider_dispatch.py` and `dispatch_cli.py` were
left untouched (concurrent work). `dispatch_cli.py` carries 1 of the remaining
18 and is allowlisted.

Refs OI-1486