### PR TITLE
feat(sidedoor-audit): three states and a recorded operator override

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -218,6 +218,13 @@ jobs:
       - name: Side-door exhaustiveness audit
         env:
           VNX_HOME: ${{ github.workspace }}/.claude/vnx-system
+          # plan_gate_panel.py is a KNOWN OPEN side door (bucket b), closed by the plan-gate
+          # door PR (part 2 of the sidedoor-drie-toestanden dispatch). Until then CI must
+          # carry the override + a reason that names the close condition — the override is
+          # recorded to the ledger, so it is counted, not a silent bypass.
+          VNX_OVERRIDE_SIDEDOOR: "1"
+          VNX_OVERRIDE_SIDEDOOR_REASON: "known open side door plan_gate_panel.py; closed by part 2 (plan_gate_panel.py door de deur) of sidedoor-drie-toestanden"
+          VNX_SIDEDOOR_LEDGER: ${{ github.workspace }}/.vnx-data/state/sidedoor_overrides.ndjson
         run: |
           set -euo pipefail
           # Audit #2: the dispatch-lane exhaustiveness invariant — fail CI if a new direct delivery

--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -15,6 +15,8 @@
 >
 > End-to-end architecture (door → assembly → delivery → govern → intelligence): see
 > **`DISPATCH_AND_INTELLIGENCE_ARCHITECTURE.md`**.
+>
+> Side-door exhaustiveness (three states + the operator override): **§14**.
 
 ## 1. Decision tree (first matching rule wins)
 
@@ -183,3 +185,38 @@ python3 scripts/receipt_query.py pull --state-dir <state-dir> --json
 - **OI-188 note:** this step belongs in the `t0-orchestrator` skill's cycle steps (`.claude/skills/t0-orchestrator/SKILL.md` §"2. Primary workflow"), mirroring the parked commit `24f71d22`'s intent. No lane can reliably write under `.claude/skills/` (Claude treats it read-only) — this section is the canonical, git-tracked source until an operator applies the equivalent edit to the skill file by hand. Track as an operator follow-up, not something to force through a lane edit.
 
 See also: `docs/operations/RECEIPT_PIPELINE.md` (pipeline mechanics), ADR-035 §5 (pull interface design), §5.3 (push retirement), §6.4 (`oi_pending` lifecycle + escalation).
+
+## 14. Side-door audit — three states and the operator override
+
+`scripts/lib/dispatch_sidedoor_audit.py` (CI step "Side-door exhaustiveness audit") proves the single-entry
+door has no un-audited delivery path. Every scanned delivery caller lands in exactly ONE state:
+
+| state | meaning | gate outcome |
+|---|---|---|
+| (a) door-handled | routes through the door (or is the door's own delivery machinery) | no finding |
+| (b) known-open side door | a known side door with an OWNER and a CLOSE condition | FAILS unless the override below is set |
+| (c) unaudited | a NEW side door on neither list | FAILS, override does not apply |
+
+State (b) is the fix: "known" used to be one list with two meanings, so a known open side door was
+exempted by being known. A bucket-(b) entry is a finding with a machine-readable rule (owner / close
+condition / follow-up). The canonical list is generated from the watcher itself, not hand-maintained:
+`KNOWN_OPEN_SIDE_DOORS` (in `scripts/lib/dispatch_sidedoor_audit.py`) is the SSOT, and the watcher's
+failure output prints `owner=` / `closes_when=` / `followup=` per open door.
+
+**Operator override (house style, mirrors `VNX_OVERRIDE_WORKER_CLAUDE`):** to temporarily let a KNOWN
+open side door pass, set BOTH `VNX_OVERRIDE_SIDEDOOR=1` and a non-empty `VNX_OVERRIDE_SIDEDOOR_REASON`.
+The flag is INERT without the reason (blocking refusal). The override downgrades ONLY bucket (b).
+
+**Recording (an override without a trace is a side door with a form):** every applied override appends
+one NDJSON record to `sidedoor_overrides.ndjson` (timestamp + reason + the bucket-(b) rule(s) concerned).
+Ledger location, first match wins: `VNX_SIDEDOOR_LEDGER` → `$VNX_STATE_DIR` → `$VNX_DATA_DIR/state` →
+`<repo_root>/.vnx-data/state`. Read back the bypass count and reasons:
+
+```bash
+grep -c '"reason"' <ledger-path>            # how many times we went around
+grep -o '"reason": "[^"]*"' <ledger-path>   # each reason, oldest first
+```
+
+CI carries the override + a reason for the current open door (`plan_gate_panel.py`, closed by the
+plan-gate door PR — part 2 of this dispatch). That is not a silent escape hatch: the side door is now
+known, owned, has a close condition, is counted, and carries a reason — before it was merely "known".

--- a/scripts/lib/dispatch_sidedoor_audit.py
+++ b/scripts/lib/dispatch_sidedoor_audit.py
@@ -18,14 +18,23 @@ Classifier notes (why it is reproducible, not hand-waved):
   * benchmarks + provider-spawn machinery are excluded — test harnesses / provider_dispatch's
     own internals, not production delivery side-doors.
 
+Audited delivery callers are partitioned into THREE states — (a) door-handled (no finding),
+(b) known-open side door (a finding, fails unless the operator override is set), (c) unaudited
+(fails like before). See the constants below and docs/core/DISPATCH_RULES.md.
+
 Run standalone:  python3 scripts/lib/dispatch_sidedoor_audit.py   (exit 1 if a new caller appears)
 """
 from __future__ import annotations
 
+import fcntl
+import json
+import os
 import re
 import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Set
+from typing import Mapping, Set
 
 _LANES = ("subprocess_dispatch", "provider_dispatch", "tmux_interactive_dispatch")
 
@@ -150,18 +159,46 @@ _RAW_SCAN_EXCLUDE_SUBSTR = (
     "/process_cleanup.py",          # process-hygiene scanner: holds claude -p/--print as DETECTION patterns to hunt forbidden spawns, never spawns (#1029)
 )
 
-# Audited delivery callers (PR-2). A scanned file outside this set is a NEW side door and
-# fails the gate until it is audited (added here) and wired through dispatch_bridge.
-KNOWN_DELIVERY_CALLERS = frozenset({
+# Audited delivery callers, partitioned into THREE states (not two). A single "known" list
+# carried two opposite meanings — routed THROUGH the door vs a KNOWN OPEN side door — so a
+# known open side door could never fail the gate: being known was what exempted it.
+#   (a) DOOR_HANDLED_CALLERS  — through the door (or the door's own machinery), no finding
+#   (b) KNOWN_OPEN_SIDE_DOORS — a known side door with OWNER + CLOSE condition; a finding
+#                               that fails unless the operator override (below) is set
+#   (c) everything else found  — UNAUDITED, a new side door, fails like before
+@dataclass(frozen=True)
+class SideDoorRule:
+    """Bucket-(b) rule the watcher and the override ledger read, not just a comment."""
+    owner: str
+    closes_when: str
+    followup: str
+
+
+DOOR_HANDLED_CALLERS = frozenset({
     "scripts/lib/dispatch_deliver.sh",
     "scripts/lib/pool_worker_runner.py",
     "scripts/lib/headless_dispatch_daemon.py",
     "scripts/lib/adapters/claude_adapter.py",
     "scripts/commands/dispatch-agent.sh",     # caught by the scan (not in the docstring's "4")
     "scripts/commands/dispatch.sh",           # caught by the scan (not in the docstring's "4")
-    "scripts/lib/plan_gate_panel.py",         # interim side door PR-7 removes
     "vnx_cli/commands/dispatch_agent.py",     # packaged CLI; now routes through deliver_via_door (flip-PR F3)
 })
+
+KNOWN_OPEN_SIDE_DOORS: dict[str, SideDoorRule] = {
+    "scripts/lib/plan_gate_panel.py": SideDoorRule(
+        owner="T0 (plan-gate door dispatch — part 2 of sidedoor-drie-toestanden)",
+        closes_when="plan_gate_panel.py routes delivery through deliver_via_door",
+        followup="part 2 PR: plan_gate_panel.py door de deur",
+    ),
+}
+
+# Operator override (house style, mirrors VNX_OVERRIDE_WORKER_CLAUDE): a per-run escape hatch
+# that lets a KNOWN OPEN side door (bucket b) pass. BOTH must hold or the refusal stands:
+#   VNX_OVERRIDE_SIDEDOOR=1 AND VNX_OVERRIDE_SIDEDOOR_REASON non-empty (inert + blocking without it).
+# A flag without a reason never passes. Bucket (c) fails regardless of the override.
+SIDEDOOR_OVERRIDE_ENV = "VNX_OVERRIDE_SIDEDOOR"
+SIDEDOOR_OVERRIDE_REASON_ENV = "VNX_OVERRIDE_SIDEDOOR_REASON"
+SIDEDOOR_LEDGER_ENV = "VNX_SIDEDOOR_LEDGER"
 
 
 def _repo_root() -> Path:
@@ -276,37 +313,152 @@ def scan_raw_claude_spawns(root: Path | None = None) -> Set[str]:
 def audit(root: Path | None = None) -> dict:
     """Return delivery-caller and raw-claude spawn scan results.
 
-    `unaudited` or `raw_claude_unaudited` non-empty = a new side door = gate fails.
+    `unaudited` (bucket c) or `raw_claude_unaudited` non-empty = a NEW side door = gate
+    fails. `known_open_side_doors` (bucket b) non-empty = a KNOWN open side door = a
+    finding that also fails unless the operator override is set.
     """
     found = scan_delivery_callers(root)
     raw = scan_raw_claude_spawns(root)
+    open_keys = set(KNOWN_OPEN_SIDE_DOORS)
+    known = set(DOOR_HANDLED_CALLERS) | open_keys
     return {
-        "known": set(KNOWN_DELIVERY_CALLERS),
+        "known": known,
         "found": found,
-        "unaudited": found - KNOWN_DELIVERY_CALLERS,
+        "unaudited": found - known,                          # bucket (c): new side doors
+        "known_open_side_doors": found & open_keys,          # bucket (b): known, open, a finding
+        "door_handled": found & set(DOOR_HANDLED_CALLERS),   # bucket (a): through the door
         "raw_claude_known": set(KNOWN_RAW_CLAUDE_CALLERS),
         "raw_claude_found": raw,
         "raw_claude_unaudited": raw - KNOWN_RAW_CLAUDE_CALLERS,
     }
 
 
+def _ledger_path() -> Path:
+    """Append-only override ledger (NDJSON, one JSON object per line).
+
+    Precedence: VNX_SIDEDOOR_LEDGER (explicit) -> $VNX_STATE_DIR -> $VNX_DATA_DIR/state ->
+    <repo_root>/.vnx-data/state. Every applied override appends the reason + the bucket-(b)
+    rule(s) it concerned, so "how many times did we go around, and why" is countable later.
+    """
+    env = os.environ.get(SIDEDOOR_LEDGER_ENV)
+    if env:
+        return Path(env).expanduser()
+    state = os.environ.get("VNX_STATE_DIR")
+    if state:
+        return Path(state) / "sidedoor_overrides.ndjson"
+    data = os.environ.get("VNX_DATA_DIR")
+    if data:
+        return Path(data) / "state" / "sidedoor_overrides.ndjson"
+    return _repo_root() / ".vnx-data" / "state" / "sidedoor_overrides.ndjson"
+
+
+def _record_override(ledger: Path, reason: str, rules: Mapping[str, SideDoorRule]) -> None:
+    """Append one ledger entry. Flocked so concurrent jobs append whole lines; a write
+    failure propagates (an override without a trace must not silently pass)."""
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "reason": reason,
+        "side_doors": [
+            {
+                "path": path,
+                "owner": rule.owner,
+                "closes_when": rule.closes_when,
+                "followup": rule.followup,
+            }
+            for path, rule in sorted(rules.items())
+        ],
+    }
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with open(ledger, "a", encoding="utf-8") as fh:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+            fh.flush()
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _read_override(environ: Mapping[str, str] | None = None) -> tuple[str, str]:
+    """Return (flag, reason) — the raw override env values, whitespace-trimmed."""
+    env = environ if environ is not None else os.environ
+    return (
+        (env.get(SIDEDOOR_OVERRIDE_ENV) or "").strip(),
+        (env.get(SIDEDOOR_OVERRIDE_REASON_ENV) or "").strip(),
+    )
+
+
+def _decide_delivery(result: dict, flag: str, reason: str, ledger: Path | None = None) -> bool:
+    """True when the delivery gate FAILS. Bucket (c) always fails; bucket (b) fails unless the
+    override is active (flag=1 AND reason) — active records a ledger entry and passes; a flag
+    without a reason is inert and the refusal stays blocking."""
+    if result["unaudited"]:
+        print(
+            f"\nFAIL: {len(result['unaudited'])} unaudited delivery caller(s); audit + wire "
+            "through dispatch_bridge before flipping VNX_SINGLE_ENTRY_DISPATCH.",
+            file=sys.stderr,
+        )
+        return True
+    open_doors = sorted(result["known_open_side_doors"])
+    if not open_doors:
+        return False
+    if flag == "1" and reason:
+        path = ledger if ledger is not None else _ledger_path()
+        try:
+            _record_override(path, reason, {p: KNOWN_OPEN_SIDE_DOORS[p] for p in open_doors})
+        except OSError as exc:
+            print(
+                f"\nFAIL: override requested but the ledger write failed ({exc}); refusing — "
+                "an override without a trace is a side door with a form.",
+                file=sys.stderr,
+            )
+            return True
+        print(
+            f"\noverride applied: {len(open_doors)} known open side door(s) allowed; "
+            f"recorded to {path}"
+        )
+        return False
+    if flag == "1":
+        print(
+            f"\nFAIL: {SIDEDOOR_OVERRIDE_ENV}=1 is set but {SIDEDOOR_OVERRIDE_REASON_ENV} is "
+            "empty — the flag is inert and the refusal stays blocking.",
+            file=sys.stderr,
+        )
+        return True
+    print(
+        f"\nFAIL: {len(open_doors)} known open side door(s) found. Set "
+        f"{SIDEDOOR_OVERRIDE_ENV}=1 and a non-empty {SIDEDOOR_OVERRIDE_REASON_ENV} to "
+        "temporarily allow (recorded to the ledger), or close the side door:",
+        file=sys.stderr,
+    )
+    for path in open_doors:
+        rule = KNOWN_OPEN_SIDE_DOORS[path]
+        print(
+            f"  {path}: owner={rule.owner}; closes_when={rule.closes_when}; followup={rule.followup}",
+            file=sys.stderr,
+        )
+    return True
+
+
 def main() -> int:
     result = audit()
     print(f"delivery callers found: {len(result['found'])}")
     for c in sorted(result["found"]):
-        flag = "  [UNAUDITED — new side door]" if c in result["unaudited"] else ""
-        print(f"  {c}{flag}")
+        if c in result["unaudited"]:
+            tag = "  [UNAUDITED — new side door]"
+        elif c in result["known_open_side_doors"]:
+            tag = "  [KNOWN OPEN — owner + close condition below]"
+        else:
+            tag = ""
+        print(f"  {c}{tag}")
 
     print(f"\nraw claude -p/--print spawns found: {len(result['raw_claude_found'])}")
     for c in sorted(result["raw_claude_found"]):
-        flag = "  [UNAUDITED — new receipt-bypass side door]" if c in result["raw_claude_unaudited"] else ""
-        print(f"  {c}{flag}")
+        tag = "  [UNAUDITED — new receipt-bypass side door]" if c in result["raw_claude_unaudited"] else ""
+        print(f"  {c}{tag}")
 
-    fail = False
-    if result["unaudited"]:
-        print(f"\nFAIL: {len(result['unaudited'])} unaudited delivery caller(s); audit + wire "
-              "through dispatch_bridge before flipping VNX_SINGLE_ENTRY_DISPATCH.", file=sys.stderr)
-        fail = True
+    flag, reason = _read_override()
+    fail = _decide_delivery(result, flag, reason)
+
     if result["raw_claude_unaudited"]:
         print(f"\nFAIL: {len(result['raw_claude_unaudited'])} unaudited raw claude -p/--print spawn(s); "
               "route via a governed lane (provider_dispatch) or audit here.", file=sys.stderr)

--- a/tests/test_dispatch_sidedoor_audit.py
+++ b/tests/test_dispatch_sidedoor_audit.py
@@ -7,6 +7,7 @@ not assert it" finding into an executable check.
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -312,3 +313,101 @@ def test_shell_string_spawn_is_not_treated_as_help_string(tmp_path):
     assert "scripts/runner.py" in found, (
         "shell-string spawn false-negatived as if it were a help= documentation string"
     )
+
+
+# --- Three-state partition + operator override (sidedoor-drie-toestanden) ---
+
+
+def _delivery_result(unaudited=(), open_doors=()):
+    return {
+        "unaudited": set(unaudited),
+        "known_open_side_doors": set(open_doors),
+    }
+
+
+def test_dispatch_agent_cli_is_door_handled_not_open():
+    # bucket (a): the packaged CLI routes through deliver_via_door — handled, no finding.
+    assert "vnx_cli/commands/dispatch_agent.py" in audit_mod.DOOR_HANDLED_CALLERS
+    assert "vnx_cli/commands/dispatch_agent.py" not in audit_mod.KNOWN_OPEN_SIDE_DOORS
+
+
+def test_plan_gate_panel_is_a_known_open_side_door():
+    # bucket (b): plan_gate_panel.py is a KNOWN OPEN side door, and its rule carries
+    # structured fields (owner / close condition / follow-up), not just a comment.
+    assert "scripts/lib/plan_gate_panel.py" in audit_mod.KNOWN_OPEN_SIDE_DOORS
+    rule = audit_mod.KNOWN_OPEN_SIDE_DOORS["scripts/lib/plan_gate_panel.py"]
+    assert rule.owner
+    assert rule.closes_when
+    assert rule.followup
+
+
+def test_partition_is_exhaustive_and_disjoint():
+    # every audited delivery caller sits in exactly one of the two "known" buckets, and the
+    # two buckets never overlap — "known" must not be one list with two meanings.
+    a = set(audit_mod.DOOR_HANDLED_CALLERS)
+    b = set(audit_mod.KNOWN_OPEN_SIDE_DOORS)
+    assert a & b == set(), "a caller cannot be both door-handled and a known open side door"
+    historical = {
+        "scripts/lib/dispatch_deliver.sh",
+        "scripts/lib/pool_worker_runner.py",
+        "scripts/lib/headless_dispatch_daemon.py",
+        "scripts/lib/adapters/claude_adapter.py",
+        "scripts/commands/dispatch-agent.sh",
+        "scripts/commands/dispatch.sh",
+        "scripts/lib/plan_gate_panel.py",
+        "vnx_cli/commands/dispatch_agent.py",
+    }
+    assert a | b == historical, "every audited caller must sit in exactly one bucket"
+    assert audit_mod.audit()["known"] == a | b, "audit()['known'] must equal the bucket union"
+
+
+def test_plan_gate_panel_surfaces_as_known_open_side_door_in_audit():
+    # the red run: on the current tree the watcher must see the open side door, not swallow it.
+    result = audit_mod.audit()
+    assert "scripts/lib/plan_gate_panel.py" in result["known_open_side_doors"]
+    assert "scripts/lib/plan_gate_panel.py" not in result["unaudited"]
+
+
+def test_known_open_side_door_fails_without_override():
+    # no override -> the known open side door is a finding and the gate FAILS.
+    result = _delivery_result(open_doors=["scripts/lib/plan_gate_panel.py"])
+    assert audit_mod._decide_delivery(result, flag="", reason="") is True
+
+
+def test_override_with_reason_allows_and_records(tmp_path):
+    # override + reason -> the known open side door is allowed AND recorded to the ledger.
+    ledger = tmp_path / "overrides.ndjson"
+    result = _delivery_result(open_doors=["scripts/lib/plan_gate_panel.py"])
+    failed = audit_mod._decide_delivery(
+        result, flag="1", reason="known open side door; closed by part 2", ledger=ledger
+    )
+    assert failed is False
+    lines = ledger.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["reason"] == "known open side door; closed by part 2"
+    assert [d["path"] for d in entry["side_doors"]] == ["scripts/lib/plan_gate_panel.py"]
+    assert entry["side_doors"][0]["owner"]
+    assert entry["side_doors"][0]["closes_when"]
+    assert entry["side_doors"][0]["followup"]
+
+
+def test_override_without_reason_refuses():
+    # flag set but reason empty -> the flag is INERT and the refusal stays blocking.
+    result = _delivery_result(open_doors=["scripts/lib/plan_gate_panel.py"])
+    assert audit_mod._decide_delivery(result, flag="1", reason="") is True
+
+
+def test_override_does_not_allow_unaudited(tmp_path):
+    # the override downgrades ONLY known open side doors; a NEW (unaudited) caller still fails.
+    ledger = tmp_path / "overrides.ndjson"
+    result = _delivery_result(unaudited=["scripts/lib/new_side_door.py"])
+    assert audit_mod._decide_delivery(result, flag="1", reason="any reason", ledger=ledger) is True
+    assert not ledger.exists(), "no override may be recorded when the gate fails on an unaudited caller"
+
+
+def test_read_override_trims_whitespace():
+    flag, reason = audit_mod._read_override(
+        {audit_mod.SIDEDOOR_OVERRIDE_ENV: " 1 ", audit_mod.SIDEDOOR_OVERRIDE_REASON_ENV: " r "}
+    )
+    assert (flag, reason) == ("1", "r")


### PR DESCRIPTION
## Wat

De zijdeur-wachter (`scripts/lib/dispatch_sidedoor_audit.py`) had één "known"-lijst met twee tegengestelde betekenissen. Een bekende open zijdeur stond in dezelfde lijst als de deur-gehandelde callers, waardoor de wachter op een bekende open zijdeur nooit kon falen: "bekend" was precies wat hem vrijstelde.

## De drie toestanden

| Toestand | Betekenis | Uitkomst |
|---|---|---|
| (a) deur-gehandeld | routeert via de enige deur | geen finding |
| (b) bekende open zijdeur | `plan_gate_panel.py`, met OWNER + close-voorwaarde + follow-up | finding, **FAALT** tenzij override |
| (c) onge-auditeerd | onbekende caller | faalt zoals voorheen |

Toestand (b) faalt alleen niet als `VNX_OVERRIDE_SIDEDOOR=1` én `VNX_OVERRIDE_SIDEDOOR_REASON` niet-leeg is. Een vlag zonder reden is inert en de weigering blijft blokkerend.

## De vastlegging

Elke toegepaste override wordt geregistreerd in een append-only NDJSON-grootboek (`fcntl.flock`, exclusive lock). Per regel: timestamp, reden, en het betrokken bucket-(b)-pad met owner + close-voorwaarde + follow-up. Pad-resolutie: `VNX_SIDEDOOR_LEDGER` → `$VNX_STATE_DIR` → `$VNX_DATA_DIR/state` → `.vnx-data/state`. Een schrijffout op het grootboek weigert de override (fail-closed).

CI draagt de override voor `plan_gate_panel.py` (gesloten door deel 2).

## De drie runs, letterlijk

- **Rood (zonder override):** `python3 scripts/lib/dispatch_sidedoor_audit.py` → exit **1**
- **Groen (override + reden):** `VNX_OVERRIDE_SIDEDOOR=1 VNX_OVERRIDE_SIDEDOOR_REASON="..." python3 scripts/lib/dispatch_sidedoor_audit.py` → exit **0**, grootboek +1 regel
- **Geweigerd (override zonder reden):** `VNX_OVERRIDE_SIDEDOOR=1 python3 scripts/lib/dispatch_sidedoor_audit.py` → exit **1**

## Verificatie

`pytest tests/test_dispatch_sidedoor_audit.py tests/test_runtime_adapter_certification.py tests/test_gate_pr_branch_resolution.py -q` → **69 passed**.

Dispatch-ID: 20260830-120000-sidedoor-drie-toestanden-en-override

🤖 Generated with [Claude Code](https://claude.com/claude-code)