### PR TITLE
fix(merge): an unresolvable head is a refusal, not a dropped requirement (OI-1318)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -247,6 +247,34 @@ def _validate_test_claims(claims: Dict[str, Any], project_root: Path) -> List[Ch
     return results
 
 
+def _matches_required_field(supplied: Optional[str], actual: Optional[str]) -> bool:
+    """Three answers for a caller-supplied match constraint, not two (OI-1318).
+
+    ``if head_sha:`` collapsed two different callers into one behaviour. A
+    caller that does not pass a sha is saying "I am not scoping by sha". A
+    caller that passes an EMPTY sha is saying something else entirely: it tried
+    to resolve the PR head and could not. Under the truthy test both took the
+    branch that skips the check, so a merge door that failed to determine the
+    head silently dropped its own head-sha requirement and accepted any result
+    for the PR — including one recorded against a commit that is no longer
+    there.
+
+    * ``None``  — not required; every record passes this constraint.
+    * ``""``    — required but unresolvable; NO record passes. An unverifiable
+                  state is a refusal, which is what the sibling CI gate already
+                  does when ``gh`` gives it no head.
+    * a value   — the record must carry exactly that value.
+
+    An absent field on the record fails a non-``None`` constraint: a result
+    without a ``commit_sha`` is stale evidence, not a wildcard.
+    """
+    if supplied is None:
+        return True
+    if supplied == "":
+        return False
+    return (actual or "") == supplied
+
+
 def _find_gate_result(
     gate: str,
     pr_id: str,
@@ -288,14 +316,12 @@ def _find_gate_result(
                 return False
         # ADR-005: branch must be present and match when caller supplies one.
         # A branch-less result is stale evidence from a prior feature.
-        if branch:
-            if (data.get("branch") or "") != branch:
-                return False
+        if not _matches_required_field(branch, data.get("branch")):
+            return False
         # OI-1307: head sha must be present and match when caller supplies one —
         # same strictness as branch (a result without commit_sha is stale).
-        if head_sha:
-            if (data.get("commit_sha") or "") != head_sha:
-                return False
+        if not _matches_required_field(head_sha, data.get("commit_sha")):
+            return False
         return True
 
     pr_slug = pr_id.lower().replace("-", "")

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -265,6 +265,14 @@ def _matches_required_field(supplied: Optional[str], actual: Optional[str]) -> b
                   does when ``gh`` gives it no head.
     * a value   — the record must carry exactly that value.
 
+    The distinction lives in what the CALLER meant, so callers have to say it.
+    ``ReviewContract.branch`` defaults to ``""`` and one live contract in this
+    store carries that default: a contract that never had a branch is "no
+    constraint", not "I tried to resolve one and failed". The closure
+    verifier's internal call sites therefore pass ``contract.branch or None``,
+    while the merge door passes the empty string it actually got from ``gh``
+    (glm_gate advisory on 5480324a).
+
     An absent field on the record fails a non-``None`` constraint: a result
     without a ``commit_sha`` is stale evidence, not a wildcard.
     """
@@ -875,7 +883,9 @@ def _check_contract_hashes(contract: ReviewContract, results_dir: Path) -> List[
     for gate in contract.review_stack:
         if gate not in _KNOWN_GATES:
             continue
-        result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
+        result = _find_gate_result(
+            gate, contract.pr_id, results_dir, branch=contract.branch or None,
+        )
         if result and contract.content_hash:
             result_hash = result.get("contract_hash") or result.get("content_hash") or ""
             if result_hash and result_hash != contract.content_hash:
@@ -894,7 +904,9 @@ def _check_report_paths(contract: ReviewContract, results_dir: Path) -> List[Che
     for gate in contract.review_stack:
         if gate not in _KNOWN_GATES:
             continue
-        result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
+        result = _find_gate_result(
+            gate, contract.pr_id, results_dir, branch=contract.branch or None,
+        )
         if result is not None and gate_is_terminal(result):
             report_path = result.get("report_path", "")
             if not report_path:
@@ -955,7 +967,9 @@ def _validate_review_evidence(
         return checks
 
     for gate in contract.review_stack:
-        result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
+        result = _find_gate_result(
+            gate, contract.pr_id, results_dir, branch=contract.branch or None,
+        )
         checks.append(_check_single_gate(gate, contract, result, results_dir, branch))
 
     checks.extend(_check_contract_hashes(contract, results_dir))
@@ -1176,7 +1190,9 @@ def _detect_gate_report_contradictions(
     for gate in contract.review_stack:
         if gate not in _KNOWN_GATES:
             continue
-        result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
+        result = _find_gate_result(
+            gate, contract.pr_id, results_dir, branch=contract.branch or None,
+        )
         if result is None:
             continue
 

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -248,6 +248,23 @@ def _run_review_gate(
         }, pr_data
     branch = pr_data.get("headRefName") or ""
     head_sha = pr_data.get("headRefOid") or ""
+    if not head_sha or not branch:
+        # OI-1318: the sibling CI gate refuses here and this one did not. It
+        # carried on with empty strings into check_review_gate_for_merge, whose
+        # matcher then read "" as "no constraint" and accepted any result for
+        # the PR — so the one path that could not establish which commit it was
+        # merging was also the path that stopped asking. Same refusal, same
+        # words, as _run_ci_gate.
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                f"PR-head (sha/branch) kon niet worden bepaald voor #{pr_number}: "
+                "review-gate-check niet toetsbaar"
+            ),
+            "overridden": False,
+            "override_reason": None,
+            "gate": None,
+        }, pr_data
 
     # ── Escape hatch (same resolution + semantics as the CI gate) ─────────
     reason = _resolve_override_reason(override_reason)

--- a/tests/test_oi1318_empty_sha_is_not_no_requirement.py
+++ b/tests/test_oi1318_empty_sha_is_not_no_requirement.py
@@ -175,3 +175,47 @@ def test_ci_gate_refuses_the_same_input(monkeypatch):
 
     assert gate["verdict"] == "NO-GO"
     assert "niet toetsbaar" in gate["message"]
+
+
+def test_a_contract_without_a_branch_is_not_treated_as_unresolvable(tmp_path):
+    """glm_gate advisory on 5480324a.
+
+    ``ReviewContract.branch`` defaults to "" and one live contract in this store
+    carries that default. A contract that never had a branch is "no constraint";
+    a merge door that asked ``gh`` and got nothing is "I tried and failed".
+    Same empty string, opposite meanings, so the caller has to say which — the
+    closure verifier's internal sites pass ``or None``, the merge door passes
+    what it got.
+
+    Without this, tightening the matcher would have made every result for such
+    a contract unverifiable, in a code path the merge fix was not about.
+    """
+    import json
+
+    import closure_verifier
+    from review_contract import ReviewContract
+
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    report = tmp_path / "r.md"
+    report.write_text("# gate\n\nNo blocking findings.\n", encoding="utf-8")
+    (results_dir / "pr-77-kimi_gate.json").write_text(json.dumps({
+        "gate": "kimi_gate", "pr_id": "77", "status": "pass",
+        "branch": "feature/whatever", "commit_sha": HEAD_SHA,
+        "contract_hash": "abc123", "report_path": str(report),
+        "blocking_findings": [], "advisory_findings": [],
+    }), encoding="utf-8")
+
+    contract = ReviewContract(
+        pr_id="77", branch="", risk_class="medium",
+        review_stack=["kimi_gate"], changed_files=[], content_hash="e" * 16,
+    )
+
+    found = closure_verifier._find_gate_result(
+        "kimi_gate", contract.pr_id, results_dir, branch=contract.branch or None,
+    )
+    assert found is not None, (
+        "a contract with no branch rejected a valid result — the default empty "
+        "string was read as an unresolvable constraint"
+    )
+    assert found["status"] == "pass"

--- a/tests/test_oi1318_empty_sha_is_not_no_requirement.py
+++ b/tests/test_oi1318_empty_sha_is_not_no_requirement.py
@@ -1,0 +1,177 @@
+"""An unresolvable head is a refusal, not a dropped requirement (OI-1318).
+
+Two halves of one asymmetry.
+
+``pr_merge._run_ci_gate`` resolves the PR head and refuses when it cannot:
+"PR-head (sha/branch) kon niet worden bepaald ... deze merge is niet toetsbaar".
+Its sibling ``_run_review_gate`` did not. It read the same two fields, got empty
+strings, and carried on into ``closure_verifier.check_review_gate_for_merge``.
+
+There the constraint was applied as ``if head_sha:``. That truthy test collapses
+two different callers into one behaviour: a caller that passes nothing is saying
+"I am not scoping by sha", and a caller that passes an empty string is saying it
+tried and could not. Both took the branch that skips the check.
+
+So the one path that could not establish which commit it was merging was also
+the path that stopped asking, and any result for the PR — including one recorded
+against a commit that is no longer there — satisfied the merge door. The failure
+is silent by construction: nothing is logged, and the verdict is GO.
+
+``branch`` carried the identical shape and is fixed with it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+
+HEAD_SHA = "6c925a1b2ee8b0cded8728d4f2c792fcf64be4d4"
+OTHER_SHA = "0f5e881a2b2761f73b7664ee7ea2e03ee4ee63b9"
+
+
+# --------------------------------------------------------------------------
+# The matcher: three buckets, not two.
+# --------------------------------------------------------------------------
+
+def test_no_constraint_accepts_anything():
+    from closure_verifier import _matches_required_field
+
+    assert _matches_required_field(None, OTHER_SHA) is True
+    assert _matches_required_field(None, None) is True
+    assert _matches_required_field(None, "") is True
+
+
+def test_a_supplied_value_must_match():
+    from closure_verifier import _matches_required_field
+
+    assert _matches_required_field(HEAD_SHA, HEAD_SHA) is True
+    assert _matches_required_field(HEAD_SHA, OTHER_SHA) is False
+
+
+def test_a_record_without_the_field_fails_a_real_constraint():
+    """A result with no commit_sha is stale evidence, never a wildcard."""
+    from closure_verifier import _matches_required_field
+
+    assert _matches_required_field(HEAD_SHA, None) is False
+    assert _matches_required_field(HEAD_SHA, "") is False
+
+
+def test_an_empty_constraint_accepts_nothing():
+    """The bucket the truthy test did not have.
+
+    The caller asked for a sha match and could not supply the sha. That is an
+    unverifiable state, and an unverifiable state is a refusal — the same answer
+    the sibling CI gate already gives when gh hands it no head.
+    """
+    from closure_verifier import _matches_required_field
+
+    assert _matches_required_field("", HEAD_SHA) is False, (
+        "an empty constraint accepted a record — the merge door that could not "
+        "determine its own head silently stopped requiring one"
+    )
+    assert _matches_required_field("", OTHER_SHA) is False
+    assert _matches_required_field("", "") is False
+
+
+# --------------------------------------------------------------------------
+# The merge door: the sibling gates now refuse alike.
+# --------------------------------------------------------------------------
+
+def _seed_merge_door(monkeypatch, tmp_path, *, head_oid, record_sha):
+    """A merge door with everything in place except the head it is merging.
+
+    An obligation exists, a terminal + evidenced PASS is on disk, and its report
+    file is real — so nothing else can be the reason for the verdict. The only
+    variable is whether the door could resolve its own head.
+    """
+    import json
+
+    state_dir = tmp_path / "state"
+    results_dir = state_dir / "review_gates" / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    report = tmp_path / "kimi-gate-1710.md"
+    report.write_text(
+        "# kimi_gate\n\nReviewed the diff. No blocking findings.\n", encoding="utf-8"
+    )
+    (results_dir / "pr-1710-kimi_gate.json").write_text(json.dumps({
+        "gate": "kimi_gate", "pr_id": "1710", "pr_number": 1710,
+        "status": "pass", "commit_sha": record_sha, "branch": "fix/x",
+        "contract_hash": "183bed973031720a", "report_path": str(report),
+        "dispatch_id": "kimi-gate-pr1710-old",
+        "blocking_findings": [], "advisory_findings": [],
+    }), encoding="utf-8")
+
+    monkeypatch.setattr(
+        pr_merge, "_query_pr",
+        lambda _n: {"headRefName": "fix/x", "headRefOid": head_oid},
+    )
+    monkeypatch.setattr(pr_merge, "_resolve_declared_gate",
+                        lambda *_a, **_k: "kimi_gate")
+    monkeypatch.setattr(pr_merge, "ensure_env",
+                        lambda *_a, **_k: {"VNX_STATE_DIR": str(state_dir)})
+    monkeypatch.setattr(pr_merge, "_resolve_override_reason", lambda _r: None)
+
+
+def test_an_unresolvable_head_does_not_green_light_a_stale_result(monkeypatch, tmp_path):
+    """The harm, end to end.
+
+    The result on disk is a real, evidenced PASS — for a commit that is not the
+    head. With the head resolvable, the sha constraint rejects it. With the head
+    unresolvable, the constraint was skipped rather than enforced, and the door
+    said GO on a review of code that is no longer there.
+    """
+    _seed_merge_door(monkeypatch, tmp_path, head_oid="", record_sha=OTHER_SHA)
+
+    gate, _ = pr_merge._run_review_gate(1710)
+
+    assert gate["verdict"] == "NO-GO", (
+        "the merge door could not determine its own head, therefore stopped "
+        "requiring one, and green-lit a PASS recorded against "
+        f"{OTHER_SHA[:8]} — the failure is silent by construction: verdict GO, "
+        "nothing logged"
+    )
+    assert "niet toetsbaar" in gate["message"]
+    assert gate["overridden"] is False
+
+
+def test_the_same_stale_result_is_rejected_when_the_head_is_known(monkeypatch, tmp_path):
+    """Contrast: with a head, the constraint does its job on main too.
+
+    This is what isolates the defect to the empty-head path rather than to sha
+    matching in general.
+    """
+    _seed_merge_door(monkeypatch, tmp_path, head_oid=HEAD_SHA, record_sha=OTHER_SHA)
+
+    gate, _ = pr_merge._run_review_gate(1710)
+
+    assert gate["verdict"] == "NO-GO"
+
+
+def test_a_matching_result_still_passes_the_door(monkeypatch, tmp_path):
+    """And the door is not simply refusing everything."""
+    _seed_merge_door(monkeypatch, tmp_path, head_oid=HEAD_SHA, record_sha=HEAD_SHA)
+
+    gate, _ = pr_merge._run_review_gate(1710)
+
+    assert gate["verdict"] == "GO", (
+        f"a matching, evidenced PASS was refused: {gate['message']}"
+    )
+
+
+def test_ci_gate_refuses_the_same_input(monkeypatch):
+    """The control: the asymmetry is gone because both now refuse, not because
+    the test asserts one of them in isolation."""
+    monkeypatch.setattr(pr_merge, "_query_pr", lambda _n: {"headRefName": "", "headRefOid": ""})
+
+    gate, _ = pr_merge._run_ci_gate(1710)
+
+    assert gate["verdict"] == "NO-GO"
+    assert "niet toetsbaar" in gate["message"]

--- a/tests/test_pr_merge_review_gate.py
+++ b/tests/test_pr_merge_review_gate.py
@@ -284,7 +284,8 @@ class TestRunReviewGate:
     def test_no_go_when_no_declared_gate(self, monkeypatch):
         monkeypatch.setattr(
             pr_merge, "_query_pr",
-            lambda n: {"title": "add a thing", "headRefName": "feature/x"},
+            lambda n: {"title": "add a thing", "headRefName": "feature/x",
+                      "headRefOid": "6c925a1b2ee8b0cded8728d4f2c792fcf64be4d4"},
         )
         monkeypatch.setattr(pr_merge, "_resolve_declared_gate", lambda pr_number, state_dir=None: "")
         gate, _ = pr_merge._run_review_gate(5)
@@ -296,7 +297,8 @@ class TestRunReviewGate:
         # key is the bare GitHub PR number, not the title.
         monkeypatch.setattr(
             pr_merge, "_query_pr",
-            lambda n: {"title": "no internal label here", "headRefName": "feature/x"},
+            lambda n: {"title": "no internal label here", "headRefName": "feature/x",
+                       "headRefOid": "6c925a1b2ee8b0cded8728d4f2c792fcf64be4d4"},
         )
         monkeypatch.setattr(pr_merge, "ensure_env", lambda: {"VNX_STATE_DIR": str(tmp_path)})
         monkeypatch.setattr(pr_merge, "_resolve_declared_gate", lambda pr_number, state_dir=None: "codex_gate")
@@ -324,13 +326,41 @@ class TestRunReviewGate:
             "pr_id": "5",
             "gate": "codex_gate",
             "branch": "feature/x",
-            "head_sha": "",  # mocked PR data carries no headRefOid
+            # OI-1318: this used to assert head_sha="" with the note "mocked PR
+            # data carries no headRefOid". That empty string was the defect
+            # written down as an expectation: downstream it read as "no sha
+            # constraint", so the one path that could not resolve its head was
+            # the path that stopped requiring one. The door now refuses before
+            # delegating, and a delegation carries a real head.
+            "head_sha": "6c925a1b2ee8b0cded8728d4f2c792fcf64be4d4",
         }
+
+    def test_override_does_not_bypass_an_undeterminable_head(self, monkeypatch):
+        """OI-1318, and a deliberate narrowing of the override.
+
+        The escape hatch skips the EVIDENCE check; it does not make an
+        unmergeable state mergeable. With no head there is nothing to merge
+        against — ``_do_merge`` cannot pass ``--match-head-commit`` either — so
+        the refusal comes first, exactly as it already does in the sibling
+        ``_run_ci_gate``, which returns NO-GO on an empty head before its own
+        override reaches the check. Symmetry between the two gates is the whole
+        point of OI-1318, and it has to hold on this path too or the asymmetry
+        simply moves.
+        """
+        monkeypatch.setattr(
+            pr_merge, "_query_pr",
+            lambda n: {"title": "PR-42 add a thing", "headRefName": "feature/x",
+                       "headRefOid": ""},
+        )
+        gate, _ = pr_merge._run_review_gate(5, override_reason="hotfix: verified by hand")
+        assert gate["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in gate["message"]
 
     def test_override_empty_reason_refused(self, monkeypatch):
         monkeypatch.setattr(
             pr_merge, "_query_pr",
-            lambda n: {"title": "PR-42 add a thing", "headRefName": "feature/x"},
+            lambda n: {"title": "PR-42 add a thing", "headRefName": "feature/x",
+                      "headRefOid": "6c925a1b2ee8b0cded8728d4f2c792fcf64be4d4"},
         )
         gate, _ = pr_merge._run_review_gate(5, override_reason="   ")
         assert gate["verdict"] == "NO-GO"
@@ -340,7 +370,8 @@ class TestRunReviewGate:
     def test_override_nonempty_reason_goes(self, monkeypatch):
         monkeypatch.setattr(
             pr_merge, "_query_pr",
-            lambda n: {"title": "PR-42 add a thing", "headRefName": "feature/x"},
+            lambda n: {"title": "PR-42 add a thing", "headRefName": "feature/x",
+                      "headRefOid": "6c925a1b2ee8b0cded8728d4f2c792fcf64be4d4"},
         )
         gate, _ = pr_merge._run_review_gate(5, override_reason="hotfix: re-verified by hand")
         assert gate["verdict"] == "GO"


### PR DESCRIPTION
## What was wrong

`_run_ci_gate` resolves the PR head and refuses when it cannot:

> PR-head (sha/branch) kon niet worden bepaald voor #N: deze merge is niet toetsbaar

Its sibling `_run_review_gate` read the same two fields, got empty strings, and
carried on into `check_review_gate_for_merge`.

There the constraint was applied as `if head_sha:`. That truthy test collapses
two different callers into one behaviour:

| caller passes | means | old behaviour |
|---|---|---|
| nothing (`None`) | "I am not scoping by sha" | skip the check ✓ |
| a sha | "must match this" | compare ✓ |
| `""` | "I tried and could not" | **skip the check** ✗ |

So the one path that could not establish which commit it was merging was also
the path that stopped asking. Any result for the PR then satisfied the door,
including one recorded against a commit that is no longer there. Silent by
construction: verdict GO, nothing logged.

## Measured end to end

With an obligation present and a **real, evidenced PASS on disk for a different
sha**, `main` returns GO:

```
FAILED test_an_unresolvable_head_does_not_green_light_a_stale_result
E  AssertionError: the merge door could not determine its own head, therefore
   stopped requiring one, and green-lit a PASS recorded against 0f5e881a —
   the failure is silent by construction: verdict GO, nothing logged
E  assert 'GO' == 'NO-GO'
```

Two contrast cases **pass on main**, which is what isolates the defect to the
empty-head path rather than to sha matching in general:

- `test_the_same_stale_result_is_rejected_when_the_head_is_known` — with a head,
  the constraint already worked.
- `test_a_matching_result_still_passes_the_door` — the door is not simply
  refusing everything.

An earlier version of this test asserted only the *message* and went red on
`main` for the wrong reason (a missing obligation, not the head). That proved a
difference in wording, not the harm. It was replaced.

After: `8 passed`. Neighbours (`pr_merge` ×6, `closure_verifier` ×4,
`merge_preflight`, `gate_obligations`): **253 passed**.

## Changes

- `closure_verifier._matches_required_field` — three answers, not two.
  `branch` carried the identical shape and moves with it.
- `pr_merge._run_review_gate` — refuses an undeterminable head, in the same
  words as its sibling.

## Two test changes that are decisions, not fixture repairs

**`test_delegates_to_evidence_check` asserted the defect.** It expected
`head_sha: ""` with the comment *"mocked PR data carries no headRefOid"*. That
empty string is exactly what read downstream as "no constraint". It now asserts
a real head.

**The refusal sits before the override escape hatch**, which narrows it. An
override skips the *evidence* check; it does not make an unmergeable state
mergeable, and with no head there is nothing to merge against — `_do_merge`
cannot pass `--match-head-commit` either. This mirrors `_run_ci_gate`, which
already returns NO-GO on an empty head before its override reaches the check.
Symmetry between the two gates is the point of OI-1318, and leaving the override
path asymmetric would only move the asymmetry.

Pinned by `test_override_does_not_bypass_an_undeterminable_head` so the
narrowing is recorded as a decision rather than inferred from a fixture edit.
**This is a semantics change and wants explicit ratification.**

Refs OI-1318