### PR TITLE
fix(pr_merge): fail closed when the receipt does not land (OI-1518)

### DIFF
--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -38,6 +38,29 @@ Efficiency: risk ≤ 0.3 + success + no blockers → fast path, skip deep verifi
 - **Receipt status:** `done`/`success`=review; `failed`/`failure`=REJECT+investigate; `unknown`=WAIT for finale (TTL 30 min, re-poll) — **`unknown` is NEVER `failure`**.
 - **Post-merge sequence (mandatory):** after `gh pr merge`, run `git pull --ff-only` then `vnx objective reconcile --project-id <pid>` to auto-close any track whose `pr_ref` points to the just-merged PR (advisory CHECK by default; add `--apply` to write).
 
+### 2.1 The governed merge contract (`scripts/pr_merge.py`)
+
+The canonical T0 merge path is not raw `gh pr merge` — it is `scripts/pr_merge.py`, which runs the gates above, executes the merge pinned to the approved head (`--match-head-commit`), and emits the binding `pr_merged` receipt. A merge is not done when GitHub says so; it is done when GitHub says so **and** the receipt landed. The CLI gives two signals for that, and they are not the same:
+
+- **`success`** means "the merge happened on GitHub." This is its original meaning and it keeps it; existing readers of `success` must not silently get a different answer (a deliberate choice in #1722, not an accident).
+- **`receipt_ok`** means "the binding `pr_merged` receipt landed in `t0_receipts.ndjson`." This is the verdict that the audit trail has its evidence.
+
+Three outcomes, three responses:
+
+| outcome | `success` | `receipt_ok` | CLI exit | what the operator does |
+|---|---|---|---|---|
+| merge happened + receipt landed | `True` | `True` | `0` | nothing — the merge and its proof are both recorded. |
+| merge happened + receipt did **not** land | `True` | `False` | non-zero | **do not re-merge.** The merge on GitHub is irreversible; only the proof is missing. Re-run `python3 scripts/pr_merge.py --pr <n>` after fixing the receipts file so the audit-trail evidence is captured. |
+| merge did not happen | `False` | `False` | non-zero | the PR is unchanged; diagnose the error and retry the merge from the top. |
+
+The middle row is the one that bites. A non-zero exit there is **not** "the merge failed" — the merge went through. Reading it as a failure and merging again operates on an already-merged PR, which is a no-op at best and a double-receipt / state corruption at worst. The error text on stderr says so explicitly, by design.
+
+`--dry-run` is the one exit-0 path that involves no merge and no receipt; it is not a fourth outcome, it skips both.
+
+The `dispatch_register.ndjson` register event is **best-effort**, not binding. Its `register_ok` flag is surfaced for visibility ("ok" / "warn-not-written") but never gates the exit code. Only the `t0_receipts.ndjson` receipt is binding. A doc that implies the register event is binding states it wrong.
+
+**Where this is enforced:** `merge_pr` returns the result dict; `main` maps the three rows to exit codes (`EXIT_OK` only on dry-run or `success and receipt_ok`, else `EXIT_ERROR`). The code is authoritative; this section describes intent.
+
 ## 3. PR size + iteration caps
 
 - Target **150–200 LOC** delta; **hard cap 300** (override `--allow-large-pr` or split via track_dependencies). Exceptions (no cap): auto-generated migration SQL, single-bug-class test surface, mechanical renames. Put the LOC budget in the dispatch instruction.

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -93,6 +93,18 @@ EXIT_ERROR = 1
 # Matches internal PR labels: pure numeric (PR-42) and alphanumeric (PR-HYG-1, PR-TMUX-3, PR-ROUTE-1).
 _PR_LABEL_RE = re.compile(r"\bPR-([A-Z0-9]+(?:-[A-Z0-9]+)*)\b", re.IGNORECASE)
 
+# OI-1518: AppendResult.status values that count as a BINDING receipt landed.
+# A grep of `AppendResult(` across the whole tree yields exactly two producers
+# (lib/append_receipt_internals/idempotency.py: "appended" + "duplicate";
+# lib/report_to_receipt_converter.py: "duplicate"). No third value exists, so
+# this is an allowlist, not a blocklist: any other value is refused. The
+# "unknown" default (a missing `append_status` key) is NOT a third value — it
+# means "this code could not read the outcome", which is its own third branch:
+# neither success nor a known fault, so it fails safe. Two failure shapes land
+# here together: _emit_receipt raising, and _emit_receipt returning a status
+# that is not recognized. Both must make the CLI exit non-zero.
+_RECEIPT_OK_STATUSES = frozenset({"appended", "duplicate"})
+
 
 def _extract_pr_id(subject: str) -> Optional[str]:
     """Extract internal PR-N/PR-LABEL from commit subject or PR title.
@@ -513,7 +525,12 @@ def merge_pr(
     callers that never ran a gate.
 
     Returns a dict with keys: success, pr_number, dispatch_id, merge_method,
-    pr_title, branch, receipt_status, register_ok, error.
+    pr_title, branch, receipt_status, receipt_ok, register_ok, error.
+
+    ``success`` means "the merge happened on GitHub" — it is NOT the CLI
+    verdict. A merge whose receipt could not be written has ``success=True``
+    but ``receipt_ok=False``, and the CLI exits non-zero (OI-1518). Use
+    ``receipt_ok`` to know whether the binding audit-trail evidence landed.
     """
     result: Dict[str, Any] = {
         "success": False,
@@ -523,6 +540,7 @@ def merge_pr(
         "pr_title": "",
         "branch": "",
         "receipt_status": None,
+        "receipt_ok": False,
         "register_ok": False,
         "error": "",
         "dry_run": dry_run,
@@ -570,7 +588,13 @@ def merge_pr(
         dispatch_id = _lookup_dispatch_id_by_pr_number(pr_number)
     result["dispatch_id"] = dispatch_id
 
-    # Emit receipt to t0_receipts.ndjson
+    # Emit receipt to t0_receipts.ndjson. OI-1518: the receipt is BINDING — a
+    # merge whose proof could not be written must NOT exit 0. Two failure
+    # shapes both land here: _emit_receipt raising (handled below), and
+    # _emit_receipt returning an `append_status` that is not a recognized
+    # success value (including a missing key -> "unknown" default). Both set
+    # receipt_ok=False so the CLI exits non-zero. The register event stays
+    # best-effort and is not touched.
     try:
         receipt = _emit_receipt(
             pr_number=pr_number,
@@ -582,10 +606,27 @@ def merge_pr(
             pr_id_resolution="" if pr_id else "unmatched",
             receipts_file=receipts_file,
         )
-        result["receipt_status"] = receipt.get("append_status", "unknown")
+        append_status = (receipt or {}).get("append_status", "unknown")
+        result["receipt_status"] = append_status
+        result["receipt_ok"] = append_status in _RECEIPT_OK_STATUSES
+        if not result["receipt_ok"]:
+            print(
+                f"FATAL: merge happened for PR #{pr_number} but the receipt did NOT "
+                f"land (append_status={append_status!r}). The merge on GitHub is "
+                f"irreversible. Re-run `python3 scripts/pr_merge.py --pr {pr_number}` "
+                f"after fixing the receipts file so the audit-trail evidence is captured.",
+                file=sys.stderr,
+            )
     except Exception as exc:
         result["receipt_status"] = f"error: {exc}"
-        print(f"WARN: receipt emit failed for PR #{pr_number}: {exc}", file=sys.stderr)
+        result["receipt_ok"] = False
+        print(
+            f"FATAL: merge happened for PR #{pr_number} but the receipt could NOT be "
+            f"written: {exc}. The merge on GitHub is irreversible. Re-run "
+            f"`python3 scripts/pr_merge.py --pr {pr_number}` after fixing the error "
+            f"so the audit-trail evidence is captured.",
+            file=sys.stderr,
+        )
 
     # Emit event to dispatch_register.ndjson (best-effort)
     result["register_ok"] = _emit_register_event(
@@ -672,16 +713,37 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if args.json:
         print(json.dumps(result, indent=2))
-    elif result["success"]:
-        dry_label = " (dry-run)" if args.dry_run else ""
-        print(f"OK: PR #{args.pr} merged{dry_label} via {method}")
-        if result.get("receipt_status") and not args.dry_run:
+    elif args.dry_run:
+        # dry-run: no merge, no receipt, exit 0 (unchanged behavior).
+        print(f"OK: PR #{args.pr} (dry-run) via {method}")
+    elif result["success"] and result["receipt_ok"]:
+        # merge gebeurd + receipt geland -> exit 0
+        print(f"OK: PR #{args.pr} merged via {method}")
+        if result.get("receipt_status"):
             print(f"    receipt: {result['receipt_status']}")
-            print(f"    register: {'ok' if result['register_ok'] else 'warn-not-written'}")
+        print(f"    register: {'ok' if result['register_ok'] else 'warn-not-written'}")
+    elif result["success"] and not result["receipt_ok"]:
+        # merge gebeurd + receipt NIET geland -> non-zero, tekst maakt
+        # onmiskenbaar duidelijk dat de merge wél is doorgegaan en alleen
+        # het bewijs ontbreekt (OI-1518). De FATAL-regel is al op stderr
+        # gezet in merge_pr(); hier de korte samenvatting op stdout.
+        print(
+            f"ERROR: PR #{args.pr} WAS MERGED but the receipt did not land "
+            f"(status={result.get('receipt_status')!r}). The merge is irreversible; "
+            f"only the audit-trail proof is missing. See stderr.",
+            file=sys.stderr,
+        )
     else:
+        # merge niet gebeurd -> non-zero, bestaande tekst
         print(f"ERROR: {result['error']}", file=sys.stderr)
 
-    return EXIT_OK if result["success"] else EXIT_ERROR
+    # CLI verdict (OI-1518): exit 0 only on dry-run, or on a merge whose
+    # binding receipt actually landed. A merge without proof is non-zero.
+    if args.dry_run:
+        return EXIT_OK
+    if result["success"] and result["receipt_ok"]:
+        return EXIT_OK
+    return EXIT_ERROR
 
 
 if __name__ == "__main__":

--- a/tests/test_file_scope_overlap.py
+++ b/tests/test_file_scope_overlap.py
@@ -190,7 +190,7 @@ def test_merge_pr_surfaces_overlap_warning(monkeypatch):
     monkeypatch.setattr(pr_merge, "_query_pr",
                         lambda pr: {"title": "fix: t", "headRefName": "dispatch/merging"})
     monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method, *a, **k: (True, ""))
-    monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "ok"})
+    monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "appended"})
     monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **kw: True)
     monkeypatch.setattr(
         fso, "warn_overlaps", lambda branch, **kw: [("other", ["shared.txt"])],
@@ -198,6 +198,7 @@ def test_merge_pr_surfaces_overlap_warning(monkeypatch):
 
     result = pr_merge.merge_pr(99, dispatch_id="d1")
     assert result["success"] is True
+    assert result["receipt_ok"] is True
     assert result["overlaps"] == [("other", ["shared.txt"])]
 
 
@@ -207,7 +208,7 @@ def test_merge_pr_overlap_check_failure_does_not_block(monkeypatch):
     monkeypatch.setattr(pr_merge, "_query_pr",
                         lambda pr: {"title": "fix: t", "headRefName": "dispatch/merging"})
     monkeypatch.setattr(pr_merge, "_do_merge", lambda pr, method, *a, **k: (True, ""))
-    monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "ok"})
+    monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {"append_status": "appended"})
     monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **kw: True)
 
     def _boom(branch, **kw):

--- a/tests/test_pr_merge_ci_gate.py
+++ b/tests/test_pr_merge_ci_gate.py
@@ -137,7 +137,8 @@ class TestMainGateWiring:
     def _ok_result(self):
         return {
             "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
-            "pr_title": "", "branch": "", "receipt_status": None, "register_ok": False,
+            "pr_title": "", "branch": "", "receipt_status": None, "receipt_ok": False,
+            "register_ok": False,
             "error": "", "dry_run": True, "overlaps": [],
         }
 

--- a/tests/test_pr_merge_match_head.py
+++ b/tests/test_pr_merge_match_head.py
@@ -56,7 +56,8 @@ def _go_gate(**kw):
 def _ok_merge_result():
     return {
         "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
-        "pr_title": "", "branch": "", "receipt_status": None, "register_ok": False,
+        "pr_title": "", "branch": "", "receipt_status": None, "receipt_ok": False,
+        "register_ok": False,
         "error": "", "dry_run": True, "overlaps": [],
     }
 

--- a/tests/test_pr_merge_outcome_exitcode.py
+++ b/tests/test_pr_merge_outcome_exitcode.py
@@ -23,6 +23,7 @@ coverage for the two new helpers (``_repo_auto_merge_allowed`` and
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -239,7 +240,8 @@ class TestExitCodeFollowsRealOutcome:
             pr_merge, "merge_pr",
             lambda **k: {
                 "success": False, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
-                "pr_title": "", "branch": "", "receipt_status": None, "register_ok": False,
+                "pr_title": "", "branch": "", "receipt_status": None, "receipt_ok": False,
+                "register_ok": False,
                 "error": "gh pr merge meldde succes voor #5, maar de PR staat nog op state=OPEN",
                 "dry_run": False, "overlaps": [],
             },
@@ -249,3 +251,216 @@ class TestExitCodeFollowsRealOutcome:
 
         assert rc == pr_merge.EXIT_ERROR
         assert "state=OPEN" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# OI-1518 — a merge whose receipt did NOT land must exit non-zero
+# ---------------------------------------------------------------------------
+#
+# Before this fix, `merge_pr` set result["success"] = True the moment
+# `_do_merge` succeeded, and the receipt-emit try/except only set
+# `receipt_status` + a WARN to stderr. `result["success"]` was never touched,
+# so `main()` returned EXIT_OK for a merge whose proof could not be written.
+#
+# Two failure shapes must both fail closed:
+#   1. `_emit_receipt` raises.
+#   2. `_emit_receipt` returns but `append_status` is not a recognized success
+#      value (incl. the key missing -> "unknown" default).
+# And the two success shapes must still pass so the test can detect an
+# over-tight fix: `appended` -> exit 0, `duplicate` -> exit 0.
+
+
+class TestReceiptEmissionFailClosed:
+    def _merge_succeeds(self, monkeypatch, vnx_env):
+        """Wire merge_pr so _do_merge succeeds; receipt behavior is set per-test."""
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: {
+            "number": n, "title": "feat: x", "headRefName": "feature/x", "state": "MERGED",
+        })
+        monkeypatch.setattr(pr_merge, "_gh", lambda args, **k: _run(0))
+        monkeypatch.setattr(pr_merge, "_repo_auto_merge_allowed", lambda: True)
+        monkeypatch.setattr(pr_merge, "_pr_actually_merged", lambda n: (True, ""))
+        monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **k: True)
+        monkeypatch.setattr(pr_merge, "_lookup_dispatch_id_by_pr_number", lambda n: "")
+
+    def test_emit_raises_exits_nonzero_and_says_merge_happened(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        """Failure shape 1: _emit_receipt raises. Merge did happen; proof missing."""
+        self._merge_succeeds(monkeypatch, vnx_env)
+
+        def _boom(**kw):
+            raise RuntimeError("receipts file unwritable (simulated)")
+
+        monkeypatch.setattr(pr_merge, "_emit_receipt", _boom)
+
+        result = pr_merge.merge_pr(
+            pr_number=99999, receipts_file=str(vnx_env["receipts_path"]),
+        )
+
+        # success = "merge happened" -> still True (do not re-merge on a retry)
+        assert result["success"] is True
+        # receipt_ok = "binding proof landed" -> False
+        assert result["receipt_ok"] is False
+        assert "receipts file unwritable" in result["receipt_status"]
+
+        err = capsys.readouterr().err
+        # The text must make unmistakably clear the MERGE happened.
+        assert "merge happened" in err.lower() or "was merged" in err.lower()
+        # And that only the proof is missing, plus a re-run instruction.
+        assert "irreversible" in err.lower()
+        assert "99999" in err
+
+    def test_emit_returns_unrecognized_status_exits_nonzero(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        """Failure shape 2: append_status not recognized (the 'unknown' branch)."""
+        self._merge_succeeds(monkeypatch, vnx_env)
+        # Missing key entirely -> merge_pr defaults to "unknown".
+        monkeypatch.setattr(pr_merge, "_emit_receipt", lambda **kw: {})
+
+        result = pr_merge.merge_pr(
+            pr_number=88888, receipts_file=str(vnx_env["receipts_path"]),
+        )
+
+        assert result["success"] is True
+        assert result["receipt_ok"] is False
+        assert result["receipt_status"] == "unknown"
+        err = capsys.readouterr().err
+        assert "irreversible" in err.lower()
+
+    def test_emit_returns_explicit_unknown_status_exits_nonzero(
+        self, vnx_env, monkeypatch,
+    ):
+        """A literal 'unknown' status is the same third branch — fail safe."""
+        self._merge_succeeds(monkeypatch, vnx_env)
+        monkeypatch.setattr(
+            pr_merge, "_emit_receipt", lambda **kw: {"append_status": "unknown"},
+        )
+
+        result = pr_merge.merge_pr(
+            pr_number=77777, receipts_file=str(vnx_env["receipts_path"]),
+        )
+
+        assert result["success"] is True
+        assert result["receipt_ok"] is False
+        assert result["receipt_status"] == "unknown"
+
+    def test_main_exits_nonzero_when_receipt_emit_raises(self, monkeypatch, capsys):
+        """End-to-end through main(): merge ok + receipt raise -> EXIT_ERROR."""
+        go = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (dict(go), {"headRefOid": "a" * 40}))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (dict(go), None))
+
+        def fake_merge(**k):
+            return {
+                "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
+                "pr_title": "", "branch": "", "receipt_status": "error: boom",
+                "receipt_ok": False, "register_ok": False,
+                "error": "", "dry_run": False, "overlaps": [],
+            }
+
+        monkeypatch.setattr(pr_merge, "merge_pr", fake_merge)
+
+        rc = pr_merge.main(["--pr", "5"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        captured = capsys.readouterr()
+        # The output must distinguish "merge happened + proof missing" from a
+        # plain merge failure. It must NOT read as "the merge failed".
+        assert "WAS MERGED" in captured.err or "was merged" in captured.err.lower()
+
+    def test_appended_receipt_exits_zero(self, vnx_env, monkeypatch, capsys):
+        """Success shape: appended -> exit 0. Guards against an over-tight fix."""
+        self._merge_succeeds(monkeypatch, vnx_env)
+        monkeypatch.setattr(
+            pr_merge, "_emit_receipt", lambda **kw: {"append_status": "appended"},
+        )
+
+        result = pr_merge.merge_pr(
+            pr_number=5, receipts_file=str(vnx_env["receipts_path"]),
+        )
+
+        assert result["success"] is True
+        assert result["receipt_ok"] is True
+        assert result["receipt_status"] == "appended"
+
+    def test_duplicate_receipt_exits_zero(self, vnx_env, monkeypatch):
+        """Success shape: duplicate -> exit 0 (idempotent re-emit is not a fault)."""
+        self._merge_succeeds(monkeypatch, vnx_env)
+        monkeypatch.setattr(
+            pr_merge, "_emit_receipt", lambda **kw: {"append_status": "duplicate"},
+        )
+
+        result = pr_merge.merge_pr(
+            pr_number=6, receipts_file=str(vnx_env["receipts_path"]),
+        )
+
+        assert result["success"] is True
+        assert result["receipt_ok"] is True
+        assert result["receipt_status"] == "duplicate"
+
+    def test_main_exits_zero_when_receipt_landed(self, monkeypatch, capsys):
+        """End-to-end through main(): merge ok + receipt ok -> EXIT_OK."""
+        go = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (dict(go), {"headRefOid": "a" * 40}))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (dict(go), None))
+
+        def fake_merge(**k):
+            return {
+                "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
+                "pr_title": "", "branch": "", "receipt_status": "appended",
+                "receipt_ok": True, "register_ok": True,
+                "error": "", "dry_run": False, "overlaps": [],
+            }
+
+        monkeypatch.setattr(pr_merge, "merge_pr", fake_merge)
+
+        rc = pr_merge.main(["--pr", "5"])
+        assert rc == pr_merge.EXIT_OK
+
+    def test_dry_run_still_exits_zero_without_receipt(self, monkeypatch, capsys):
+        """--dry-run is unchanged: no merge, no receipt, exit 0."""
+        go = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (dict(go), {"headRefOid": "a" * 40}))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (dict(go), None))
+
+        def fake_merge(**k):
+            return {
+                "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
+                "pr_title": "", "branch": "", "receipt_status": None, "receipt_ok": False,
+                "register_ok": False,
+                "error": "dry_run: no merge executed", "dry_run": True, "overlaps": [],
+            }
+
+        monkeypatch.setattr(pr_merge, "merge_pr", fake_merge)
+
+        rc = pr_merge.main(["--pr", "5", "--dry-run"])
+        assert rc == pr_merge.EXIT_OK
+        assert "dry-run" in capsys.readouterr().out
+
+    def test_json_carries_receipt_ok_and_distinguishes_three_outcomes(
+        self, monkeypatch, capsys,
+    ):
+        """--json is machine-readable and carries the three outcomes distinctly."""
+        go = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (dict(go), {"headRefOid": "a" * 40}))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (dict(go), None))
+
+        def fake_merge(**k):
+            return {
+                "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
+                "pr_title": "", "branch": "", "receipt_status": "error: boom",
+                "receipt_ok": False, "register_ok": False,
+                "error": "", "dry_run": False, "overlaps": [],
+            }
+
+        monkeypatch.setattr(pr_merge, "merge_pr", fake_merge)
+
+        rc = pr_merge.main(["--pr", "5", "--json"])
+        assert rc == pr_merge.EXIT_ERROR
+        raw = capsys.readouterr().out
+        # main() prints gate lines before the JSON; take the last JSON object.
+        out = json.loads(raw[raw.index("{"):])
+        # merge happened but proof missing — both fields present and distinct.
+        assert out["success"] is True
+        assert out["receipt_ok"] is False

--- a/tests/test_pr_merge_review_gate.py
+++ b/tests/test_pr_merge_review_gate.py
@@ -388,7 +388,8 @@ class TestMainReviewGateWiring:
     def _ok_result(self):
         return {
             "success": True, "pr_number": 5, "dispatch_id": "", "merge_method": "squash",
-            "pr_title": "", "branch": "", "receipt_status": None, "register_ok": False,
+            "pr_title": "", "branch": "", "receipt_status": None, "receipt_ok": False,
+            "register_ok": False,
             "error": "", "dry_run": True, "overlaps": [],
         }
 


### PR DESCRIPTION
## Summary

A governed merge whose audit-trail proof could not be written reported `success` and exit 0. `merge_pr` set `result["success"] = True` the moment `_do_merge` succeeded; the receipt-emit `try/except` only recorded `receipt_status` + a WARN to stderr. The binding evidence was optional.

Two failure shapes both passed silently:
1. `_emit_receipt` raised (the OI's measured case).
2. `_emit_receipt` returned an `append_status` that is not a recognized success value, including a missing key -> `"unknown"` default.

`"unknown"` is a third branch, not a third value: it means "this code could not read the outcome". Neither success nor a known fault -> fails safe.

## Changes

- `scripts/pr_merge.py`: introduce `result["receipt_ok"]` (bool: binding proof landed), backed by an allowlist `_RECEIPT_OK_STATUSES = {"appended", "duplicate"}`. Verified by grepping `AppendResult(` across the whole tree (only two producers: `lib/append_receipt_internals/idempotency.py` -> `appended`/`duplicate`, `lib/report_to_receipt_converter.py` -> `duplicate`). No third value exists.
- `success` keeps meaning "the merge happened on GitHub", so a retry does not re-merge an already-merged PR. The CLI verdict becomes `dry_run or (merged and receipt_ok)`.
- A merge without proof exits non-zero, with text that makes unmistakably clear the merge is irreversible and only the proof is missing, plus a re-run instruction.
- The register event stays best-effort and is untouched. `--dry-run` is unchanged. `--json` carries `receipt_ok` so the three outcomes are machine-distinguishable.

## Verification

Red before fix (on pre-fix `scripts/pr_merge.py`):
```
pytest tests/test_pr_merge_outcome_exitcode.py::TestReceiptEmissionFailClosed::test_main_exits_nonzero_when_receipt_emit_raises
-> assert 0 == 1   (pre-fix main returned EXIT_OK for a merge without a receipt)
```
7 of 9 new OI-1518 tests red on pre-fix (KeyError on `receipt_ok` in `merge_pr`-level tests; EXIT_OK-instead-of-EXIT_ERROR on `main`-level tests; json shape).

Green after fix:
```
pytest tests/test_pr_merge_outcome_exitcode.py tests/test_pr_merge_receipt.py tests/test_pr_merge_ci_gate.py tests/test_pr_merge_review_gate.py tests/test_pr_merge_dual_scheme.py tests/test_pr_merge_match_head.py tests/test_backfill_pr_merged.py tests/test_file_scope_overlap.py tests/test_review_gate_dispatch_id.py
-> 134 passed
```

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)