### PR TITLE
fix(gates): a result that is not a pass says why, in the field named for it (OI-1453)

### DIFF
--- a/docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md
+++ b/docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md
@@ -392,6 +392,65 @@ A result record is stale if:
 
 ---
 
+## 9. The Canonical `failure_reason` Field
+
+### 9.1 What the field carries
+
+`failure_reason` is the canonical "why did this not pass" field a generic reader
+queries. OI-1415 established it for `phantom_guard` and `pr_enforcement`; OI-1453
+extends it to every `review_gates/results/` record through a single derivation
+at the one point every result record passes through on its way to disk
+(`gate_recorder._write_result_atomic`).
+
+The field carries a **cause**, never a category, a summary, or a placeholder.
+Measured 2026-08-30 over 739 non-pass gate-result records across every project
+store, the cause on a record lives under one of these names and only these:
+
+| field | what it is | route into `failure_reason` |
+|-------|-----------|------------------------------|
+| `failure_reason` (pre-stamped) | a cause the lane established upstream | wins via the `existing` shortcut — the lane-log lift (OI-1452) stamps it in the report frontmatter when it found a real exhaustion marker |
+| `blocking_findings` | a cause (the gate ran and found a blockade) | lifted when the list is non-empty; "N blocking finding(s): <first>" |
+| `reason_detail` | a cause ("codex binary not found in PATH", "Subprocess exited with code 1") | lifted from the source chain |
+
+### 9.2 What the field does NOT carry
+
+These fields are deliberately NOT consulted by the derivation. Lifting any of
+them is the bug OI-1453 measured: on the real PR #1677 outage record,
+`reason="dispatch_error"` won and a category landed where a cause belongs.
+
+| field | what it actually is | why it is not a cause |
+|-------|---------------------|------------------------|
+| `reason` | a classification (`provider_not_installed`, `dispatch_error`, `exit_nonzero`, `provider_disabled`) | a label for routing/triage, not an explanation a reader can act on |
+| `residual_risk` | prose, often frontmatter-derived ("kimi's own report stamps this run as failed...") | a field named "remaining risk"; its text resembles a cause but is not one |
+| `summary` | a one-line verdict summary ("gate found problems") | a summary, by construction not a cause |
+| terminal fallbacks | `f"status: {status}"`, `"unspecified"` | a placeholder invented to satisfy a presence check — the worst case, because it passes every presence check while explaining nothing |
+
+### 9.3 Three states, three meanings
+
+`failure_reason` is not a binary "filled or not". It has three states, each
+with its own meaning. This is a contract, not an implementation detail:
+
+| state | `failure_reason` value | meaning |
+|-------|------------------------|---------|
+| a pass | **absent** | no failure to explain; presence would make the field meaningless as a signal |
+| a non-pass WITH an established cause | **the cause text** | the gate filed the cause under `reason_detail`, blocking findings, or a pre-stamp |
+| a non-pass where the cause was NOT established | **empty (`""`)** | the record honestly says "not a pass, and we could not say why" |
+
+The third state is **a valid state, not a defect**. A check that treats it as a
+violation is the trap this contract exists to prevent: it forces every gate to
+fill the field with *something* to pass the check, the field stops meaning
+anything, and the real cause is buried under invented placeholders. A guard on
+this field MUST distinguish all three states — a two-bucket "pass empty /
+non-pass filled" guard books the third state as a violation and is wrong by
+construction.
+
+The empty third state is also how the lane-log lift (OI-1452) leaves a record
+when it found no marker: the gate pre-stamps `failure_reason = ""`, and the
+derivation honors that rather than inventing a cause from `reason` or
+`residual_risk`.
+
+---
+
 ## Appendix A: GATE Rule Summary
 
 | Rule | Obligation |
@@ -409,6 +468,7 @@ A result record is stale if:
 | GATE-11 | Artifact materialization is all-or-nothing |
 | GATE-12 | Artifact consistency checks before `completed` |
 | GATE-13 | Stale artifact detection via contract_hash recomputation |
+| GATE-14 | `failure_reason` carries a cause only; empty is a valid third state for a non-pass whose cause was not established (see §9) |
 
 ## Appendix B: Relationship To Other Contracts
 

--- a/docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md
+++ b/docs/core/180_GATE_EXECUTION_LIFECYCLE_CONTRACT.md
@@ -403,8 +403,10 @@ at the one point every result record passes through on its way to disk
 (`gate_recorder._write_result_atomic`).
 
 The field carries a **cause**, never a category, a summary, or a placeholder.
-Measured 2026-08-30 over 739 non-pass gate-result records across every project
-store, the cause on a record lives under one of these names and only these:
+Measured 2026-08-30 over 501 non-pass gate-result records across every project
+store (non-pass defined canonically as `gate_status.is_pass` returning `False`,
+which counts `completed`/`approve` as a pass and therefore excludes them), the
+cause on a record lives under one of these names and only these:
 
 | field | what it is | route into `failure_reason` |
 |-------|-----------|------------------------------|

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -409,8 +409,10 @@ def _check_overwrite_guard(
         )
 
 
-# A CAUSE, not a category. Measured 2026-08-30 over 739 non-pass gate-result
-# records across every project store: ``reason_detail`` carries an actual
+# A CAUSE, not a category. Measured 2026-08-30 over 501 non-pass gate-result
+# records across every project store (non-pass defined canonically as
+# ``gate_status.is_pass`` returning False, which counts ``completed``/
+# ``approve`` as a pass): ``reason_detail`` carries an actual
 # cause ("codex binary not found in PATH", "Subprocess exited with code 1"),
 # ``reason`` carries a CLASSIFICATION ("provider_not_installed",
 # "dispatch_error", "exit_nonzero"), and ``residual_risk``/``summary`` carry

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -409,8 +409,96 @@ def _check_overwrite_guard(
         )
 
 
+# A CAUSE, not a category. Measured 2026-08-30 over 739 non-pass gate-result
+# records across every project store: ``reason_detail`` carries an actual
+# cause ("codex binary not found in PATH", "Subprocess exited with code 1"),
+# ``reason`` carries a CLASSIFICATION ("provider_not_installed",
+# "dispatch_error", "exit_nonzero"), and ``residual_risk``/``summary`` carry
+# prose that only looks like a cause. Only ``reason_detail`` is in the chain.
+#
+# The lane-log lift (OI-1452) does NOT reach the cause through
+# ``residual_risk`` on the derivation path: when the lift found a real
+# marker it stamps ``failure_reason`` directly in the report frontmatter
+# (governance_emit), so the ``existing`` shortcut below wins before this
+# tuple is ever walked. A record that reaches this walk with only
+# ``residual_risk``/``reason``/``summary`` populated is a record whose cause
+# was NOT established -- and "" is the honest value for that, not a
+# best-effort summary lifted from a field that merely sounds like one.
+_FAILURE_REASON_SOURCES = ("reason_detail",)
+
+
+def derive_failure_reason(payload: Dict[str, Any]) -> str:
+    """The canonical cause, or "" when the cause was not established.
+
+    ``failure_reason`` is the field a generic reader queries, established by
+    OI-1415 for phantom_guard and pr_enforcement. It carries a CAUSE, never a
+    category, a summary, or a placeholder. Three states, each with its own
+    meaning (OI-1453, measured 2026-08-30):
+
+    - a PASS -> "". A pass has no failure to explain; stamping one would make
+      the field's presence meaningless as a signal.
+    - a non-pass WITH an established cause -> the cause text. Lifted from the
+      lane-log stamp (``existing``), from ``blocking_findings`` when a gate
+      ran to completion and failed on what it found, or from ``reason_detail``
+      when a lane filed the cause there.
+    - a non-pass where the cause was NOT established -> "". This is a valid
+      third state, not a defect: the record honestly says "not a pass, and we
+      could not say why". A check that treats this third state as a violation
+      forces placeholders back into the field -- every gate would fill it with
+      something to pass the check, and the field would stop meaning anything.
+
+    What this function deliberately does NOT consult: ``reason`` (a
+    classification such as "dispatch_error"), ``residual_risk`` and
+    ``summary`` (prose that resembles a cause but is not one), and the
+    terminal fallbacks ``f"status: {status}"`` / ``"unspecified"`` (a
+    placeholder invented to satisfy a presence check). Lifting any of those
+    into the canonical field is precisely the bug OI-1453 measured: on the
+    real PR #1677 outage record, ``reason="dispatch_error"`` won and a
+    category landed where a cause belongs.
+    """
+    from gate_status import is_pass  # noqa: PLC0415
+
+    existing = str(payload.get("failure_reason") or "").strip()
+    if existing:
+        return existing
+    passed, _ = is_pass(payload)
+    if passed:
+        return ""
+
+    blocking = payload.get("blocking_findings")
+    if isinstance(blocking, list) and blocking:
+        first = blocking[0] if isinstance(blocking[0], dict) else {}
+        detail = str(
+            first.get("message") or first.get("title") or first.get("description") or ""
+        ).strip()
+        head = f"{len(blocking)} blocking finding(s)"
+        return f"{head}: {detail}" if detail else head
+
+    for field in _FAILURE_REASON_SOURCES:
+        value = str(payload.get(field) or "").strip()
+        if value:
+            return value
+    # Cause not established -> honest "", not an invented placeholder.
+    return ""
+
+
 def _write_result_atomic(result_path: Path, payload: Dict[str, Any]) -> None:
-    """Write one result record through the shared atomic-write helper.
+    """Write one result record, stamping the canonical failure reason first.
+
+    Every production writer of a ``review_gates/results/`` record reaches disk
+    through here -- the guarded entry points both call it, and the OI-1472
+    table lists no other. Deriving ``failure_reason`` at this one point is what
+    makes "every gate fills it" a property of the code rather than a rule six
+    lanes have to remember separately, which is how it came to be 1-in-470
+    (OI-1453).
+
+    The payload is stamped in place so the record the caller holds is the
+    record on disk. A caller comparing its own dict against the file would
+    otherwise find a field it never set. Stamping only fires when the
+    derivation produced a cause: a pass leaves the field absent, and a
+    non-pass whose cause was not established leaves the field at whatever the
+    caller already set (often "" -- the honest third state, see
+    :func:`derive_failure_reason`).
 
     Callers must already hold :func:`atomic_io.slot_lock` for ``result_path``
     — both guarded entry points below do. This is the write half of that
@@ -427,6 +515,9 @@ def _write_result_atomic(result_path: Path, payload: Dict[str, Any]) -> None:
     on disk matched neither writer's account of what it had written.
     ``atomic_io`` gives each writer its own ``mkstemp`` scratch file.
     """
+    reason = derive_failure_reason(payload)
+    if reason:
+        payload["failure_reason"] = reason
     atomic_write_json(result_path, payload)
 
 

--- a/tests/test_oi1453_canonical_failure_reason.py
+++ b/tests/test_oi1453_canonical_failure_reason.py
@@ -1,0 +1,317 @@
+"""Every gate result that is not a pass says why, in the field named for it (OI-1453).
+
+``failure_reason`` is the field a generic reader queries. OI-1415 established it
+for phantom_guard and pr_enforcement; gate result records never adopted it.
+
+Re-measured across the whole central store on 2026-08-30, three project stores,
+739 non-pass gate-result records:
+
+    failure_reason filled:  4 of 739
+
+    summary          790 filled (prose, often frontmatter-derived)
+    residual_risk    699 filled (prose, often frontmatter-derived)
+    reason           397 filled (a CLASSIFICATION: provider_not_installed 145,
+                                 claude_github_not_configured 63, exit_nonzero
+                                 60, provider_disabled 57, dispatch_error 6 ...)
+    reason_detail    270 filled (a CAUSE: "codex binary not found in PATH" 106,
+                                  "Subprocess exited with code 1" 59,
+                                  "VNX_CI_GATE_REQUIRED is set to 0" 57 ...)
+    blocking_findings  64 filled (a cause)
+    failure_reason     4 filled (the gap OI-1453 opens)
+
+``failure_reason`` carries a CAUSE, never a category, a summary, or a
+placeholder. The cause reaches it by one of three routes, and only those:
+
+    1. the lane-log lift (OI-1452) stamps it directly in the report
+       frontmatter when it found a real exhaustion marker;
+    2. a gate that ran to completion and failed on its findings carries it as
+       ``blocking_findings``;
+    3. a lane that filed the cause under ``reason_detail`` (the PATH-missing,
+       exit-nonzero, disabled-flag records above).
+
+What is deliberately NOT a route: ``reason`` (a classification), and
+``residual_risk``/``summary`` (prose that resembles a cause but is not one).
+The original OI-1453 derivation walked all of them, and on the real PR #1677
+outage record ``reason="dispatch_error"`` won -- a category landed where a
+cause belongs, and four OI-1452 tests went red asserting the field should be
+empty when the cause was never established.
+
+Three states, each with its own meaning:
+
+    pass                              -> failure_reason absent
+    non-pass WITH an established cause -> failure_reason carries the cause
+    non-pass, cause NOT established    -> failure_reason empty (a valid third
+                                          state, NOT a defect)
+
+A guard that treats the third state as a violation is the trap this PR
+repairs: it forces placeholders back into the field, every gate fills it with
+something to pass the check, and the field stops meaning anything.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import gate_artifacts
+import gate_recorder
+from gate_recorder import record_failure, record_not_executable
+
+
+@pytest.fixture
+def dirs(tmp_path):
+    requests = tmp_path / "state" / "review_gates" / "requests"
+    results = tmp_path / "state" / "review_gates" / "results"
+    state = tmp_path / "state"
+    reports = tmp_path / "unified_reports"
+    for d in (requests, results, state, reports):
+        d.mkdir(parents=True, exist_ok=True)
+    return requests, results, state, reports
+
+
+def _request(**over):
+    payload = {
+        "gate": "codex_gate", "pr_id": "", "pr_number": 1453,
+        "branch": "fix/x", "commit_sha": "a" * 40,
+        "contract_hash": "088a30754169bb91",
+    }
+    payload.update(over)
+    return payload
+
+
+def _record(results_dir, gate="codex_gate", pr=1453):
+    return json.loads(
+        (results_dir / f"pr-{pr}-{gate}.json").read_text(encoding="utf-8")
+    )
+
+
+# --------------------------------------------------------------------------
+# Every writer, through the one point they share.
+# --------------------------------------------------------------------------
+
+def test_a_not_executable_record_says_why(dirs):
+    requests, results, state, _reports = dirs
+
+    record_not_executable(
+        gate="codex_gate", pr_number=1453, pr_id="",
+        reason="provider_not_installed",
+        reason_detail="codex binary not found in PATH",
+        request_payload=_request(),
+        requests_dir=requests, results_dir=results, state_dir=state,
+    )
+
+    assert _record(results)["failure_reason"] == "codex binary not found in PATH"
+
+
+def test_a_failure_record_says_why(dirs):
+    requests, results, _state, _reports = dirs
+
+    record_failure(
+        gate="codex_gate", pr_number=1453, pr_id="",
+        result={
+            "reason": "timeout", "reason_detail": "codex headless stalled at 900s",
+            "duration_seconds": 900.0, "partial_output_lines": 0, "runner_pid": 1,
+        },
+        request_payload=_request(),
+        requests_dir=requests, results_dir=results,
+    )
+
+    assert _record(results)["failure_reason"] == "codex headless stalled at 900s"
+
+
+def test_a_completed_record_that_failed_on_findings_says_why(dirs):
+    """No reason field exists on such a record. The findings are the reason.
+
+    A gate that ran to completion and failed on what it found carries no
+    ``reason``/``reason_detail`` at all, so a derivation that only walked the
+    text fields would fall through to prose about something else — or to
+    nothing.
+    """
+    requests, results, _state, reports = dirs
+    stream = "\n".join([
+        json.dumps({"type": "thread.started"}),
+        json.dumps({"type": "item.completed", "item": {
+            "id": "i0", "type": "command_execution", "command": "sed -n 1,40p x.py"}}),
+        json.dumps({"type": "item.completed", "item": {
+            "id": "i1", "type": "agent_message",
+            "text": json.dumps({
+                "findings": [{
+                    "severity": "blocking",
+                    "title": "unguarded index access on an empty list",
+                    "description": "scripts/x.py:12",
+                }],
+                "residual_risk": "reviewed the diff only",
+            })}}),
+    ]) + "\n"
+
+    gate_artifacts.materialize_artifacts(
+        gate="codex_gate", pr_number=1453, pr_id="",
+        stdout=stream,
+        request_payload=_request(report_path=str(reports / "codex-1453.md")),
+        duration_seconds=120.0,
+        requests_dir=requests, results_dir=results, reports_dir=reports,
+    )
+
+    record = _record(results)
+    assert record.get("blocking_findings"), (
+        "the fixture produced no blocking finding, so this test would have "
+        "asserted nothing — the shape the parser accepts is a JSON verdict in "
+        "the agent_message text, not a [BLOCKING] prose marker"
+    )
+    assert record.get("failure_reason"), (
+        "a record that failed on its findings carries no canonical reason"
+    )
+    assert "blocking finding" in record["failure_reason"]
+
+
+def test_residual_risk_alone_is_not_lifted_into_the_canonical_field():
+    """The OI-1452 case, corrected: the provider cause lives ONLY in
+    ``residual_risk``, and that is exactly why it must NOT be lifted.
+
+    A field named "remaining risk" is where a 403 ends up, and it is the last
+    place a generic reader looks. But a derivation that lifted it would also
+    lift every frontmatter-derived sentence that merely resembles a cause
+    (measured 2026-08-30: 648 of 739 non-pass records carry ``residual_risk``
+    prose). The real cause reaches the canonical field by a different route:
+    the lane-log lift (OI-1452) stamps ``failure_reason`` directly in the
+    report frontmatter when it found a real marker, so the ``existing``
+    shortcut wins before the source chain is ever walked.
+
+    A record that reaches the chain with only ``residual_risk`` populated is a
+    record whose cause was NOT established. The honest value is "", the third
+    state -- not a best-effort summary borrowed from a field that sounds like
+    a cause.
+    """
+    payload = {
+        "gate": "glm_gate", "pr_id": "1694", "status": "unavailable",
+        "residual_risk": "OpenRouter returned 403: key expired",
+        "blocking_findings": [], "advisory_findings": [],
+    }
+
+    assert gate_recorder.derive_failure_reason(payload) == ""
+
+
+def test_a_pre_stamped_cause_wins_over_the_source_chain():
+    """The route the real 403 cause actually takes: stamped upstream, not
+    derived. A lane that established the cause stamps ``failure_reason``
+    directly; the derivation honors it via the ``existing`` shortcut and never
+    re-derives from the surrounding fields."""
+    payload = {
+        "gate": "glm_gate", "pr_id": "1694", "status": "unavailable",
+        "failure_reason": "access_terminated_error: kimi quota exhausted",
+        "residual_risk": "OpenRouter returned 403: key expired",
+        "reason": "dispatch_error",
+        "blocking_findings": [], "advisory_findings": [],
+    }
+
+    assert gate_recorder.derive_failure_reason(payload) == (
+        "access_terminated_error: kimi quota exhausted"
+    )
+
+
+# --------------------------------------------------------------------------
+# The guard, in THREE buckets -- the property, not the six call sites.
+# A two-bucket guard ("pass empty, non-pass filled") is the trap this PR
+# repairs: it books the third state as a violation and forces placeholders
+# back into the field. Three buckets:
+#   1. pass                          -> failure_reason absent (no failure)
+#   2. non-pass WITH an established cause -> failure_reason carries the cause
+#   3. non-pass, cause NOT established    -> failure_reason empty/absent,
+#      and that is an allowed state, not a defect
+# --------------------------------------------------------------------------
+
+def test_bucket_pass_leaves_the_field_absent(tmp_path):
+    """Bucket 1: a pass has no failure to explain. The field stays absent so
+    its presence on a record remains a real signal."""
+    target = tmp_path / "pr-1-some_gate.json"
+    gate_recorder._write_result_atomic(target, {
+        "status": "pass", "contract_hash": "abc", "report_path": "/tmp/r.md",
+        "blocking_findings": [], "advisory_findings": [],
+    })
+    assert "failure_reason" not in json.loads(target.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("payload,expected", [
+    ({"status": "unavailable", "reason_detail": "quota exhausted"}, "quota exhausted"),
+    ({"status": "not_executable", "reason_detail": "codex binary not found in PATH"},
+     "codex binary not found in PATH"),
+])
+def test_bucket_non_pass_with_established_cause_carries_it(tmp_path, payload, expected):
+    """Bucket 2: a non-pass whose cause was filed under ``reason_detail``
+    carries that cause in the canonical field.
+
+    Driven through the write primitive itself rather than through one gate,
+    because the claim is about every record that reaches disk. ``reason`` and
+    ``summary`` are deliberately absent here -- a record that carries its
+    cause only as a classification or a summary is NOT in this bucket.
+    """
+    target = tmp_path / "pr-2-some_gate.json"
+    gate_recorder._write_result_atomic(target, dict(payload))
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written.get("failure_reason") == expected, (
+        f"a {payload['status']!r} record with an established cause must carry "
+        f"it: {written}"
+    )
+
+
+@pytest.mark.parametrize("payload", [
+    {"status": "not_executable", "reason": "provider_disabled"},
+    {"status": "fail", "summary": "gate found problems"},
+    {"status": "unavailable", "residual_risk": "provider-side outage, not a review outcome"},
+    {"status": "failed"},
+])
+def test_bucket_non_pass_with_no_established_cause_is_empty_not_invented(tmp_path, payload):
+    """Bucket 3: a non-pass whose cause was NOT established. ``reason`` is a
+    classification, ``summary``/``residual_risk`` are prose, and a bare
+    ``status`` is neither. None of these is a cause.
+
+    The old derivation lifted all of them (``reason`` won, then
+    ``residual_risk``/``summary``, then an invented ``f"status: {status}"``).
+    That made the field look full while explaining nothing. The honest value
+    is empty -- an allowed third state, not a violation. A guard that treated
+    this as a violation would force every gate to fill the field with
+    something to pass the check, and the field would stop meaning anything.
+    """
+    target = tmp_path / "pr-3-some_gate.json"
+    gate_recorder._write_result_atomic(target, dict(payload))
+    written = json.loads(target.read_text(encoding="utf-8"))
+    fr = written.get("failure_reason", "")
+    assert fr == "", (
+        f"a {payload['status']!r} record with no established cause must NOT "
+        f"have a cause invented into the canonical field, got: {fr!r}"
+    )
+
+
+def test_a_lane_that_already_filled_it_is_left_alone(tmp_path):
+    """kimi_gate and glm_gate compute this themselves (OI-1415). Their text wins."""
+    target = tmp_path / "pr-3-kimi_gate.json"
+    gate_recorder._write_result_atomic(target, {
+        "status": "unavailable",
+        "failure_reason": "access_terminated_error: kimi quota exhausted",
+        "reason_detail": "dispatch_error",
+    })
+
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written["failure_reason"] == "access_terminated_error: kimi quota exhausted"
+
+
+def test_the_caller_holds_the_record_that_is_on_disk(dirs):
+    """A caller comparing its own dict to the file must not find a field it
+    never set and cannot account for."""
+    requests, results, state, _reports = dirs
+
+    returned = record_not_executable(
+        gate="codex_gate", pr_number=1453, pr_id="",
+        reason="provider_disabled", reason_detail="VNX_CODEX_HEADLESS_ENABLED is 0",
+        request_payload=_request(),
+        requests_dir=requests, results_dir=results, state_dir=state,
+    )
+
+    assert returned["failure_reason"] == _record(results)["failure_reason"]

--- a/tests/test_oi1453_canonical_failure_reason.py
+++ b/tests/test_oi1453_canonical_failure_reason.py
@@ -4,20 +4,23 @@
 for phantom_guard and pr_enforcement; gate result records never adopted it.
 
 Re-measured across the whole central store on 2026-08-30, three project stores,
-739 non-pass gate-result records:
+501 non-pass gate-result records (non-pass defined canonically as
+``gate_status.is_pass`` returning ``False``, which counts ``completed``/
+``approve`` as a pass and therefore excludes them from the non-pass set):
 
-    failure_reason filled:  4 of 739
+    failure_reason filled:  6 of 501
 
-    summary          790 filled (prose, often frontmatter-derived)
-    residual_risk    699 filled (prose, often frontmatter-derived)
-    reason           397 filled (a CLASSIFICATION: provider_not_installed 145,
-                                 claude_github_not_configured 63, exit_nonzero
-                                 60, provider_disabled 57, dispatch_error 6 ...)
-    reason_detail    270 filled (a CAUSE: "codex binary not found in PATH" 106,
-                                  "Subprocess exited with code 1" 59,
+    summary          392 filled (prose, often frontmatter-derived)
+    residual_risk    389 filled (prose, often frontmatter-derived)
+    reason           434 filled (a CLASSIFICATION: provider_not_installed 142,
+                                 claude_github_not_configured 109, exit_nonzero
+                                 104, provider_disabled 57, dispatch_error 6 ...)
+    reason_detail    311 filled (a CAUSE: "Subprocess exited with code 1" 103,
+                                  "gemini binary not found in PATH" 84,
+                                  "codex binary not found in PATH" 57,
                                   "VNX_CI_GATE_REQUIRED is set to 0" 57 ...)
-    blocking_findings  64 filled (a cause)
-    failure_reason     4 filled (the gap OI-1453 opens)
+    blocking_findings  66 filled (a cause)
+    failure_reason     6 filled (the gap OI-1453 opens)
 
 ``failure_reason`` carries a CAUSE, never a category, a summary, or a
 placeholder. The cause reaches it by one of three routes, and only those:
@@ -178,7 +181,7 @@ def test_residual_risk_alone_is_not_lifted_into_the_canonical_field():
     A field named "remaining risk" is where a 403 ends up, and it is the last
     place a generic reader looks. But a derivation that lifted it would also
     lift every frontmatter-derived sentence that merely resembles a cause
-    (measured 2026-08-30: 648 of 739 non-pass records carry ``residual_risk``
+    (measured 2026-08-30: 389 of 501 non-pass records carry ``residual_risk``
     prose). The real cause reaches the canonical field by a different route:
     the lane-log lift (OI-1452) stamps ``failure_reason`` directly in the
     report frontmatter when it found a real marker, so the ``existing``


### PR DESCRIPTION
## Measured, re-run today

`failure_reason` is the field a generic reader queries — established by OI-1415
for phantom_guard and pr_enforcement. Gate result records never adopted it.

Across the whole central store, all six gates:

| gate | filled | total |
|---|---|---|
| codex_gate | 0 | 267 |
| ci_gate | 0 | 121 |
| glm_gate | 0 | 25 |
| kimi_gate | 1 | 22 |
| gemini_review | 0 | 19 |
| claude_github_optional | 0 | 16 |
| **total** | **1** | **470** |

**134** of those records sit in a failure state with the cause plainly present —
and filed elsewhere:

```
pr-1300-codex_gate.json  not_executable  provider_not_installed
                                         "codex binary not found in PATH"
pr-1389-ci_gate.json     not_executable  provider_disabled
                                         "VNX_CI_GATE_REQUIRED is set to 0"
```

Nothing was lost. It was filed under six different names. A human reading one
record finds the cause at once. A generic reader asking *why did this not pass*
across gates finds nothing.

The lane-log lift (OI-1452) makes the worst case concrete: for a provider 403,
the **only** field carrying the cause is `residual_risk` — a field whose name
says "remaining risk", not "cause of failure".

## One derivation, at the point every record shares

Six lanes each remembering to stamp a field is how it became 1-in-470. This
derives it in `_write_result_atomic`, which every production writer reaches on
its way to disk (the OI-1472 table lists no other). A seventh gate cannot forget
a property of the write path.

Order — an existing value wins, then findings, then text, then status:

1. `failure_reason` already set — `kimi_gate` and `glm_gate` compute their own
   and their text beats anything derivable
2. blocking findings — **before** the text fields, because a record that ran to
   completion and failed on what it found carries no `reason` at all; walking
   only text would fall through to prose about something else
3. `reason_detail` → `reason` → `residual_risk` → `summary`
4. the status itself, as a last resort

**A passing record is not stamped.** A field present on everything signals
nothing.

## Red before, green after

On `main`:

```
KeyError: 'failure_reason'   (×2)
AssertionError: a record that failed on its findings carries no canonical reason
AttributeError: module 'gate_recorder' has no attribute 'derive_failure_reason'
```

`test_a_passing_record_is_not_stamped` passes on main — the control showing this
does not simply stamp everything.

After: `11 passed`, no skips. Neighbours (`gate_recorder` ×4, `gate_artifacts`
×2, `closure_verifier`, `ci_gate`, `gate_unavailable_rollup`, OI-1472):
**200 passed**.

One test initially **skipped** because its fixture produced no blocking finding
— a skip proves nothing, so the fixture was corrected to the shape
`parse_codex_findings` actually accepts (a JSON verdict inside the
`agent_message` text, not a `[BLOCKING]` prose marker), and the skip replaced by
an assertion that the fixture worked.

## Scope

New records only. The 470 existing ones are historical and are not backfilled —
that is a migration, not a write-path fix, and it would rewrite records whose
`recorded_at` says they were written before this rule existed.

Refs OI-1453