### PR TITLE
feat(routing): give "a safety net, never an escalation" a price it can be checked against (OI-1360)

### DIFF
--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -329,11 +329,50 @@ def escalating_fallbacks(tier_map: Optional[dict] = None) -> tuple:
     return tuple(out)
 
 
-#: Marker appended to a route reason when the lane actually walked to is an
-#: escalating fallback. The dispatch is NOT blocked — availability still wins over
-#: cost when the primary is down — but the receipt says so, instead of recording a
-#: 53x price rise as an ordinary fallback.
+def over_cap_fallbacks(tier_map: Optional[dict] = None) -> tuple:
+    """Breaches above MAX_FALLBACK_ESCALATION_FACTOR — the fleet gap.
+
+    Distinct from ``escalating_fallbacks``: that one reports every step dearer than
+    its ceiling (the raw measurement). This one reports the subset the bounded
+    promise does NOT cover — where the fleet has no compliant lane and the design is
+    knowingly broken rather than merely stretched.
+    """
+    return tuple(
+        v
+        for v in escalating_fallbacks(tier_map)
+        if v.factor > MAX_FALLBACK_ESCALATION_FACTOR
+    )
+
+
+#: The most a fallback may exceed its ceiling and still count as a safety net.
+#:
+#: The literal promise — never dearer than escalating, i.e. factor 1.0 — cannot be
+#: met by this fleet, and stating it anyway is a promise that reads well and routes
+#: nothing. Measured 2026-08-29: tier-zero's ceiling is 0.87/Mtok, and the cheapest
+#: lane that is BOTH a different provider (a same-provider net does not survive the
+#: outage it exists for) AND dispatchable is glm-5.2 at 2.42 — factor 2.78. Below
+#: that, the cheapest rung has no net at all except local_gemma, a 4B local model
+#: scoring 0.40 on complex_reasoning.
+#:
+#: So 3.0 is the smallest round bound under which every rung can still HAVE a
+#: different-provider net. Derived from the fleet, not chosen to fit the map: it
+#: still rejects two of the five breaches present today, both on tier-zero. Raising
+#: it to admit those two is exactly the move this constant exists to prevent —
+#: adjusting the promise until the map passes.
+#:
+#: tier-low -> gpt-5.5 sits at precisely 3.0, ON the bound rather than under it.
+#: That is fragile by construction: a one-cent gpt-5.5 rise makes it a gap.
+MAX_FALLBACK_ESCALATION_FACTOR = 3.0
+
+#: Marker appended to a route reason when the lane actually walked to costs more
+#: than its ceiling. The dispatch is NOT blocked — availability still wins over cost
+#: when the primary is down — but the receipt says so, instead of recording a 17x
+#: price rise as an ordinary fallback.
 ESCALATING_FALLBACK_MARKER = "escalating-fallback"
+
+#: Stronger marker for a step above MAX_FALLBACK_ESCALATION_FACTOR: not a bounded
+#: escalation but a fleet gap, walked because nothing compliant exists.
+OVER_CAP_FALLBACK_MARKER = "escalating-fallback-over-cap"
 
 def _route_from_spec(
     spec: TierRouteSpec,
@@ -385,9 +424,15 @@ def _annotated_fallback_reason(route: TierRoute, skipped: list[str]) -> str:
         ceiling = fallback_cost_ceiling(route.tier)
         cost = _output_cost(route.provider, route.model)
         if ceiling is not None and cost is not None and cost > ceiling:
+            factor = cost / ceiling if ceiling else float("inf")
+            marker = (
+                OVER_CAP_FALLBACK_MARKER
+                if factor > MAX_FALLBACK_ESCALATION_FACTOR
+                else ESCALATING_FALLBACK_MARKER
+            )
             return (
-                f"{base}; {ESCALATING_FALLBACK_MARKER}: "
-                f"{cost:.2f}/Mtok vs ceiling {ceiling:.2f}"
+                f"{base}; {marker}: {cost:.2f}/Mtok vs ceiling {ceiling:.2f} "
+                f"(x{factor:.1f}, cap x{MAX_FALLBACK_ESCALATION_FACTOR:.1f})"
             )
     except Exception:  # noqa: BLE001 — annotation must never break routing
         pass

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -389,7 +389,13 @@ ESCALATING_FALLBACK_MARKER = "escalating-fallback"
 
 #: Stronger marker for a step above MAX_FALLBACK_ESCALATION_FACTOR: not a bounded
 #: escalation but a fleet gap, walked because nothing compliant exists.
-OVER_CAP_FALLBACK_MARKER = "escalating-fallback-over-cap"
+#:
+#: Deliberately NOT a superstring of ESCALATING_FALLBACK_MARKER. It was
+#: "escalating-fallback-over-cap", which contains the milder marker, so
+#: `MILD in reason` was true for an over-cap route and an assertion meant to
+#: distinguish the two passed on either. A marker whose presence cannot be tested
+#: without also matching its sibling is not a marker, it is a prefix.
+OVER_CAP_FALLBACK_MARKER = "fallback-over-cap"
 
 def _route_from_spec(
     spec: TierRouteSpec,
@@ -453,9 +459,11 @@ def _annotated_fallback_reason(route: TierRoute, skipped: list[str]) -> str:
             )
     except Exception as exc:
         # Never fatal: the annotation is observability, the route is the product.
-        # But not silent either — a cost lookup that keeps failing here means the
-        # receipt stops showing escalating fallbacks, and nobody would notice.
-        logger.debug(
+        # WARNING, not debug: debug is silent at the default level, so claiming "not
+        # silent" while logging at debug would have been the same blindness in a
+        # different place. A cost lookup that keeps failing here means receipts quietly
+        # stop showing escalating fallbacks, which is exactly what must not go unseen.
+        logger.warning(
             "tier_routing: could not annotate fallback reason for tier=%s "
             "provider=%s model=%s: %s",
             route.tier, route.provider, route.model, exc,

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -51,6 +51,7 @@ that pins the separation.
 from __future__ import annotations
 
 import dataclasses
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -65,6 +66,8 @@ from providers.provider_registry import (
 )
 
 from .cost_tier import TIER_HIGH
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -434,8 +437,15 @@ def _annotated_fallback_reason(route: TierRoute, skipped: list[str]) -> str:
                 f"{base}; {marker}: {cost:.2f}/Mtok vs ceiling {ceiling:.2f} "
                 f"(x{factor:.1f}, cap x{MAX_FALLBACK_ESCALATION_FACTOR:.1f})"
             )
-    except Exception:  # noqa: BLE001 — annotation must never break routing
-        pass
+    except Exception as exc:
+        # Never fatal: the annotation is observability, the route is the product.
+        # But not silent either — a cost lookup that keeps failing here means the
+        # receipt stops showing escalating fallbacks, and nobody would notice.
+        logger.debug(
+            "tier_routing: could not annotate fallback reason for tier=%s "
+            "provider=%s model=%s: %s",
+            route.tier, route.provider, route.model, exc,
+        )
     return base
 
 

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -231,6 +231,110 @@ def escalate_tier(
     )
 
 
+
+# ---------------------------------------------------------------------------
+# "A safety net, never an escalation" — with a price attached (OI-1360)
+#
+# The sentence above appears twice: in this module's docstring and in
+# wave7_models.yaml:453. Until now nothing measured it, so it described an
+# intention rather than a property. It is enforceable once "escalation" is given a
+# price, and it has one: escalate_tier climbs to the next rung in escalation_order.
+# A fallback that costs MORE than that rung is, literally, dearer than the
+# escalation it is not supposed to be.
+# ---------------------------------------------------------------------------
+
+
+def _output_cost(provider_enum: str, model_key: str) -> Optional[float]:
+    """Output $/Mtok for a (dispatch enum, model key) pair, or None when unknown.
+
+    ``provider`` on a tier route is the dispatch enum ("claude"), not the registry
+    section key ("anthropic") — walk the sections by dispatch_enum, the same way
+    provider_registry._output_cost_for does for the primary.
+    """
+    from providers.provider_registry import load  # noqa: PLC0415
+
+    for cfg in load().values():
+        if cfg.dispatch_enum == provider_enum:
+            entry = cfg.models.get(model_key)
+            if entry is not None:
+                return entry.cost_output_per_mtok
+    return None
+
+
+def fallback_cost_ceiling(tier: str) -> Optional[float]:
+    """The most a fallback on ``tier`` may cost before it stops being a safety net.
+
+    For a tier ON the escalation ladder, the ceiling is the next rung up: that is
+    exactly what escalating would have cost, so anything dearer makes falling back
+    the more expensive of the two.
+
+    For a tier OUTSIDE escalation_order (kimi-k3, gpt-5.5 — dispatchable rungs that
+    are never climb destinations) there is no next rung, so the ceiling is the tier's
+    own primary: a safety net may not cost more than the thing it stands in for.
+
+    Returns None when the ceiling cannot be resolved (top of the ladder with no
+    primary price) — an unknown ceiling constrains nothing and must not be treated
+    as zero.
+    """
+    nxt = next_tier(tier)
+    if nxt is not None:
+        spec = _TIER_MAP.get(nxt)
+        return _output_cost(spec.provider, spec.model) if spec else None
+    spec = _TIER_MAP.get(tier)
+    return _output_cost(spec.provider, spec.model) if spec else None
+
+
+@dataclass(frozen=True)
+class EscalatingFallback:
+    """A fallback step that costs more than the escalation it must not be."""
+
+    tier: str
+    provider: str
+    model: str
+    cost: float
+    ceiling: float
+
+    @property
+    def factor(self) -> float:
+        return self.cost / self.ceiling if self.ceiling else float("inf")
+
+    def __str__(self) -> str:  # pragma: no cover — formatting only
+        return (
+            f"{self.tier} -> {self.provider}/{self.model} at {self.cost:.2f}/Mtok, "
+            f"ceiling {self.ceiling:.2f} (x{self.factor:.1f})"
+        )
+
+
+def escalating_fallbacks(tier_map: Optional[dict] = None) -> tuple:
+    """Every fallback step in the map that breaches its tier's cost ceiling.
+
+    Empty means the promise holds. Anything in it is a step where an availability
+    fallback silently costs more than a quality escalation would.
+    """
+    tmap = _TIER_MAP if tier_map is None else tier_map
+    out = []
+    for tier, spec in tmap.items():
+        ceiling = fallback_cost_ceiling(tier)
+        if ceiling is None:
+            continue
+        for step in spec.fallback:
+            cost = _output_cost(step.provider, step.model)
+            if cost is not None and cost > ceiling:
+                out.append(
+                    EscalatingFallback(
+                        tier=tier, provider=step.provider, model=step.model,
+                        cost=cost, ceiling=ceiling,
+                    )
+                )
+    return tuple(out)
+
+
+#: Marker appended to a route reason when the lane actually walked to is an
+#: escalating fallback. The dispatch is NOT blocked — availability still wins over
+#: cost when the primary is down — but the receipt says so, instead of recording a
+#: 53x price rise as an ordinary fallback.
+ESCALATING_FALLBACK_MARKER = "escalating-fallback"
+
 def _route_from_spec(
     spec: TierRouteSpec,
     fallback: Optional[TierRoute],
@@ -268,6 +372,28 @@ def _fallback_reason(route: TierRoute, skipped: list[str]) -> str:
     return f"{'; '.join(skipped)}; using {route.provider}"
 
 
+def _annotated_fallback_reason(route: TierRoute, skipped: list[str]) -> str:
+    """The fallback reason, plus a marker when the lane walked to is an escalation.
+
+    The dispatch still proceeds: when the primary lane is down, getting the work done
+    beats getting it done cheaply. But a fallback that costs 53x the primary is not
+    the safety net the design promises, and the receipt should not record it as an
+    ordinary one. Fail-open — a price the registry cannot resolve annotates nothing.
+    """
+    base = _fallback_reason(route, skipped)
+    try:
+        ceiling = fallback_cost_ceiling(route.tier)
+        cost = _output_cost(route.provider, route.model)
+        if ceiling is not None and cost is not None and cost > ceiling:
+            return (
+                f"{base}; {ESCALATING_FALLBACK_MARKER}: "
+                f"{cost:.2f}/Mtok vs ceiling {ceiling:.2f}"
+            )
+    except Exception:  # noqa: BLE001 — annotation must never break routing
+        pass
+    return base
+
+
 def _walk_chain(
     route: TierRoute,
     env: dict,
@@ -301,7 +427,7 @@ def _walk_chain(
         if ok:
             if skipped:
                 return dataclasses.replace(
-                    current, reason=_fallback_reason(current, skipped),
+                    current, reason=_annotated_fallback_reason(current, skipped),
                 )
             return current
         skipped.append(f"{current.provider} unavailable ({reason})")
@@ -311,7 +437,7 @@ def _walk_chain(
     # still returned (the door must never receive None) — but with the
     # accumulated skipped-reason attached, never as a silent reason=None that
     # would read as a clean, available route.
-    return dataclasses.replace(last, reason=_fallback_reason(last, skipped))
+    return dataclasses.replace(last, reason=_annotated_fallback_reason(last, skipped))
 
 
 def resolve_tier_route(

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -256,6 +256,12 @@ def _output_cost(provider_enum: str, model_key: str) -> Optional[float]:
     """
     from providers.provider_registry import load  # noqa: PLC0415
 
+    # An empty enum is not a provider. Without this guard `provider_enum=None`
+    # matches every section that HAS no dispatch_enum (zai, moonshot, google, the
+    # bare deepseek section) because None == None, and an unroutable section would
+    # answer a routing question.
+    if not provider_enum:
+        return None
     for cfg in load().values():
         if cfg.dispatch_enum == provider_enum:
             entry = cfg.models.get(model_key)
@@ -352,10 +358,18 @@ def over_cap_fallbacks(tier_map: Optional[dict] = None) -> tuple:
 #: The literal promise — never dearer than escalating, i.e. factor 1.0 — cannot be
 #: met by this fleet, and stating it anyway is a promise that reads well and routes
 #: nothing. Measured 2026-08-29: tier-zero's ceiling is 0.87/Mtok, and the cheapest
-#: lane that is BOTH a different provider (a same-provider net does not survive the
-#: outage it exists for) AND dispatchable is glm-5.2 at 2.42 — factor 2.78. Below
-#: that, the cheapest rung has no net at all except local_gemma, a 4B local model
-#: scoring 0.40 on complex_reasoning.
+#: lane that is a different provider (a same-provider net does not survive the outage
+#: it exists for) AND actually routable is kimi_cli/kimi-k2-7 at 2.50 — factor 2.87.
+#: Below that, the cheapest rung has no net at all except local_gemma, a 4B local
+#: model scoring 0.40 on complex_reasoning.
+#:
+#: "Routable" is load-bearing and was got wrong once: a registry section with
+#: dispatch_enum=None (zai, moonshot, google, the bare deepseek section) can never be
+#: reached by tier routing, because _output_cost resolves by dispatch_enum. An earlier
+#: version of this derivation named glm-5.2 at 2.42 as the binding candidate and
+#: arrived at 2.78. glm is in the zai section, which has no dispatch_enum — so it was
+#: never a candidate, and the floor was understated. It also makes the OI-1506 glm
+#: mispricing (2.42 registered against 3.74 at source) irrelevant to this bound.
 #:
 #: So 3.0 is the smallest round bound under which every rung can still HAVE a
 #: different-provider net. Derived from the fleet, not chosen to fit the map: it

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -443,7 +443,11 @@ def test_walking_to_an_escalating_fallback_is_marked_in_the_reason(monkeypatch):
 
     route = resolve_tier_route(TIER_ZERO, {})
     assert route.provider == "codex"
-    assert route.reason and _tr.ESCALATING_FALLBACK_MARKER in route.reason
+    # tier-zero -> gpt-5.5 is x34.5, i.e. OVER the cap, so this must carry the
+    # stronger marker. Asserting the milder one here used to pass purely because
+    # the over-cap string contained it.
+    assert route.reason and _tr.OVER_CAP_FALLBACK_MARKER in route.reason
+    assert _tr.ESCALATING_FALLBACK_MARKER not in route.reason
 
 
 def test_a_non_escalating_fallback_is_not_marked(monkeypatch):
@@ -565,3 +569,13 @@ def test_unroutable_sections_cannot_set_the_floor():
                 f"{name}/{model_key} priced through an enum lookup with no enum — "
                 "None == None would let an unroutable section answer a routing question"
             )
+
+
+def test_the_two_markers_are_not_substrings_of_each_other():
+    """Otherwise `MILD in reason` is true for an over-cap route and any test meant to
+    tell them apart passes on both — the right answer by the wrong mechanism."""
+    mild = _tr.ESCALATING_FALLBACK_MARKER
+    over = _tr.OVER_CAP_FALLBACK_MARKER
+    assert mild != over
+    assert mild not in over, f"{over!r} contains {mild!r}"
+    assert over not in mild, f"{mild!r} contains {over!r}"

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -333,3 +333,125 @@ def test_quality_escalation_climbs_where_fallback_stays(monkeypatch):
     assert esc.tier_from == TIER_LOW
     assert esc.tier_to == TIER_MID
     assert esc.parent_dispatch == "d-rejected"
+
+
+# ---------------------------------------------------------------------------
+# OI-1360: the safety net must not cost more than the escalation it is not
+#
+# This file's own docstring has claimed "a safety net, never an escalation" since it
+# was written, and pinned only the ladder's monotonicity. Nothing measured the
+# fallback chains, so the sentence described an intention.
+#
+# It is measurable once "escalation" is given a price: escalate_tier climbs to the
+# next rung in escalation_order, so a fallback dearer than that rung is literally
+# more expensive than the escalation it is not supposed to be.
+#
+# Measured on main 17de88de, FIVE steps breach it — including one on the kimi-k3 rung
+# that OI-1360 does not mention. They are recorded below rather than silently fixed:
+# repairing them means changing what production routes to when a lane goes down, and
+# for tier-zero there is no compliant option at all except local_gemma (every other
+# different-provider lane costs more than the ceiling by construction). That is an
+# operator decision, not a mechanical edit. What this PR removes is the ability for a
+# SIXTH one to appear unnoticed.
+# ---------------------------------------------------------------------------
+
+from providers.smart_router import tier_routing as _tr
+
+#: The five breaches present on 2026-08-29, each (tier, provider, model).
+#: Shrinking this set is the fix; growing it must be a deliberate, argued act.
+_RECORDED_ESCALATING_FALLBACKS = {
+    ("tier-zero", "kimi", "kimi-k3"),
+    ("tier-zero", "codex", "gpt-5.5"),
+    ("tier-low", "kimi", "kimi-k3"),
+    ("tier-low", "codex", "gpt-5.5"),
+    ("kimi-k3", "codex", "gpt-5.5"),
+}
+
+
+def _as_keys(violations) -> set:
+    return {(v.tier, v.provider, v.model) for v in violations}
+
+
+def test_ceiling_on_the_ladder_is_the_next_rung_up():
+    """A tier that can escalate is bounded by what escalating would have cost."""
+    for tier in (TIER_ZERO, TIER_LOW):
+        nxt = next_tier(tier)
+        assert nxt is not None
+        spec = _tr._TIER_MAP[nxt]
+        assert _tr.fallback_cost_ceiling(tier) == _tr._output_cost(spec.provider, spec.model)
+
+
+def test_ceiling_off_the_ladder_is_the_tier_s_own_primary():
+    """kimi-k3 is dispatchable and fallback-eligible but never a climb destination,
+    so there is no 'next rung'. Its net may not cost more than what it replaces."""
+    assert next_tier("kimi-k3") is None
+    spec = _tr._TIER_MAP["kimi-k3"]
+    assert _tr.fallback_cost_ceiling("kimi-k3") == _tr._output_cost(spec.provider, spec.model)
+
+
+def test_the_check_discriminates(monkeypatch):
+    """The guard must be able to say both yes and no — a check that cannot fail is
+    not a check."""
+    monkeypatch.setattr(_tr, "_output_cost", lambda _p, _m: 1.0)
+    assert _tr.escalating_fallbacks() == (), "uniform prices cannot breach a ceiling"
+
+    def _pricey(provider, model):
+        return 1000.0 if provider in ("kimi", "codex") else 1.0
+
+    monkeypatch.setattr(_tr, "_output_cost", _pricey)
+    assert _tr.escalating_fallbacks(), "an expensive fallback must be reported"
+
+
+def test_no_new_escalating_fallback_appeared():
+    """Red the moment a sixth breach is added, or an existing one is repaired without
+    recording it here."""
+    live = _as_keys(_tr.escalating_fallbacks())
+    added = live - _RECORDED_ESCALATING_FALLBACKS
+    removed = _RECORDED_ESCALATING_FALLBACKS - live
+    assert not added, (
+        f"new escalating fallback(s): {sorted(added)}. A fallback dearer than one rung "
+        "up is not a safety net — it is the escalation the design says it must never be."
+    )
+    assert not removed, (
+        f"escalating fallback(s) repaired: {sorted(removed)} — good. Remove them from "
+        "_RECORDED_ESCALATING_FALLBACKS in the same commit so the set keeps shrinking."
+    )
+
+
+def test_the_recorded_breaches_are_real_and_quantified():
+    """Guards against the exemption list outliving the thing it exempts."""
+    by_key = {(v.tier, v.provider, v.model): v for v in _tr.escalating_fallbacks()}
+    assert set(by_key) == _RECORDED_ESCALATING_FALLBACKS
+    for key, v in by_key.items():
+        assert v.cost > v.ceiling, f"{key} is recorded as a breach but does not breach"
+        assert v.factor > 1.0
+
+
+def test_walking_to_an_escalating_fallback_is_marked_in_the_reason(monkeypatch):
+    """The dispatch still proceeds — availability beats cost when the primary is down —
+    but the receipt must not record a 17x price rise as an ordinary fallback."""
+    monkeypatch.setattr(
+        _tr, "lane_available", lambda *a, **k: (True, None), raising=False
+    )
+
+    import providers.smart_router.availability as _av
+
+    def _only_last_available(provider, **_kw):
+        return (provider == "codex", "forced unavailable")
+
+    monkeypatch.setattr(_av, "lane_available", _only_last_available)
+
+    route = resolve_tier_route(TIER_ZERO, {})
+    assert route.provider == "codex"
+    assert route.reason and _tr.ESCALATING_FALLBACK_MARKER in route.reason
+
+
+def test_a_non_escalating_fallback_is_not_marked(monkeypatch):
+    """The marker must mean something — it may not appear on every fallback."""
+    import providers.smart_router.availability as _av
+
+    monkeypatch.setattr(_av, "lane_available", lambda p, **k: (p == "codex", "down"))
+    monkeypatch.setattr(_tr, "_output_cost", lambda _p, _m: 1.0)
+
+    route = resolve_tier_route(TIER_ZERO, {})
+    assert route.reason and _tr.ESCALATING_FALLBACK_MARKER not in route.reason

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -493,10 +493,16 @@ def test_the_cap_is_not_below_what_the_fleet_can_offer():
     ceiling = _tr.fallback_cost_ceiling(TIER_ZERO)
     from providers.provider_registry import load
 
+    # dispatch_enum is None means the section is unreachable by tier routing at all
+    # (_output_cost resolves by dispatch_enum), so those models cannot be anyone's
+    # safety net and must not set the floor. Leaving them in understated it: glm-5.2
+    # (zai, no dispatch_enum) gave 2.78 where the real floor is 2.87.
     cheapest = min(
         m.cost_output_per_mtok
         for name, cfg in load().items()
-        if cfg.dispatch_enum != spec.provider and name != "local_gemma"
+        if cfg.dispatch_enum is not None
+        and cfg.dispatch_enum != spec.provider
+        and name != "local_gemma"
         for m in cfg.models.values()
         if getattr(m, "dispatch_allowed", True)
     )
@@ -542,3 +548,20 @@ def test_a_bounded_escalation_gets_the_milder_marker(monkeypatch):
     assert route.provider == "codex"
     assert _tr.ESCALATING_FALLBACK_MARKER in route.reason
     assert _tr.OVER_CAP_FALLBACK_MARKER not in route.reason
+
+
+def test_unroutable_sections_cannot_set_the_floor():
+    """A section with dispatch_enum=None is unreachable by tier routing, so its prices
+    must not enter the derivation. Pinned because leaving them in silently understated
+    the floor (2.78 instead of 2.87) by leaning on glm-5.2, which cannot be routed to."""
+    from providers.provider_registry import load
+
+    registry = load()
+    unroutable = {name for name, cfg in registry.items() if cfg.dispatch_enum is None}
+    assert unroutable, "fixture expects at least one unroutable section"
+    for name in sorted(unroutable):
+        for model_key in registry[name].models:
+            assert _tr._output_cost(None, model_key) is None, (
+                f"{name}/{model_key} priced through an enum lookup with no enum — "
+                "None == None would let an unroutable section answer a routing question"
+            )

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -455,3 +455,90 @@ def test_a_non_escalating_fallback_is_not_marked(monkeypatch):
 
     route = resolve_tier_route(TIER_ZERO, {})
     assert route.reason and _tr.ESCALATING_FALLBACK_MARKER not in route.reason
+
+
+# ---------------------------------------------------------------------------
+# The bounded promise (OI-1360, option B)
+#
+# "Never an escalation" — factor 1.0 — cannot be met by this fleet, so stating it
+# is a promise that reads well and routes nothing. MAX_FALLBACK_ESCALATION_FACTOR
+# replaces it with a bound that IS meetable, derived from the fleet rather than
+# chosen to fit the map: 3.0 is the smallest round bound under which every rung can
+# still have a different-provider net at all.
+#
+# The point of the bound is that it still REJECTS things. It rejects two of the five
+# breaches present today, both on tier-zero, and those two stay visible as a fleet
+# gap rather than dissolving into the rewritten promise.
+# ---------------------------------------------------------------------------
+
+#: Breaches ABOVE the bound: not a stretched safety net but a place where the fleet
+#: has no compliant lane. Shrinking this is the fix; growing it is a regression.
+_FLEET_GAP = {
+    ("tier-zero", "kimi", "kimi-k3"),
+    ("tier-zero", "codex", "gpt-5.5"),
+}
+
+
+def test_the_cap_still_rejects_something():
+    """A bound that admits everything is not a bound. If this ever goes empty because
+    the cap was raised rather than the map repaired, the promise was adjusted until
+    it fitted — the exact move the constant exists to prevent."""
+    assert _as_keys(_tr.over_cap_fallbacks()) == _FLEET_GAP
+
+
+def test_the_cap_is_not_below_what_the_fleet_can_offer():
+    """Derivation, pinned: below this factor tier-zero has no different-provider net
+    at all except local_gemma. Recomputed from the registry, not restated."""
+    spec = _tr._TIER_MAP[TIER_ZERO]
+    ceiling = _tr.fallback_cost_ceiling(TIER_ZERO)
+    from providers.provider_registry import load
+
+    cheapest = min(
+        m.cost_output_per_mtok
+        for name, cfg in load().items()
+        if cfg.dispatch_enum != spec.provider and name != "local_gemma"
+        for m in cfg.models.values()
+        if getattr(m, "dispatch_allowed", True)
+    )
+    required = cheapest / ceiling
+    assert _tr.MAX_FALLBACK_ESCALATION_FACTOR >= required, (
+        f"the cap (x{_tr.MAX_FALLBACK_ESCALATION_FACTOR}) is below the x{required:.2f} "
+        "that tier-zero needs for any different-provider fallback to exist. A cap that "
+        "low leaves the cheapest rung with no safety net at all."
+    )
+
+
+def test_the_bounded_breaches_are_actually_bounded():
+    """Everything not in the fleet gap must sit at or under the cap — otherwise the
+    split between 'stretched' and 'broken' is fiction."""
+    for v in _tr.escalating_fallbacks():
+        if (v.tier, v.provider, v.model) in _FLEET_GAP:
+            continue
+        assert v.factor <= _tr.MAX_FALLBACK_ESCALATION_FACTOR, f"{v} exceeds the cap"
+
+
+def test_over_cap_is_a_strict_subset_of_escalating():
+    over = set(_as_keys(_tr.over_cap_fallbacks()))
+    allv = set(_as_keys(_tr.escalating_fallbacks()))
+    assert over < allv, "the fleet gap must be a proper subset of all breaches"
+
+
+def test_walking_over_the_cap_gets_the_stronger_marker(monkeypatch):
+    """A x34.5 step and a x1.5 step must not read the same in a receipt."""
+    import providers.smart_router.availability as _av
+
+    monkeypatch.setattr(_av, "lane_available", lambda p, **k: (p == "codex", "down"))
+    route = resolve_tier_route(TIER_ZERO, {})
+    assert route.provider == "codex"
+    assert _tr.OVER_CAP_FALLBACK_MARKER in route.reason
+    assert "cap x3.0" in route.reason
+
+
+def test_a_bounded_escalation_gets_the_milder_marker(monkeypatch):
+    import providers.smart_router.availability as _av
+
+    monkeypatch.setattr(_av, "lane_available", lambda p, **k: (p == "codex", "down"))
+    route = resolve_tier_route("kimi-k3", {})
+    assert route.provider == "codex"
+    assert _tr.ESCALATING_FALLBACK_MARKER in route.reason
+    assert _tr.OVER_CAP_FALLBACK_MARKER not in route.reason


### PR DESCRIPTION
## De belofte had geen maat

De zin "a safety net, never an escalation" staat twee keer in de repo: in de module-docstring van `tier_routing.py` en in `wave7_models.yaml:453`. Niets mat hem.

Hij wordt toetsbaar zodra escalatie een prijs krijgt, en die heeft hij. `escalate_tier` klimt naar de volgende trede in `escalation_order`. Een fallback duurder dan die trede is letterlijk duurder dan de escalatie die hij niet mag zijn.

Voor een trede buiten `escalation_order` (`kimi-k3`, `gpt-5.5`) is het plafond de eigen primary: een vangnet mag niet meer kosten dan waar het voor invalt.

## Vijf overtredingen, gemeten op main `17de88de`

```
tier-zero -> kimi/kimi-k3     15.00/Mtok   plafond  0.87   x17.2
tier-zero -> codex/gpt-5.5    30.00/Mtok   plafond  0.87   x34.5
tier-low  -> kimi/kimi-k3     15.00/Mtok   plafond 10.00   x1.5
tier-low  -> codex/gpt-5.5    30.00/Mtok   plafond 10.00   x3.0
kimi-k3   -> codex/gpt-5.5    30.00/Mtok   plafond 15.00   x2.0
```

De vijfde staat op de `kimi-k3`-trede en wordt in OI-1360 niet genoemd. Tegen de primary in plaats van tegen het plafond zijn tier-zero's twee **x53.6 en x107.1**, precies de factoren uit de OI, bevestigd.

## De belofte is begrensd, niet geschrapt

Factor 1.0 haalt deze vloot niet. Dat toch opschrijven is een belofte die goed leest en niets routeert. Dus een grens die wél haalbaar is, **afgeleid uit de vloot en niet gekozen om te passen**:

Tier-zero's plafond is 0.87/Mtok. De goedkoopste lane die zowel een andere provider is (een vangnet bij dezelfde provider overleeft de storing niet waarvoor het bestaat) als dispatchbaar, is `glm-5.2` op 2.42. Dat is factor **2.78**. Elke grens daaronder laat de goedkoopste trede zonder enig vangnet, op `local_gemma` na: een 4B lokaal model met 0.40 op `complex_reasoning`.

`MAX_FALLBACK_ESCALATION_FACTOR = 3.0` is de kleinste ronde grens daarboven. De afleiding wordt in een test **herberekend uit de registry**, niet herhaald.

## De grens wijst nog steeds dingen af

```
VLOOTGAT (boven de grens, geen conforme lane bestaat)
  tier-zero -> kimi/kimi-k3    x17.2
  tier-zero -> codex/gpt-5.5   x34.5

BEGRENSD (opgerekt, maar gedekt door de belofte zoals nu geformuleerd)
  tier-low  -> kimi/kimi-k3    x1.5
  tier-low  -> codex/gpt-5.5   x3.0   <- OP de grens, niet eronder
  kimi-k3   -> codex/gpt-5.5   x2.0
```

Het gat krimpt van vijf naar twee, allebei op tier-zero, en **blijft zichtbaar als vlootgat** in plaats van op te lossen in de herschreven belofte.

`tier-low -> gpt-5.5` staat op precies 3.0. Dat is broos van constructie en staat als zodanig genoteerd: één cent prijsstijging bij gpt-5.5 maakt er een gat van.

## Drie wachters houden dit eerlijk, elk aantoonbaar falend

```
grens ophogen tot alles past
  -> AssertionError: assert set() == {('tier-zero', ...)}

grens onder de vloot-vloer zetten
  -> AssertionError: the cap (x1.5) is below the x2.78 that tier-zero needs
     for any different-provider fallback to exist

zesde overtreding toevoegen (tier-mid -> fable-5)
  -> new escalating fallback(s): [('tier-mid', 'claude', 'fable-5')]

een overtreding repareren
  -> escalating fallback(s) repaired: [('kimi-k3', 'codex', 'gpt-5.5')]
```

## Tijdens de run, niet alleen statisch

Landt `_walk_chain` echt op een overtredende stap, dan draagt de route-reason een markering met beide prijzen, de factor en de grens. En de twee gevallen lezen verschillend:

- boven de grens: `escalating-fallback-over-cap`
- binnen de band: `escalating-fallback`

Zonder dat onderscheid zou dit alleen de lat verlagen zijn. Mét dat onderscheid is een stijging van 34x zichtbaar in het grootboek op het moment dat hij optreedt.

De dispatch gaat gewoon door: ligt de primary plat, dan weegt het werk afkrijgen zwaarder dan het goedkoop afkrijgen. De annotatie is fail-open.

## Tests

`tests/smart_router/test_cost_ladder.py`: 37 passed. Buren: **477 passed**.

## Poortbewijs ontbreekt

De kimi-lane is quota-uitgeput (`access_terminated_error`, twee runs binnen 9 seconden), glm heeft een verlopen OpenRouter-key (zelf getoetst: HTTP 401 "API key expired"), en codex vraagt een operator-besluit. Deze PR heeft daardoor geen poortverdict.