### PR TITLE
feat(gates): the record pins the prompt the run actually sent (OI-1443)

### DIFF
--- a/scripts/lib/final_prompt_integrity.py
+++ b/scripts/lib/final_prompt_integrity.py
@@ -312,6 +312,41 @@ def _default_bundle_dir(data_dir: "str | Path", dispatch_id: str) -> Path:
     return Path(data_dir) / "dispatches" / "pending" / dispatch_id
 
 
+def final_prompt_sha_for_dispatch(
+    dispatch_id: str,
+    data_dir: "str | Path",
+) -> str:
+    """The sha of the prompt a dispatch actually sent, or "" if unrecoverable.
+
+    Read from the bundle rather than from a spec field: a gate dispatch bundle
+    contains ``final_prompt.md`` but no ``dispatch-spec.json``, so the value
+    :func:`persist_final_prompt` would have stamped was never written anywhere
+    for gate runs. The prompt itself is on disk, so the sha is recoverable
+    without adding a capture step.
+
+    Never raises. A missing bundle, an unreadable file or an empty dispatch id
+    all yield "", because a gate result must not fail to be recorded over a
+    provenance field that could not be resolved. An empty string means "not
+    recovered", never "no prompt" -- callers must not stamp it.
+    """
+    if not dispatch_id:
+        return ""
+    for candidate in (
+        _default_bundle_dir(data_dir, dispatch_id),
+        Path(data_dir) / "dispatches" / "completed" / dispatch_id,
+        Path(data_dir) / "dispatches" / "failed" / dispatch_id,
+    ):
+        prompt_file = candidate / "final_prompt.md"
+        try:
+            if prompt_file.is_file():
+                return compute_sha256(prompt_file.read_text(encoding="utf-8"))
+        except OSError as exc:
+            logger.debug(
+                "final_prompt_integrity: could not read %s: %s", prompt_file, exc,
+            )
+    return ""
+
+
 def record_final_prompt_integrity(
     *,
     dispatch_id: str,

--- a/scripts/lib/gate_artifacts.py
+++ b/scripts/lib/gate_artifacts.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from governance_receipts import utc_now_iso
 import gate_recorder
+from final_prompt_integrity import final_prompt_sha_for_dispatch
 from codex_parser import parse_codex_findings
 
 logger = logging.getLogger(__name__)
@@ -329,6 +330,22 @@ def materialize_artifacts(
         "duration_seconds": duration_seconds,
         "recorded_at": now,
     }
+    # OI-1443: pin the prompt this run actually sent. Two glm_gate runs on the
+    # same commit differed by 227 input tokens (26829 against 27056) and there
+    # was no way to ask what was different about them, because the record names
+    # the commit and the contract but not the thing the model was handed. The
+    # contract_hash covers the review CONTRACT; it does not cover the assembled
+    # prompt, which is where injected context and skill bodies land.
+    #
+    # results_dir is <data_dir>/state/review_gates/results, so the data dir is
+    # three levels up. Derived from the explicit parameter rather than from an
+    # ambient resolver so a test or a migration can point this anywhere.
+    if real_dispatch_id:
+        prompt_sha = final_prompt_sha_for_dispatch(
+            real_dispatch_id, results_dir.parents[2],
+        )
+        if prompt_sha:
+            result_payload["final_prompt_sha256"] = prompt_sha
     gate_recorder.stamp_request_identity(result_payload, request_payload)
     if real_dispatch_id:
         result_payload["dispatch_id"] = real_dispatch_id

--- a/tests/test_oi1443_prompt_pinned_on_record.py
+++ b/tests/test_oi1443_prompt_pinned_on_record.py
@@ -1,0 +1,169 @@
+"""The record pins the prompt the run actually sent (OI-1443).
+
+Two glm_gate runs on the same commit differed by 227 input tokens — 26829
+against 27056 — and nobody could ask what was different about them. The record
+names the commit and the `contract_hash`, and neither covers the assembled
+prompt: the contract hash covers the review CONTRACT, while injected context,
+skill bodies and lane preludes all land in the prompt afterwards.
+
+Measured across the central store on 2026-08-29:
+
+    gate result records with final_prompt_sha256:   0 of 472
+    receipts        with final_prompt_sha256:    1991 of 28455
+
+So the fact is captured — on the receipt, and in the dispatch bundle — and it
+simply never reaches the record a merge decision reads. A gate dispatch bundle
+holds `final_prompt.md` but no `dispatch-spec.json`, so the field
+`persist_final_prompt` would have stamped was never written for gate runs at
+all. The prompt itself is on disk, so nothing new has to be captured: it is
+recoverable.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+PROMPT = "You are reviewing PR #1443.\n\nDiff:\n- one line\n"
+PROMPT_SHA = hashlib.sha256(PROMPT.encode("utf-8")).hexdigest()
+DISPATCH_ID = "kimi-gate-pr1443-1788000000"
+
+
+@pytest.fixture
+def store(tmp_path):
+    data_dir = tmp_path / "data"
+    results = data_dir / "state" / "review_gates" / "results"
+    requests = data_dir / "state" / "review_gates" / "requests"
+    reports = data_dir / "unified_reports"
+    for d in (results, requests, reports):
+        d.mkdir(parents=True, exist_ok=True)
+    return data_dir, requests, results, reports
+
+
+def _seed_bundle(data_dir: Path, state: str = "pending", text: str = PROMPT):
+    bundle = data_dir / "dispatches" / state / DISPATCH_ID
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / "final_prompt.md").write_text(text, encoding="utf-8")
+    return bundle
+
+
+@pytest.mark.parametrize("state", ["pending", "completed", "failed"])
+def test_the_sha_is_recovered_from_wherever_the_bundle_sits(store, state):
+    """A dispatch moves between pending, completed and failed while the gate
+    record is written. Looking in only one of them finds nothing most of the
+    time, and finding nothing is indistinguishable from having no prompt."""
+    from final_prompt_integrity import final_prompt_sha_for_dispatch
+
+    data_dir, *_ = store
+    _seed_bundle(data_dir, state)
+
+    assert final_prompt_sha_for_dispatch(DISPATCH_ID, data_dir) == PROMPT_SHA
+
+
+def test_an_unrecoverable_sha_is_empty_and_not_an_error(store):
+    """A gate result must not fail to be recorded over a provenance field."""
+    from final_prompt_integrity import final_prompt_sha_for_dispatch
+
+    data_dir, *_ = store
+
+    assert final_prompt_sha_for_dispatch(DISPATCH_ID, data_dir) == ""
+    assert final_prompt_sha_for_dispatch("", data_dir) == ""
+    assert final_prompt_sha_for_dispatch(DISPATCH_ID, data_dir / "nope") == ""
+
+
+def test_two_runs_of_the_same_prompt_pin_the_same_sha(store):
+    from final_prompt_integrity import final_prompt_sha_for_dispatch
+
+    data_dir, *_ = store
+    _seed_bundle(data_dir)
+    first = final_prompt_sha_for_dispatch(DISPATCH_ID, data_dir)
+    second = final_prompt_sha_for_dispatch(DISPATCH_ID, data_dir)
+
+    assert first == second == PROMPT_SHA
+
+
+def test_a_different_prompt_pins_a_different_sha(store):
+    """The whole point: two runs on one commit that sent different prompts must
+    be distinguishable afterwards."""
+    from final_prompt_integrity import final_prompt_sha_for_dispatch
+
+    data_dir, *_ = store
+    _seed_bundle(data_dir, text=PROMPT + "\n<injected-context>extra</injected-context>\n")
+
+    other = final_prompt_sha_for_dispatch(DISPATCH_ID, data_dir)
+    assert other != PROMPT_SHA
+    assert len(other) == 64
+
+
+def test_the_result_record_carries_the_pin(store):
+    from gate_artifacts import materialize_artifacts
+
+    data_dir, requests, results, reports = store
+    _seed_bundle(data_dir)
+
+    materialize_artifacts(
+        gate="kimi_gate", pr_number=1443, pr_id="",
+        stdout="## Review\n\nNo blocking findings. Two advisories follow.\n"
+               "1. scripts/x.py:4 — the loop re-reads config each pass.\n"
+               "2. tests/test_x.py:9 — the fixture builds its own tmp dir.\n"
+               "Residual risk: reviewed against main.\n",
+        request_payload={
+            "gate": "kimi_gate", "pr_id": "1443", "pr_number": 1443,
+            "branch": "fix/x", "commit_sha": "b" * 40,
+            "report_path": str(reports / "kimi-1443.md"),
+            "contract_hash": "183bed973031720a",
+            "dispatch_id": DISPATCH_ID,
+        },
+        duration_seconds=60.0,
+        requests_dir=requests, results_dir=results, reports_dir=reports,
+    )
+
+    record = json.loads(
+        (results / "pr-1443-kimi_gate.json").read_text(encoding="utf-8")
+    )
+    assert record.get("final_prompt_sha256") == PROMPT_SHA, (
+        "the record names the commit and the contract but not the prompt, so "
+        "two runs on one commit cannot be told apart"
+    )
+
+
+def test_a_record_without_a_recoverable_prompt_is_not_stamped_with_an_empty_sha(store):
+    """An empty string means "not recovered", never "no prompt".
+
+    Stamping "" would put a field on the record that reads as a pinned prompt
+    until someone compares it, at which point every unrecovered run matches
+    every other one.
+    """
+    from gate_artifacts import materialize_artifacts
+
+    data_dir, requests, results, reports = store  # no bundle seeded
+
+    materialize_artifacts(
+        gate="kimi_gate", pr_number=1443, pr_id="",
+        stdout="## Review\n\nNo blocking findings. Two advisories follow.\n"
+               "1. scripts/x.py:4 — the loop re-reads config each pass.\n"
+               "2. tests/test_x.py:9 — the fixture builds its own tmp dir.\n"
+               "Residual risk: reviewed against main.\n",
+        request_payload={
+            "gate": "kimi_gate", "pr_id": "1443", "pr_number": 1443,
+            "branch": "fix/x", "commit_sha": "b" * 40,
+            "report_path": str(reports / "kimi-1443.md"),
+            "contract_hash": "183bed973031720a",
+            "dispatch_id": DISPATCH_ID,
+        },
+        duration_seconds=60.0,
+        requests_dir=requests, results_dir=results, reports_dir=reports,
+    )
+
+    record = json.loads(
+        (results / "pr-1443-kimi_gate.json").read_text(encoding="utf-8")
+    )
+    assert "final_prompt_sha256" not in record


### PR DESCRIPTION
## What was missing

Two `glm_gate` runs on the same commit differed by **227 input tokens** — 26829
against 27056 — and there was no way to ask what was different about them.

The record names the commit and the `contract_hash`. Neither covers the
assembled prompt: `contract_hash` covers the review **contract**, while injected
context, skill bodies and lane preludes land in the prompt afterwards.

Measured across the central store:

| carrier | with `final_prompt_sha256` |
|---|---|
| gate result records | **0 of 472** |
| receipts | 1991 of 28455 |

The fact is already captured — on the receipt, and in the dispatch bundle. It
never reaches the record a merge decision reads.

## Nothing new is captured

A gate dispatch bundle holds `final_prompt.md` but **no** `dispatch-spec.json`,
so the field `persist_final_prompt` would have stamped was never written for
gate runs at all. The prompt itself is on disk, so the sha is recoverable
rather than needing a new capture step.

`final_prompt_sha_for_dispatch` reads it from whichever of
`pending`/`completed`/`failed` the bundle currently sits in — a dispatch moves
between them while the record is being written, and looking in only one finds
nothing most of the time. Finding nothing is indistinguishable from having no
prompt, which is the failure mode this is meant to remove.

It never raises: a missing bundle, an unreadable file or an empty dispatch id
all yield `""`. And `""` is **not stamped** — an empty string means "not
recovered", never "no prompt", and a field that reads as a pinned prompt until
someone compares it would make every unrecovered run match every other one.

## Red before, green after

On `main`:

```
FAILED test_the_result_record_carries_the_pin
E  AssertionError: the record names the commit and the contract but not the
   prompt, so two runs on one commit cannot be told apart
E  assert None == 'd3465b2bdfe54932bc55f17ca98047ca814fabd0e35dfedf2ab238c873332250'
```

After: `8 passed`. Neighbours (`gate_artifacts` ×2, `f37`, `closure_verifier`,
`gate_recorder`): **99 passed**.

## Unrelated finding, measured while gating this

`tests/test_final_prompt_integrity.py` has **3 tests that pass on a normal
checkout and fail inside any git worktree**:

```
NotADirectoryError: [Errno 20] Not a directory: '<worktree>/.git/worktrees'
```

In a worktree `.git` is a *file*, not a directory. Confirmed environmental, not
caused by this change: the same three fail in a different worktree that does not
touch `final_prompt_integrity.py` at all (22 pass on `main`, 19 pass + 3 fail in
both worktrees).

Every dispatch runs in a worktree, so CI is green on these while any worker
running them locally sees red. Not fixed here — it is a test-environment defect,
not a gate-record one.

Refs OI-1443