### PR TITLE
feat(gates): a gate run that investigated nothing is not a PASS (OI-1485)

### DIFF
--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from governance_receipts import utc_now_iso
+import gate_depth
 import gate_recorder
 from codex_parser import parse_codex_findings
 
@@ -309,6 +311,41 @@ def materialize_artifacts(
             **_fail, reason=content_err[0], reason_detail=content_err[1],
         )
 
+    # OI-1485: what the run DID, beside what it concluded. Measured from the
+    # same stream the report already embeds, so this adds no new capture path
+    # — the numbers were on disk all along and simply never reached the record
+    # anyone merges on.
+    depth = gate_depth.measure_execution_depth(stdout)
+
+    # A run that reached a verdict without a single investigative action is an
+    # absence of evidence, not a clean review. It books `unavailable` and lands
+    # in required_reruns so it is bought again, rather than passing every
+    # invariant and being read as a PASS. The report stays on disk: it is the
+    # evidence of what the refused run said, and deleting it would repeat the
+    # evidence loss the overwrite guard exists to prevent.
+    if gate_depth.is_degenerate(depth):
+        logger.warning(
+            "gate_artifacts: REFUSING a degenerate %s run pr=%s — %s",
+            gate, pr_id or pr_number, gate_depth.degenerate_detail(depth),
+        )
+        return gate_recorder.record_failure(
+            gate=gate, pr_number=pr_number, pr_id=pr_id,
+            result={
+                "reason": "gate_execution_degenerate",
+                "reason_detail": gate_depth.degenerate_detail(depth),
+                "duration_seconds": duration_seconds,
+                "partial_output_lines": len(stdout.splitlines()),
+                "runner_pid": os.getpid(),
+            },
+            request_payload=request_payload,
+            requests_dir=requests_dir,
+            results_dir=results_dir,
+            extra={
+                "execution_depth": depth.to_dict(),
+                "degenerate_report_path": str(report_file),
+            },
+        )
+
     contract_hash = _compute_contract_hash(request_payload, gate)
     now = utc_now_iso()
 
@@ -327,6 +364,7 @@ def materialize_artifacts(
         "required_reruns": [],
         "residual_risk": residual_risk,
         "duration_seconds": duration_seconds,
+        "execution_depth": depth.to_dict(),
         "recorded_at": now,
     }
     gate_recorder.stamp_request_identity(result_payload, request_payload)

--- a/scripts/lib/gate_depth.py
+++ b/scripts/lib/gate_depth.py
@@ -48,11 +48,35 @@ logger = logging.getLogger(__name__)
 # least one action" needs no tuning and rejects only the degenerate shape.
 MIN_INVESTIGATIVE_ACTIONS = 1
 
-# item.completed types that are the model talking rather than the model
-# working. Everything else counts as an investigative action, so a new tool
-# type in the stream counts on the day it appears instead of the day someone
-# remembers to add it here.
-_NON_INVESTIGATIVE_ITEM_TYPES = frozenset({"agent_message", "reasoning", "todo_list"})
+# Item types are classified from two explicit sets, with a third bucket for
+# anything in neither. An earlier version listed only the message types and
+# counted EVERYTHING else as investigative, so that a new tool type would count
+# on the day it appeared. That reasoning is right for tools and exactly wrong
+# for messages: a message alias this module does not know — codex also emits
+# `assistant_message` and `output_text` in some versions — would have been
+# counted as work, and a run that took zero tools while emitting one would have
+# cleared the floor. The permissive default has to sit where being wrong is
+# safe, and for a degeneracy check that is nowhere.
+#
+# Measured across 348 headless reports in this store: `command_execution`
+# (3854), `agent_message` (736), `file_change` (56), `web_search` (8). Nothing
+# else appears, so the sets below are the observed vocabulary plus the aliases
+# codex is known to emit elsewhere.
+_INVESTIGATIVE_ITEM_TYPES = frozenset({
+    "command_execution",
+    "file_change",
+    "web_search",
+    "mcp_tool_call",
+    "patch_apply",
+})
+_MESSAGE_ITEM_TYPES = frozenset({
+    "agent_message",
+    "assistant_message",
+    "output_text",
+    "reasoning",
+    "todo_list",
+    "error",
+})
 
 # Commands whose point is to get file content in front of the model.
 _FILE_READ_RE = re.compile(r"\b(sed|cat|head|tail|less|rg|grep|awk|find|ls)\b")
@@ -78,6 +102,7 @@ class ExecutionDepth:
     agent_messages: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
+    unrecognised_item_types: tuple = ()
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -96,6 +121,7 @@ def measure_execution_depth(stdout: str) -> ExecutionDepth:
 
     recognised = False
     investigative = shell = reads = messages = 0
+    unrecognised: set = set()
     input_tokens = output_tokens = 0
     seen_items: set = set()
 
@@ -124,8 +150,11 @@ def measure_execution_depth(stdout: str) -> ExecutionDepth:
             if item_id is not None:
                 seen_items.add(item_id)
             item_type = item.get("type")
-            if item_type in _NON_INVESTIGATIVE_ITEM_TYPES:
+            if item_type in _MESSAGE_ITEM_TYPES:
                 messages += 1
+                continue
+            if item_type not in _INVESTIGATIVE_ITEM_TYPES:
+                unrecognised.add(str(item_type))
                 continue
             investigative += 1
             if item_type == "command_execution":
@@ -149,6 +178,7 @@ def measure_execution_depth(stdout: str) -> ExecutionDepth:
         agent_messages=messages,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        unrecognised_item_types=tuple(sorted(unrecognised)),
     )
 
 
@@ -161,6 +191,12 @@ def is_degenerate(depth: ExecutionDepth) -> bool:
     lane become measurable first.
     """
     if not depth.parsed:
+        return False
+    if depth.unrecognised_item_types:
+        # The stream carried an item type this module cannot classify, so the
+        # action count is a floor and not a measurement. Refusing on it would
+        # be refusing on something not measured, which is the one thing this
+        # check must never do.
         return False
     return depth.investigative_actions < MIN_INVESTIGATIVE_ACTIONS
 

--- a/scripts/lib/gate_depth.py
+++ b/scripts/lib/gate_depth.py
@@ -1,0 +1,186 @@
+"""How much investigation a gate run actually did (OI-1485).
+
+A gate result record says the gate ran. It did not say whether the gate
+LOOKED. Measured on PR #1707: two codex_gate runs on the same head sha
+(00e64792) under the same contract_hash (088a30754169bb91) — the same
+instruction over the same diff — produced
+
+    run A   14s    0 shell calls    18219 input tokens   0 findings
+    run B  227s   16 shell calls   239992 input tokens   1 real defect
+
+and run A's own residual_risk said what had happened: "The review is limited
+to the provided diff." Across the twelve gate runs of that day the normal
+range is 5-42 shell calls and 86k-2.5M input tokens, so run A is two orders
+below the floor of the distribution, not the low end of it.
+
+The acceptance gap is that all seven headless-review invariants hold for run A
+exactly as they hold for run B: request record present, execution completed,
+result record present, contract_hash non-empty and matching, report_path
+non-empty, report file on disk, and JSON and report agreeing. Nothing in that
+list asks whether the gate did any work, so a PASS from a run that read only
+the diff is indistinguishable from a PASS from a run that read the tree and
+ran the tests. It was caught only because 14 seconds stood out beside 150.
+
+The shape of the two runs, from the event stream both of them emitted::
+
+    degenerate  item.completed: {agent_message: 1}
+    real        item.completed: {command_execution: 16, agent_message: 1}
+
+An ``agent_message`` is the verdict itself; emitting one is not evidence of
+anything. What separates the two is whether the run took a single
+investigative action. That is the floor this module measures against, and it
+is deliberately the weakest possible one: not "enough" investigation, just
+some.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# The floor is 1, not a percentile of the observed distribution. A threshold
+# tuned to look like normal runs would need re-tuning whenever the fleet's
+# habits change, and would start rejecting honest small reviews. "Took at
+# least one action" needs no tuning and rejects only the degenerate shape.
+MIN_INVESTIGATIVE_ACTIONS = 1
+
+# item.completed types that are the model talking rather than the model
+# working. Everything else counts as an investigative action, so a new tool
+# type in the stream counts on the day it appears instead of the day someone
+# remembers to add it here.
+_NON_INVESTIGATIVE_ITEM_TYPES = frozenset({"agent_message", "reasoning", "todo_list"})
+
+# Commands whose point is to get file content in front of the model.
+_FILE_READ_RE = re.compile(r"\b(sed|cat|head|tail|less|rg|grep|awk|find|ls)\b")
+
+
+@dataclass(frozen=True)
+class ExecutionDepth:
+    """What a gate run did, as opposed to what it concluded.
+
+    ``parsed`` is the field that decides whether the rest means anything. A
+    stream this module does not recognise yields ``parsed=False`` and zeros,
+    and zeros that mean "not measured" must never be read as zeros that mean
+    "did nothing" — that is the difference between an unmeasured gate and a
+    degenerate one, and collapsing it would fail every gate whose lane emits
+    no event stream. Only codex_gate emits one today; kimi_gate and glm_gate
+    reports carry no events at all.
+    """
+
+    parsed: bool = False
+    investigative_actions: int = 0
+    shell_calls: int = 0
+    files_read: int = 0
+    agent_messages: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def measure_execution_depth(stdout: str) -> ExecutionDepth:
+    """Count what the run did, from the event stream it emitted.
+
+    Never raises: an unparseable or absent stream is a measurement this
+    module could not make, not a gate failure. A malformed line is skipped
+    rather than aborting the count, because a truncated stream still carries
+    evidence about the part that did arrive.
+    """
+    if not stdout:
+        return ExecutionDepth()
+
+    recognised = False
+    investigative = shell = reads = messages = 0
+    input_tokens = output_tokens = 0
+    seen_items: set = set()
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type in {"thread.started", "turn.started", "item.started",
+                          "item.completed", "turn.completed"}:
+            recognised = True
+
+        if event_type == "item.completed":
+            item = event.get("item")
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("id")
+            if item_id is not None and item_id in seen_items:
+                continue
+            if item_id is not None:
+                seen_items.add(item_id)
+            item_type = item.get("type")
+            if item_type in _NON_INVESTIGATIVE_ITEM_TYPES:
+                messages += 1
+                continue
+            investigative += 1
+            if item_type == "command_execution":
+                shell += 1
+                if _FILE_READ_RE.search(str(item.get("command") or "")):
+                    reads += 1
+        elif event_type == "turn.completed":
+            usage = event.get("usage")
+            if isinstance(usage, dict):
+                input_tokens += int(usage.get("input_tokens") or 0)
+                output_tokens += int(usage.get("output_tokens") or 0)
+
+    if not recognised:
+        return ExecutionDepth()
+
+    return ExecutionDepth(
+        parsed=True,
+        investigative_actions=investigative,
+        shell_calls=shell,
+        files_read=reads,
+        agent_messages=messages,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+def is_degenerate(depth: ExecutionDepth) -> bool:
+    """True when the run reached a verdict without taking a single action.
+
+    False whenever the depth was not measured. A gate whose lane emits no
+    event stream must keep working exactly as before: this check exists to
+    stop a measured emptiness from being accepted, not to demand that every
+    lane become measurable first.
+    """
+    if not depth.parsed:
+        return False
+    return depth.investigative_actions < MIN_INVESTIGATIVE_ACTIONS
+
+
+def degenerate_detail(depth: ExecutionDepth) -> str:
+    """The human-readable why, carried into the result record's reason_detail."""
+    return (
+        f"the run produced {depth.agent_messages} message(s) and "
+        f"{depth.investigative_actions} investigative action(s) "
+        f"(minimum {MIN_INVESTIGATIVE_ACTIONS}); "
+        f"{depth.shell_calls} shell call(s), {depth.files_read} file read(s), "
+        f"{depth.input_tokens} input tokens — a verdict reached without "
+        f"looking at anything beyond the prompt is not gate evidence"
+    )
+
+
+__all__ = [
+    "ExecutionDepth",
+    "MIN_INVESTIGATIVE_ACTIONS",
+    "degenerate_detail",
+    "is_degenerate",
+    "measure_execution_depth",
+]

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -98,6 +98,12 @@ EXECUTION_FAILURE_REASONS: frozenset = frozenset({
     "network_error", "auth_error",
     # Vertex REST path (gemini_review) API failures (OI-1178)
     "vertex_api_error",
+    # The gate ran to completion and investigated nothing (OI-1485). Absence
+    # of evidence, exactly like a timeout: the PR was never actually reviewed,
+    # so this must book `unavailable` and be re-bought, never `failed` (which
+    # would read as a rejected PR) and never `completed` (which would read as
+    # a clean review).
+    "gate_execution_degenerate",
 })
 
 
@@ -568,6 +574,7 @@ def record_failure(
     request_payload: Dict[str, Any],
     requests_dir: Path,
     results_dir: Path,
+    extra: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Record a failed gate execution (timeout/stall/error).
 
@@ -578,6 +585,12 @@ def record_failure(
     verdict failure (the gate ran and found a blockade) still books
     ``failed``, but that path flows through
     :func:`gate_artifacts.materialize_artifacts`, not here.
+
+    ``extra`` merges into the record before it is written, for the evidence
+    that explains the refusal. A record saying a run was rejected as
+    degenerate without the counts behind that word is an assertion the next
+    reader cannot check (OI-1485). Reserved keys are not overridable: the
+    status and the reason are the record's own, not a caller's to restate.
     """
     now = utc_now_iso()
     reason = result["reason"]
@@ -613,6 +626,11 @@ def record_failure(
         "residual_risk": f"Gate {reason}. Re-run required.",
         "recorded_at": now,
     }
+    if extra:
+        reserved = {"status", "reason", "reason_detail", "gate", "pr_id", "pr_number"}
+        failure_payload.update(
+            {k: v for k, v in extra.items() if k not in reserved}
+        )
     stamp_request_identity(failure_payload, request_payload)
 
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -627,7 +627,18 @@ def record_failure(
         "recorded_at": now,
     }
     if extra:
-        reserved = {"status", "reason", "reason_detail", "gate", "pr_id", "pr_number"}
+        # Identity and verdict are the record's own. So is the evidence trio:
+        # `report_path`, `contract_hash` and `required_reruns` are what
+        # gate_status.has_complete_evidence reads to decide whether a terminal
+        # record is DECIDED, so a caller able to set them through `extra` could
+        # dress a failure record as evidenced without a report existing. The
+        # degenerate-run path deliberately passes its report under a separate
+        # key (`degenerate_report_path`) for exactly this reason: an
+        # `unavailable` record must not claim a report as gate evidence.
+        reserved = {
+            "status", "reason", "reason_detail", "gate", "pr_id", "pr_number",
+            "report_path", "contract_hash", "required_reruns",
+        }
         failure_payload.update(
             {k: v for k, v in extra.items() if k not in reserved}
         )

--- a/tests/test_oi1485_gate_execution_depth.py
+++ b/tests/test_oi1485_gate_execution_depth.py
@@ -1,0 +1,234 @@
+"""A gate run that investigated nothing is not a PASS (OI-1485).
+
+Measured on PR #1707: two codex_gate runs on the same head sha under the same
+contract_hash — same instruction, same diff — where one took 16 shell calls,
+read 11 files, spent 239992 input tokens and found a real defect, and the
+other took none, spent 18219, and returned clean in 14 seconds. Its own
+residual_risk said so: "The review is limited to the provided diff."
+
+Every one of the seven headless-review invariants held for both. Nothing in
+that list asks whether the gate did any work, so the shallow PASS was
+indistinguishable from the real one on the record a merge decision reads.
+
+Two things are asserted here. The record must carry what the run DID, not only
+what it concluded; and a run that reached a verdict without a single
+investigative action must not be recorded as a completed review.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_artifacts import materialize_artifacts
+
+# The two shapes, as codex actually emits them. The degenerate run's single
+# item.completed is an agent_message: the verdict itself. Emitting a verdict is
+# not evidence of having looked at anything.
+DEGENERATE_STREAM = "\n".join([
+    json.dumps({"type": "thread.started", "thread_id": "01a0-dead-beef"}),
+    json.dumps({"type": "turn.started"}),
+    json.dumps({"type": "item.completed", "item": {
+        "id": "item_0", "type": "agent_message",
+        "text": "No blocking issues found. The review is limited to the provided diff.",
+    }}),
+    json.dumps({"type": "turn.completed",
+                "usage": {"input_tokens": 18219, "output_tokens": 602}}),
+]) + "\n"
+
+REAL_STREAM = "\n".join(
+    [
+        json.dumps({"type": "thread.started", "thread_id": "01a0-live-0001"}),
+        json.dumps({"type": "turn.started"}),
+    ]
+    + [
+        json.dumps({"type": "item.completed", "item": {
+            "id": f"item_{i}", "type": "command_execution",
+            "command": f"/bin/zsh -lc \"sed -n '1,200p' scripts/lib/mod_{i}.py\"",
+            "exit_code": 0, "status": "completed",
+        }})
+        for i in range(16)
+    ]
+    + [
+        json.dumps({"type": "item.completed", "item": {
+            "id": "item_99", "type": "agent_message",
+            "text": "One advisory: heredoc termination is looser than Bash.",
+        }}),
+        json.dumps({"type": "turn.completed",
+                    "usage": {"input_tokens": 239992, "output_tokens": 11728}}),
+    ]
+) + "\n"
+
+# A lane that emits no event stream at all. kimi_gate and glm_gate reports
+# carry prose only — measured, both had zero JSON event lines.
+NO_STREAM = (
+    "## Review\n\n"
+    "No blocking findings. Two advisories below.\n\n"
+    "1. scripts/lib/mod.py:41 — the retry loop re-reads the config each pass;\n"
+    "   hoisting it out is cheaper and removes a window where a mid-run edit\n"
+    "   changes behaviour between attempts.\n"
+    "2. tests/test_mod.py:12 — the fixture builds its own tmp dir instead of\n"
+    "   taking tmp_path, so a failed run leaves it behind.\n\n"
+    "Residual risk: the diff was reviewed against main at 17de88de.\n"
+)
+
+
+@pytest.fixture
+def gate_dirs(tmp_path):
+    requests = tmp_path / "state" / "review_gates" / "requests"
+    results = tmp_path / "state" / "review_gates" / "results"
+    reports = tmp_path / "unified_reports"
+    for d in (requests, results, reports):
+        d.mkdir(parents=True, exist_ok=True)
+    return requests, results, reports
+
+
+def _request(reports_dir: Path, gate: str = "codex_gate") -> dict:
+    return {
+        "gate": gate,
+        "pr_id": "1707",
+        "pr_number": 1707,
+        "branch": "fix/oi1482-bin-vnx-command-parser",
+        "report_path": str(reports_dir / f"{gate}-report.md"),
+        "contract_hash": "088a30754169bb91",
+        "dispatch_id": "20260828-t0-alpha-oi1482-parser",
+    }
+
+
+def _run(gate_dirs, stdout: str, gate: str = "codex_gate", duration: float = 14.0):
+    requests, results, reports = gate_dirs
+    return materialize_artifacts(
+        gate=gate, pr_number=1707, pr_id="1707", stdout=stdout,
+        request_payload=_request(reports, gate), duration_seconds=duration,
+        requests_dir=requests, results_dir=results, reports_dir=reports,
+    )
+
+
+def test_a_run_that_investigated_nothing_is_not_recorded_as_completed(gate_dirs):
+    """The core of OI-1485: 14 seconds and no actions must not read as a review."""
+    payload = _run(gate_dirs, DEGENERATE_STREAM)
+
+    assert payload["status"] != "completed", (
+        "a gate run that took zero investigative actions was recorded as a "
+        "completed review — every headless invariant passes on this record, so "
+        "nothing downstream can tell it from a real PASS"
+    )
+    assert payload["status"] == "unavailable", (
+        "a degenerate run is an absence of evidence, like a timeout — not a "
+        f"rejected PR; got status={payload['status']!r}"
+    )
+    assert payload.get("required_reruns") == ["codex_gate"], (
+        "the run must be bought again, not silently accepted"
+    )
+
+
+def test_the_refusal_carries_the_counts_that_justify_it(gate_dirs):
+    """A record that says "degenerate" without the numbers cannot be checked."""
+    payload = _run(gate_dirs, DEGENERATE_STREAM)
+
+    depth = payload.get("execution_depth")
+    assert isinstance(depth, dict), (
+        f"the refusal record carries no execution_depth: {payload.get('reason')!r}"
+    )
+    assert depth["parsed"] is True
+    assert depth["investigative_actions"] == 0
+    assert depth["shell_calls"] == 0
+    assert depth["agent_messages"] == 1
+    assert depth["input_tokens"] == 18219
+    assert "18219" in payload["reason_detail"], (
+        "reason_detail must name the measurement, not just the verdict"
+    )
+
+
+def test_the_refused_runs_report_is_kept_as_evidence(gate_dirs):
+    """Deleting it would repeat the evidence loss the overwrite guard prevents."""
+    _requests, _results, reports = gate_dirs
+    payload = _run(gate_dirs, DEGENERATE_STREAM)
+
+    report = reports / "codex_gate-report.md"
+    assert report.exists(), "the refused run's report was deleted"
+    assert payload.get("degenerate_report_path") == str(report), (
+        "the record must point at the report of the run it refused, or the "
+        "evidence is on disk with nothing referring to it"
+    )
+    assert payload["report_path"] == "", (
+        "an unavailable record must not claim a report as gate evidence"
+    )
+
+
+def test_a_real_run_is_recorded_with_what_it_did(gate_dirs):
+    payload = _run(gate_dirs, REAL_STREAM, duration=227.0)
+
+    assert payload["status"] == "completed"
+    depth = payload.get("execution_depth")
+    assert isinstance(depth, dict), (
+        "the result record carries no execution_depth — the record still says "
+        "the gate ran without saying whether it looked"
+    )
+    assert depth["investigative_actions"] == 16
+    assert depth["shell_calls"] == 16
+    assert depth["files_read"] == 16
+    assert depth["input_tokens"] == 239992
+
+
+def test_a_lane_that_emits_no_event_stream_is_unaffected(gate_dirs):
+    """Fail open on measurement, closed only on measured emptiness.
+
+    kimi_gate and glm_gate emit no events. Unmeasured must never be read as
+    "did nothing" — that would take every unmeasurable lane offline.
+    """
+    payload = _run(gate_dirs, NO_STREAM, gate="kimi_gate")
+
+    assert payload["status"] == "completed", (
+        "a lane without an event stream was refused as degenerate — "
+        "unparsed depth is not measured emptiness"
+    )
+    depth = payload.get("execution_depth")
+    assert isinstance(depth, dict)
+    assert depth["parsed"] is False
+
+
+def test_depth_measurement_matches_the_two_measured_shapes():
+    """Unit-level, against the shapes taken from the real PR #1707 reports."""
+    from gate_depth import is_degenerate, measure_execution_depth
+
+    shallow = measure_execution_depth(DEGENERATE_STREAM)
+    assert shallow.parsed is True
+    assert shallow.investigative_actions == 0
+    assert shallow.agent_messages == 1
+    assert is_degenerate(shallow) is True
+
+    real = measure_execution_depth(REAL_STREAM)
+    assert real.parsed is True
+    assert real.investigative_actions == 16
+    assert real.files_read == 16
+    assert is_degenerate(real) is False
+
+    unmeasured = measure_execution_depth(NO_STREAM)
+    assert unmeasured.parsed is False
+    assert is_degenerate(unmeasured) is False, (
+        "an unmeasured run must never be judged degenerate"
+    )
+
+
+def test_a_truncated_stream_still_yields_what_arrived():
+    """A malformed line must not abort the count of the lines that parsed."""
+    from gate_depth import measure_execution_depth
+
+    truncated = (
+        json.dumps({"type": "thread.started"}) + "\n"
+        + json.dumps({"type": "item.completed", "item": {
+            "id": "a", "type": "command_execution", "command": "cat x.py"}}) + "\n"
+        + '{"type": "item.completed", "item": {"id": "b", "type": "comm\n'
+    )
+    depth = measure_execution_depth(truncated)
+    assert depth.parsed is True
+    assert depth.investigative_actions == 1
+    assert depth.files_read == 1

--- a/tests/test_oi1485_gate_execution_depth.py
+++ b/tests/test_oi1485_gate_execution_depth.py
@@ -232,3 +232,82 @@ def test_a_truncated_stream_still_yields_what_arrived():
     assert depth.parsed is True
     assert depth.investigative_actions == 1
     assert depth.files_read == 1
+
+
+# --------------------------------------------------------------------------
+# Item-type classification. The permissive default has to sit where being
+# wrong is safe, and for a degeneracy check that is nowhere.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("alias", ["assistant_message", "output_text", "reasoning"])
+def test_a_message_alias_is_not_an_investigative_action(alias):
+    """kimi_gate blocking finding on baabcec4.
+
+    Classifying by "everything that is not a known message is work" reads an
+    unknown MESSAGE alias as work. A run that took zero tools while emitting
+    one would then clear the floor — the exact shape the floor exists to catch,
+    let through by the alias it happened not to know.
+    """
+    from gate_depth import is_degenerate, measure_execution_depth
+
+    stream = "\n".join([
+        json.dumps({"type": "thread.started"}),
+        json.dumps({"type": "turn.started"}),
+        json.dumps({"type": "item.completed", "item": {
+            "id": "item_0", "type": alias, "text": "No blocking issues found."}}),
+        json.dumps({"type": "turn.completed",
+                    "usage": {"input_tokens": 18219, "output_tokens": 602}}),
+    ]) + "\n"
+
+    depth = measure_execution_depth(stream)
+    assert depth.investigative_actions == 0, (
+        f"{alias!r} counted as an investigative action"
+    )
+    assert depth.agent_messages == 1
+    assert depth.unrecognised_item_types == ()
+    assert is_degenerate(depth) is True, (
+        f"a zero-tool run emitting {alias!r} cleared the degeneracy floor"
+    )
+
+
+@pytest.mark.parametrize("work_type", ["command_execution", "file_change", "web_search"])
+def test_the_measured_work_types_all_count(work_type):
+    """The three that actually occur in this store, plus command_execution."""
+    from gate_depth import is_degenerate, measure_execution_depth
+
+    stream = "\n".join([
+        json.dumps({"type": "thread.started"}),
+        json.dumps({"type": "item.completed", "item": {
+            "id": "w", "type": work_type, "command": "sed -n '1,40p' x.py"}}),
+    ]) + "\n"
+
+    depth = measure_execution_depth(stream)
+    assert depth.investigative_actions == 1
+    assert depth.unrecognised_item_types == ()
+    assert is_degenerate(depth) is False
+
+
+def test_an_unknown_item_type_suspends_the_judgement_and_is_named():
+    """Neither bucket: the count becomes a floor, not a measurement.
+
+    Refusing on it would be refusing on something not measured — the one thing
+    this check must never do (the same rule that keeps stream-less lanes
+    working). Counting it as work would restore the hole. So it is recorded,
+    named, and the judgement is suspended.
+    """
+    from gate_depth import is_degenerate, measure_execution_depth
+
+    stream = "\n".join([
+        json.dumps({"type": "thread.started"}),
+        json.dumps({"type": "item.completed", "item": {
+            "id": "u", "type": "some_future_type", "detail": "?"}}),
+        json.dumps({"type": "turn.completed", "usage": {"input_tokens": 900}}),
+    ]) + "\n"
+
+    depth = measure_execution_depth(stream)
+    assert depth.investigative_actions == 0
+    assert depth.unrecognised_item_types == ("some_future_type",), (
+        "an unclassifiable item type vanished from the record — a reader "
+        "cannot tell a clean zero from an unmeasured one"
+    )
+    assert is_degenerate(depth) is False

--- a/tests/test_oi1485_gate_execution_depth.py
+++ b/tests/test_oi1485_gate_execution_depth.py
@@ -270,9 +270,16 @@ def test_a_message_alias_is_not_an_investigative_action(alias):
     )
 
 
-@pytest.mark.parametrize("work_type", ["command_execution", "file_change", "web_search"])
-def test_the_measured_work_types_all_count(work_type):
-    """The three that actually occur in this store, plus command_execution."""
+@pytest.mark.parametrize("work_type", [
+    # The three that actually occur in this store (measured over 348 reports),
+    "command_execution", "file_change", "web_search",
+    # plus the two carried for codex versions this store has not seen. Listed
+    # in the set but unexercised, they were a claim rather than a behaviour --
+    # a typo in either would have gone unnoticed until a run depended on it.
+    "mcp_tool_call", "patch_apply",
+])
+def test_every_declared_work_type_counts(work_type):
+    """Every member of the investigative set, not only the observed ones."""
     from gate_depth import is_degenerate, measure_execution_depth
 
     stream = "\n".join([
@@ -311,3 +318,49 @@ def test_an_unknown_item_type_suspends_the_judgement_and_is_named():
         "cannot tell a clean zero from an unmeasured one"
     )
     assert is_degenerate(depth) is False
+
+
+def test_extra_cannot_dress_a_failure_record_as_evidenced(tmp_path):
+    """glm_gate advisory on 7fa96753.
+
+    `has_complete_evidence` reads report_path + contract_hash to decide whether
+    a terminal record is DECIDED. A caller able to set those through `extra`
+    could hand an `unavailable` record the shape of a real verdict without any
+    report existing. Identity and verdict were already reserved; the evidence
+    trio is the same class of field and was not.
+    """
+    from gate_recorder import record_failure
+
+    requests = tmp_path / "requests"
+    results = tmp_path / "results"
+    for d in (requests, results):
+        d.mkdir(parents=True, exist_ok=True)
+
+    payload = record_failure(
+        gate="codex_gate", pr_number=1485, pr_id="",
+        result={
+            "reason": "gate_execution_degenerate", "reason_detail": "0 actions",
+            "duration_seconds": 14.0, "partial_output_lines": 4, "runner_pid": 1,
+        },
+        request_payload={"gate": "codex_gate", "pr_number": 1485,
+                         "commit_sha": "c" * 40, "branch": "fix/x"},
+        requests_dir=requests, results_dir=results,
+        extra={
+            "execution_depth": {"parsed": True, "investigative_actions": 0},
+            "report_path": "/tmp/forged-report.md",
+            "contract_hash": "forged",
+            "required_reruns": [],
+        },
+    )
+
+    assert payload["report_path"] == "", (
+        "a caller set report_path through extra — an unavailable record now "
+        "claims a report as gate evidence"
+    )
+    assert payload["contract_hash"] != "forged"
+    assert payload["required_reruns"] == ["codex_gate"], (
+        "required_reruns was overwritten, so the run would never be bought again"
+    )
+    assert payload["execution_depth"]["investigative_actions"] == 0, (
+        "the non-reserved key that extra exists for must still get through"
+    )


### PR DESCRIPTION
## What was wrong

A gate result record said the gate **ran**. It did not say whether the gate
**looked**.

Measured on PR #1707 — two `codex_gate` runs on the same head sha `00e64792`
under the same `contract_hash` `088a30754169bb91`, i.e. the same instruction
over the same diff:

| | duration | shell calls | input tokens | findings |
|---|---|---|---|---|
| run A | 14s | 0 | 18 219 | 0 |
| run B | 227s | 16 | 239 992 | 1 real defect |

Run A said it itself, in its own `residual_risk`: *"The review is limited to
the provided diff."*

Re-measured today across all 256 headless codex reports on disk, PR #1707
carries **two** runs of that shape, not one (1 action / 18 219 tokens, and
1 action / 20 530 tokens), beside a real run of 16 actions. Normal range that
day: 5–42 shell calls, 86k–2.5M input tokens. Run A is two orders below the
floor of the distribution, not its low end.

### The acceptance gap

All seven headless-review invariants hold for a degenerate run **exactly** as
they hold for a real one: request record present, execution completed, result
record present, `contract_hash` non-empty and matching, `report_path`
non-empty, report file on disk, JSON and report agreeing.

Not one of them asks whether the gate did any work. So on the record a merge
decision reads, a PASS from a run that read only the diff was indistinguishable
from a PASS from a run that read the tree and ran the tests. It was caught only
because 14 seconds stood out beside 150.

The two shapes, from the stream both runs emitted:

```
degenerate  item.completed: {agent_message: 1}
real        item.completed: {command_execution: 16, agent_message: 1}
```

An `agent_message` is the verdict itself. Emitting one is not evidence of
having looked at anything.

## What changed

- **`scripts/lib/gate_depth.py`** (new) — measures investigative actions, shell
  calls, file reads, agent messages and token usage from the event stream the
  report already embeds. No new capture path: the numbers were on disk all
  along and simply never reached the record.
- **`gate_artifacts`** — stamps `execution_depth` into every result record, and
  when depth is measured *and* zero, books `unavailable` with reason
  `gate_execution_degenerate` instead of `completed`.
- **`gate_recorder`** — gains that reason, plus an `extra` merge so the refusal
  record carries the counts that justify it.

`unavailable`, not `failed`: this is absence of evidence like a timeout, not a
rejected PR. It lands in `required_reruns` and gets bought again.

### The floor is one action, deliberately

Not a percentile of the observed distribution. A threshold tuned to resemble
normal runs needs re-tuning whenever the fleet's habits change, and starts
rejecting honest small reviews. *"Took at least one action"* needs no tuning and
rejects only the degenerate shape.

### Fail open on measurement, closed only on measured emptiness

A lane that emits no event stream yields `parsed=False` and is untouched.
Verified against the Vertex path (`gemini_review`, prose) and against
`kimi_gate` and `glm_gate` reports — measured, both carry **zero** JSON event
lines. Unmeasured must never read as "did nothing", or every unmeasurable lane
goes offline.

The refused run's report is kept on disk and referenced from the record.
Deleting it would repeat the evidence loss the overwrite guard exists to prevent.

## Red before, green after

`tests/test_oi1485_gate_execution_depth.py` on `main` 17de88de:

```
FAILED test_a_run_that_investigated_nothing_is_not_recorded_as_completed
E  AssertionError: a gate run that took zero investigative actions was recorded
   as a completed review — every headless invariant passes on this record, so
   nothing downstream can tell it from a real PASS
E  assert 'completed' != 'completed'
FAILED test_the_refusal_carries_the_counts_that_justify_it
FAILED test_a_real_run_is_recorded_with_what_it_did
E  AssertionError: the result record carries no execution_depth
ERROR  ModuleNotFoundError: No module named 'gate_depth'
```

`test_a_lane_that_emits_no_event_stream_is_unaffected` **passes on main** — the
control that shows this change does not alter unmeasurable lanes.

After: `7 passed`. Neighbours (`gate_artifacts`, `gate_recorder`, `f37`,
`closure_verifier`, `codex_parser`, OI-1472): **250 passed**.

The depth parser was validated against the two real PR #1707 reports before any
wiring: degenerate → `parsed=True, actions=0` → refused; real → `actions=16,
files_read=11` → accepted; prose → `parsed=False` → untouched.

## Second-place sweep

`materialize_artifacts` is the single materialization door for a completed gate
result — two call sites in `gate_runner.py`, both covered.
`gate_report_generator._write_failure_result` writes only `failed` records with
an empty `report_path` and is not a verdict-bearing path.

Refs OI-1485