### PR TITLE
fix(panel): reconcile seat coverage with the receipt ledger, not the seat's own frontmatter (OI-1519)

### DIFF
--- a/.claude/skills/horizon/SKILL.md
+++ b/.claude/skills/horizon/SKILL.md
@@ -69,8 +69,18 @@ a diverse-family panel BEFORE any implementation.
   (the FLOOR per deliverable, not a hand-picked lane), `## Open questions`.
 - **Panel = the full 5-family DEFAULT_PANEL: opus + kimi + glm-harness + deepseek-harness +
   codex** (`scripts/lib/plan_gate_panel.py`, #991; gemini omitted until a CLI exists — five
-  families -> real disagreement). A flaked/undispatched lane ABSTAINS (non-scoring, #910);
-  liveness-quorum = min(2, panel size), so one flake never forces REVISE. Operational
+  families -> real disagreement). A lane lands in one of THREE outcomes, not
+  two-plus-abstain (#910, OI-1519): it SCORES (a real, parseable verdict), it ABSTAINS
+  (the model answered but its verdict JSON would not parse — retried once, then
+  non-scoring), or it is NO-VERDICT (timeout, governance-synthesized report, or no
+  report file — a third branch the runner reports by name as `no-verdict
+  (timeout/no-report)`, NEVER folded into the abstains and never to be read as
+  "probably in order": an unmeasured lane is not an implicit OK). The general
+  deliberation panel's coverage tally enforces the same three-branch rule by
+  reconciling every seat's dispatch-id against the t0 receipt ledger — the ledger wins
+  over the seat's self-reported `exit_code`, and the divergence itself is reported
+  (OI-1519; see the `/panel` skill). liveness-quorum = min(2, panel size), so one
+  flake never forces REVISE. Operational
   preconditions: the glm litellm proxy on :4141, `DEEPSEEK_API_KEY`, kimi + codex CLIs.
 - **Run it**: `vnx horizon plan-gate run <track> --doc <plan.md> --project-id <pid>`. The
   panel runs on the **governed worker path**, and each panelist routes by its lane (the

--- a/.claude/skills/panel/SKILL.md
+++ b/.claude/skills/panel/SKILL.md
@@ -24,6 +24,49 @@ Reach for it when a single model's answer would be a guess, and you'd otherwise 
 3. **Verify** — the top claims are adversarially checked (against the CODE for sweeps — real `file:line`; against SOURCES for research — try to refute).
 4. **Synthesis** — one cited report: consensus + surviving dissent + verified/refuted claims, ranked and deduped.
 
+## How seat coverage is counted (OI-1519)
+
+"N of M lenses present" is reconciled against the t0 receipt ledger
+(`t0_receipts.ndjson`), never taken from the `exit_code` a seat writes about ITSELF in
+its own report frontmatter. After each stage completes, every seat's dispatch-id is
+looked up in the ledger via `receipt_provenance.find_receipts_by_dispatch` and lands in
+one of THREE outcomes:
+
+- **present** — the ledger holds a decisive SUCCESS record for the seat's dispatch-id
+  (`status` in the ADR-035 success set `done`/`success`/`complete`/`completed`, or
+  `verdict.decision=accept`).
+- **failed** — the ledger holds a decisive FAILURE record (`status` in the ADR-035
+  hard-failure set `failed`/`failure`/`error`/`blocked`/`timeout`/`contract_invalid`,
+  or `verdict.decision=reject`; multiple receipts for one dispatch-id reconcile
+  failure-beats-success — a success record never launders a recorded failure). A
+  dispatcher that RAISED before the seat completed is failed on direct local evidence.
+- **unmeasured** — the ledger has NO decisive record for the dispatch-id (no receipt
+  at all, or only indecisive ones). This is a third BRANCH, not a third value: the
+  seat counts as NEITHER present NOR failed and is named in the report
+  (`**Unmeasured seats:**`, `[SEAT UNMEASURED — no decisive ledger record]`).
+  Reading "unmeasured" as "probably fine" repeats exactly the bug OI-1519 repaired —
+  a measurement gap is not a lens.
+
+Where the ledger and the seat's own frontmatter DISAGREE, the ledger WINS the count and
+the divergence itself is reported (`## Ledger reconciliation — divergences` in the
+report, `result.ledger_divergences`) — a silent correction would produce a panel that
+cannot be weighed. When no ledger exists or can be read at all (fresh checkout) the
+tally falls back to the pre-OI-1519 frontmatter measurement, flagged loudly via
+`ledger_available=False` in the report — never silently.
+
+This holds for the diverge fan-out AND for the sequential stages (contrarian, verify,
+synthesis), which accept a seat via `_first_ok` under the same measurement: a
+ledger-failed seat is skipped; an unmeasured seat is kept only as a last-resort
+fallback so a measurement gap cannot collapse a stage to `[empty]` when real content
+exists.
+
+Measured case (2026-08-29, the dispatch that opened OI-1519): seat
+`panel-sweep-diverge-0-a6421f` (codex) wrote `exit_code: 0` in its own report
+frontmatter while the receipt ledger records `status=timeout`,
+`verdict.decision=reject` after the 600s deadline. Pre-fix it counted PRESENT (4/5
+lenses reported; really 3 + a timeout). Post-fix it counts FAILED, and the divergence
+is printed in the report.
+
 ## Run it
 
 ```bash

--- a/docs/governance/decisions/ADR-028-orchestration-target-architecture.md
+++ b/docs/governance/decisions/ADR-028-orchestration-target-architecture.md
@@ -73,6 +73,7 @@ Ratified under an explicit overnight operator mandate. The four open operator-de
 
 4. **Is panel coverage complete?**
    **Resolved: YES — no re-run needed.** deepseek + codex + kimi-r2 converge (high confidence); glm is dead for long synthesis (flaked empty twice, persistent). The draft's own conclusion, carried forward.
+   **Addendum (2026-08-30, OI-1519):** the resolution above records a 2026-07 panel run and stands as history. How a panel seat's coverage is COUNTED has since changed: the tally is reconciled against the t0 receipt ledger with three outcomes — present / failed / unmeasured — where the ledger wins over a seat's self-reported `exit_code` and any divergence is itself reported. See the `/panel` skill ("How seat coverage is counted") and `scripts/lib/deliberation_panel.py`.
 
 ### Ratification status
 Target architecture (§1–§7) and the migration sequence (§6) are **Accepted**. Adoption remains **gated per-phase**: each phase ships behind its own feature flag with a rollback, and Phases 2→4 (which touch the decision path) each require an explicit operator go/no-go at the transition, per the human-in-the-loop principle. Nothing here authorizes an autonomous execution bypass.

--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -23,7 +23,10 @@ import logging
 import os
 import uuid
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from receipt_verdict import HARD_FAILURE_STATUSES, SUCCESS_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -132,18 +135,38 @@ class DeliberationResult:
     # refused, recorded here so to_report() renders it loudly, never silently.
     synthesis_refused_reason: str = ""   # non-empty => synthesis refused (coverage floor)
     degraded_synthesis: bool = False     # synthesis ran below the floor (--allow-degraded)
+    # Ledger reconciliation (OI-1519): per-seat measurement records ({provider, lens,
+    # stage, dispatch_id, outcome, source, frontmatter_*, ledger_*, divergent, reason}).
+    # The coverage tally is reconciled against the t0 receipt ledger, never taken from
+    # the exit_code a seat writes about ITSELF.
+    seat_measurements: List[Dict[str, Any]] = field(default_factory=list)
+    unmeasured_seats: List[Dict[str, str]] = field(default_factory=list)  # {provider, lens, dispatch_id, reason}
+    ledger_available: bool = True  # False => legacy frontmatter fallback (UNVERIFIED)
+
+    @property
+    def ledger_divergences(self) -> List[Dict[str, Any]]:
+        """Seats where the receipt ledger and the seat's own frontmatter DISAGREE on
+        the outcome. The divergence itself is the finding — a silent correction would
+        leave a panel that cannot be weighed (OI-1519)."""
+        return [m for m in self.seat_measurements if m.get("divergent")]
 
     @property
     def coverage(self) -> str:
         """Human-readable coverage summary, e.g. "3/5 lenses present; glm-harness
         (alternative-approaches lens) failed". A dead seat must never be rendered as if
-        it silently contributed to the panel (OI-810) — this is the explicit signal."""
+        it silently contributed to the panel (OI-810) — this is the explicit signal.
+        An UNMEASURED seat (ledger has no decisive record, OI-1519) is neither present
+        nor failed and is named as its own category."""
         total = len(self.fan_out)
         present = len(self.present_lenses)
-        if not self.failed_seats:
-            return f"{present}/{total} lenses present"
-        failed = ", ".join(f"{s['provider']} ({s['lens']})" for s in self.failed_seats)
-        return f"{present}/{total} lenses present; {failed} failed"
+        parts = [f"{present}/{total} lenses present"]
+        if self.failed_seats:
+            failed = ", ".join(f"{s['provider']} ({s['lens']})" for s in self.failed_seats)
+            parts.append(f"{failed} failed")
+        if self.unmeasured_seats:
+            unmeasured = ", ".join(f"{s['provider']} ({s['lens']})" for s in self.unmeasured_seats)
+            parts.append(f"{unmeasured} unmeasured (no decisive ledger record)")
+        return "; ".join(parts)
 
     @property
     def zero_seats_delivered(self) -> bool:
@@ -161,6 +184,17 @@ class DeliberationResult:
             f"\n**Question:** {self.question}\n",
             f"**Coverage:** {self.coverage}\n",
         ]
+        if not self.ledger_available:
+            lines.append(
+                "**Ledger:** receipt ledger UNAVAILABLE — coverage measured against the "
+                "seats' own report frontmatter only (UNVERIFIED, pre-OI-1519 fallback)\n"
+            )
+        if self.unmeasured_seats:
+            seats = ", ".join(f"{s['provider']} ({s['lens']})" for s in self.unmeasured_seats)
+            lines.append(
+                f"**Unmeasured seats:** {seats} — the receipt ledger has no decisive record; "
+                "counted as NEITHER present nor failed\n"
+            )
         if self.synthesis_refused_reason:
             lines.append(f"**Synthesis:** REFUSED — {self.synthesis_refused_reason}\n")
         if self.degraded_synthesis:
@@ -179,9 +213,37 @@ class DeliberationResult:
             "\n---\n## Divergent views (fan-out)\n",
         ]
         for fo in self.fan_out:
-            failed_tag = " — **[SEAT FAILED — no report]**" if _is_error(fo["text"]) else ""
+            # Use the RECONCILED outcome recorded at measurement time (OI-1519) — the
+            # tag must agree with the count. Hand-built results (no reconciliation ran)
+            # fall back to the legacy text check.
+            outcome = fo.get("seat_outcome")
+            if outcome is None:
+                outcome = SEAT_FAILED if _is_error(fo["text"]) else SEAT_PRESENT
+            if outcome == SEAT_FAILED:
+                failed_tag = " — **[SEAT FAILED — no report]**"
+            elif outcome == SEAT_UNMEASURED:
+                failed_tag = " — **[SEAT UNMEASURED — no decisive ledger record]**"
+            else:
+                failed_tag = ""
             lines.append(f"\n### {fo['provider']} — lens: {fo['lens']}{failed_tag}\n")
             lines.append(fo["text"] or "_(empty)_")
+        divergences = self.ledger_divergences
+        if divergences:
+            lines += [
+                "\n---\n## Ledger reconciliation — divergences\n",
+                "These seats' own report frontmatter and the receipt ledger DISAGREE on the "
+                "outcome. The ledger wins the count (OI-1519); the divergence itself is the "
+                "finding:\n",
+            ]
+            for d in divergences:
+                lens = f", lens: {d['lens']}" if d.get("lens") else ""
+                lines.append(
+                    f"- **{d['provider']}** ({d['stage']}{lens}, dispatch `{d['dispatch_id']}`): "
+                    f"frontmatter said {d['frontmatter_outcome']} "
+                    f"(exit_code={d['frontmatter_exit_code']}); ledger said {d['ledger_outcome']} "
+                    f"(status={d['ledger_status']}, verdict.decision={d['ledger_decision']}) "
+                    f"→ counted {d['outcome'].upper()}"
+                )
         return "\n".join(lines)
 
 
@@ -351,6 +413,7 @@ def run_deliberation(
     max_workers: int = 5,
     min_seats: Optional[int] = None,
     allow_degraded: bool = False,
+    receipts_path: Optional["Path | str"] = None,
 ) -> DeliberationResult:
     """Run the 4-stage deliberation. ``dispatcher(provider, model, prompt, dispatch_id)`` runs
     one panelist and returns its report text (governed lane). ``context`` is optional extra
@@ -363,7 +426,13 @@ def run_deliberation(
     ``None`` (the default) disables the floor entirely — callers that already bound coverage
     their own way stay unaffected. ``allow_degraded`` is the operator escape: with it True the
     synthesis proceeds below the floor, and ``result.degraded_synthesis`` marks that choice so
-    the report renders it, never silently."""
+    the report renders it, never silently.
+
+    ``receipts_path`` (OI-1519) points at the t0 receipt ledger (``t0_receipts.ndjson``)
+    each seat's dispatch-id is reconciled against. ``None`` resolves the canonical state
+    dir's ledger. When no ledger exists or can be read (fresh checkout), the tally falls
+    back to the pre-OI-1519 frontmatter measurement — flagged on the result
+    (``ledger_available=False``) and in the report, never silently."""
     spec = MODES.get(mode)
     if spec is None:
         raise ValueError(f"unknown mode {mode!r}; choose one of {sorted(MODES)}")
@@ -382,11 +451,17 @@ def run_deliberation(
             "(file:line for code, a named source for research). Give your strongest findings, "
             "then one thing you are UNSURE about. Terse."
         )
+        # OI-1519: the dispatch-id is CARRIED through — reconciliation against the
+        # receipt ledger is impossible when the id is built here and thrown away.
+        did = f"panel-{mode}-diverge-{idx}-{uuid.uuid4().hex[:6]}"
+        raised = False
         try:
-            text = dispatcher(provider, model, prompt, f"panel-{mode}-diverge-{idx}-{uuid.uuid4().hex[:6]}")
+            text = dispatcher(provider, model, prompt, did)
         except Exception as exc:  # noqa: BLE001 — a dead provider degrades the panel, never kills it
             text = f"[dispatch error: {exc!r}]"
-        return {"provider": provider, "lens": lens, "text": text or "[empty]"}
+            raised = True
+        return {"provider": provider, "lens": lens, "text": text or "[empty]",
+                "dispatch_id": did, "_raised": raised}
 
     with _cf.ThreadPoolExecutor(max_workers=max_workers) as ex:
         futures = [ex.submit(_one, i, p, m) for i, (p, m) in enumerate(roster)]
@@ -395,19 +470,61 @@ def run_deliberation(
     order = {p: i for i, (p, _) in enumerate(roster)}
     result.fan_out.sort(key=lambda fo: order.get(fo["provider"], 99))
 
-    # Coverage bookkeeping (OI-810): a failed/empty seat must never silently look like a
-    # contributing lens. Exclude it from what downstream stages see, and record it so the
-    # result/report say so explicitly.
-    present_fan_out = [fo for fo in result.fan_out if not _is_error(fo["text"])]
-    failed_fan_out = [fo for fo in result.fan_out if _is_error(fo["text"])]
+    # Coverage bookkeeping, reconciled against the receipt LEDGER (OI-1519) — the
+    # ledger is loaded AFTER the fan-out completes so the seats' receipts exist by
+    # the time we measure (the governed lane writes the receipt before the dispatcher
+    # returns). A seat's own frontmatter exit_code is the seat testifying about
+    # itself; the ledger is the independent record and WINS when the two disagree
+    # (the disagreement is reported, never silently corrected). A seat the ledger
+    # cannot give a decisive record for is UNMEASURED — its own branch, counted as
+    # neither present nor failed. When no ledger exists at all (fresh checkout) the
+    # tally falls back to the legacy frontmatter measurement so the panel keeps
+    # working — flagged via result.ledger_available, never silently.
+    ledger = _ReceiptLedger.load(receipts_path)
+    result.ledger_available = ledger is not None
+    fan_out_measurements = []
+    for fo in result.fan_out:
+        measurement = _measure_seat(
+            fo["provider"], fo["lens"], fo.get("dispatch_id", ""), fo["text"],
+            stage="diverge", ledger=ledger, raised=fo.pop("_raised", False),
+        )
+        fo["seat_outcome"] = measurement["outcome"]
+        fan_out_measurements.append(measurement)
+    result.seat_measurements.extend(fan_out_measurements)
+    present_fan_out = [fo for fo in result.fan_out if fo["seat_outcome"] == SEAT_PRESENT]
+    failed_fan_out = [fo for fo in result.fan_out if fo["seat_outcome"] == SEAT_FAILED]
+    unmeasured_fan_out = [fo for fo in result.fan_out if fo["seat_outcome"] == SEAT_UNMEASURED]
     result.present_lenses = [fo["lens"] for fo in present_fan_out]
-    result.failed_seats = [{"provider": fo["provider"], "lens": fo["lens"]} for fo in failed_fan_out]
+    result.failed_seats = [
+        {"provider": fo["provider"], "lens": fo["lens"], "dispatch_id": fo.get("dispatch_id", "")}
+        for fo in failed_fan_out
+    ]
+    result.unmeasured_seats = [
+        {"provider": m["provider"], "lens": m["lens"], "dispatch_id": m["dispatch_id"],
+         "reason": m["reason"]}
+        for m in fan_out_measurements if m["outcome"] == SEAT_UNMEASURED
+    ]
     if failed_fan_out:
         logger.warning(
             "panel: %d/%d seats produced no usable report (%s) — %s",
             len(failed_fan_out), len(result.fan_out),
             ", ".join(f"{fo['provider']} ({fo['lens']})" for fo in failed_fan_out),
             result.coverage,
+        )
+    if unmeasured_fan_out:
+        logger.warning(
+            "panel: %d/%d seats are UNMEASURED — the receipt ledger has no decisive "
+            "record (%s); counted as neither present nor failed — %s",
+            len(unmeasured_fan_out), len(result.fan_out),
+            ", ".join(f"{fo['provider']} ({fo['lens']})" for fo in unmeasured_fan_out),
+            result.coverage,
+        )
+    if result.ledger_divergences:
+        logger.warning(
+            "panel: %d seat(s) where the ledger DISAGREES with the seat's own frontmatter "
+            "(ledger wins): %s",
+            len(result.ledger_divergences),
+            ", ".join(f"{d['provider']} ({d['stage']})" for d in result.ledger_divergences),
         )
 
     # ── Coverage floor for the synthesis (OI-1154) ──────────────────────────
@@ -440,9 +557,10 @@ def run_deliberation(
     digest = _digest(present_fan_out)
     coverage_note = (
         f"PANEL COVERAGE: {result.coverage}. Reason only from the lenses that actually "
-        "responded — a failed seat contributed NOTHING; do not assume its perspective is "
-        "represented.\n"
-    ) if failed_fan_out else ""
+        "responded — a failed seat contributed NOTHING, and an unmeasured seat could not "
+        "be confirmed against the receipt ledger and is excluded; do not assume either "
+        "perspective is represented.\n"
+    ) if failed_fan_out or unmeasured_fan_out else ""
 
     # ── Stage 2: CONTRARIAN (one red-team seat — the strongest reasoner) ──────
     # Instruction FIRST, bounded distillate of stage 1 AFTER (OI-809) — a downstream
@@ -462,6 +580,7 @@ def run_deliberation(
     result.contrarian = _first_ok(
         dispatcher, _ordered_seats(roster, ("codex", "deepseek-harness", "claude")),
         contra_prompt, f"panel-{mode}-contrarian",
+        ledger=ledger, measure_sink=result.seat_measurements, stage="contrarian",
     )
 
     # ── Stage 3: VERIFY (adversarial factcheck of the top claims) ────────────
@@ -484,6 +603,7 @@ def run_deliberation(
     result.factcheck = _first_ok(
         dispatcher, _ordered_seats(roster, ("codex", "kimi", "claude")),
         verify_prompt, f"panel-{mode}-verify",
+        ledger=ledger, measure_sink=result.seat_measurements, stage="verify",
     )
 
     # ── Stage 4: SYNTHESIS (one cited report) ────────────────────────────────
@@ -506,6 +626,7 @@ def run_deliberation(
     result.synthesis = _first_ok(
         dispatcher, _ordered_seats(roster, ("claude", "codex", "kimi")),
         synth_prompt, f"panel-{mode}-synth",
+        ledger=ledger, measure_sink=result.seat_measurements, stage="synthesis",
     )
 
     return result
@@ -573,7 +694,12 @@ def _is_error(text: str) -> bool:
     check ONLY when no frontmatter is present (no report on disk, or a worker-authored
     report without frontmatter) — this is the pre-existing behaviour, not a regression: a
     report with no frontmatter carries no readable outcome, so it stays exactly as
-    permissive as it was before this fix."""
+    permissive as it was before this fix.
+
+    NOTE (OI-1519): this is the LEGACY measure — the seat testifying about itself. The
+    reconciled coverage tally goes through ``_measure_seat``, which lets the receipt
+    ledger overrule this answer (and reports the divergence). ``_is_error`` remains the
+    fallback when no ledger exists."""
     exit_code = _seat_exit_code(text)
     if exit_code is not None:
         return exit_code != 0
@@ -581,26 +707,270 @@ def _is_error(text: str) -> bool:
     return (not t) or t.startswith("[dispatch error") or t == "[empty]"
 
 
+# ── Ledger reconciliation (OI-1519) ──────────────────────────────────────────
+# A seat's coverage outcome is reconciled against the t0 receipt ledger
+# (t0_receipts.ndjson), never taken from the ``exit_code`` the seat writes about
+# ITSELF in its own report frontmatter. Measured live on dispatch
+# ``panel-sweep-diverge-0-a6421f`` (2026-08-30): ledger ``status=timeout`` /
+# ``verdict.decision=reject`` while the report frontmatter says ``exit_code: 0`` —
+# the frontmatter-only tally counted that timed-out seat as a PRESENT lens.
+#
+# The vocabulary is NOT hand-rolled here: it reuses the fabric's canonical,
+# measured sets from ``receipt_verdict`` (ADR-035 §3.1) — HARD_FAILURE_STATUSES
+# (failed/failure/error/blocked/timeout/contract_invalid) and SUCCESS_STATUSES
+# (done/success/complete/completed) — the same rule table that produced the
+# ``verdict.decision`` values in the ledger itself. ``status`` is the primary
+# signal, ``verdict.decision`` the secondary (consulted only when the status is
+# indecisive, e.g. "unknown"). Measured on the live ledger (28,592 receipts,
+# 2026-08-30): every frequent status literal lands in exactly one of the three
+# branches (success / hard-failure / indecisive), and verdict.decision carries
+# accept(15) / reject(3015) / investigate(7027).
+
+SEAT_PRESENT = "present"
+SEAT_FAILED = "failed"
+SEAT_UNMEASURED = "unmeasured"
+
+
+def _default_receipts_path() -> Optional[Path]:
+    """Default t0 receipt ledger location, via the canonical state-dir resolver (the
+    same resolution family the governed dispatch lane writes receipts under). Returns
+    None when the resolver itself is unavailable — the caller then measures in legacy
+    mode. Callers and tests that need a specific ledger pass ``receipts_path``
+    explicitly; ambient env-vars are deliberately NOT read here so tests stay
+    hermetic."""
+    try:
+        from vnx_paths import resolve_state_dir
+        return Path(resolve_state_dir()) / "t0_receipts.ndjson"
+    except Exception as exc:  # resolver failure = no known ledger → legacy mode
+        logger.debug("panel: could not resolve the default receipt ledger path: %r", exc)
+        return None
+
+
+class _ReceiptLedger:
+    """Per-dispatch-id lookup against the t0 receipt ledger (OI-1519).
+
+    ``lookup`` returns:
+      - a non-empty list  → the ledger KNOWS this dispatch-id (decisive or not),
+      - an empty list     → the ledger is readable but has NO record of it
+                            (an UNMEASURED seat — its own branch, never silently
+                            counted present),
+      - None              → the ledger could not be read right now (degrade to the
+                            legacy frontmatter measurement for this seat).
+    Results are cached per dispatch-id. Lookups go through
+    ``receipt_provenance.find_receipts_by_dispatch`` — the shared, tested NDJSON
+    reader — instead of parsing the ledger here.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._cache: Dict[str, Optional[List[Dict[str, Any]]]] = {}
+
+    @classmethod
+    def load(cls, receipts_path: Optional["Path | str"]) -> Optional["_ReceiptLedger"]:
+        """Open the ledger once, after the seats completed (their receipts exist by
+        then). Returns None — legacy fallback mode — when no path resolves, the file
+        does not exist (fresh checkout), or it cannot be read."""
+        path = Path(receipts_path) if receipts_path is not None else _default_receipts_path()
+        if path is None:
+            return None
+        try:
+            if not path.is_file():
+                return None
+            with path.open("r", encoding="utf-8"):
+                pass  # readability probe only
+        except OSError as exc:
+            logger.debug("panel: receipt ledger %s unreadable: %r", path, exc)
+            return None
+        return cls(path)
+
+    def lookup(self, dispatch_id: str) -> Optional[List[Dict[str, Any]]]:
+        if not dispatch_id:
+            return []
+        if dispatch_id in self._cache:
+            return self._cache[dispatch_id]
+        receipts: Optional[List[Dict[str, Any]]]
+        try:
+            from receipt_provenance import find_receipts_by_dispatch
+            receipts = find_receipts_by_dispatch(self.path, dispatch_id)
+        except (ImportError, OSError, ValueError, TypeError) as exc:
+            logger.warning(
+                "panel: receipt ledger lookup failed for %s: %r — legacy fallback for this seat",
+                dispatch_id, exc,
+            )
+            receipts = None
+        self._cache[dispatch_id] = receipts
+        return receipts
+
+
+def _receipt_outcome(receipt: Dict[str, Any]) -> Optional[bool]:
+    """One receipt's answer: True = success, False = failure, None = indecisive.
+
+    ``status`` is the primary signal (canonical ADR-035 sets); ``verdict.decision``
+    the secondary, consulted only when the status is indecisive."""
+    status = str(receipt.get("status") or "").strip().lower()
+    if status in HARD_FAILURE_STATUSES:
+        return False
+    if status in SUCCESS_STATUSES:
+        return True
+    verdict = receipt.get("verdict")
+    decision = ""
+    if isinstance(verdict, dict):
+        decision = str(verdict.get("decision") or "").strip().lower()
+    if decision == "reject":
+        return False
+    if decision == "accept":
+        return True
+    return None
+
+
+def _ledger_outcome(receipts: List[Dict[str, Any]]) -> Optional[bool]:
+    """Reconcile possibly-multiple receipts for one dispatch-id (measured:
+    ``panel-architecture-diverge-1-094e47`` carries both ``success`` and
+    ``unknown``). Fail-closed on conflict: ANY failure record fails the seat — a
+    success record never launders a recorded failure. None = the ledger knows the
+    id but every receipt is indecisive."""
+    outcomes = [o for o in (_receipt_outcome(r) for r in receipts) if o is not None]
+    if not outcomes:
+        return None
+    if any(o is False for o in outcomes):
+        return False
+    return True
+
+
+def _receipt_decision_str(receipt: Dict[str, Any]) -> str:
+    verdict = receipt.get("verdict")
+    if isinstance(verdict, dict):
+        decision = str(verdict.get("decision") or "").strip().lower()
+        if decision:
+            return decision
+    return "<none>"
+
+
+def _measure_seat(
+    provider: str,
+    lens: str,
+    dispatch_id: str,
+    text: str,
+    *,
+    stage: str,
+    ledger: Optional[_ReceiptLedger],
+    raised: bool = False,
+) -> Dict[str, Any]:
+    """Reconcile one seat's outcome against the receipt ledger (OI-1519).
+
+    Three branches, never two:
+      1. the ledger knows this dispatch-id and says FAILURE → ``failed``
+      2. the ledger knows this dispatch-id and says SUCCESS → ``present``
+      3. the ledger has NO decisive record (unknown dispatch-id, indecisive
+         receipts) → ``unmeasured`` — its own branch, counted as neither present
+         nor failed, never a silent fail-open to present.
+
+    Two degradations are explicit, not silent: a dispatcher that RAISED is failed on
+    direct local evidence (no receipt will ever exist for it); a missing/unreadable
+    ledger falls back to the legacy frontmatter measurement (``source="legacy"``) so
+    the panel keeps working in a fresh checkout — flagged on the result via
+    ``ledger_available=False``.
+
+    When the ledger is decisive and DISAGREES with the seat's own frontmatter, the
+    ledger wins and ``divergent`` is set — the divergence itself is the finding and
+    must be reported, not silently corrected.
+    """
+    legacy_failed = _is_error(text)
+    record: Dict[str, Any] = {
+        "provider": provider,
+        "lens": lens,
+        "stage": stage,
+        "dispatch_id": dispatch_id,
+        "outcome": "",
+        "source": "",
+        "frontmatter_exit_code": _seat_exit_code(text),
+        "frontmatter_outcome": SEAT_FAILED if legacy_failed else SEAT_PRESENT,
+        "ledger_status": "",
+        "ledger_decision": "",
+        "ledger_outcome": "",
+        "divergent": False,
+        "reason": "",
+    }
+    if raised:
+        record.update(
+            outcome=SEAT_FAILED, source="local",
+            reason="dispatcher raised before the seat completed — local evidence",
+        )
+        return record
+    receipts = ledger.lookup(dispatch_id) if ledger is not None else None
+    if receipts is None:
+        record.update(
+            outcome=record["frontmatter_outcome"], source="legacy",
+            reason="receipt ledger unavailable/unreadable — frontmatter fallback (UNVERIFIED)",
+        )
+        return record
+    if receipts:
+        record["ledger_status"] = "+".join(sorted({
+            str(r.get("status") or "").strip().lower() or "<none>" for r in receipts
+        }))
+        record["ledger_decision"] = "+".join(sorted({_receipt_decision_str(r) for r in receipts}))
+    outcome = _ledger_outcome(receipts)
+    if outcome is None:
+        record.update(
+            outcome=SEAT_UNMEASURED, source="ledger",
+            reason=("ledger receipts are indecisive (no success/failure signal)"
+                    if receipts else "ledger has no receipt for this dispatch-id"),
+        )
+        return record
+    record.update(
+        outcome=SEAT_PRESENT if outcome else SEAT_FAILED,
+        source="ledger",
+        ledger_outcome=SEAT_PRESENT if outcome else SEAT_FAILED,
+        reason=("ledger records success for this dispatch-id" if outcome
+                else "ledger records a failure for this dispatch-id"),
+    )
+    record["divergent"] = record["outcome"] != record["frontmatter_outcome"]
+    return record
+
+
 def _first_ok(
     dispatcher: DispatcherFn,
     seats: List[Tuple[str, str]],
     prompt: str,
     did_prefix: str,
+    *,
+    ledger: Optional[_ReceiptLedger] = None,
+    measure_sink: Optional[List[Dict[str, Any]]] = None,
+    stage: str = "",
 ) -> str:
     """Try each seat in order until one returns a real (non-error) report. This keeps the
     critical sequential stages (contrarian / verify / synthesis) from collapsing the whole
-    panel when the first-choice provider is down (sales-copilot T0, 2026-07-10)."""
+    panel when the first-choice provider is down (sales-copilot T0, 2026-07-10).
+
+    OI-1519: the accept decision is reconciled against the receipt ledger with the
+    SAME ``_measure_seat`` the fan-out uses — these stages deliver the final verdict,
+    so the identical frontmatter-lie bug may not survive here. A ledger-failed seat is
+    skipped; an UNMEASURED seat (ledger has no decisive record, e.g. a receipt-lag
+    window) is kept as a last-resort fallback so a measurement gap cannot cascade
+    through the whole roster and collapse the stage to ``[empty]`` when real content
+    exists — and every measurement is recorded on the result via ``measure_sink`` so
+    the gap stays visible."""
     last = "[empty]"
+    unmeasured_fallback: Optional[str] = None
     for provider, model in seats:
+        did = f"{did_prefix}-{provider}-{uuid.uuid4().hex[:6]}"
+        raised = False
         try:
-            out = dispatcher(provider, model, prompt, f"{did_prefix}-{provider}-{uuid.uuid4().hex[:6]}")
+            out = dispatcher(provider, model, prompt, did)
         except Exception as exc:  # noqa: BLE001
-            last = f"[dispatch error {provider}: {exc!r}]"
-            continue
-        if not _is_error(out):
+            out = f"[dispatch error {provider}: {exc!r}]"
+            raised = True
+        measurement = _measure_seat(
+            provider, "", did, out, stage=stage or did_prefix, ledger=ledger, raised=raised,
+        )
+        if measure_sink is not None:
+            measure_sink.append(measurement)
+        if measurement["outcome"] == SEAT_PRESENT:
             return out
+        if measurement["outcome"] == SEAT_UNMEASURED and unmeasured_fallback is None and out:
+            unmeasured_fallback = out
         last = out or "[empty]"
-    return last
+    return unmeasured_fallback if unmeasured_fallback is not None else last
 
 
 __all__ = ["MODES", "DEFAULT_ROSTER", "ModeSpec", "DeliberationResult", "run_deliberation"]

--- a/skills/horizon/SKILL.md
+++ b/skills/horizon/SKILL.md
@@ -75,8 +75,18 @@ a diverse-family panel BEFORE any implementation, sized to the plan's governance
   (docs, reversible) up to 3 (core / irreversible); a new feature
   (`task_class 01_code_generation`) gets the full 5 seats regardless of paths. The exact
   ladder lives in `docs/core/HORIZON_PLANNING.md`; do not copy it here (a second copy drifts
-  the moment the ladder changes). A flaked/undispatched lane ABSTAINS (non-scoring, #910);
-  liveness-quorum = min(2, panel size), so one flake never forces REVISE. Operational
+  the moment the ladder changes). A lane lands in one of THREE outcomes, not
+  two-plus-abstain (#910, OI-1519): it SCORES (a real, parseable verdict), it ABSTAINS
+  (the model answered but its verdict JSON would not parse — retried once, then
+  non-scoring), or it is NO-VERDICT (timeout, governance-synthesized report, or no
+  report file — a third branch the runner reports by name as `no-verdict
+  (timeout/no-report)`, NEVER folded into the abstains and never to be read as
+  "probably in order": an unmeasured lane is not an implicit OK). The general
+  deliberation panel's coverage tally enforces the same three-branch rule by
+  reconciling every seat's dispatch-id against the t0 receipt ledger — the ledger wins
+  over the seat's self-reported `exit_code`, and the divergence itself is reported
+  (OI-1519; see the `/panel` skill). liveness-quorum = min(2, panel size), so one
+  flake never forces REVISE. Operational
   preconditions for the heavier seats: the glm litellm proxy on :4141, `DEEPSEEK_API_KEY`,
   kimi + codex CLIs.
 - **Run it**: `vnx horizon plan-gate run <track> --doc <plan.md> --project-id <pid>`. The

--- a/tests/test_deliberation_panel.py
+++ b/tests/test_deliberation_panel.py
@@ -4,6 +4,7 @@ Uses a FAKE dispatcher (records calls) so no live provider is hit."""
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -18,6 +19,21 @@ if _LIB not in sys.path:
     sys.path.insert(0, _LIB)
 
 import deliberation_panel as dp  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_ledger(monkeypatch, tmp_path):
+    """Hermeticity (OI-1519): without an explicit ``receipts_path``, run_deliberation
+    resolves the machine's REAL receipt ledger — which on a dev machine exists and
+    knows none of these tests' random dispatch-ids, flipping every seat to
+    'unmeasured'. Pin the default resolution to a path that never exists so the
+    pre-ledger tests exercise the legacy fallback exactly as before. Tests of the
+    ledger path itself override this per-test."""
+    monkeypatch.setattr(
+        dp, "_default_receipts_path",
+        lambda: tmp_path / "no-ledger-here" / "t0_receipts.ndjson",
+        raising=False,  # pre-fix the function does not exist yet; setting it is harmless
+    )
 
 
 class _Recorder:
@@ -791,3 +807,318 @@ class TestMinSeatsFloorWithOutcomeBasedCounting:
         assert res.synthesis_refused_reason == ""
         assert not res.degraded_synthesis
         assert res.synthesis
+
+
+def _append_receipt(ledger_path, record):
+    """Append one receipt to a tmp NDJSON ledger — mirrors the governed lane, which
+    writes a seat's receipt before the dispatcher returns its report."""
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+class TestLedgerReconciliation:
+    """OI-1519: the panel's coverage tally must be reconciled against the receipt
+    LEDGER (t0_receipts.ndjson), not against the ``exit_code`` a seat writes about
+    ITSELF in its own report frontmatter. Measured live on dispatch
+    ``panel-sweep-diverge-0-a6421f`` (2026-08-30): the ledger says
+    ``status=timeout`` / ``verdict.decision=reject`` while the report frontmatter
+    says ``exit_code: 0`` — the pre-ledger tally counted that timed-out seat as a
+    PRESENT lens (4/5 reported, really 3 + a timeout).
+
+    Three branches, never two: ledger-says-failed → FAILED, ledger-says-success →
+    PRESENT, ledger-has-no-decisive-record (or no ledger at all) → UNMEASURED —
+    never silently counted as present on the seat's own say-so.
+    """
+
+    def test_ledger_timeout_beats_frontmatter_exit_code_zero(self, tmp_path, monkeypatch):
+        """The exact measured divergence, rebuilt: seat frontmatter claims
+        ``exit_code: 0``; the ledger says ``status=timeout, verdict.decision=reject``.
+        The ledger must win the count AND the divergence must be reported."""
+        ledger = tmp_path / "state" / "t0_receipts.ndjson"
+        # Resolve via the default-path hook (no receipts_path kwarg) so this test
+        # fails with a plain ASSERTION on the pre-fix tree, not a TypeError.
+        monkeypatch.setattr(dp, "_default_receipts_path", lambda: ledger, raising=False)
+
+        def dispatcher(provider, model, prompt, did):
+            if provider == "kimi" and "-diverge-" in did:
+                _append_receipt(ledger, {
+                    "dispatch_id": did, "status": "timeout",
+                    "verdict": {"decision": "reject"},
+                    "failure_reason": "deadline exceeded (source: openai-api) [600.1s]",
+                })
+                # the lie, exactly as measured: exit_code 0 over a wrapper-echo body
+                return _fake_report(did, provider, 0, REFUSAL_BODY)
+            _append_receipt(ledger, {
+                "dispatch_id": did, "status": "success",
+                "verdict": {"decision": "accept"},
+            })
+            return _fake_report(did, provider, 0, "real analysis, cites file:line")
+
+        res = dp.run_deliberation("sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3)
+
+        assert len(res.present_lenses) == 2, (
+            "a seat the ledger recorded as timeout/reject must NOT count as present "
+            "just because its own frontmatter says exit_code: 0"
+        )
+        assert len(res.failed_seats) == 1
+        assert res.failed_seats[0]["provider"] == "kimi"
+        assert "2/3" in res.coverage
+
+        # the divergence itself is the finding — visible on the result object
+        assert len(res.ledger_divergences) == 1
+        d = res.ledger_divergences[0]
+        assert d["provider"] == "kimi"
+        assert d["dispatch_id"]
+        assert d["frontmatter_outcome"] == "present"
+        assert d["ledger_outcome"] == "failed"
+        assert d["ledger_status"] == "timeout"
+        assert d["ledger_decision"] == "reject"
+
+        # ... and in the rendered report
+        report = res.to_report()
+        assert "timeout" in report
+        assert "reject" in report
+        assert "exit_code" in report
+        assert "SEAT FAILED" in report  # to_report agrees with the count
+
+    def test_ledger_success_counts_present(self, tmp_path):
+        """Branch 2: the ledger knows the dispatch-id and says success → PRESENT."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+
+        def dispatcher(provider, model, prompt, did):
+            _append_receipt(ledger, {"dispatch_id": did, "status": "success"})
+            return _fake_report(did, provider, 0, "real analysis")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert res.ledger_available is True
+        assert len(res.present_lenses) == 3
+        assert res.failed_seats == []
+        assert res.unmeasured_seats == []
+        assert res.ledger_divergences == []
+
+    def test_ledger_without_record_marks_seat_unmeasured_not_present(self, tmp_path):
+        """Branch 3a: the ledger EXISTS and is readable but has NO record of this
+        dispatch-id (e.g. receipt-processing lag) → the seat is UNMEASURED: not
+        counted as present (fail-closed), not counted as failed (no evidence of
+        failure), and visibly its own category."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+        _append_receipt(ledger, {"dispatch_id": "someone-else", "status": "success"})
+
+        def dispatcher(provider, model, prompt, did):
+            return _fake_report(did, provider, 0, "real-looking analysis")  # writes NO receipt
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert res.ledger_available is True
+        assert res.present_lenses == [], "an unconfirmed seat must not fail open to present"
+        assert res.failed_seats == [], "no evidence of failure either — this is its own branch"
+        assert len(res.unmeasured_seats) == 3
+        assert {s["provider"] for s in res.unmeasured_seats} == {"codex", "kimi", "claude"}
+        assert all(s["dispatch_id"] for s in res.unmeasured_seats)
+        assert "unmeasured" in res.coverage
+        report = res.to_report()
+        assert "UNMEASURED" in report
+        assert "unmeasured" in report.lower()
+
+    def test_indecisive_receipts_are_unmeasured(self, tmp_path):
+        """Branch 3b: the ledger knows the dispatch-id but every receipt is indecisive
+        (status=unknown, no reject/accept decision) → UNMEASURED, not present."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+
+        def dispatcher(provider, model, prompt, did):
+            if "-diverge-" in did:
+                _append_receipt(ledger, {
+                    "dispatch_id": did, "status": "unknown",
+                    "verdict": {"decision": "investigate"},
+                })
+            else:
+                _append_receipt(ledger, {"dispatch_id": did, "status": "success"})
+            return _fake_report(did, provider, 0, "real-looking analysis")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert res.present_lenses == []
+        assert len(res.unmeasured_seats) == 3
+
+    def test_absent_ledger_falls_back_to_legacy_measurement_visibly(self, tmp_path):
+        """Point 4: no ledger at all (fresh checkout) must not crash the panel. The
+        tally falls back to the pre-OI-1519 frontmatter measurement — but LOUDLY:
+        the result and report flag the coverage as unverified, never silently."""
+        ledger = tmp_path / "no-such-dir" / "t0_receipts.ndjson"  # never created
+
+        def dispatcher(provider, model, prompt, did):
+            if provider == "kimi" and "-diverge-" in did:
+                return _fake_report(did, provider, 1, REFUSAL_BODY)
+            return _fake_report(did, provider, 0, "real analysis")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert res.ledger_available is False
+        # legacy measurement still works — the panel keeps functioning
+        assert len(res.present_lenses) == 2
+        assert len(res.failed_seats) == 1
+        assert res.failed_seats[0]["provider"] == "kimi"
+        # ... but the missing measurement instrument is visible, not silent
+        report = res.to_report()
+        assert "ledger" in report.lower()
+        assert "unverified" in report.lower()
+
+    def test_unreadable_ledger_path_is_legacy_mode_not_a_crash(self, tmp_path):
+        """Negative path: a receipts_path that is a DIRECTORY (not a file) counts as
+        'ledger unavailable' → legacy fallback, never an exception."""
+        def dispatcher(provider, model, prompt, did):
+            return _fake_report(did, provider, 0, "real analysis")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=tmp_path,  # a directory — unreadable as an ndjson file
+        )
+        assert res.ledger_available is False
+        assert len(res.present_lenses) == 3
+
+    def test_multiple_receipts_success_and_unknown_resolve_present(self, tmp_path):
+        """Point 6, as measured: ``panel-architecture-diverge-1-094e47`` carries BOTH
+        a success and an unknown receipt. No failure record → PRESENT."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+
+        def dispatcher(provider, model, prompt, did):
+            _append_receipt(ledger, {
+                "dispatch_id": did, "status": "success",
+                "verdict": {"decision": "investigate"},
+            })
+            _append_receipt(ledger, {
+                "dispatch_id": did, "status": "unknown",
+                "verdict": {"decision": "investigate"},
+            })
+            return _fake_report(did, provider, 0, "real analysis")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert len(res.present_lenses) == 3
+        assert res.unmeasured_seats == []
+
+    def test_multiple_receipts_failure_beats_success(self, tmp_path):
+        """Point 6, fail-closed direction: when one dispatch-id carries BOTH a success
+        and a failure record, the failure wins — a success record never launders a
+        recorded failure."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+
+        def dispatcher(provider, model, prompt, did):
+            _append_receipt(ledger, {"dispatch_id": did, "status": "success"})
+            if provider == "kimi" and "-diverge-" in did:
+                _append_receipt(ledger, {
+                    "dispatch_id": did, "status": "timeout",
+                    "verdict": {"decision": "reject"},
+                })
+            return _fake_report(did, provider, 0, "real analysis")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert len(res.present_lenses) == 2
+        assert [s["provider"] for s in res.failed_seats] == ["kimi"]
+
+    def test_verdict_reject_is_the_secondary_failure_signal(self, tmp_path):
+        """Point 5: ``status`` is primary, ``verdict.decision`` secondary — a receipt
+        with a NON-decisive status but ``decision=reject`` still fails the seat."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+
+        def dispatcher(provider, model, prompt, did):
+            if provider == "kimi" and "-diverge-" in did:
+                _append_receipt(ledger, {
+                    "dispatch_id": did, "status": "unknown",
+                    "verdict": {"decision": "reject"},
+                })
+            else:
+                _append_receipt(ledger, {"dispatch_id": did, "status": "success"})
+            return _fake_report(did, provider, 0, "real analysis")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert len(res.present_lenses) == 2
+        assert [s["provider"] for s in res.failed_seats] == ["kimi"]
+
+    def test_dispatch_ids_carried_on_fan_out_entries(self, tmp_path):
+        """Reconciliation needs the dispatch-id: every fan-out entry must carry the
+        id its seat was dispatched under (pre-fix it was built and thrown away)."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+        seen = []
+
+        def dispatcher(provider, model, prompt, did):
+            seen.append(did)
+            _append_receipt(ledger, {"dispatch_id": did, "status": "success"})
+            return _fake_report(did, provider, 0, "ok")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        fan_out_ids = {fo.get("dispatch_id") for fo in res.fan_out}
+        assert None not in fan_out_ids
+        diverge_ids = {d for d in seen if "-diverge-" in d}
+        assert fan_out_ids == diverge_ids
+
+    def test_first_ok_reconciles_sequential_stages_against_the_ledger(self, tmp_path):
+        """The second place: _first_ok serves the contrarian/verify/synthesis stages
+        on the SAME _is_error that trusted the seat's own frontmatter. A stage seat
+        whose frontmatter lies (exit_code 0) but whose ledger record says
+        timeout/reject must be SKIPPED, and the divergence recorded."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+
+        def dispatcher(provider, model, prompt, did):
+            if "-contrarian-" in did and provider == "codex":
+                _append_receipt(ledger, {
+                    "dispatch_id": did, "status": "timeout",
+                    "verdict": {"decision": "reject"},
+                })
+                return _fake_report(did, provider, 0, "FAKE-CONTRARIAN wrapper echo")
+            _append_receipt(ledger, {"dispatch_id": did, "status": "success"})
+            return _fake_report(did, provider, 0, f"real-{provider}-output")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        # contrarian prefers codex first; codex's ledger record says failed, so the
+        # stage output must come from the NEXT seat, not codex's lying frontmatter
+        assert "FAKE-CONTRARIAN" not in res.contrarian
+        assert "real-" in res.contrarian
+        stage_divergences = [d for d in res.ledger_divergences if d["stage"] == "contrarian"]
+        assert len(stage_divergences) == 1
+        assert stage_divergences[0]["provider"] == "codex"
+
+    def test_unmeasured_stage_seat_falls_back_without_cascading(self, tmp_path):
+        """_first_ok with a ledger that knows nothing (lag window): an unmeasured
+        seat's real content is kept as the stage result rather than burning the
+        whole roster and collapsing to '[empty]' — but the seats are recorded as
+        unmeasured so the gap is visible."""
+        ledger = tmp_path / "t0_receipts.ndjson"
+        _append_receipt(ledger, {"dispatch_id": "someone-else", "status": "success"})
+
+        def dispatcher(provider, model, prompt, did):
+            return _fake_report(did, provider, 0, f"real-{provider}-output")
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=dispatcher, roster=ROSTER, max_workers=3,
+            receipts_path=ledger,
+        )
+        assert "real-" in res.contrarian
+        assert "real-" in res.synthesis
+        stage_unmeasured = [m for m in res.seat_measurements
+                            if m["stage"] != "diverge" and m["outcome"] == "unmeasured"]
+        assert stage_unmeasured, "unmeasured stage seats must be recorded, not silently accepted"


### PR DESCRIPTION
## What

The deliberation panel counted a **timed-out seat as a present lens** because it trusted the `exit_code` the seat writes about *itself* in its own report frontmatter. Measured on dispatch `panel-sweep-diverge-0-a6421f` (2026-08-30):

- Ledger (`t0_receipts.ndjson`): `status=timeout`, `verdict.decision=reject`, `failure_reason="deadline exceeded [600.1s]"`
- That exact report's frontmatter: `exit_code: 0`
- Replayed through the real code: `_seat_exit_code = 0` → `_is_error = False` → counted **PRESENT** (panel reported 4/5 lenses; really 3 + a timeout)

## Changes (`scripts/lib/deliberation_panel.py`)

- **Dispatch-id carried through**: `_one` built `panel-{mode}-diverge-{idx}-{uuid}` and threw it away; it now rides on the fan-out entry, making ledger reconciliation possible at all.
- **Ledger reconciliation** (`_measure_seat` + `_ReceiptLedger`): every seat — fan-out *and* the `_first_ok` sequential stages (contrarian/verify/synthesis, which deliver the final verdict) — is reconciled against `t0_receipts.ndjson` via `receipt_provenance.find_receipts_by_dispatch`.
- **Three branches, never two**: ledger-says-failed → FAILED; ledger-says-success → PRESENT; no decisive ledger record (unknown dispatch-id or indecisive receipts) → **UNMEASURED**, its own branch — never silently fail-open to present, never counted as failed without evidence.
- **Canonical vocabulary**: reuses ADR-035's measured sets from `receipt_verdict` (`HARD_FAILURE_STATUSES` / `SUCCESS_STATUSES`); `status` primary, `verdict.decision` secondary. Multiple receipts per dispatch-id reconcile failure-beats-success (measured: `panel-architecture-diverge-1-094e47` carries both `success` and `unknown` → present).
- **Divergences are reported**: `result.ledger_divergences` + a `## Ledger reconciliation — divergences` report section — the divergence itself is the finding, never a silent correction. `to_report`'s `[SEAT FAILED]` tag now reads the reconciled outcome so the report agrees with the count.
- **Fresh checkout safe**: no readable ledger → legacy frontmatter fallback, flagged `ledger_available=False` and rendered as UNVERIFIED in the report — the panel keeps working, but not silently.

## Verification

- Red before fix: `tests/test_deliberation_panel.py::TestLedgerReconciliation::test_ledger_timeout_beats_frontmatter_exit_code_zero` → `AssertionError: assert 3 == 2` (timed-out seat counted present).
- Green after: `tests/test_deliberation_panel.py` **59 passed** (47 existing + 12 new); neighbours `test_panel_cli.py`, `test_plan_gate_panel_effectiveness.py`, `test_deliberation_panelist_role.py`, `test_phantom_guard.py`, `test_receipt_provenance.py`, `test_dispatch_govern.py` — **297 passed** total.
- `tests/test_plan_gate_panel.py` has 5 failures, identical on clean `main` (file is on `scripts/ci/test_exclusions.txt`, OI-946) — pre-existing, untouched by this change.

Dispatch-ID: 20260830-090100-oi1519-panel-ledger-reconcile
