### PR TITLE
fix(routing): pin the dormant fallback axis so a fix cannot land on it by mistake (OI-1347)

### DIFF
--- a/scripts/lib/providers/routing_policy.yaml
+++ b/scripts/lib/providers/routing_policy.yaml
@@ -38,21 +38,39 @@ rules:
 
 # Fallback chain when preferred lane fails (API down, rate-limited, etc)
 #
-# STATUS (2026-07-09, OI-223 lane_safety loader): still ADVISORY. decide_lane()
-# reads this block and resolves a chain onto RoutingDecision.fallback_chain, but
-# subprocess_dispatch._select_dispatch_path deliberately discards it for non-Claude
-# lanes ("This function never touches fallback_chain for non-Claude lanes") to avoid
-# silently rerouting a cheap-lane dispatch back onto Claude. No caller triggers
-# automatic lane switching on a failure. This is unrelated to the lane_safety block
-# below — OI-223 wired lane_safety.headless_block live, NOT fallback_chain. The kimi
-# entry below reflects the corrected kimi CLI lane — litellm:moonshot:* entries are
-# kept for reference but litellm:moonshot routing is blocked by kimi-via-cli-only.
+# THIS BLOCK IS DORMANT. IT IS NOT THE FALLBACK AXIS THAT ROUTES.
 #
-# worker-provider-kimi-flip (2026-07-23): "kimi" has NO fallback entry — a kimi-lane
-# failure on a build-worker dispatch must fail loud, never silently re-route onto the
-# Claude subscription. The other lanes' chains (litellm:deepseek:*, litellm:zai:*)
-# still list kimi as A step in THEIR OWN fallback, which is unrelated to kimi's own
-# (empty) chain.
+# STATUS (re-measured 2026-08-29, OI-1347): decide_lane() still parses this block
+# onto RoutingDecision.fallback_chain, and nothing in production reads that field —
+# its only readers anywhere are two tests that assert it is empty. decide_lane()
+# itself has exactly one caller (subprocess_dispatch._maybe_route_cheap_lane), which
+# short-circuits unless VNX_ROUTING_POLICY_ENABLED=1 (unset fleet-wide) and which
+# deliberately discards the chain for non-Claude lanes, to avoid silently rerouting
+# a cheap-lane dispatch back onto Claude. So: no caller switches lanes on a failure
+# from here. Pinned by tests/test_routing_policy.py::
+# test_fallback_chain_has_no_production_reader.
+#
+# THE LIVE FALLBACK AXIS IS ELSEWHERE: wave7_models.yaml routing.tier_map, walked by
+# smart_router.tier_routing.resolve_tier_route. A change meant to alter what actually
+# happens on a lane failure belongs THERE, not here. This distinction is not cosmetic:
+# it is how a fix lands on the dormant copy and ships as a no-op while the routing
+# lane it was meant to change carries on unchanged.
+#
+# Unrelated to the lane_safety block below — OI-223 wired lane_safety.headless_block
+# live, NOT fallback_chain.
+#
+# worker-provider-kimi-flip (2026-07-23): "kimi" has NO fallback entry, and that empty
+# list is a decision, not a gap — a kimi-lane failure on a build-worker dispatch must
+# fail loud rather than silently re-route onto the Claude subscription. It does NOT
+# mean "kimi was removed as a fallback destination"; that question lives in the live
+# axis above.
+#
+# Two claims that used to stand here were false against the data three lines below and
+# have been removed (2026-08-29): that litellm:deepseek:*/litellm:zai:* "still list
+# kimi as a step in their own fallback" (they have not since OI-940 put codex there),
+# and that "litellm:moonshot:* entries are kept for reference" (no moonshot key is
+# configured). Both are now pinned by tests so the comment cannot drift off the data
+# again without a red test.
 fallback_chain:
   "litellm:deepseek:*": ["codex", "claude/sonnet-5"]
   "kimi": []

--- a/tests/test_routing_policy.py
+++ b/tests/test_routing_policy.py
@@ -417,3 +417,108 @@ def test_headless_blocked_defaults_env_to_os_environ(monkeypatch: pytest.MonkeyP
     assert is_claude_headless_blocked(lane_safety) is True
     monkeypatch.setenv("VNX_OVERRIDE_CLAUDE_HEADLESS", "1")
     assert is_claude_headless_blocked(lane_safety) is False
+
+
+# ---------------------------------------------------------------------------
+# The dormant fallback axis (OI-1347 / OI-1499)
+#
+# routing_policy.yaml's `fallback_chain` is DECLARATIVE. It is parsed into
+# RoutingDecision.fallback_chain and then read by nobody in production: the only
+# readers anywhere are tests. The one caller of decide_lane
+# (subprocess_dispatch._maybe_route_cheap_lane) sits behind
+# VNX_ROUTING_POLICY_ENABLED, which is unset, and explicitly refuses to consult
+# fallback_chain for non-Claude lanes.
+#
+# The live fallback axis is elsewhere: wave7_models.yaml routing.tier_map, walked
+# by smart_router.tier_routing.resolve_tier_route.
+#
+# That split is the hazard. A fix aimed at "the fallback chain" naturally lands on
+# this file, because this is the one that says fallback_chain in it — and then has
+# no effect, while the axis that actually routes is untouched. These tests pin the
+# dormancy so the next such fix trips a red test instead of shipping a no-op.
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+_SRC_ROOTS = ("scripts", "vnx_cli", "bin")
+_REPO_ROOT = _POLICY_PATH.parents[3]
+# Where the field is legitimately defined/populated rather than consumed.
+_FALLBACK_CHAIN_OWNERS = {"scripts/lib/routing_policy.py"}
+
+
+def _production_fallback_chain_readers() -> list[str]:
+    """Source locations that READ a resolved `.fallback_chain`, outside its owner.
+
+    Assignments (`fallback_chain=`) and the dataclass field declaration are
+    population, not consumption, and are excluded.
+    """
+    hits: list[str] = []
+    pattern = _re.compile(r"\.fallback_chain\b")
+    for root in _SRC_ROOTS:
+        base = _REPO_ROOT / root
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            if rel in _FALLBACK_CHAIN_OWNERS:
+                continue
+            for lineno, line in enumerate(
+                path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+            ):
+                if pattern.search(line) and "fallback_chain=" not in line:
+                    hits.append(f"{rel}:{lineno}: {line.strip()}")
+    return hits
+
+
+def test_fallback_chain_has_no_production_reader():
+    """If this goes red you are wiring the DORMANT fallback axis.
+
+    Before adding a reader, reconcile it with the live axis
+    (wave7_models.yaml routing.tier_map, walked by resolve_tier_route) — the two
+    describe fallback differently and have never been reconciled. Wiring this one
+    without that reconciliation gives the fleet two disagreeing fallback engines.
+    """
+    readers = _production_fallback_chain_readers()
+    assert readers == [], (
+        "routing_policy.yaml's fallback_chain gained a production reader:\n  "
+        + "\n  ".join(readers)
+        + "\n\nThe live fallback axis is wave7_models.yaml routing.tier_map "
+        "(smart_router.tier_routing.resolve_tier_route). Reconcile the two before "
+        "wiring this one, then update this test with the decision."
+    )
+
+
+def test_kimi_has_an_empty_chain_by_design():
+    """`kimi: []` is a deliberate fail-loud choice (worker-provider-kimi-flip,
+    2026-07-23), NOT "kimi was removed as a destination". A kimi-lane failure on a
+    build worker must fail loud rather than silently re-route onto the Claude
+    subscription. Pinned so the intent is not re-read as an accidental gap."""
+    policy = load_routing_policy(_POLICY_PATH)
+    assert policy["fallback_chain"]["kimi"] == []
+
+
+def test_no_lane_falls_back_to_kimi():
+    """Pins the post-OI-940 state: codex replaced kimi as the vangnet for the
+    litellm chains. The block's own comment claimed the opposite for weeks."""
+    policy = load_routing_policy(_POLICY_PATH)
+    with_kimi = {
+        lane: chain
+        for lane, chain in policy["fallback_chain"].items()
+        if any("kimi" in str(step) for step in chain)
+    }
+    assert with_kimi == {}, (
+        f"a lane now falls back to kimi: {with_kimi}. If that is intended, update "
+        "the comment above fallback_chain in routing_policy.yaml in the same commit "
+        "— a stale comment there is what OI-1347 tripped over."
+    )
+
+
+def test_no_moonshot_lane_is_configured():
+    """kimi-via-cli-only blocks litellm:moonshot routing, and no moonshot key is
+    configured. The block's comment claimed such entries were "kept for reference"
+    long after they were gone."""
+    policy = load_routing_policy(_POLICY_PATH)
+    moonshot = [lane for lane in policy["fallback_chain"] if "moonshot" in lane]
+    assert moonshot == []


### PR DESCRIPTION
## De OI klopte op de vorm, niet op de inhoud

OI-1347 meldde "twee onafhankelijke fallback-lagen spreken elkaar tegen". De meting laat iets anders zien: de lagen zijn niet gelijkwaardig. **Eén is dood.**

Gemeten op main `17de88de`:

| | `routing_policy.yaml` `fallback_chain` | `wave7_models.yaml` `routing.tier_map` |
|---|---|---|
| productie-lezers van het veld | **0** (enige lezers: 2 tests die op `[]` asserten) | live |
| aanroepers van de motor | 1, achter `VNX_ROUTING_POLICY_ENABLED` | `resolve_tier_route` |
| die vlag | `None` in env én in `config_runtime` | n.v.t. |
| aangetoond gedrag | geen | lost tier-zero op naar `deepseek-harness/deepseek-v4-flash` |

`subprocess_dispatch._maybe_route_cheap_lane` gooit de keten bovendien expliciet weg voor niet-Claude-lanes, met een eigen commentaarregel dat dat een bewuste regressie-fix was.

Dat is het gevaar, en het is niet hypothetisch. Een wijziging die bedoeld is om te veranderen wat er bij een lane-failure gebeurt landt vanzelf op dit bestand, want dit is het bestand waar `fallback_chain` in staat. En verdwijnt dan als no-op, terwijl de as die echt routeert onaangeroerd doorloopt.

## Pinnen, niet opruimen

Overwogen en verworpen: het blok verwijderen.

- `routing_policy.yaml` is wél live voor iets anders. `lane_safety.headless_block` wordt gelezen door `dispatch_bridge.py` en `process_cleanup.py`.
- De slapende motor wordt wakker zodra iemand `VNX_ROUTING_POLICY_ENABLED=1` zet. Data weghalen ruilt een zichtbare no-op in voor een stille gedragswijziging voor wie die vlag aanzet.
- Consumer-repo's installeren deze YAML's. Een sleutel verwijderen is een consumer-zichtbare wijziging die ik hiervandaan niet kan verifiëren.

## Vier wachters, elk aantoonbaar falend

Een wachter die groen staat op main bewijst niets tot je hem laat falen. Alle vier zijn met de echte drift rood gemaakt en na terugdraaien weer groen:

```
DRIFT 1  productie-lezer toegevoegd aan dispatch_bridge.py
  -> AssertionError: routing_policy.yaml's fallback_chain gained a production reader

DRIFT 2  "litellm:zai:*" -> ["kimi", "codex"]
  -> AssertionError: a lane now falls back to kimi: {'litellm:zai:*': ['kimi', 'codex']}

DRIFT 3  "litellm:moonshot:*" toegevoegd
  -> FAILED test_no_moonshot_lane_is_configured

teruggedraaid -> 40 passed
```

## Twee onware regels in het commentaar

Het commentaarblok boven `fallback_chain` beweerde twee dingen die de data drie regels lager tegenspreken:

1. `litellm:deepseek:*` en `litellm:zai:*` "still list kimi as a step in their own fallback" — **onwaar**, codex verving kimi daar in OI-940.
2. "litellm:moonshot:* entries are kept for reference" — **onwaar**, er is geen moonshot-sleutel geconfigureerd.

Allebei rechtgezet, en allebei nu door een test gepind zodat het commentaar niet opnieuw stil van zijn eigen data af kan drijven.

## Wat ik gemeten heb en NIET heb aangeraakt

`"kimi": []` is een bewuste fail-loud-keuze uit worker-provider-kimi-flip (2026-07-23): een kimi-failure op een build-worker moet hard falen in plaats van stil terug te vallen op de Claude-subscription. Het betekent **niet** "kimi is als bestemming verwijderd". OI-1347 las het als het laatste.

Of kimi thuishoort in de live `tier_map`-fallback is een kwaliteitsvraag over een gemeten slagingskans van ongeveer 16 procent als build-worker (7 success tegen 33 failure sinds 2026-08-10). Die hoort bij het "a safety net, never an escalation"-werk, niet hier.

## Tests

`tests/test_routing_policy.py`: 40 passed. Buren: **226 passed** over `tests/smart_router/`, `test_routing_policy.py`, `test_dispatch_bridge_staging.py`.