### PR TITLE
fix(cost): price the kimi model that actually ran, and refuse to guess (OI-1361)

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -562,18 +562,26 @@ def _kimi_entry_from_cli_arg(cfg: Any, model: Optional[str]) -> Optional[Any]:
     the registry keys never match.
 
     This is a lookup, not a guess: each registry entry carries its own
-    ``cli_model_arg``, so the mapping comes from the registry itself. Exact match only.
+    ``cli_model_arg``, so the mapping comes from the registry itself. Comparison is
+    case-insensitive, matching ``_kimi_resolve_cli_model_arg``'s own reverse scan —
+    a case variant that resolves at spawn must not miss at cost.
+
+    It deliberately does NOT skip ``dispatch_allowed=false`` entries, where the spawn
+    side does. Those are different questions: spawn asks "may this run", cost asks
+    "what did the thing that already ran charge". Refusing to price a receipt because
+    the model has since been disabled would lose real spend.
+
     Two entries sharing one CLI arg is registry drift, and is reported as a miss rather
     than resolved by picking one — the whole point of OI-1361 is not to let iteration
     order decide a price.
     """
-    raw = (model or "").strip()
+    raw = (model or "").strip().lower()
     if not raw:
         return None
     matches = [
         (key, entry)
         for key, entry in cfg.models.items()
-        if getattr(entry, "cli_model_arg", None) == raw
+        if str(getattr(entry, "cli_model_arg", None) or "").lower() == raw
     ]
     if len(matches) > 1:
         logger.warning(
@@ -636,13 +644,19 @@ def _compute_kimi_cost(model: Optional[str], token_usage: Dict[str, Any]) -> Opt
         target_key = _kimi_resolve_requested_key(model)
         entry = _resolve_registry_model_entry(cfg, "kimi_cli", target_key)
         if entry is None:
-            # The envelope lane hands us the CLI arg form, not a registry key.
-            entry = _kimi_entry_from_cli_arg(cfg, model)
+            # The envelope lane hands us the CLI arg form, not a registry key. It can
+            # arrive either raw (adapter_result.model) or already carried through the
+            # canonical resolver (VNX_KIMI_MODEL set in CLI-arg form, no explicit -m,
+            # so target_key IS the CLI arg). Try both.
+            entry = _kimi_entry_from_cli_arg(cfg, target_key) or _kimi_entry_from_cli_arg(
+                cfg, model
+            )
         if entry is None:
             logger.warning(
-                "_compute_kimi_cost: no match for model=%s (registry_key=kimi_cli, "
-                "%d models in section) — miss, not a fabricated price",
-                target_key, len(cfg.models),
+                "_compute_kimi_cost: no match for model=%r (resolved key %r, "
+                "registry_key=kimi_cli, %d models in section) — miss, not a "
+                "fabricated price",
+                model, target_key, len(cfg.models),
             )
             return None
         cost_in = (token_usage.get("input", 0) / 1_000_000) * entry.cost_input_per_mtok

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -552,6 +552,39 @@ def _load_pricing_from_registry(provider: str, model: str) -> Optional[Dict[str,
         return None
 
 
+def _kimi_entry_from_cli_arg(cfg: Any, model: Optional[str]) -> Optional[Any]:
+    """Reverse-map a kimi CLI ARG form back to its registry entry.
+
+    The envelope lane does not stamp the registry key. ``envelope_adapters_provider``
+    resolves the spawn model through ``_kimi_resolve_cli_model_arg`` and stamps
+    ``adapter_result.model`` with the CLI arg (e.g. "kimi-code/k3"); ``envelope_govern``
+    then hands exactly that string to the cost path. So the cost path receives a form
+    the registry keys never match.
+
+    This is a lookup, not a guess: each registry entry carries its own
+    ``cli_model_arg``, so the mapping comes from the registry itself. Exact match only.
+    Two entries sharing one CLI arg is registry drift, and is reported as a miss rather
+    than resolved by picking one — the whole point of OI-1361 is not to let iteration
+    order decide a price.
+    """
+    raw = (model or "").strip()
+    if not raw:
+        return None
+    matches = [
+        (key, entry)
+        for key, entry in cfg.models.items()
+        if getattr(entry, "cli_model_arg", None) == raw
+    ]
+    if len(matches) > 1:
+        logger.warning(
+            "_kimi_entry_from_cli_arg: cli_model_arg=%s maps to %d registry keys (%s) "
+            "— ambiguous, refusing to pick one",
+            raw, len(matches), ", ".join(k for k, _ in matches),
+        )
+        return None
+    return matches[0][1] if matches else None
+
+
 def _compute_kimi_cost(model: Optional[str], token_usage: Dict[str, Any]) -> Optional[float]:
     """Compute cost via wave7_models.yaml kimi_cli section for kimi provider.
 
@@ -581,6 +614,14 @@ def _compute_kimi_cost(model: Optional[str], token_usage: Dict[str, Any]) -> Opt
     "kimi-default", "kimi_cli") all resolve through that shared path. Note this is why
     the old guess looked harmless: for "default"/"sonnet" the first-entry fallback
     happened to land on kimi-k3, which was the right answer for the wrong reason.
+
+    One caller does not speak registry keys at all: the envelope lane stamps
+    ``adapter_result.model`` with the CLI ARG ("kimi-code/k3"), which
+    ``envelope_govern`` forwards here. ``_kimi_entry_from_cli_arg`` reverse-maps that
+    through the registry's own ``cli_model_arg`` field. Removing the guess without
+    this step would have blacked out cost on the whole envelope door — the guess was
+    masking a second, independent gap, and priced "kimi-code/kimi-for-coding" as K3
+    (18.00) when the model that ran was K2-7 (3.10).
     """
     if not token_usage or token_usage.get("unavailable") or (
         token_usage.get("input", 0) == 0 and token_usage.get("output", 0) == 0
@@ -594,6 +635,9 @@ def _compute_kimi_cost(model: Optional[str], token_usage: Dict[str, Any]) -> Opt
             return None
         target_key = _kimi_resolve_requested_key(model)
         entry = _resolve_registry_model_entry(cfg, "kimi_cli", target_key)
+        if entry is None:
+            # The envelope lane hands us the CLI arg form, not a registry key.
+            entry = _kimi_entry_from_cli_arg(cfg, model)
         if entry is None:
             logger.warning(
                 "_compute_kimi_cost: no match for model=%s (registry_key=kimi_cli, "

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -553,7 +553,35 @@ def _load_pricing_from_registry(provider: str, model: str) -> Optional[Dict[str,
 
 
 def _compute_kimi_cost(model: Optional[str], token_usage: Dict[str, Any]) -> Optional[float]:
-    """Compute cost via wave7_models.yaml kimi_cli section for kimi provider."""
+    """Compute cost via wave7_models.yaml kimi_cli section for kimi provider.
+
+    A model the registry does not know returns None — never a price (OI-1361). This
+    used to end on ``next(iter(cfg.models.values()), None)``, so an unknown model name
+    inherited whichever entry happened to sit FIRST in the kimi_cli section (today
+    kimi-k3 at 3.00 in / 15.00 out), and that invented number reached the receipt as a
+    confirmed ``cost_usd``, indistinguishable from a measured one.
+
+    Resolution now goes through ``_resolve_registry_model_entry``, the same
+    deterministic, iteration-order-independent lookup the sibling
+    ``_load_pricing_from_registry`` has used since OI-1355 / PR #1609. Both pricing
+    handlers therefore resolve identically and cannot drift apart again — the
+    asymmetry was the whole defect: the guess was removed from one handler and left
+    standing in the other.
+
+    The model key comes from ``_kimi_resolve_requested_key`` — the SAME resolver the
+    spawn seam, governance labeling and the constraint pre-flight already share — so
+    the price is now computed for the model that actually ran. It previously used its
+    own ad-hoc rule (``(model or "").strip() or "kimi-default"``), which disagreed with
+    the canonical resolver on seven of ten real inputs. The worst case was an absent
+    model: the dispatch RUNS on the registry's K3 default (3.00 in / 15.00 out) and was
+    PRICED as kimi-default (0.60 / 2.50) — a factor 5.8 under-report on every kimi
+    dispatch that did not name a model explicitly.
+
+    The CLI placeholders ("default", "sonnet", "") and the bare aliases ("kimi",
+    "kimi-default", "kimi_cli") all resolve through that shared path. Note this is why
+    the old guess looked harmless: for "default"/"sonnet" the first-entry fallback
+    happened to land on kimi-k3, which was the right answer for the wrong reason.
+    """
     if not token_usage or token_usage.get("unavailable") or (
         token_usage.get("input", 0) == 0 and token_usage.get("output", 0) == 0
     ):
@@ -564,9 +592,14 @@ def _compute_kimi_cost(model: Optional[str], token_usage: Dict[str, Any]) -> Opt
         cfg = registry.get("kimi_cli")
         if cfg is None or not cfg.models:
             return None
-        target_key = (model or "").strip() or "kimi-default"
-        entry = cfg.models.get(target_key) or next(iter(cfg.models.values()), None)
+        target_key = _kimi_resolve_requested_key(model)
+        entry = _resolve_registry_model_entry(cfg, "kimi_cli", target_key)
         if entry is None:
+            logger.warning(
+                "_compute_kimi_cost: no match for model=%s (registry_key=kimi_cli, "
+                "%d models in section) — miss, not a fabricated price",
+                target_key, len(cfg.models),
+            )
             return None
         cost_in = (token_usage.get("input", 0) / 1_000_000) * entry.cost_input_per_mtok
         cost_out = (token_usage.get("output", 0) / 1_000_000) * entry.cost_output_per_mtok

--- a/tests/test_provider_dispatch_kimi.py
+++ b/tests/test_provider_dispatch_kimi.py
@@ -258,3 +258,143 @@ class TestComputeKimiCost(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestComputeKimiCostRefusesToGuess(unittest.TestCase):
+    """OI-1361: an unknown kimi model must yield None, never a fabricated price.
+
+    ``_compute_kimi_cost`` ended on ``next(iter(cfg.models.values()), None)``, so any
+    model name the registry does not know inherited the price of whichever entry
+    happened to sit FIRST in the kimi_cli section — today ``kimi-k3`` at 3.00 in /
+    15.00 out. That invented number was then written to the receipt as a confirmed
+    ``cost_usd``, indistinguishable from a real one.
+
+    The sibling lookup ``_load_pricing_from_registry`` had exactly this construction
+    removed in PR #1609 (OI-1355) and now logs "miss, not a fabricated price". This is
+    the same fix in the handler that was left behind.
+    """
+
+    #: One MTok in and one MTok out, so cost_usd equals the per-MTok prices summed.
+    ONE_MTOK = {"input": 1_000_000, "output": 1_000_000, "cache_hit": 0}
+
+    def test_unknown_model_returns_none_instead_of_the_first_entry_price(self):
+        import provider_dispatch as pd
+
+        # kimi-k3 is first in the section (3.00 + 15.00), so the old guess was 18.0.
+        self.assertIsNone(pd._compute_kimi_cost("kimi-k9-does-not-exist", self.ONE_MTOK))
+
+    def test_unknown_model_is_not_priced_as_any_registry_entry(self):
+        """Stronger than the previous test: the miss must not equal ANY known price,
+        so a future reordering of the section cannot make this test pass by accident."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        every_price = {
+            round(m.cost_input_per_mtok + m.cost_output_per_mtok, 8)
+            for m in cfg.models.values()
+        }
+        cost = pd._compute_kimi_cost("totally-not-a-kimi-model", self.ONE_MTOK)
+        self.assertIsNone(cost)
+        self.assertNotIn(cost, every_price)
+
+    def test_known_models_keep_pricing_exactly(self):
+        """Every registry key that names a real model prices as itself.
+
+        Keys that the canonical resolver treats as a bare ALIAS are skipped and covered
+        by test_alias_key_prices_as_the_model_it_aliases below — asserting an alias
+        prices as its own registry row would be asserting the bug."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        for key, entry in cfg.models.items():
+            if pd._kimi_resolve_requested_key(key) != key:
+                continue  # alias, not a selectable model
+            expected = round(entry.cost_input_per_mtok + entry.cost_output_per_mtok, 8)
+            with self.subTest(model=key):
+                self.assertEqual(pd._compute_kimi_cost(key, self.ONE_MTOK), expected)
+
+    def test_alias_key_prices_as_the_model_it_aliases(self):
+        """"kimi-default" is a bare alias for the K3 default (_KIMI_BARE_ALIASES), and
+        ALSO exists as its own registry row at a different price. A dispatch naming it
+        runs on K3, so it must be priced as K3 — the same-named row is unreachable.
+
+        The unreachable row itself is a registry-hygiene problem, not a pricing one; it
+        is reported separately rather than silently deleted here."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        self.assertIn("kimi-default", cfg.models, "fixture assumes the shadowed row exists")
+
+        aliased_to = cfg.models[pd._kimi_resolve_requested_key("kimi-default")]
+        expected = round(aliased_to.cost_input_per_mtok + aliased_to.cost_output_per_mtok, 8)
+        self.assertEqual(pd._compute_kimi_cost("kimi-default", self.ONE_MTOK), expected)
+
+    def test_absent_model_is_priced_as_the_model_that_actually_runs(self):
+        """An absent model name must be priced as the model the spawn seam will really
+        use, not as the "kimi-default" registry entry.
+
+        This is the expensive half of OI-1361. _kimi_resolve_requested_key (shared by
+        the spawn seam, governance labeling and the constraint pre-flight) resolves an
+        absent model to the registry's K3 default at 3.00/15.00. _compute_kimi_cost had
+        its own rule and charged kimi-default's 0.60/2.50 instead — every kimi dispatch
+        without an explicit model was under-reported by a factor 5.8."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        ran = cfg.models[pd._kimi_resolve_requested_key(None)]
+        expected = round(ran.cost_input_per_mtok + ran.cost_output_per_mtok, 8)
+
+        wrong = cfg.models["kimi-default"]
+        wrong_price = round(wrong.cost_input_per_mtok + wrong.cost_output_per_mtok, 8)
+        self.assertNotEqual(expected, wrong_price, "fixture no longer discriminates")
+
+        for placeholder in ("", None, "default", "sonnet", "kimi", "kimi_cli"):
+            with self.subTest(model=placeholder):
+                self.assertEqual(pd._compute_kimi_cost(placeholder, self.ONE_MTOK), expected)
+
+    def test_pricing_key_agrees_with_the_canonical_resolver(self):
+        """The pricing handler and the spawn seam must never disagree about which model
+        a dispatch is. Two independent resolvers for one question is the defect."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        for raw in ("", None, "default", "sonnet", "kimi", "kimi-default", "kimi_cli",
+                    "kimi-k3", "kimi-k2-6", "kimi-k2-7"):
+            key = pd._kimi_resolve_requested_key(raw)
+            entry = cfg.models.get(key)
+            if entry is None:
+                continue
+            expected = round(entry.cost_input_per_mtok + entry.cost_output_per_mtok, 8)
+            with self.subTest(model=raw, resolved=key):
+                self.assertEqual(pd._compute_kimi_cost(raw, self.ONE_MTOK), expected)
+
+    def test_dated_suffix_resolves_to_its_base_model(self):
+        """A real dated model id must still resolve — refusing to guess is not the same
+        as refusing to resolve.
+
+        Deliberately uses a suffix of kimi-k2-6, NOT of kimi-k3. A kimi-k3 suffix would
+        pass on the broken code too, because the first-entry guess happens to BE kimi-k3
+        — the same correct answer reached by the wrong mechanism. Pinning a non-first
+        model makes the test discriminate."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        k26 = _reg.load().get("kimi_cli").models["kimi-k2-6"]
+        expected = round(k26.cost_input_per_mtok + k26.cost_output_per_mtok, 8)
+        self.assertEqual(pd._compute_kimi_cost("kimi-k2-6-20260901", self.ONE_MTOK), expected)
+
+    def test_miss_is_logged_as_a_miss(self):
+        import logging
+
+        import provider_dispatch as pd
+
+        with self.assertLogs("provider_dispatch", level=logging.WARNING) as captured:
+            pd._compute_kimi_cost("kimi-k9-does-not-exist", self.ONE_MTOK)
+        joined = "\n".join(captured.output)
+        self.assertIn("kimi-k9-does-not-exist", joined)
+        self.assertIn("not a fabricated price", joined)

--- a/tests/test_provider_dispatch_kimi.py
+++ b/tests/test_provider_dispatch_kimi.py
@@ -338,20 +338,29 @@ class TestComputeKimiCostRefusesToGuess(unittest.TestCase):
         absent model to the registry's K3 default at 3.00/15.00. _compute_kimi_cost had
         its own rule and charged kimi-default's 0.60/2.50 instead — every kimi dispatch
         without an explicit model was under-reported by a factor 5.8."""
+        import os
+        from unittest.mock import patch
+
         import provider_dispatch as pd
         from providers import provider_registry as _reg
 
-        cfg = _reg.load().get("kimi_cli")
-        ran = cfg.models[pd._kimi_resolve_requested_key(None)]
-        expected = round(ran.cost_input_per_mtok + ran.cost_output_per_mtok, 8)
+        # _kimi_resolve_requested_key consults VNX_KIMI_MODEL. Leaning on that var
+        # being absent makes the test depend on the operator's shell; pin it empty.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VNX_KIMI_MODEL", None)
+            cfg = _reg.load().get("kimi_cli")
+            ran = cfg.models[pd._kimi_resolve_requested_key(None)]
+            expected = round(ran.cost_input_per_mtok + ran.cost_output_per_mtok, 8)
 
-        wrong = cfg.models["kimi-default"]
-        wrong_price = round(wrong.cost_input_per_mtok + wrong.cost_output_per_mtok, 8)
-        self.assertNotEqual(expected, wrong_price, "fixture no longer discriminates")
+            wrong = cfg.models["kimi-default"]
+            wrong_price = round(wrong.cost_input_per_mtok + wrong.cost_output_per_mtok, 8)
+            self.assertNotEqual(expected, wrong_price, "fixture no longer discriminates")
 
-        for placeholder in ("", None, "default", "sonnet", "kimi", "kimi_cli"):
-            with self.subTest(model=placeholder):
-                self.assertEqual(pd._compute_kimi_cost(placeholder, self.ONE_MTOK), expected)
+            for placeholder in ("", None, "default", "sonnet", "kimi", "kimi_cli"):
+                with self.subTest(model=placeholder):
+                    self.assertEqual(
+                        pd._compute_kimi_cost(placeholder, self.ONE_MTOK), expected
+                    )
 
     def test_pricing_key_agrees_with_the_canonical_resolver(self):
         """The pricing handler and the spawn seam must never disagree about which model

--- a/tests/test_provider_dispatch_kimi.py
+++ b/tests/test_provider_dispatch_kimi.py
@@ -256,9 +256,6 @@ class TestComputeKimiCost(unittest.TestCase):
         self.assertIsNone(pd._compute_cost("kimi", "kimi-default", usage))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 
 class TestComputeKimiCostRefusesToGuess(unittest.TestCase):
     """OI-1361: an unknown kimi model must yield None, never a fabricated price.
@@ -398,3 +395,50 @@ class TestComputeKimiCostRefusesToGuess(unittest.TestCase):
         joined = "\n".join(captured.output)
         self.assertIn("kimi-k9-does-not-exist", joined)
         self.assertIn("not a fabricated price", joined)
+
+    def test_cli_arg_form_prices_the_model_that_ran(self):
+        """The envelope lane stamps adapter_result.model with the CLI ARG, not a
+        registry key (envelope_adapters_provider -> envelope_govern -> _compute_cost).
+
+        On main the first-entry guess made "kimi-code/k3" come out right by accident
+        and "kimi-code/kimi-for-coding" come out 5.8x too high (18.00 for a model that
+        costs 3.10). Both now resolve through the registry's own cli_model_arg field."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        priced = 0
+        for key, entry in cfg.models.items():
+            arg = getattr(entry, "cli_model_arg", None)
+            if not arg:
+                continue
+            expected = round(entry.cost_input_per_mtok + entry.cost_output_per_mtok, 8)
+            with self.subTest(cli_arg=arg, registry_key=key):
+                self.assertEqual(pd._compute_kimi_cost(arg, self.ONE_MTOK), expected)
+            priced += 1
+        self.assertGreaterEqual(priced, 2, "fixture expects at least two mapped CLI args")
+
+    def test_cli_arg_form_that_maps_to_nothing_is_still_a_miss(self):
+        import provider_dispatch as pd
+
+        self.assertIsNone(pd._compute_kimi_cost("kimi-code/not-a-real-arg", self.ONE_MTOK))
+
+    def test_ambiguous_cli_arg_refuses_to_pick(self):
+        """Two registry entries sharing one CLI arg is drift. Picking one would put
+        iteration order back in charge of a price, which is the defect being closed."""
+        import copy
+
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = copy.deepcopy(_reg.load().get("kimi_cli"))
+        keys = [k for k, m in cfg.models.items() if getattr(m, "cli_model_arg", None)]
+        self.assertGreaterEqual(len(keys), 2)
+        shared = cfg.models[keys[0]].cli_model_arg
+        object.__setattr__(cfg.models[keys[1]], "cli_model_arg", shared)
+
+        self.assertIsNone(pd._kimi_entry_from_cli_arg(cfg, shared))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_dispatch_kimi.py
+++ b/tests/test_provider_dispatch_kimi.py
@@ -440,5 +440,63 @@ class TestComputeKimiCostRefusesToGuess(unittest.TestCase):
         self.assertIsNone(pd._kimi_entry_from_cli_arg(cfg, shared))
 
 
+    def test_cli_arg_arriving_via_the_env_override_is_priced(self):
+        """VNX_KIMI_MODEL can itself hold the CLI-arg form. With no explicit -m the
+        canonical resolver returns it unchanged, so the CLI-arg reverse map has to be
+        tried on the RESOLVED key too, not only on the raw argument."""
+        import os
+        from unittest.mock import patch
+
+        import provider_dispatch as pd
+
+        with patch.dict(os.environ, {"VNX_KIMI_MODEL": "kimi-code/k3"}):
+            self.assertEqual(pd._kimi_resolve_requested_key(None), "kimi-code/k3")
+            expected = pd._compute_kimi_cost("kimi-k3", self.ONE_MTOK)
+            self.assertEqual(pd._compute_kimi_cost(None, self.ONE_MTOK), expected)
+
+    def test_cli_arg_match_is_case_insensitive_like_the_spawn_side(self):
+        """_kimi_resolve_cli_model_arg compares cli_model_arg case-insensitively. A
+        case variant that resolves at spawn must not miss at cost."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        arg = next(
+            m.cli_model_arg for m in cfg.models.values() if getattr(m, "cli_model_arg", None)
+        )
+        self.assertEqual(
+            pd._compute_kimi_cost(arg.upper(), self.ONE_MTOK),
+            pd._compute_kimi_cost(arg, self.ONE_MTOK),
+        )
+
+    def test_disabled_models_are_still_priceable(self):
+        """Spawn asks "may this run"; cost asks "what did the thing that already ran
+        charge". A model disabled after the fact must still price, or real spend is
+        lost from the ledger."""
+        import provider_dispatch as pd
+        from providers import provider_registry as _reg
+
+        cfg = _reg.load().get("kimi_cli")
+        disabled = [
+            (k, m) for k, m in cfg.models.items() if not getattr(m, "dispatch_allowed", True)
+        ]
+        self.assertTrue(disabled, "fixture expects at least one disabled kimi model")
+        for key, entry in disabled:
+            expected = round(entry.cost_input_per_mtok + entry.cost_output_per_mtok, 8)
+            with self.subTest(model=key):
+                self.assertEqual(pd._compute_kimi_cost(key, self.ONE_MTOK), expected)
+
+    def test_the_miss_warning_names_the_raw_input_too(self):
+        """The forensic value of the miss log is the string that actually arrived, not
+        only what it resolved to."""
+        import logging
+
+        import provider_dispatch as pd
+
+        with self.assertLogs("provider_dispatch", level=logging.WARNING) as captured:
+            pd._compute_kimi_cost("kimi-code/not-a-real-arg", self.ONE_MTOK)
+        self.assertIn("kimi-code/not-a-real-arg", "\n".join(captured.output))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## De gemelde fout

`_compute_kimi_cost` eindigde op `next(iter(cfg.models.values()), None)`. Een kimi-modelnaam die de registry niet kent kreeg daarmee de prijs van het model dat toevallig **eerst** in de `kimi_cli`-sectie staat: vandaag `kimi-k3`, 3.00 in en 15.00 uit. Dat verzonnen getal ging als bevestigde `cost_usd` de receipt in, niet te onderscheiden van een gemeten getal.

Dezelfde constructie is in PR #1609 (OI-1355) al uit de broer `_load_pricing_from_registry` gehaald. Die logt sindsdien "miss, not a fabricated price". Deze handler bleef achter. Dat is het patroon: de fix landde op plek A, plek B bleef staan.

## Wat de meting daarnaast opleverde

Er waren **twee onafhankelijke resolvers voor één vraag**. `_kimi_resolve_requested_key` is de kanonieke, gedeeld door de spawn-naad, governance-labeling en de constraint-preflight. `_compute_kimi_cost` had zijn eigen regel. Ze verschillen op zeven van de tien echte invoeren:

| input | kanonieke resolver | prijs-handler | gevolg |
|---|---|---|---|
| `''` / `None` | `kimi-k3` | `kimi-default` | draait K3, beprijsd als default |
| `'default'` | `kimi-k3` | `default` | miss, dan gok K3 |
| `'sonnet'` | `kimi-k3` | `sonnet` | miss, dan gok K3 |
| `'kimi'` | `kimi-k3` | `kimi` | miss, dan gok K3 |
| `'kimi-default'` | `kimi-k3` | `kimi-default` | 3.10 gerekend in plaats van 18.00 |
| `'kimi_cli'` | `kimi-k3` | `kimi_cli` | miss, dan gok K3 |

Elke kimi-dispatch zonder expliciet model draaide dus op K3 (3.00/15.00) en werd beprijsd als `kimi-default` (0.60/2.50). Een factor 5,8 te laag gerapporteerd.

En de gok maskeerde dat voor `'default'` en `'sonnet'`: daar viel de eerste-entry-gok toevallig op precies het juiste model. De juiste uitkomst via het verkeerde mechanisme. Een naïeve fix die alleen `None` teruggeeft bij een miss zou die twee gevallen van een toevallig juiste prijs naar géén prijs hebben gebracht.

## De fix

De sleutel loopt nu door de kanonieke resolver, daarna door de gedeelde deterministische `_resolve_registry_model_entry`, en geeft bij een miss `None` met dezelfde `miss, not a fabricated price`-waarschuwing die de broer al emit. Eén resolver, één lookup, geen gok.

## Apart gemeld, niet stil gewijzigd

De `kimi_cli`-sectie draagt een rij `kimi-default` op 0.60/2.50 die de kanonieke resolver **nooit kan selecteren**, omdat diezelfde string in `_KIMI_BARE_ALIASES` een alias voor de K3-default is. Dode prijsdata die er levend uitziet. Registry-hygiëne, grenst aan OI-1335; niet in deze PR opgeruimd.

## Tests

8 tests in `TestComputeKimiCostRefusesToGuess`. **7 rood op schone main**, gemeten met alleen het testbestand op `origin/main`:

```
AssertionError: 18.0 is not None      (onbekend model kreeg de eerste-entry-prijs)
AssertionError: 3.1 != 18.0           (afwezig model beprijsd als default i.p.v. K3)
AssertionError: 18.0 != 4.95          (kimi-k2-6-20260901 gegokt als k3)
AssertionError: no logs of level WARNING or higher triggered
```

De dated-suffix-test pint bewust een suffix van `kimi-k2-6` en niet van `kimi-k3`, zodat hij niet per ongeluk kan slagen op de kapotte code.

## Buren

23 failed / 93 passed, **identiek met en zonder mijn wijziging** (gemeten in twee worktrees, een met en een zonder de fix). Nul regressies.

Die 23 zijn een worktree-artefact, geen bevinding: `NotADirectoryError: <wt>/.git/worktrees`, want in een worktree is `.git` een bestand en geen map. Dezelfde bestanden geven **26 passed** in de hoofd-checkout op schone main. Apart gemeld aan T0, want de voorgeschreven werkwijze is een worktree per PR en die kan deze tests dus nooit groen krijgen.