### PR TITLE
fix(gates): a verdict about another commit is not evidence about this one (OI-1488)

### DIFF
--- a/scripts/lib/gate_executor.py
+++ b/scripts/lib/gate_executor.py
@@ -315,8 +315,12 @@ class GateExecutorMixin:
             # OI-1469/OI-1470: refuse a write that would downgrade an existing
             # terminal, evidenced result (e.g. a stale "running" re-check must
             # never overwrite an already-decided pass/fail).
-            result_payload, _written = _rec.write_result_guarded(
+            payload_on_disk, written = _rec.write_result_guarded(
                 rf, result_payload, gate=gate, pr_ref=pr_id or str(pr_number or ""),
+            )
+            result_payload = (
+                payload_on_disk if written
+                else _rec.annotate_refused_write(payload_on_disk, result_payload)
             )
 
         # When checks are still running, reset request to "requested" so it
@@ -358,7 +362,22 @@ class GateExecutorMixin:
         gates: List[Dict[str, Any]] = []
         has_required_failure = False
 
+        import gate_recorder as _rec
         from gate_status import has_complete_evidence, is_pass
+
+        # OI-1488: a result record is evidence about the commit it names, and
+        # nothing had been checking that this is the commit being merged. The
+        # overwrite guard preserves a decided verdict rather than let a later,
+        # less-decided write replace it (OI-1469/OI-1470) -- correct, and it
+        # means a run on a NEW head can come back holding the OLD head's
+        # record, complete and valid-looking, with no field that reads as
+        # wrong. Measured on PR #1705: a request about 1425faa1 answered with
+        # the full record of 109181d2. All seven headless-review invariants
+        # hold on such a record; every one of them is satisfied by a verdict
+        # about a different commit.
+        #
+        # Fetched once per call, not per gate: it is a gh round-trip.
+        head_sha = _rec.get_pr_head_sha(pr_number)
 
         for req in request_result.get("requested", []):
             gate_name = req.get("gate", "")
@@ -376,6 +395,20 @@ class GateExecutorMixin:
                 # or report_path; either missing means "did not run", which must
                 # never sum up to a PASS (OI-1178).
                 decided_pass = bool(passed) and has_complete_evidence(exec_result)
+                result_sha = str(exec_result.get("commit_sha") or "")
+                sha_binding = _classify_sha_binding(head_sha, result_sha)
+                if sha_binding == "mismatch":
+                    # Evidence about another commit is not evidence about this
+                    # one. Never the reverse: an unknown sha on either side is
+                    # an unmeasured binding, not a mismatch, and must not
+                    # downgrade a gate that is otherwise decided -- that is the
+                    # difference between "we checked and it is wrong" and "we
+                    # could not check".
+                    decided_pass = False
+                    pass_reason = (
+                        f"result records commit {result_sha[:8]} but the PR head "
+                        f"is {head_sha[:8]} — this verdict is about other code"
+                    )
                 gates.append({
                     "gate": gate_name,
                     "request_status": req_status,
@@ -384,6 +417,10 @@ class GateExecutorMixin:
                     "pass_reason": pass_reason,
                     "report_path": exec_result.get("report_path", ""),
                     "contract_hash": exec_result.get("contract_hash", ""),
+                    "sha_binding": sha_binding,
+                    "head_sha": head_sha,
+                    "result_commit_sha": result_sha,
+                    "write_refused": bool(exec_result.get("write_refused")),
                     "detail": exec_result,
                 })
                 required = req.get("required", True)
@@ -458,6 +495,21 @@ class GateExecutorMixin:
         for path in sorted(self.requests_dir.glob(f"pr-{pr_number}-*.json")):
             requests.append(json.loads(path.read_text(encoding="utf-8")))
         return {"pr_number": pr_number, "requests": requests, "results": results}
+
+
+def _classify_sha_binding(head_sha: str, result_sha: str) -> str:
+    """Three answers, not two: ``match``, ``mismatch``, ``unknown``.
+
+    ``unknown`` is not a polite ``mismatch``. Either sha can be absent for
+    reasons that say nothing about the code under review -- ``gh`` unreachable,
+    a gate whose writer never stamped identity, an offline run. Folding that
+    into ``mismatch`` would fail every gate the moment GitHub is briefly
+    unavailable; folding it into ``match`` would restore the hole this check
+    closes. It is its own state and callers get told which one it is.
+    """
+    if not head_sha or not result_sha:
+        return "unknown"
+    return "match" if head_sha == result_sha else "mismatch"
 
 
 def _ci_gate_summary(

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -409,6 +409,36 @@ def _write_result_atomic(result_path: Path, payload: Dict[str, Any]) -> None:
     tmp.replace(result_path)
 
 
+def annotate_refused_write(
+    payload_on_disk: Dict[str, Any],
+    attempted: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Mark a returned record as one THIS call did not write (OI-1488).
+
+    :func:`write_result_guarded` reports the true on-disk state when it
+    refuses, and that stays: a caller has to be able to see that its write did
+    not land (OI-1469/OI-1470). What was missing is any sign that the record it
+    got back is about something else.
+
+    Measured on PR #1705: a request for a verdict on ``1425faa1`` came back
+    with the complete record of ``109181d2`` — findings, duration,
+    ``recorded_at``, every field populated. Nothing marked it as another
+    commit's. That instance was conservative because the preserved verdict was
+    a FAIL; the mechanism is symmetric, and a preserved PASS reads as a clean
+    review of code that is no longer there.
+
+    This annotation is the signal, not the protection. The protection is the
+    sha binding in ``gate_executor._execute_requested_gates``: a flag only
+    helps a caller that reads it, and the harm here happens in a caller that
+    reads ``status`` and ``contract_hash``.
+    """
+    annotated = dict(payload_on_disk)
+    annotated["write_refused"] = True
+    annotated["attempted_status"] = attempted.get("status", "")
+    annotated["attempted_commit_sha"] = attempted.get("commit_sha", "")
+    return annotated
+
+
 def write_result_guarded(
     result_path: Path,
     payload: Dict[str, Any],
@@ -546,8 +576,12 @@ def record_not_executable(
 
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
     if rf:
-        result_payload, _written = write_result_guarded(
+        payload_on_disk, written = write_result_guarded(
             rf, result_payload, gate=gate, pr_ref=pr_id or str(pr_number or ""),
+        )
+        result_payload = (
+            payload_on_disk if written
+            else annotate_refused_write(payload_on_disk, result_payload)
         )
 
     write_skip_rationale(
@@ -618,8 +652,12 @@ def record_failure(
     rf = result_file_path(results_dir, gate, pr_number=pr_number, pr_id=pr_id)
     written = True
     if rf:
-        failure_payload, written = write_result_guarded(
+        payload_on_disk, written = write_result_guarded(
             rf, failure_payload, gate=gate, pr_ref=pr_id or str(pr_number or ""),
+        )
+        failure_payload = (
+            payload_on_disk if written
+            else annotate_refused_write(payload_on_disk, failure_payload)
         )
 
     # Emit gate_failed for codex_gate only when the gate itself reported a verdict

--- a/tests/test_oi1488_refused_write_is_not_a_verdict.py
+++ b/tests/test_oi1488_refused_write_is_not_a_verdict.py
@@ -1,0 +1,268 @@
+"""A verdict about another commit is not evidence about this one (OI-1488).
+
+The overwrite guard preserves a decided, evidenced result rather than let a
+later, less-decided write replace it (OI-1469/OI-1470). That is correct and is
+not changed here: the record on disk stays, and the caller is still told the
+true on-disk state, which is what that contract requires.
+
+What was missing sat one level up. A run against a NEW head can come back
+holding the OLD head's record, and that record does not announce itself: it is
+complete and valid, every field populated, including a ``commit_sha`` for a
+commit nobody asked about. Measured on PR #1705: a request for a verdict on
+``1425faa1`` was answered with the full record of ``109181d2`` — findings,
+duration, ``recorded_at``, ``has_required_failure``. That instance was
+conservative because the preserved verdict was a FAIL. The mechanism is
+symmetric, and a preserved PASS reads as a clean review of code that is no
+longer there.
+
+None of the seven headless-review invariants catches it. The request record
+exists, the result record exists, ``contract_hash`` is non-empty, ``report_path``
+is non-empty, the report is on disk, and the JSON and the report agree — with
+each other, about the wrong commit. The only thing that caught it was a human
+comparing the record's sha to the PR head. This makes that comparison a
+mechanism.
+
+Two changes, and the second is the load-bearing one. A refused write is
+annotated so a caller can see its result never landed; and the consumer that
+turns a result into ``decided_pass`` refuses to count a record whose commit is
+not the head being merged. The annotation alone would not be enough: a flag
+only protects a caller that reads it, and the harm happens in a caller that
+reads ``status`` and ``contract_hash``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import gate_executor
+import gate_recorder
+from gate_recorder import record_failure, record_not_executable
+
+PRIOR_SHA = "109181d2c0ffee0000000000000000000000beef"
+REQUESTED_SHA = "1425faa1deadbeef0000000000000000000012345"
+
+PRIOR_RECORD = {
+    "gate": "codex_gate",
+    "pr_id": "1705",
+    "pr_number": 1705,
+    "status": "fail",
+    "commit_sha": PRIOR_SHA,
+    "contract_hash": "088a30754169bb91",
+    "report_path": "/tmp/codex-1705-old.md",
+    "dispatch_id": "codex-gate-pr1705-old",
+    "recorded_at": "2026-08-28T18:49:22Z",
+    "duration_seconds": 428.0,
+    "blocking_findings": [{"severity": "blocking", "message": "old finding"}],
+    "advisory_findings": [],
+}
+
+
+# ``pr_id`` selects the naming convention: non-empty picks
+# ``{slug}-{gate}-contract.json``, empty picks ``pr-{n}-{gate}.json``. The
+# measured case is the latter (``results/pr-1705-codex_gate.json``), so every
+# call below passes ``pr_id=""`` — seeding one convention and writing the other
+# leaves the guard looking at an absent file and refusing nothing.
+@pytest.fixture
+def dirs(tmp_path):
+    requests = tmp_path / "state" / "review_gates" / "requests"
+    results = tmp_path / "state" / "review_gates" / "results"
+    state = tmp_path / "state"
+    for d in (requests, results, state):
+        d.mkdir(parents=True, exist_ok=True)
+    (results / "pr-1705-codex_gate.json").write_text(
+        json.dumps(PRIOR_RECORD), encoding="utf-8"
+    )
+    return requests, results, state
+
+
+def _request_payload():
+    return {
+        "gate": "codex_gate", "pr_id": "1705", "pr_number": 1705,
+        "branch": "fix/whatever", "commit_sha": REQUESTED_SHA,
+        "contract_hash": "088a30754169bb91",
+    }
+
+
+# --------------------------------------------------------------------------
+# The signal: a caller can see that its own write never landed.
+# --------------------------------------------------------------------------
+
+def test_a_refused_not_executable_is_marked_as_not_written(dirs):
+    requests, results, state = dirs
+
+    payload = record_not_executable(
+        gate="codex_gate", pr_number=1705, pr_id="",
+        reason="provider_unavailable", reason_detail="codex quota exhausted",
+        request_payload=_request_payload(),
+        requests_dir=requests, results_dir=results, state_dir=state,
+    )
+
+    assert payload["status"] == "fail", (
+        "the on-disk contract (OI-1469/OI-1470) is unchanged: the caller is "
+        "still told the true state of the store"
+    )
+    assert payload.get("write_refused") is True, (
+        "nothing distinguishes this preserved record from a record this call "
+        "actually wrote"
+    )
+    assert payload.get("attempted_status") == "not_executable"
+    assert payload.get("attempted_commit_sha") == REQUESTED_SHA, (
+        "without the attempted sha beside the preserved one, a reader cannot "
+        "see that the two are about different commits"
+    )
+
+
+def test_a_refused_failure_is_marked_as_not_written(dirs):
+    requests, results, _state = dirs
+
+    payload = record_failure(
+        gate="codex_gate", pr_number=1705, pr_id="",
+        result={
+            "reason": "timeout", "reason_detail": "codex stalled at 900s",
+            "duration_seconds": 900.0, "partial_output_lines": 0, "runner_pid": 42,
+        },
+        request_payload=_request_payload(),
+        requests_dir=requests, results_dir=results,
+    )
+
+    assert payload["status"] == "fail"
+    assert payload.get("write_refused") is True
+    assert payload.get("attempted_status") == "unavailable"
+
+
+def test_a_landed_write_is_not_marked_refused(dirs):
+    """The flag must distinguish, so it must be absent on success."""
+    requests, results, state = dirs
+    (results / "pr-1705-codex_gate.json").unlink()
+
+    payload = record_not_executable(
+        gate="codex_gate", pr_number=1705, pr_id="",
+        reason="provider_unavailable", reason_detail="quota",
+        request_payload=_request_payload(),
+        requests_dir=requests, results_dir=results, state_dir=state,
+    )
+
+    assert "write_refused" not in payload
+    assert payload["status"] == "not_executable"
+    assert payload["commit_sha"] == REQUESTED_SHA
+
+
+def test_the_decided_record_on_disk_is_untouched(dirs):
+    requests, results, state = dirs
+
+    record_not_executable(
+        gate="codex_gate", pr_number=1705, pr_id="",
+        reason="provider_unavailable", reason_detail="quota",
+        request_payload=_request_payload(),
+        requests_dir=requests, results_dir=results, state_dir=state,
+    )
+
+    on_disk = json.loads((results / "pr-1705-codex_gate.json").read_text(encoding="utf-8"))
+    assert on_disk["commit_sha"] == PRIOR_SHA
+    assert on_disk["status"] == "fail"
+    assert "write_refused" not in on_disk, (
+        "the annotation is for the caller, not for the store — writing it to "
+        "disk would corrupt the preserved record"
+    )
+
+
+# --------------------------------------------------------------------------
+# The protection: a record about another commit cannot be a decided pass.
+# --------------------------------------------------------------------------
+
+class _Stub(gate_executor.GateExecutorMixin):
+    def __init__(self, exec_result):
+        self._exec_result = exec_result
+        self.executed = []
+
+    def execute_gate(self, *, gate, pr_number):
+        self.executed.append((gate, pr_number))
+        return self._exec_result
+
+
+def _requested(gate="codex_gate"):
+    return {"requested": [{"gate": gate, "status": "requested", "required": True}]}
+
+
+def _evidenced_pass(commit_sha):
+    return {
+        "gate": "codex_gate", "status": "pass", "commit_sha": commit_sha,
+        "contract_hash": "088a30754169bb91",
+        "report_path": "/tmp/codex-1705.md",
+        "dispatch_id": "codex-gate-pr1705-new",
+        "blocking_findings": [], "advisory_findings": [],
+    }
+
+
+def test_a_pass_for_another_commit_is_not_a_decided_pass(monkeypatch):
+    """The symmetric case the measured instance was lucky enough to avoid."""
+    monkeypatch.setattr(gate_recorder, "get_pr_head_sha", lambda _n: REQUESTED_SHA)
+    stub = _Stub(_evidenced_pass(PRIOR_SHA))
+
+    gates, has_required_failure = stub._execute_requested_gates(_requested(), 1705)
+
+    assert gates[0]["passed"] is False, (
+        "an evidenced PASS recording another commit counted as this head's "
+        "gate evidence — a merge on code that is no longer there"
+    )
+    assert gates[0]["sha_binding"] == "mismatch"
+    assert has_required_failure is True
+    assert "109181d2" in gates[0]["pass_reason"]
+
+
+def test_a_pass_for_this_commit_still_passes(monkeypatch):
+    monkeypatch.setattr(gate_recorder, "get_pr_head_sha", lambda _n: REQUESTED_SHA)
+    stub = _Stub(_evidenced_pass(REQUESTED_SHA))
+
+    gates, has_required_failure = stub._execute_requested_gates(_requested(), 1705)
+
+    assert gates[0]["passed"] is True
+    assert gates[0]["sha_binding"] == "match"
+    assert has_required_failure is False
+
+
+def test_an_unknown_head_sha_does_not_downgrade_a_decided_gate(monkeypatch):
+    """Unknown is its own bucket, not a polite mismatch.
+
+    ``gh`` being unreachable says nothing about the code under review. Folding
+    that into ``mismatch`` fails every gate the moment GitHub hiccups; folding
+    it into ``match`` restores the hole. Three buckets, not two.
+    """
+    monkeypatch.setattr(gate_recorder, "get_pr_head_sha", lambda _n: "")
+    stub = _Stub(_evidenced_pass(PRIOR_SHA))
+
+    gates, has_required_failure = stub._execute_requested_gates(_requested(), 1705)
+
+    assert gates[0]["sha_binding"] == "unknown"
+    assert gates[0]["passed"] is True
+    assert has_required_failure is False
+
+
+def test_a_result_without_a_sha_is_unknown_not_mismatch(monkeypatch):
+    monkeypatch.setattr(gate_recorder, "get_pr_head_sha", lambda _n: REQUESTED_SHA)
+    stub = _Stub({**_evidenced_pass(REQUESTED_SHA), "commit_sha": ""})
+
+    gates, _ = stub._execute_requested_gates(_requested(), 1705)
+
+    assert gates[0]["sha_binding"] == "unknown"
+    assert gates[0]["passed"] is True
+
+
+def test_the_binding_is_reported_even_when_it_changes_nothing(monkeypatch):
+    """A check whose result is invisible cannot be audited afterwards."""
+    monkeypatch.setattr(gate_recorder, "get_pr_head_sha", lambda _n: REQUESTED_SHA)
+    stub = _Stub(_evidenced_pass(REQUESTED_SHA))
+
+    gates, _ = stub._execute_requested_gates(_requested(), 1705)
+
+    assert gates[0]["head_sha"] == REQUESTED_SHA
+    assert gates[0]["result_commit_sha"] == REQUESTED_SHA
+    assert gates[0]["write_refused"] is False


### PR DESCRIPTION
## What was wrong

Measured on PR #1705: a request for a verdict on `1425faa1` was answered with
the **complete record of `109181d2`** — findings, duration, `recorded_at`,
`has_required_failure`, every field populated, nothing marking it as another
commit's.

That instance was conservative, because the preserved verdict happened to be a
FAIL. The mechanism is symmetric: a preserved PASS reads as a clean review of
code that is no longer there.

None of the seven headless-review invariants catches it. Request record exists,
result record exists, `contract_hash` non-empty, `report_path` non-empty, report
on disk, JSON and report agree — with each other, about the wrong commit. The
only thing that caught it was a human comparing the record's sha to the PR head.

## The holding is correct and is unchanged

The overwrite guard preserves a decided, evidenced result rather than let a
later, less-decided write replace it (OI-1469/OI-1470). That stays. The caller
is still told the true on-disk state, which is what that contract requires.
**All 21 of its tests stay green.**

## What changed

**1. A refused write is annotated.** `write_refused`, plus the attempted status
and sha beside the preserved ones — so a caller can see its own result never
reached the store.

**2. The consumer refuses a record about the wrong commit.**
`_execute_requested_gates` no longer counts a result as `decided_pass` when its
`commit_sha` is not the PR head.

The annotation alone would not have been enough. A flag only protects a caller
that reads it, and the harm happens in a caller that reads `status` and
`contract_hash`.

### An attempt that was reverted, and why

The first version made the recorder return the *attempted* payload instead of
the preserved one. Six OI-1469/OI-1470 tests then failed, one of them stating
the opposite contract in its own comment:

> `# The function must report the true on-disk state, not the refused attempt.`

Rewriting those would have resolved a conflict between two governance items by
deleting one. So it was measured instead: **every caller returns the payload
unread**, and the single consumer of its status is the `decided_pass`
computation — which is exactly where the harm lands, and where the fix belongs.
Nothing needed the contract changed.

### Three buckets, not two

`sha_binding` is `match`, `mismatch`, or `unknown`. Either sha can be absent for
reasons that say nothing about the code under review: `gh` unreachable, a writer
that never stamped identity, an offline run. Folding that into `mismatch` fails
every gate the moment GitHub hiccups; folding it into `match` restores the hole.

Only a measured mismatch downgrades. The binding is reported on **every** gate
even when it changes nothing, so it can be audited afterwards.

## Red before, green after

On `main` 17de88de:

```
FAILED test_a_pass_for_another_commit_is_not_a_decided_pass
E  AssertionError: an evidenced PASS recording another commit counted as this
   head's gate evidence — a merge on code that is no longer there
E  assert True is False
FAILED test_a_refused_not_executable_is_marked_as_not_written
E  AssertionError: nothing distinguishes this preserved record from a record
   this call actually wrote
KeyError: 'sha_binding'   (×3)
```

`test_a_pass_for_this_commit_still_passes` passes on main — the control showing
the check does not simply reject everything.

After: `9 passed`. Neighbours (`gate_recorder`, `ci_gate`, `closure_verifier`,
`gate_obligations`, OI-1472, review-gate chain): **296 passed**.

A NameError in the first wiring (`_rec` is imported inside a *different* method
in this file) was caught by these tests before push, not after.

## Scope note

This covers stale records **however they arrive**, not only the refusal path
that surfaced them. That matters right now: two of the open PRs were measured
today carrying a gate PASS for a sha that is no longer their head.

Refs OI-1488