### PR TITLE
fix(closure): a record and its own report must name the same model (OI-1450)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -1129,6 +1129,67 @@ def verify_pr_closure(
     }
 
 
+# The producer line a gate report writes about itself. Accepts the bold-field
+# form the report contract requires (``**Model**: x``) and the bare/frontmatter
+# forms that also occur, because the point is to READ what the report claims,
+# not to police how it is written.
+_REPORT_MODEL_RE = re.compile(
+    r"(?im)^\s*[-*]?\s*\**\s*model\s*\**\s*[:=]\s*\**\s*([A-Za-z0-9._\-/]+)"
+)
+
+
+def _report_declared_model(report_content: str) -> str:
+    """The model the report says produced it, or "" when it does not say."""
+    match = _REPORT_MODEL_RE.search(report_content)
+    return match.group(1).strip() if match else ""
+
+
+def _detect_producer_identity_contradiction(
+    gate: str,
+    result: Dict[str, Any],
+    report_content: str,
+) -> Optional[CheckResult]:
+    """The record and its own report must name the same model (OI-1450).
+
+    Measured across the central store on 2026-08-29: of 48 gate result records
+    carrying a ``model``, **7 name a different model than the report they point
+    at** — every one of them ``kimi-k2-7-code`` in the record against
+    ``kimi-default`` in the report. Both are producer-identity claims about the
+    same run, and they cannot both be true.
+
+    That matters beyond tidiness, because producer identity is what
+    ``record_terminal_result`` refuses a terminal write without: a record whose
+    identity disagrees with its own evidence is not authenticated by it, it is
+    merely accompanied by it. Cost attribution, model-quality comparison and
+    "which model missed this" all read one of the two numbers and neither
+    knows the other exists.
+
+    Returns ``None`` when there is nothing to compare — no model on the record,
+    or no model line in the report. Silence about an unmeasurable pair is the
+    honest answer; asserting agreement would be inventing it.
+    """
+    record_model = str(result.get("model") or "").strip()
+    if not record_model:
+        return None
+    report_model = _report_declared_model(report_content)
+    if not report_model:
+        return None
+    if record_model == report_model:
+        return CheckResult(
+            f"producer_identity_{gate}",
+            "PASS",
+            f"{gate}: record and report agree on model={record_model}",
+        )
+    return CheckResult(
+        f"producer_identity_{gate}",
+        "FAIL",
+        f"{gate}: result record says model={record_model!r} but its own report "
+        f"says model={report_model!r} — two producer-identity claims about one "
+        f"run, and the record is not authenticated by evidence that disagrees "
+        f"with it",
+    )
+
+
 def _detect_gate_report_contradictions(
     contract: ReviewContract,
     results_dir: Path,
@@ -1162,6 +1223,20 @@ def _detect_gate_report_contradictions(
 
         report_path_str = result.get("report_path", "")
         if not report_path_str:
+            # A record that carries producer identity but points at no report
+            # is the shape that hid OI-1450: all seven contradicting records
+            # have report_path=None, so a detector keyed on report_path never
+            # looked at them. Silently skipping reads as "consistent" in a
+            # list of PASS lines. Say what is actually true instead.
+            if str(result.get("model") or "").strip():
+                checks.append(CheckResult(
+                    f"producer_identity_{gate}",
+                    "WARN",
+                    f"{gate}: result record claims model="
+                    f"{str(result.get('model')).strip()!r} but carries no "
+                    f"report_path — the claim cannot be checked against any "
+                    f"evidence",
+                ))
             continue
 
         report_path = Path(report_path_str)
@@ -1208,6 +1283,12 @@ def _detect_gate_report_contradictions(
                 "PASS",
                 f"{gate}: gate result and report content are consistent",
             ))
+
+        identity_check = _detect_producer_identity_contradiction(
+            gate, result, report_content,
+        )
+        if identity_check is not None:
+            checks.append(identity_check)
 
     return checks
 

--- a/tests/test_oi1450_producer_identity_contradiction.py
+++ b/tests/test_oi1450_producer_identity_contradiction.py
@@ -1,0 +1,163 @@
+"""A record and its own report must name the same model (OI-1450).
+
+Measured across the central store on 2026-08-29 by joining each result record to
+its report through ``dispatch_id``:
+
+    records carrying a model:   48
+      agree:                    40
+      contradict:                7
+      report has no model line:  1
+      sub_provider missing:     48 of 48
+
+All seven contradictions are the same pair — ``kimi-k2-7-code`` on the record
+against ``kimi-default`` in the report:
+
+    pr-904-kimi_gate.json  pr-905  pr-906  pr-907  pr-0  pr-1  pr-2
+
+Both are producer-identity claims about one run and they cannot both be true.
+This is not tidiness. Producer identity is what ``record_terminal_result``
+refuses a terminal write without, so a record whose identity disagrees with its
+own evidence is not authenticated by that evidence — it is merely accompanied by
+it. Cost attribution, model comparison and "which model missed this" each read
+one of the two and none of them knows the other exists.
+
+An earlier pass of this same measurement reported **zero** contradictions. That
+was a join failure, not an absence: it joined on ``report_path``, and every one
+of the seven records has ``report_path = None``. The same blind spot is why the
+existing contradiction detector never saw them — it skips a record with no
+``report_path``, and skipping silently reads as "consistent" in a list of PASS
+lines.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+# Imported inside each test that needs them, so the end-to-end test below
+# fails on its own assertion against the pre-fix code instead of erroring at
+# collection on a symbol that does not exist there yet. A red run that only
+# says "new symbol missing" proves nothing about the behaviour.
+
+REPORT_WITH_MODEL = """# kimi_gate — Gate Report
+
+**PR**: 904
+**Model**: kimi-default
+**Provider**: kimi
+
+## Findings
+
+No blocking findings.
+"""
+
+
+def _result(**over):
+    payload = {"gate": "kimi_gate", "pr_id": "904", "status": "pass",
+               "model": "kimi-k2-7-code"}
+    payload.update(over)
+    return payload
+
+
+def test_the_measured_contradiction_is_caught():
+    from closure_verifier import _detect_producer_identity_contradiction
+
+    check = _detect_producer_identity_contradiction(
+        "kimi_gate", _result(), REPORT_WITH_MODEL,
+    )
+
+    assert check is not None
+    assert check.status == "FAIL", (
+        "the record says kimi-k2-7-code and its own report says kimi-default; "
+        "nothing flagged it"
+    )
+    assert "kimi-k2-7-code" in check.detail
+    assert "kimi-default" in check.detail
+
+
+def test_agreement_is_reported_as_agreement():
+    """A check that only ever speaks up on failure cannot be distinguished from
+    a check that is not running."""
+    from closure_verifier import _detect_producer_identity_contradiction
+
+    check = _detect_producer_identity_contradiction(
+        "kimi_gate", _result(model="kimi-default"), REPORT_WITH_MODEL,
+    )
+
+    assert check is not None
+    assert check.status == "PASS"
+    assert "kimi-default" in check.detail
+
+
+def test_a_record_without_a_model_is_not_judged():
+    """Silence about an unmeasurable pair is the honest answer.
+
+    424 of 470 records in the store carry no model at all. Asserting agreement
+    for them would be inventing it, and asserting disagreement would fail the
+    overwhelming majority of the history for saying nothing.
+    """
+    from closure_verifier import _detect_producer_identity_contradiction
+
+    assert _detect_producer_identity_contradiction(
+        "kimi_gate", _result(model=None), REPORT_WITH_MODEL,
+    ) is None
+    assert _detect_producer_identity_contradiction(
+        "kimi_gate", _result(model=""), REPORT_WITH_MODEL,
+    ) is None
+
+
+def test_a_report_without_a_model_line_is_not_judged():
+    from closure_verifier import _detect_producer_identity_contradiction
+
+    assert _detect_producer_identity_contradiction(
+        "kimi_gate", _result(), "# report\n\nNo blocking findings.\n",
+    ) is None
+
+
+def test_the_report_model_is_read_in_the_forms_reports_actually_use():
+    """Bold field, bare field, and frontmatter all occur in this store."""
+    from closure_verifier import _report_declared_model
+
+    assert _report_declared_model("**Model**: kimi-k3\n") == "kimi-k3"
+    assert _report_declared_model("Model: glm-5.2\n") == "glm-5.2"
+    assert _report_declared_model("- Model: kimi-default\n") == "kimi-default"
+    assert _report_declared_model("model = opus-5\n") == "opus-5"
+    assert _report_declared_model("The model was chosen carefully.\n") == ""
+
+
+def test_a_claimed_model_with_no_report_to_check_it_against_is_surfaced(tmp_path):
+    """The shape that hid all seven: identity claimed, nothing to check it with.
+
+    A detector keyed on report_path never looked at these records, and a silent
+    skip renders as "consistent" among the PASS lines. It has to say what is
+    actually true, which is that the claim is uncheckable.
+    """
+    import closure_verifier
+    from review_contract import ReviewContract
+
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    import json
+    (results_dir / "904-kimi_gate-contract.json").write_text(json.dumps({
+        "gate": "kimi_gate", "pr_id": "904", "status": "pass",
+        "model": "kimi-k2-7-code", "report_path": None,
+        "branch": "fix/x", "blocking_findings": [], "advisory_findings": [],
+    }), encoding="utf-8")
+
+    contract = ReviewContract(
+        pr_id="904", branch="fix/x", risk_class="medium",
+        review_stack=["kimi_gate"], changed_files=[], content_hash="d" * 16,
+    )
+
+    checks = closure_verifier._detect_gate_report_contradictions(contract, results_dir)
+
+    identity = [c for c in checks if c.name == "producer_identity_kimi_gate"]
+    assert identity, (
+        "a record claiming a model with no report_path produced no check at "
+        "all — the claim was skipped silently"
+    )
+    assert identity[0].status == "WARN"
+    assert "cannot be checked" in identity[0].detail


### PR DESCRIPTION
## Measured, re-run today

Joining each gate result record to its report through `dispatch_id`:

| | count |
|---|---|
| records carrying a `model` | 48 |
| record and report **agree** | 40 |
| record and report **contradict** | **7** |
| report has no model line | 1 |
| `sub_provider` missing | **48 of 48** |

All seven contradictions are the same pair — `kimi-k2-7-code` on the record
against `kimi-default` in the report:

```
pr-904-kimi_gate.json   pr-905   pr-906   pr-907   pr-0   pr-1   pr-2
```

Both are producer-identity claims about one run. They cannot both be true.

This is not tidiness. Producer identity is what `record_terminal_result` refuses
a terminal write without — so a record whose identity disagrees with its own
evidence is not *authenticated* by that evidence, it is merely *accompanied* by
it. Cost attribution, model comparison, and "which model missed this" each read
one of the two numbers, and none of them knows the other exists.

## A zero that was a join failure

A first pass of this measurement reported **zero** contradictions. It joined on
`report_path` — and every one of the seven records has `report_path = None`.

The same blind spot is why the existing `_detect_gate_report_contradictions`
never saw them: it `continue`s past a record with no `report_path`, and a silent
skip renders as "consistent" among the PASS lines.

## What changed

- `_detect_producer_identity_contradiction` — compares the record's `model`
  against the model its own report declares, and is wired into the existing
  detector rather than added beside it.
- The `report_path`-less case now produces a **WARN** ("the claim cannot be
  checked against any evidence") instead of vanishing.

It stays **silent** when there is nothing to compare — no model on the record
(424 of 470 records carry none), or no model line in the report. Asserting
agreement there would be inventing it.

## Red before, green after

On `main`, the end-to-end test fails on its own assertion:

```
FAILED test_a_claimed_model_with_no_report_to_check_it_against_is_surfaced
E  AssertionError: a record claiming a model with no report_path produced no
   check at all — the claim was skipped silently
E  assert []
```

After: `6 passed`. Neighbours (`closure_verifier` ×4): **80 passed**.

## Not addressed here

`sub_provider` is absent from **48 of 48** records — worse than the 17-of-17 the
item recorded. Nothing in the gate write path populates it; the field is
consumed by `failure_classification` and written only by the tmux lane and the
state aggregator. That is a missing writer rather than a contradiction, and it
wants its own change.

Refs OI-1450