### PR TITLE
fix(gate): retire a dead dispatch only when dead, and bound the unbounded wait (OI-1532)

### DIFF
--- a/docs/operations/PRODUCER_FRESHNESS_MONITOR.md
+++ b/docs/operations/PRODUCER_FRESHNESS_MONITOR.md
@@ -90,6 +90,46 @@ De derde producentgroep in de registry, `review_gate_obligations`
    cadans → stale-finding voor díé gate — een levende zuster-gate maskeert een
    dode niet meer (de les uit OI-881).
 
+## 1c. De verplichtingslevenscyclus — drie toestanden, twee grenzen (OI-1532)
+
+Een `awaiting`-obligatie (repo resolveert, `gh` werkt, geen PR) kent twee
+beslissingen die een CONTRACT zijn, niet een implementatiedetail:
+
+**Tak A — `branch_exists is False` is drieledig.** Dat ene signaal vouwt
+"branch bestond en is verwijderd" samen met "branch is nog nooit aangemaakt
+omdat de dispatch NOG DRAAIT". De discriminator die ze scheidt is de
+occupancy-lock van de dispatch
+(`<state_dir>/dispatch_worktree_claims/<safe_id>.occupancy`): een `fcntl.flock`
+op een open file description die de KERNEL vrijgeeft zodra de houder eindigt.
+Drie antwoorden, nooit een stille keuze voor een van de twee:
+
+| `dispatch_live` | Betekenis | Beslissing |
+|---|---|---|
+| `False` | dispatch dood, lock vrijgegeven | `retired` (`no_pr_branch_gone`) |
+| `True`  | dispatch draait nog, niet gepusht | `pending` (`no_pr_branch_gone_live`) — nooit retired |
+| `None`  | liveness niet vast te stellen | `pending` (`no_pr_branch_gone_unmeasured`) — niet retired, zichtbaar |
+
+De `None`-tak is een DERDE antwoord, geen stille default: een levende dispatch
+mag nooit op ambigu bewijs worden afgeboekt (OI-1388), en een onmeetbare wordt
+zichtbaar gemarkeerd zodat hij niet als normale wacht wordt weggelezen.
+
+**Tak B — `stay_pending` is begrensd.** Een echte wacht (branch bestaat of
+onduidelijk) probeert niet eeuwig opnieuw. Na
+`_STAY_PENDING_ESCALATION_ATTEMPTS` pogingen (== `_UNRESOLVABLE_ESCALATION_ATTEMPTS`,
+96 × 900s ≈ 24u — dezelfde constante als de twee andere begrensde takken,
+nooit een tweede grens ernaast) escaleert de wacht luid naar `not_executable`
+(`stay_pending_timeout`).
+
+**Waarom de monitor dit niet alleen oppakt.** De docstring bij de runner
+verwijst naar de producer-freshness-monitor als vangnet voor eeuwig wachtende
+verplichtingen. Dat vangnet werkt alleen op stores waar de monitor draait.
+Gemeten 30-08: op `mission-control` draait de monitor niet (geen heartbeat,
+geen NDJSON — de launchd-plist resolveert naar `vnx-dev`); op `vnx-dev` draait
+hij wel (10 findings, status stale). De 11 obligaties op 776 pogingen op
+mission-control hebben daarom acht dagen niets gealarmeerd. De grens in de
+runner is niet overbodig: hij is het vangnet dat werkt ongeacht of de monitor
+draait, en hij sluit de wachtlus die de monitor veronderstelt te vangen.
+
 ## 2. Exit-status-capture
 
 Twee capture-paden naar `<state_dir>/job_exits.ndjson`:

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -1340,7 +1340,11 @@ def _pre_execution_decision(
                 # (live on 20260830-124500-sidedoor). Stays pending, distinctly
                 # labelled so the recorded reason says "live, not pushed" and
                 # not a generic "no PR yet".
-                return {"kind": "stay_pending_live", "mismatch_detail": lookup.get("detail")}
+                return {
+                    "kind": "stay_pending_live",
+                    "mismatch_detail": lookup.get("detail"),
+                    "rejected_evidence": lookup["kind"],
+                }
             if resolution.dispatch_live is None:
                 # Liveness could not be measured — a THIRD state. Do not retire
                 # (a live dispatch must never be closed on ambiguous evidence),
@@ -1350,13 +1354,18 @@ def _pre_execution_decision(
                     "kind": "stay_pending_unmeasured",
                     "liveness": "unmeasured",
                     "mismatch_detail": lookup.get("detail"),
+                    "rejected_evidence": lookup["kind"],
                 }
             # dispatch_live is False: the dispatch ended and its branch is gone
             # — nothing will ever gate this obligation. The existing, correct
             # retirement, unchanged — except it now documents WHY any rejected
             # evidence did not count (mismatch/unverifiable detail), never
             # silently proceeding as if nothing existed at all (OI-1571 tak 3).
-            return {"kind": "retire", "mismatch_detail": lookup.get("detail")}
+            return {
+                "kind": "retire",
+                "mismatch_detail": lookup.get("detail"),
+                "rejected_evidence": lookup["kind"],
+            }
         # branch_exists is True (branch still there) or None (gh could not
         # tell) — a genuine wait. OI-1532: this branch was unbounded; it now
         # escalates loudly past the same threshold the other branches use, so
@@ -1462,6 +1471,34 @@ def _dry_run_outcome(
         if decision.get("mismatch_detail"):
             outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
     return outcome
+
+
+def _rejected_evidence_note(gate: str, decision: Dict[str, Any]) -> str:
+    """Render the audit note for evidence a decision REJECTED, or ``""``.
+
+    Two rejected shapes reach a retire/escalate/stay-pending record (OI-1571
+    tak 3 meets OI-1532): a proven ``mismatch`` (the verdict is about another
+    commit) and an ``unverifiable`` binding (whether it is current could not
+    even be determined). The note must name the shape accurately — claiming
+    "about a DIFFERENT commit" for a merely unverifiable record would assert
+    as proven what was actually unmeasurable. ``decision["mismatch_detail"]``
+    carries the underlying detail text either way (both shas for a mismatch,
+    the missing-sha explanation for the unverifiable case).
+    """
+    detail = decision.get("mismatch_detail")
+    if not detail:
+        return ""
+    if decision.get("rejected_evidence") == "unverifiable":
+        return (
+            f" A prior {gate} result exists for this dispatch but its sha "
+            f"binding to the PR head could not be verified ({detail}); it was "
+            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
+        )
+    return (
+        f" A prior {gate} result exists for this dispatch but is about a "
+        f"DIFFERENT commit ({detail}) and was "
+        "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
+    )
 
 
 def fulfill_obligation(
@@ -1618,12 +1655,7 @@ def fulfill_obligation(
         # misconfigured obligation can never masquerade as "not yet". It stays
         # retryable — the env may be fixed — until it crosses the escalation
         # threshold, where it becomes the loud terminal not_executable.
-        mismatch_note = (
-            f" A prior {gate} result exists for this dispatch but is about a "
-            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
-            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
-            if decision.get("mismatch_detail") else ""
-        )
+        mismatch_note = _rejected_evidence_note(gate, decision)
         update_obligation(
             path,
             status=STATUS_UNRESOLVABLE,
@@ -1658,12 +1690,7 @@ def fulfill_obligation(
         # gone from origin — nothing will ever gate this obligation.
         # Terminal, distinct from `fulfilled` (no gate ever reviewed it).
         branch_name = f"dispatch/{dispatch_id}"
-        mismatch_note = (
-            f" A prior {gate} result exists for this dispatch but is about a "
-            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
-            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
-            if decision.get("mismatch_detail") else ""
-        )
+        mismatch_note = _rejected_evidence_note(gate, decision)
         update_obligation(
             path,
             status=STATUS_RETIRED,
@@ -1691,12 +1718,7 @@ def fulfill_obligation(
         # pid 82207). Stays pending — NEVER retired — with a named reason so
         # the recorded state says "live, not pushed" and not a generic wait.
         branch_name = f"dispatch/{dispatch_id}"
-        mismatch_note = (
-            f" A prior {gate} result exists for this dispatch but is about a "
-            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
-            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
-            if decision.get("mismatch_detail") else ""
-        )
+        mismatch_note = _rejected_evidence_note(gate, decision)
         update_obligation(
             path,
             status=STATUS_PENDING,
@@ -1732,12 +1754,7 @@ def fulfill_obligation(
         # the freshness monitor and any reader can tell it apart from a normal
         # wait. Stays under the same bounded escalation as stay_pending below.
         branch_name = f"dispatch/{dispatch_id}"
-        mismatch_note = (
-            f" A prior {gate} result exists for this dispatch but is about a "
-            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
-            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
-            if decision.get("mismatch_detail") else ""
-        )
+        mismatch_note = _rejected_evidence_note(gate, decision)
         update_obligation(
             path,
             status=STATUS_PENDING,

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -1255,7 +1255,7 @@ def _pre_execution_decision(
         the two other bounded branches already do
       - ``retire``                     — dead dispatch (branch gone AND not
         live), no rescuing evidence
-      - ``retire_live``                — OI-1532: branch gone but the dispatch
+      - ``stay_pending_live``          — OI-1532: branch gone but the dispatch
         is still running — stays pending (NOT retired), carried distinctly so
         the caller records WHY it stayed pending, not just that it did
       - ``fulfill_by_evidence``        — OI-1388 defect 1: a complete-evidence
@@ -1295,8 +1295,8 @@ def _pre_execution_decision(
         never be closed on ambiguous evidence, per the OI-1388 docstring) and
         to record the liveness-unmeasured state VISIBLY so it is not mistaken
         for a normal wait — carried as ``decision["liveness"] = "unmeasured"``
-        and routed through ``retire_unmeasured`` (which itself stays pending,
-        never retires).
+        and routed through ``stay_pending_unmeasured`` (which itself stays
+        pending, never retires).
 
     The sha check and the liveness check answer DIFFERENT questions and are
     never folded into a single rejection: the sha check answers whether THIS
@@ -1340,14 +1340,14 @@ def _pre_execution_decision(
                 # (live on 20260830-124500-sidedoor). Stays pending, distinctly
                 # labelled so the recorded reason says "live, not pushed" and
                 # not a generic "no PR yet".
-                return {"kind": "retire_live", "mismatch_detail": lookup.get("detail")}
+                return {"kind": "stay_pending_live", "mismatch_detail": lookup.get("detail")}
             if resolution.dispatch_live is None:
                 # Liveness could not be measured — a THIRD state. Do not retire
                 # (a live dispatch must never be closed on ambiguous evidence),
                 # and carry the reason visibly so it is not mistaken for a
                 # normal wait. Stays pending under the same bound as below.
                 return {
-                    "kind": "retire_unmeasured",
+                    "kind": "stay_pending_unmeasured",
                     "liveness": "unmeasured",
                     "mismatch_detail": lookup.get("detail"),
                 }
@@ -1376,8 +1376,8 @@ _DRY_RUN_ACTION_LABELS: Dict[str, str] = {
     "fulfill_by_failed_evidence": "would_stamp_failed",
     "sha_unverifiable": "would_stay_pending_sha_unverifiable",
     "retire": "would_retire",
-    "retire_live": "would_stay_pending_live",
-    "retire_unmeasured": "would_stay_pending_unmeasured",
+    "stay_pending_live": "would_stay_pending_live",
+    "stay_pending_unmeasured": "would_stay_pending_unmeasured",
     "stay_pending": "would_stay_pending",
     "escalate_stay_pending": "would_escalate_stay_pending",
     "attempt_gate": "would_fulfill",
@@ -1436,14 +1436,14 @@ def _dry_run_outcome(
         outcome["detail"] = resolution.reason or "dispatch died without ever producing a PR; branch gone"
         if decision.get("mismatch_detail"):
             outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
-    elif decision["kind"] == "retire_live":
+    elif decision["kind"] == "stay_pending_live":
         outcome["detail"] = (
             "dispatch branch is gone on GitHub but the dispatch is still RUNNING "
             "(occupancy lock held) — not pushed yet, NOT retired (OI-1532)"
         )
         if decision.get("mismatch_detail"):
             outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
-    elif decision["kind"] == "retire_unmeasured":
+    elif decision["kind"] == "stay_pending_unmeasured":
         outcome["detail"] = (
             "dispatch branch is gone on GitHub but liveness could not be measured "
             "(no occupancy lock file or probe failed) — staying pending rather than "
@@ -1683,7 +1683,7 @@ def fulfill_obligation(
         outcome["detail"] = "dispatch died without ever producing a PR; branch gone — retired"
         return outcome
 
-    if decision["kind"] == "retire_live":
+    if decision["kind"] == "stay_pending_live":
         # OI-1532: the branch is gone on GitHub but the dispatch is still
         # RUNNING (its occupancy lock is held by a live process). It has simply
         # not pushed its branch yet. Retiring here was the defect this dispatch
@@ -1719,7 +1719,7 @@ def fulfill_obligation(
         )
         return outcome
 
-    if decision["kind"] == "retire_unmeasured":
+    if decision["kind"] == "stay_pending_unmeasured":
         # OI-1532 third state: the branch is gone but liveness could not be
         # measured (no occupancy lock file — the dispatch never created a
         # worktree, a dry-run, a hand-registered obligation, or a lane without
@@ -2239,7 +2239,7 @@ def run(
         if not write:
             outcome = _dry_run_outcome(state_dir, path, record, result_index)
             outcomes.append(outcome)
-            # OI-1532: retire_live and retire_unmeasured stay pending too
+            # OI-1532: stay_pending_live and stay_pending_unmeasured stay pending too
             # (a live / unmeasured dispatch is never closed), so their dry-run
             # labels count toward the pending backlog alongside the normal
             # wait. escalate_stay_pending is terminal and does NOT count.

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -109,6 +109,15 @@ runner fulfils them:
       loudly past the SAME threshold the other bounded branches use
       (``_STAY_PENDING_ESCALATION_ATTEMPTS`` reuses
       ``_UNRESOLVABLE_ESCALATION_ATTEMPTS`` — never a second, drift-prone bound).
+      OI-1587 (2026-09-02): the liveness-unmeasurable branch was unbounded the
+      same way — its return sat before the attempts check. It now shares the
+      SAME threshold: a state that could not be measured once is "unknown", a
+      state that failed 96 consecutive measurements is a defect in the
+      measurement, escalated loudly under its own reason
+      (``stay_pending_unmeasured_timeout``). The alive branch stays
+      DELIBERATELY unbounded — a held occupancy lock is kernel-enforced proof
+      of a live process and self-corrects the instant the holder exits, so an
+      attempt count must never escalate over a provably-running dispatch.
 
 Scheduling: launchd ``com.vnx.gate-obligation-runner.plist`` (StartInterval
 900s); also safe to run manually at any time — fulfilment is idempotent
@@ -230,17 +239,23 @@ _TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
 _FAST_FULFILLMENT_MTIME_THRESHOLD_SECONDS = 60
 
 # OI-1532: the ``stay_pending`` branch (a genuine wait for a PR the dispatch
-# could still produce, OR liveness-unmeasurable) used to retry FOREVER — no
-# attempt bound, no escalation. Measured live on mission-control 2026-08-30:
-# 11 obligations on 776 attempts, three on 779, one on 724 — at the 900s launchd
-# cadence that is over EIGHT DAYS of unbroken retrying with nothing alarming.
-# Reuse the SAME constant and the SAME mechanism as the two existing bounded
-# branches (``_UNRESOLVABLE_ESCALATION_ATTEMPTS`` on :854 and the temporary-
+# could still produce) used to retry FOREVER — no attempt bound, no
+# escalation. Measured live on mission-control 2026-08-30: 11 obligations on
+# 776 attempts, three on 779, one on 724 — at the 900s launchd cadence that is
+# over EIGHT DAYS of unbroken retrying with nothing alarming. Reuse the SAME
+# constant and the SAME mechanism as the two existing bounded branches
+# (``_UNRESOLVABLE_ESCALATION_ATTEMPTS`` on :854 and the temporary-
 # refusal escalation via ``_TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS`` on :1261) —
 # a SECOND bound that drifts out of step with these is the next defect. 96
 # attempts at 900s ≈ 24h, matching the producer-freshness cadence window; a wait
 # that exceeds a full day without producing a PR is no longer "not yet" but a
-# loud terminal ``not_executable`` so someone is forced to look.
+# loud terminal ``not_executable`` so someone is forced to look. OI-1587: the
+# liveness-unmeasurable branch (``stay_pending_unmeasured``) shares this SAME
+# bound — an unmeasurable state that never resolves is a measurement defect,
+# not a wait. The ``stay_pending_live`` branch is the ONE deliberate exception:
+# it carries kernel-enforced proof of a live process and self-corrects on
+# holder exit, so no attempt count applies to it (see the branch's own
+# comment in :func:`_pre_execution_decision`).
 _STAY_PENDING_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
 
 # PR-resolution outcomes. The runner must tell "no PR yet" (a wait) apart from
@@ -1247,8 +1262,8 @@ def _pre_execution_decision(
     Returns ``{"kind": ..., ...}`` where ``kind`` is one of:
       - ``unresolvable``               — env fault, stays retryable (below threshold)
       - ``escalate``                   — env fault, past threshold: terminal escalation
-      - ``stay_pending``               — genuine wait (branch alive / liveness
-        unmeasured / branch-gone-but-live), below the stay-pending threshold
+      - ``stay_pending``               — genuine wait (branch exists, or its
+        existence could not be determined), below the stay-pending threshold
       - ``escalate_stay_pending``      — OI-1532: a ``stay_pending`` that has
         retried past the stay-pending threshold without producing a PR — the
         unbounded wait is replaced by a loud terminal escalation, exactly as
@@ -1257,7 +1272,18 @@ def _pre_execution_decision(
         live), no rescuing evidence
       - ``stay_pending_live``          — OI-1532: branch gone but the dispatch
         is still running — stays pending (NOT retired), carried distinctly so
-        the caller records WHY it stayed pending, not just that it did
+        the caller records WHY it stayed pending, not just that it did.
+        OI-1587: DELIBERATELY unbounded, no attempts threshold — see the
+        branch's own comment for the reasoning
+      - ``stay_pending_unmeasured``    — OI-1532 third state: branch gone and
+        liveness could not be measured — stays pending (never retired on
+        ambiguous evidence), carried distinctly; OI-1587: bounded by the SAME
+        stay-pending threshold
+      - ``escalate_stay_pending_unmeasured`` — OI-1587: liveness unmeasurable
+        past the stay-pending threshold. An unmeasurable state that never
+        resolves is a defect in the measurement, not a wait — escalated to
+        the same loud terminal outcome, under its own reason so the record
+        says the MEASUREMENT failed, never that a dispatch outwaited a PR
       - ``fulfill_by_evidence``        — OI-1388 defect 1: a complete-evidence
         DECIDED PASS, sha-current with the PR head, already exists for this
         dispatch_id + gate; carried as ``decision["evidence"] = (path, record)``
@@ -1295,8 +1321,11 @@ def _pre_execution_decision(
         never be closed on ambiguous evidence, per the OI-1388 docstring) and
         to record the liveness-unmeasured state VISIBLY so it is not mistaken
         for a normal wait — carried as ``decision["liveness"] = "unmeasured"``
-        and routed through ``stay_pending_unmeasured`` (which itself stays
-        pending, never retires).
+        and routed through ``stay_pending_unmeasured`` (which stays pending,
+        never retires — and since OI-1587 is bounded by the SAME
+        ``_STAY_PENDING_ESCALATION_ATTEMPTS``: an unmeasurable state that
+        never resolves is a measurement defect, escalated loudly via
+        ``escalate_stay_pending_unmeasured``, not waited out forever).
 
     The sha check and the liveness check answer DIFFERENT questions and are
     never folded into a single rejection: the sha check answers whether THIS
@@ -1340,6 +1369,19 @@ def _pre_execution_decision(
                 # (live on 20260830-124500-sidedoor). Stays pending, distinctly
                 # labelled so the recorded reason says "live, not pushed" and
                 # not a generic "no PR yet".
+                # OI-1587: DELIBERATELY UNBOUNDED — no attempts threshold here,
+                # on purpose. A held occupancy lock is kernel-enforced POSITIVE
+                # evidence that a live process owns this dispatch right now,
+                # and the kernel releases the lock the instant the holder exits
+                # (clean finish OR crash) — the state self-corrects without a
+                # timer, unlike every other branch that waits on an absence.
+                # Escalating on an attempt count would book a loud terminal
+                # not_executable over a dispatch that is provably still
+                # working — the exact retire-the-live defect in a new shape.
+                # The remaining unbounded case (a holder that never exits AND
+                # never pushes) is a HUNG dispatch: detecting that needs a
+                # runtime/stall signal owned by dispatch supervision, not a
+                # gate-obligation runner that only sees the lock every 900s.
                 return {
                     "kind": "stay_pending_live",
                     "mismatch_detail": lookup.get("detail"),
@@ -1349,7 +1391,24 @@ def _pre_execution_decision(
                 # Liveness could not be measured — a THIRD state. Do not retire
                 # (a live dispatch must never be closed on ambiguous evidence),
                 # and carry the reason visibly so it is not mistaken for a
-                # normal wait. Stays pending under the same bound as below.
+                # normal wait. OI-1587: this branch IS bounded — by the SAME
+                # _STAY_PENDING_ESCALATION_ATTEMPTS the genuine-wait branch
+                # below uses, never a second bound. A state that could not be
+                # measured once is "unknown"; a state that failed 96
+                # consecutive measurements (≈24h at the 900s cadence) is a
+                # defect in the MEASUREMENT itself — waiting longer cannot fix
+                # a probe that never answers, so it escalates loudly under its
+                # own reason instead of retrying forever (the pre-fix comment
+                # here claimed "the same bound as below"; no bound existed —
+                # the attempts check lived only in the branch_exists
+                # True/None tak and this return never reached it).
+                if attempts >= _STAY_PENDING_ESCALATION_ATTEMPTS:
+                    return {
+                        "kind": "escalate_stay_pending_unmeasured",
+                        "liveness": "unmeasured",
+                        "mismatch_detail": lookup.get("detail"),
+                        "rejected_evidence": lookup["kind"],
+                    }
                 return {
                     "kind": "stay_pending_unmeasured",
                     "liveness": "unmeasured",
@@ -1389,6 +1448,7 @@ _DRY_RUN_ACTION_LABELS: Dict[str, str] = {
     "stay_pending_unmeasured": "would_stay_pending_unmeasured",
     "stay_pending": "would_stay_pending",
     "escalate_stay_pending": "would_escalate_stay_pending",
+    "escalate_stay_pending_unmeasured": "would_escalate_stay_pending_unmeasured",
     "attempt_gate": "would_fulfill",
 }
 
@@ -1466,6 +1526,15 @@ def _dry_run_outcome(
             f"(branch exists or undetermined) — escalating the unbounded wait to a "
             f"loud terminal outcome (OI-1532)"
         )
+    elif decision["kind"] == "escalate_stay_pending_unmeasured":
+        outcome["detail"] = (
+            "dispatch branch is gone on GitHub and liveness could not be measured "
+            f"for {attempts} consecutive attempts — an unmeasurable state that "
+            "never resolves is a measurement defect, not a wait; escalating to a "
+            "loud terminal outcome (OI-1587)"
+        )
+        if decision.get("mismatch_detail"):
+            outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
     elif decision["kind"] in ("unresolvable", "escalate"):
         outcome["detail"] = resolution.reason
         if decision.get("mismatch_detail"):
@@ -1752,7 +1821,10 @@ def fulfill_obligation(
         # choice is to stay pending (never close on ambiguous evidence, per
         # the OI-1388 docstring) and record the unmeasured state VISIBLY so
         # the freshness monitor and any reader can tell it apart from a normal
-        # wait. Stays under the same bounded escalation as stay_pending below.
+        # wait. OI-1587: this wait IS bounded — the decision above escalates
+        # it to ``escalate_stay_pending_unmeasured`` once the measurement has
+        # failed ``_STAY_PENDING_ESCALATION_ATTEMPTS`` times in a row (the SAME
+        # bound the genuine-wait branch uses, never a second one).
         branch_name = f"dispatch/{dispatch_id}"
         mismatch_note = _rejected_evidence_note(gate, decision)
         update_obligation(
@@ -1779,14 +1851,60 @@ def fulfill_obligation(
         )
         return outcome
 
+    if decision["kind"] == "escalate_stay_pending_unmeasured":
+        # OI-1587: the branch is gone AND liveness could not be measured for
+        # _STAY_PENDING_ESCALATION_ATTEMPTS consecutive attempts (≈24h at the
+        # 900s cadence). An unmeasured state once is "unknown"; unmeasured 96
+        # times in a row is a defect in the MEASUREMENT itself — no amount of
+        # extra waiting fixes a probe that never answers, and retiring is
+        # still forbidden (ambiguous evidence never closes a live dispatch).
+        # Escalate to the SAME loud terminal not_executable the other bounded
+        # branches book, under its OWN reason so the record says the liveness
+        # measurement failed — never the generic stay_pending_timeout, which
+        # would read as "the dispatch simply outwaited a PR".
+        branch_name = f"dispatch/{dispatch_id}"
+        mismatch_note = _rejected_evidence_note(gate, decision)
+        update_obligation(
+            path,
+            status=STATUS_NOT_EXECUTABLE,
+            branch=branch_name,
+            attempts=attempts,
+            last_attempt_at=now,
+            resolved_at=now,
+            reason="stay_pending_unmeasured_timeout",
+            reason_detail=(
+                f"dispatch {dispatch_id} has no PR, its head branch "
+                f"{branch_name} is not on GitHub, and liveness could not be "
+                f"measured (no occupancy lock file at "
+                f"{_occupancy_lock_path(state_dir, dispatch_id)} or the probe "
+                f"failed) for {attempts} consecutive attempts (≈ "
+                f"{round(attempts * 900 / 3600, 1)}h at the 900s cadence). An "
+                "unmeasurable state that never resolves is a measurement "
+                "defect, not a wait (OI-1587). Restore the occupancy lock "
+                "lane for this dispatch class, or reset this obligation to "
+                f"pending if the dispatch is known to be live.{mismatch_note}"
+            ),
+        )
+        outcome["action"] = "not_executable"
+        outcome["detail"] = (
+            f"liveness unmeasurable for {attempts} consecutive attempts — "
+            "escalating the unbounded unmeasured wait to a loud terminal "
+            "outcome (OI-1587)"
+        )
+        return outcome
+
     if decision["kind"] == "escalate_stay_pending":
-        # OI-1532: the genuine-wait branch (branch exists / undetermined / live
-        # / unmeasured) used to retry FOREVER — no bound, no escalation.
+        # OI-1532: the genuine-wait branch (branch exists or its existence
+        # undetermined) used to retry FOREVER — no bound, no escalation.
         # Measured on mission-control 2026-08-30: 11 obligations on 776
         # attempts (8+ days) with nothing alarming. After the stay-pending
         # threshold a wait that never produced a PR escalates to the SAME loud
         # terminal not_executable the other bounded branches use, reusing the
-        # SAME constant — never a second, drift-prone bound.
+        # SAME constant — never a second, drift-prone bound. (The two sibling
+        # branches are NOT escalated here: stay_pending_live is deliberately
+        # unbounded — kernel-enforced proof of a live process — and
+        # stay_pending_unmeasured escalates under its own reason just above,
+        # OI-1587.)
         update_obligation(
             path,
             status=STATUS_NOT_EXECUTABLE,

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -91,6 +91,24 @@ runner fulfils them:
      file no longer exists) does NOT count — that is a third, distinct
      outcome (chain walked, nothing usable found anywhere), never conflated
      with either "found at the declared gate" or "found via takeover".
+  10. OI-1532 (2026-08-30): item 6's ``branch_exists is False`` retirement folded
+      two states into one — "the branch existed and was deleted" (the dispatch
+      is dead) and "the branch was never pushed because the dispatch is STILL
+      RUNNING" (it is alive). Retiring on the second was caught live on
+      ``20260830-124500-sidedoor``: ``would_retire`` while the dispatch held an
+      occupancy lock (13 min runtime, held by pid 82207). The fix adds a THIRD
+      discriminator — the dispatch's occupancy lock
+      (``<state_dir>/dispatch_worktree_claims/<safe_id>.occupancy``, an
+      fcntl.flock on an open file description the kernel releases the instant
+      its holder exits) — so ``branch_exists is False`` splits three ways:
+      dead (retire, unchanged), alive (stay pending, never retired), and
+      liveness-unmeasurable (stay pending, visibly, never a silent default for
+      either). The genuine-wait branch (item 4) was also unbounded — it retried
+      forever with no escalation; measured on mission-control, 11 obligations
+      sat on 776 attempts (8+ days) with nothing alarming. It now escalates
+      loudly past the SAME threshold the other bounded branches use
+      (``_STAY_PENDING_ESCALATION_ATTEMPTS`` reuses
+      ``_UNRESOLVABLE_ESCALATION_ATTEMPTS`` — never a second, drift-prone bound).
 
 Scheduling: launchd ``com.vnx.gate-obligation-runner.plist`` (StartInterval
 900s); also safe to run manually at any time — fulfilment is idempotent
@@ -104,6 +122,7 @@ Exit codes: 0 = no open obligations remain after this run;
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import logging
 import os
@@ -122,6 +141,8 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 from gate_obligations import (  # noqa: E402
     NO_GATE_KEY,
     REASON_NO_PR_BRANCH_GONE,
+    REASON_NO_PR_BRANCH_GONE_LIVE,
+    REASON_NO_PR_BRANCH_GONE_UNMEASURED,
     STATUS_FAILED,
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
@@ -208,6 +229,20 @@ _TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
 # genuine-run bucket measured; see _flag_fast_fulfillment_if_evidence_predates_attempt.
 _FAST_FULFILLMENT_MTIME_THRESHOLD_SECONDS = 60
 
+# OI-1532: the ``stay_pending`` branch (a genuine wait for a PR the dispatch
+# could still produce, OR liveness-unmeasurable) used to retry FOREVER — no
+# attempt bound, no escalation. Measured live on mission-control 2026-08-30:
+# 11 obligations on 776 attempts, three on 779, one on 724 — at the 900s launchd
+# cadence that is over EIGHT DAYS of unbroken retrying with nothing alarming.
+# Reuse the SAME constant and the SAME mechanism as the two existing bounded
+# branches (``_UNRESOLVABLE_ESCALATION_ATTEMPTS`` on :854 and the temporary-
+# refusal escalation via ``_TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS`` on :1261) —
+# a SECOND bound that drifts out of step with these is the next defect. 96
+# attempts at 900s ≈ 24h, matching the producer-freshness cadence window; a wait
+# that exceeds a full day without producing a PR is no longer "not yet" but a
+# loud terminal ``not_executable`` so someone is forced to look.
+_STAY_PENDING_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
+
 # PR-resolution outcomes. The runner must tell "no PR yet" (a wait) apart from
 # "cannot resolve because the environment is wrong" (a fault) IN THE RECORD,
 # not only in a log line — a pending obligation that is actually misconfigured
@@ -225,6 +260,15 @@ class PrResolution:
     ``True``/``False`` when GitHub was actually queried, ``None`` when it
     could not be determined (or wasn't queried) — never treated as "gone"
     (OI-1388: an obligation must never be retired on ambiguous evidence).
+
+    ``dispatch_live`` (OI-1532) splits the ``branch_exists is False`` case in
+    two: a branch that is gone because the dispatch DIED (``False``) vs gone
+    because the dispatch is STILL RUNNING and has not pushed yet (``True``).
+    ``None`` means liveness could not be measured (no occupancy lock file, or
+    the probe failed) — a THIRD state the caller must not collapse into either
+    of the other two: retiring on ``None`` reintroduces the exact defect this
+    field exists to close. Only populated when ``status == RESOLUTION_AWAITING``
+    and ``branch_exists is False``; the other branches do not need it.
     """
 
     status: str
@@ -232,6 +276,7 @@ class PrResolution:
     owner_repo: Optional[str] = None
     reason: Optional[str] = None
     branch_exists: Optional[bool] = None
+    dispatch_live: Optional[bool] = None
 
 
 def utc_now_iso() -> str:
@@ -447,6 +492,124 @@ def _branch_exists_on_github(dispatch_id: str, owner_repo: str) -> Optional[bool
     return None
 
 
+# ---------------------------------------------------------------------------
+# OI-1532: is this dispatch still RUNNING?
+# ---------------------------------------------------------------------------
+#
+# ``_branch_exists_on_github`` returns ``False`` for two states this runner used
+# to fold into one: "the branch existed and was deleted" (the dispatch is dead)
+# and "the branch was never pushed because the dispatch is still in flight" (it
+# is alive). Retiring on the second is the defect this dispatch fixes.
+#
+# The discriminator that splits them is the occupancy lock
+# ``<state_dir>/dispatch_worktree_claims/<safe_id>.occupancy`` — an fcntl.flock
+# on an OPEN FILE DESCRIPTION whose holder the KERNEL releases the instant its
+# process exits (scripts/lib/dispatch_worktree_isolation.py:502-520). A
+# non-blocking flock against that file answers "is a live process still holding
+# this dispatch" hard, with no timer and no gh call.
+#
+# Three-valued on purpose (OI-1532, mirroring the three-valued
+# ``_branch_exists_on_github``): True (alive), False (dead), None (liveness
+# could not be measured — a THIRD answer, never a silent default for either of
+# the other two). ``None`` can mean the lock file does not exist at all (the
+# dispatch never created a worktree — e.g. a dry-run, a hand-registered
+# obligation, or a lane that does not use occupancy locks) OR that the probe
+# itself failed; the caller must treat both as "unmeasured" and choose the safe
+# side (do not retire), visibly.
+#
+# The lock is per-OPEN-FILE-DESCRIPTION, not per-process: a probe that takes the
+# lock in the same process that already holds it would measure itself. This
+# function opens its OWN file descriptor and asks for LOCK_SH | LOCK_NB, which a
+# holder's LOCK_EX blocks — it never re-enters the holder's own description, so
+# it is safe to call from any process, including the one that dispatched (a
+# dispatch's worker runs in a different process than this runner anyway).
+_DISPATCH_UNSAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
+_DISPATCH_MAX_SAFE_ID_LEN = 60
+
+
+def _sanitize_dispatch_id_local(dispatch_id: str) -> str:
+    """Mirror ``dispatch_worktree_isolation._sanitize_dispatch_id``.
+
+    The runner stays a lightweight stdlib script and must not import that
+    module (same contract as ``_owner_repo_from_remote_url`` mirroring
+    ``chain_origin_anchor``). The regex and length cap are copied verbatim so
+    the safe id this computes matches the one the isolation layer wrote the
+    occupancy lock under — a drift here would probe a non-existent file and
+    silently read ``None`` (unmeasured) for a dispatch that is in fact alive.
+    """
+    return _DISPATCH_UNSAFE_RE.sub("-", dispatch_id or "")[:_DISPATCH_MAX_SAFE_ID_LEN]
+
+
+def _occupancy_lock_path(state_dir: Path, dispatch_id: str) -> Path:
+    """Resolve the occupancy lock file for ``dispatch_id`` under ``state_dir``.
+
+    The claim registry lives at ``<data_dir>/state/dispatch_worktree_claims``
+    (ADR-026 SSOT, see ``dispatch_worktree_isolation._claim_dir``). The runner's
+    ``state_dir`` IS that ``<data_dir>/state``, so the lock file is
+    ``<state_dir>/dispatch_worktree_claims/<safe_id>.occupancy``.
+    """
+    safe_id = _sanitize_dispatch_id_local(dispatch_id)
+    return Path(state_dir) / "dispatch_worktree_claims" / f"{safe_id}.occupancy"
+
+
+def _dispatch_is_live(state_dir: Path, dispatch_id: str) -> Optional[bool]:
+    """Whether a live process is still holding the dispatch's worktree.
+
+    Returns ``True`` when another live process holds the occupancy lock (a
+    running dispatch that has not pushed its branch yet), ``False`` when the
+    lock file exists but no process holds it (the dispatch ended and its lock
+    was released, or the holder crashed and the kernel freed the lock), and
+    ``None`` when liveness could not be measured: the lock file does not exist
+    (no worktree was ever created for this dispatch) or the probe itself raised.
+
+    OI-1532: the caller must treat ``None`` as a THIRD state — "do not know" —
+    never as ``False`` ("dead"). Retiring on ``None`` would reintroduce the
+    exact defect retiring on ``branch_exists is False`` had for a live
+    dispatch. See :func:`_pre_execution_decision`.
+    """
+    lock_path = _occupancy_lock_path(state_dir, dispatch_id)
+    try:
+        # O_EXCL semantics do not apply here — the isolation layer creates the
+        # file with open(..., "a") before flock-ing it, so a missing file means
+        # no worktree was ever claimed for this dispatch. Do NOT create it: a
+        # probe that fabricates the lock file would mask a real "never created"
+        # state and could interfere with a dispatch that creates one later.
+        if not lock_path.exists():
+            return None
+        fh = open(lock_path, "a")
+    except OSError as exc:
+        _LOG.debug(
+            "occupancy probe could not open %s for %s: %s — treating as "
+            "unmeasured, not dead",
+            lock_path, dispatch_id, exc,
+        )
+        return None
+    try:
+        # LOCK_SH | LOCK_NB: a shared, non-blocking request. A holder's LOCK_EX
+        # blocks this (BlockingIOError => a live holder => True); success means
+        # no holder holds it (the dispatch is not running => False). We release
+        # immediately so this probe never interferes with a future holder.
+        try:
+            fcntl.flock(fh, fcntl.LOCK_SH | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        # We acquired the shared lock — no exclusive holder exists. Release it.
+        fcntl.flock(fh, fcntl.LOCK_UN)
+        return False
+    except OSError as exc:
+        _LOG.debug(
+            "occupancy probe flock failed for %s: %s — treating as "
+            "unmeasured, not dead",
+            lock_path, exc,
+        )
+        return None
+    finally:
+        try:
+            fh.close()
+        except OSError:
+            pass
+
+
 def _owner_repo_from_remote_url(url: str) -> Optional[str]:
     """Derive ``owner/repo`` from a GitHub remote URL (https or ssh form).
 
@@ -596,10 +759,21 @@ def resolve_pr_number(state_dir: Path, record: Dict[str, Any]) -> PrResolution:
     # also ask whether the dispatch could still produce one. A dead branch is
     # the one fact that answers that without a timer.
     branch_exists = _branch_exists_on_github(dispatch_id, owner_repo)
+    # OI-1532: ``branch_exists is False`` folds two states into one. Before
+    # retiring on it (the caller's temptation), split it with the occupancy
+    # lock: a live holder means the dispatch is still running and has simply
+    # not pushed yet. Probe only when the branch is gone — the other cases
+    # (exists / unknown) never reach the retire branch, so liveness adds no
+    # information there and probing it would be wasted work on every pending
+    # obligation that still has a branch.
+    dispatch_live: Optional[bool] = None
+    if branch_exists is False:
+        dispatch_live = _dispatch_is_live(state_dir, dispatch_id)
     return PrResolution(
         RESOLUTION_AWAITING,
         owner_repo=owner_repo,
         branch_exists=branch_exists,
+        dispatch_live=dispatch_live,
         reason=f"no PR yet for head branch dispatch/{dispatch_id}",
     )
 
@@ -1073,8 +1247,17 @@ def _pre_execution_decision(
     Returns ``{"kind": ..., ...}`` where ``kind`` is one of:
       - ``unresolvable``               — env fault, stays retryable (below threshold)
       - ``escalate``                   — env fault, past threshold: terminal escalation
-      - ``stay_pending``               — genuine wait (branch alive / undetermined)
-      - ``retire``                     — dead dispatch, no rescuing evidence
+      - ``stay_pending``               — genuine wait (branch alive / liveness
+        unmeasured / branch-gone-but-live), below the stay-pending threshold
+      - ``escalate_stay_pending``      — OI-1532: a ``stay_pending`` that has
+        retried past the stay-pending threshold without producing a PR — the
+        unbounded wait is replaced by a loud terminal escalation, exactly as
+        the two other bounded branches already do
+      - ``retire``                     — dead dispatch (branch gone AND not
+        live), no rescuing evidence
+      - ``retire_live``                — OI-1532: branch gone but the dispatch
+        is still running — stays pending (NOT retired), carried distinctly so
+        the caller records WHY it stayed pending, not just that it did
       - ``fulfill_by_evidence``        — OI-1388 defect 1: a complete-evidence
         DECIDED PASS, sha-current with the PR head, already exists for this
         dispatch_id + gate; carried as ``decision["evidence"] = (path, record)``
@@ -1098,6 +1281,32 @@ def _pre_execution_decision(
     carries ``decision["mismatch_detail"]`` when one was seen, so whatever
     record documents the retirement/escalation can also document why the
     rejected evidence did not count.
+
+    OI-1532 — the AWAITING branch is THREE-valued on ``branch_exists is False``:
+      - ``dispatch_live is False`` -> the dispatch is dead and its branch is
+        gone: ``retire`` (the existing, correct behaviour).
+      - ``dispatch_live is True``  -> the dispatch is still RUNNING and has not
+        pushed yet: ``stay_pending``, never ``retire`` (the defect this fixes).
+      - ``dispatch_live is None``  -> liveness could not be measured: a THIRD
+        answer. Choosing ``retire`` here reintroduces the defect for a live
+        dispatch whose lock file is absent (e.g. a lane that does not use
+        occupancy locks); choosing ``stay_pending`` silently hides a genuinely
+        dead dispatch. The safe choice is to NOT retire (a live dispatch must
+        never be closed on ambiguous evidence, per the OI-1388 docstring) and
+        to record the liveness-unmeasured state VISIBLY so it is not mistaken
+        for a normal wait — carried as ``decision["liveness"] = "unmeasured"``
+        and routed through ``retire_unmeasured`` (which itself stays pending,
+        never retires).
+
+    The sha check and the liveness check answer DIFFERENT questions and are
+    never folded into a single rejection: the sha check answers whether THIS
+    evidence counts, the liveness check answers whether MORE evidence is
+    still coming. So on ``branch_exists is False`` the order is: usable
+    (sha-matching, decided) evidence fulfils REGARDLESS of liveness; with no
+    usable evidence, liveness decides — a live or unmeasured dispatch stays
+    pending (its own gate run may still produce current evidence), only a
+    DEAD dispatch is retired, with ``mismatch_detail`` recorded when rejected
+    evidence existed (OI-1571 tak 3 meets OI-1532).
     """
     if resolution.status == RESOLUTION_UNRESOLVABLE:
         lookup = _fulfilling_result(result_index, dispatch_id, gate)
@@ -1110,13 +1319,51 @@ def _pre_execution_decision(
         return {"kind": "unresolvable"}
 
     if resolution.status == RESOLUTION_AWAITING:
+        # OI-1532: branch_exists is False folds "dead and deleted" together
+        # with "still running, not pushed yet". Split it with the occupancy
+        # lock before any retire decision — see PrResolution.dispatch_live.
         if resolution.branch_exists is False:
             lookup = _fulfilling_result(result_index, dispatch_id, gate)
             if lookup["kind"] == "found":
+                # Usable (decided, sha-matching) evidence fulfils REGARDLESS
+                # of liveness — the gate already reviewed this dispatch; the
+                # branch being gone afterwards changes nothing about that.
                 return _evidence_decision(lookup["entry"])
-            if lookup["kind"] == "unverifiable":
-                return {"kind": "sha_unverifiable", "detail": lookup["detail"]}
+            # No usable evidence. OI-1571 tak 3 meets OI-1532: the sha check
+            # answered "does THIS evidence count" (no — mismatch, or
+            # unverifiable); the liveness check answers the SEPARATE question
+            # "is MORE evidence still coming". Never fold the two into one
+            # rejection: a live dispatch is never retired on a sha mismatch.
+            if resolution.dispatch_live is True:
+                # The dispatch is still running — it has simply not pushed its
+                # branch yet. Retiring here is the defect this dispatch fixes
+                # (live on 20260830-124500-sidedoor). Stays pending, distinctly
+                # labelled so the recorded reason says "live, not pushed" and
+                # not a generic "no PR yet".
+                return {"kind": "retire_live", "mismatch_detail": lookup.get("detail")}
+            if resolution.dispatch_live is None:
+                # Liveness could not be measured — a THIRD state. Do not retire
+                # (a live dispatch must never be closed on ambiguous evidence),
+                # and carry the reason visibly so it is not mistaken for a
+                # normal wait. Stays pending under the same bound as below.
+                return {
+                    "kind": "retire_unmeasured",
+                    "liveness": "unmeasured",
+                    "mismatch_detail": lookup.get("detail"),
+                }
+            # dispatch_live is False: the dispatch ended and its branch is gone
+            # — nothing will ever gate this obligation. The existing, correct
+            # retirement, unchanged — except it now documents WHY any rejected
+            # evidence did not count (mismatch/unverifiable detail), never
+            # silently proceeding as if nothing existed at all (OI-1571 tak 3).
             return {"kind": "retire", "mismatch_detail": lookup.get("detail")}
+        # branch_exists is True (branch still there) or None (gh could not
+        # tell) — a genuine wait. OI-1532: this branch was unbounded; it now
+        # escalates loudly past the same threshold the other branches use, so
+        # a wait that never produces a PR cannot retry silently for eight days
+        # (measured on mission-control 2026-08-30).
+        if attempts >= _STAY_PENDING_ESCALATION_ATTEMPTS:
+            return {"kind": "escalate_stay_pending"}
         return {"kind": "stay_pending"}
 
     return {"kind": "attempt_gate"}
@@ -1129,7 +1376,10 @@ _DRY_RUN_ACTION_LABELS: Dict[str, str] = {
     "fulfill_by_failed_evidence": "would_stamp_failed",
     "sha_unverifiable": "would_stay_pending_sha_unverifiable",
     "retire": "would_retire",
+    "retire_live": "would_stay_pending_live",
+    "retire_unmeasured": "would_stay_pending_unmeasured",
     "stay_pending": "would_stay_pending",
+    "escalate_stay_pending": "would_escalate_stay_pending",
     "attempt_gate": "would_fulfill",
 }
 
@@ -1186,6 +1436,27 @@ def _dry_run_outcome(
         outcome["detail"] = resolution.reason or "dispatch died without ever producing a PR; branch gone"
         if decision.get("mismatch_detail"):
             outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
+    elif decision["kind"] == "retire_live":
+        outcome["detail"] = (
+            "dispatch branch is gone on GitHub but the dispatch is still RUNNING "
+            "(occupancy lock held) — not pushed yet, NOT retired (OI-1532)"
+        )
+        if decision.get("mismatch_detail"):
+            outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
+    elif decision["kind"] == "retire_unmeasured":
+        outcome["detail"] = (
+            "dispatch branch is gone on GitHub but liveness could not be measured "
+            "(no occupancy lock file or probe failed) — staying pending rather than "
+            "retiring on ambiguous evidence (OI-1532)"
+        )
+        if decision.get("mismatch_detail"):
+            outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
+    elif decision["kind"] == "escalate_stay_pending":
+        outcome["detail"] = (
+            f"obligation has waited {attempts} attempts for a PR that never appeared "
+            f"(branch exists or undetermined) — escalating the unbounded wait to a "
+            f"loud terminal outcome (OI-1532)"
+        )
     elif decision["kind"] in ("unresolvable", "escalate"):
         outcome["detail"] = resolution.reason
         if decision.get("mismatch_detail"):
@@ -1412,11 +1683,125 @@ def fulfill_obligation(
         outcome["detail"] = "dispatch died without ever producing a PR; branch gone — retired"
         return outcome
 
+    if decision["kind"] == "retire_live":
+        # OI-1532: the branch is gone on GitHub but the dispatch is still
+        # RUNNING (its occupancy lock is held by a live process). It has simply
+        # not pushed its branch yet. Retiring here was the defect this dispatch
+        # fixes (live on 20260830-124500-sidedoor, 13 min runtime, held by
+        # pid 82207). Stays pending — NEVER retired — with a named reason so
+        # the recorded state says "live, not pushed" and not a generic wait.
+        branch_name = f"dispatch/{dispatch_id}"
+        mismatch_note = (
+            f" A prior {gate} result exists for this dispatch but is about a "
+            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
+            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
+            if decision.get("mismatch_detail") else ""
+        )
+        update_obligation(
+            path,
+            status=STATUS_PENDING,
+            branch=branch_name,
+            attempts=attempts,
+            last_attempt_at=now,
+            reason=REASON_NO_PR_BRANCH_GONE_LIVE,
+            reason_detail=(
+                f"dispatch {dispatch_id} has no PR yet and its head branch "
+                f"{branch_name} is not on GitHub, but the dispatch's occupancy "
+                f"lock is held by a live process — it is still running and has "
+                f"not pushed yet. Staying pending; a live dispatch must never be "
+                f"retired (OI-1532).{mismatch_note}"
+            ),
+        )
+        outcome["action"] = "pending"
+        outcome["detail"] = (
+            "dispatch still running (occupancy lock held) — not pushed yet, "
+            "NOT retired (OI-1532)"
+        )
+        return outcome
+
+    if decision["kind"] == "retire_unmeasured":
+        # OI-1532 third state: the branch is gone but liveness could not be
+        # measured (no occupancy lock file — the dispatch never created a
+        # worktree, a dry-run, a hand-registered obligation, or a lane without
+        # occupancy locks — or the flock probe itself failed). This is NOT
+        # "dead" and NOT "alive": it is a THIRD answer. Retiring would
+        # reintroduce the defect for a live dispatch whose lock file is absent;
+        # a silent stay_pending would hide a genuinely dead dispatch. The safe
+        # choice is to stay pending (never close on ambiguous evidence, per
+        # the OI-1388 docstring) and record the unmeasured state VISIBLY so
+        # the freshness monitor and any reader can tell it apart from a normal
+        # wait. Stays under the same bounded escalation as stay_pending below.
+        branch_name = f"dispatch/{dispatch_id}"
+        mismatch_note = (
+            f" A prior {gate} result exists for this dispatch but is about a "
+            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
+            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
+            if decision.get("mismatch_detail") else ""
+        )
+        update_obligation(
+            path,
+            status=STATUS_PENDING,
+            branch=branch_name,
+            attempts=attempts,
+            last_attempt_at=now,
+            reason=REASON_NO_PR_BRANCH_GONE_UNMEASURED,
+            reason_detail=(
+                f"dispatch {dispatch_id} has no PR yet and its head branch "
+                f"{branch_name} is not on GitHub, and liveness could not be "
+                f"measured (no occupancy lock file at "
+                f"{_occupancy_lock_path(state_dir, dispatch_id)} or the probe "
+                f"failed). Staying pending rather than retiring on ambiguous "
+                f"evidence — a live dispatch must never be closed unmeasured "
+                f"(OI-1532).{mismatch_note}"
+            ),
+        )
+        outcome["action"] = "pending"
+        outcome["detail"] = (
+            "dispatch branch gone but liveness unmeasurable — staying pending "
+            "rather than retiring on ambiguous evidence (OI-1532)"
+        )
+        return outcome
+
+    if decision["kind"] == "escalate_stay_pending":
+        # OI-1532: the genuine-wait branch (branch exists / undetermined / live
+        # / unmeasured) used to retry FOREVER — no bound, no escalation.
+        # Measured on mission-control 2026-08-30: 11 obligations on 776
+        # attempts (8+ days) with nothing alarming. After the stay-pending
+        # threshold a wait that never produced a PR escalates to the SAME loud
+        # terminal not_executable the other bounded branches use, reusing the
+        # SAME constant — never a second, drift-prone bound.
+        update_obligation(
+            path,
+            status=STATUS_NOT_EXECUTABLE,
+            attempts=attempts,
+            last_attempt_at=now,
+            resolved_at=now,
+            reason="stay_pending_timeout",
+            reason_detail=(
+                f"obligation waited {attempts} attempts (≈ "
+                f"{round(attempts * 900 / 3600, 1)}h at the 900s cadence) for "
+                f"a PR that never appeared, with the branch existing or "
+                f"undetermined. The unbounded wait is closed loudly: either "
+                f"the dispatch is stuck (its gate will never run) or it was "
+                f"never going to produce a PR. Reset to pending if the "
+                f"dispatch is known to be live (OI-1532)."
+            ),
+        )
+        outcome["action"] = "not_executable"
+        outcome["detail"] = (
+            f"obligation waited {attempts} attempts for a PR that never "
+            f"appeared — escalating the unbounded wait to a loud terminal "
+            f"outcome (OI-1532)"
+        )
+        return outcome
+
     if decision["kind"] == "stay_pending":
         # The repo resolves and gh works, but no PR exists yet for the head
         # branch, and the branch is still there (or its existence could not be
         # determined) — a genuine wait: stays pending for the freshness
-        # monitor, never closed on ambiguous evidence.
+        # monitor, never closed on ambiguous evidence. OI-1532: now bounded
+        # — past _STAY_PENDING_ESCALATION_ATTEMPTS the decision above
+        # escalates loudly instead of retrying forever.
         update_obligation(
             path,
             status=STATUS_PENDING,
@@ -1854,8 +2239,16 @@ def run(
         if not write:
             outcome = _dry_run_outcome(state_dir, path, record, result_index)
             outcomes.append(outcome)
+            # OI-1532: retire_live and retire_unmeasured stay pending too
+            # (a live / unmeasured dispatch is never closed), so their dry-run
+            # labels count toward the pending backlog alongside the normal
+            # wait. escalate_stay_pending is terminal and does NOT count.
             if outcome["action"] in (
-                "would_stay_pending", "would_stay_unresolvable", "would_fulfill",
+                "would_stay_pending",
+                "would_stay_pending_live",
+                "would_stay_pending_unmeasured",
+                "would_stay_unresolvable",
+                "would_fulfill",
                 "would_stay_pending_sha_unverifiable",
             ):
                 pending_after += 1

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -100,6 +100,15 @@ REASON_PR_MERGED = "pr_merged"
 REASON_PR_CLOSED = "pr_closed"
 REASON_NO_PR_BRANCH_GONE = "no_pr_branch_gone"
 REASON_NO_PR_BRANCH_EXISTS = "no_pr_branch_exists"
+# OI-1532 (2026-08-30): a live dispatch holds an occupancy lock on an open file
+# description, and the kernel releases it the instant the holder exits
+# (scripts/lib/dispatch_worktree_isolation.py:502-520). The runner asks that
+# lock to split branch_exists=False ("gone" | "never pushed yet") into three
+# answers: gone AND dead, gone but still running, or gone and liveness
+# unmeasurable. These three reasons book exactly those branches — never the
+# silent default the old two-way ``False`` collapsed them into.
+REASON_NO_PR_BRANCH_GONE_LIVE = "no_pr_branch_gone_live"
+REASON_NO_PR_BRANCH_GONE_UNMEASURED = "no_pr_branch_gone_unmeasured"
 
 # Distinct sentinel gate key for explicit no-gate records (dispatch
 # 20260816-gate-never-skippable). Deliberately NOT a member of the Gate enum: a
@@ -469,6 +478,8 @@ __all__ = [
     "REASON_PR_CLOSED",
     "REASON_NO_PR_BRANCH_GONE",
     "REASON_NO_PR_BRANCH_EXISTS",
+    "REASON_NO_PR_BRANCH_GONE_LIVE",
+    "REASON_NO_PR_BRANCH_GONE_UNMEASURED",
     "TERMINAL_STATUSES",
     "NO_GATE_KEY",
     "obligations_dir",

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -649,6 +649,12 @@ def test_runner_retires_obligation_when_dispatch_died_without_pr(tmp_path, monke
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
     monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
     monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: False)
+    # OI-1532: a dead dispatch's occupancy lock is held by nobody — the kernel
+    # released it when the holder exited. Mock the liveness probe to False so
+    # the three-way branch reaches the unchanged "retire" outcome; without this
+    # the probe reads None (no lock file in the temp state dir) and the runner
+    # correctly stays pending rather than retiring on unmeasured liveness.
+    monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: False)
 
     summary = runner.run(state_dir)
 
@@ -1462,6 +1468,8 @@ def test_runner_still_retires_when_no_evidence_exists(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
     monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
     monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: False)
+    # OI-1532: dead dispatch — occupancy lock held by nobody.
+    monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: False)
 
     summary = runner.run(state_dir)
 
@@ -1647,6 +1655,10 @@ def test_evidence_discriminator_verdict_split(
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
     monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
     monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: False)
+    # OI-1532: dead dispatch — occupancy lock held by nobody. The not_executable
+    # row falls through to retire (no usable evidence); the decided rows are
+    # rescued by evidence before the liveness branch is reached.
+    monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: False)
     _write_result_record(
         state_dir, filename=f"pr-9750-{result_status}-codex_gate",
         dispatch_id=dispatch_id, gate="codex_gate", pr_number=9750,
@@ -1706,6 +1718,14 @@ def test_dry_run_and_real_run_choose_the_same_action(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
     monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
     monkeypatch.setattr(runner, "_branch_exists_on_github", branch_exists)
+    # OI-1532: the parity-retire dispatch is dead (branch gone, no live holder).
+    # parity-rescued is rescued by evidence before the liveness branch; the
+    # branch_exists mock already returns True for parity-pending so liveness is
+    # never probed there. Mock once for the one case that reaches the probe.
+    monkeypatch.setattr(
+        runner, "_dispatch_is_live",
+        lambda sd, did: False if did.endswith("parity-retire") else None,
+    )
 
     dry_summary = runner.run(dry_dir, write=False)
     real_summary = runner.run(real_dir, write=True)
@@ -1744,6 +1764,8 @@ def test_summary_reports_action_counts_breakdown(tmp_path, monkeypatch):
         runner, "_branch_exists_on_github",
         lambda did, owner_repo: did.endswith("counts-pending"),
     )
+    # OI-1532: counts-retire is a dead dispatch (branch gone, no live holder).
+    monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: False)
 
     summary = runner.run(state_dir, write=False)
 

--- a/tests/test_oi1532_live_dispatch_not_retired.py
+++ b/tests/test_oi1532_live_dispatch_not_retired.py
@@ -47,6 +47,7 @@ for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
 
 import gate_obligation_runner as runner  # noqa: E402
 from gate_obligations import (  # noqa: E402
+    STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
     STATUS_RETIRED,
@@ -462,3 +463,271 @@ class TestDryRunParity:
 
         assert dry_summary["outcomes"][0]["action"] == "would_escalate_stay_pending"
         assert dry_summary["pending_after"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Rebase on #1740 (dispatch 20260902-oi1532-rebase-1729) — the
+# evidence-x-liveness matrix. #1740 rebuilt the evidence layer underneath
+# this PR: ``_fulfilling_result`` no longer returns "an entry or None" but a
+# three-kind dict (``found`` / ``unverifiable`` / ``absent`` with a mismatch
+# detail), and ``_has_decided_evidence`` binds every candidate's commit_sha
+# to the PR head via ``gate_executor._classify_sha_binding``. The merge rule
+# is a design decision, pinned here so neither side of it can silently drift:
+#
+#   The sha check answers "does THIS evidence count".
+#   The liveness check answers "is MORE evidence still coming".
+#   A no on the first says nothing about the second — the two are never
+#   folded into a single rejection.
+#
+# Five combinations, five tests:
+#   evidence found + dispatch live            -> fulfil
+#   evidence found + dispatch dead            -> fulfil
+#   rejected evidence + dispatch live         -> stay PENDING
+#   rejected evidence + dispatch dead         -> retire, WITH mismatch detail
+#   liveness NOT MEASURABLE                   -> stay PENDING (its OWN branch —
+#                                                an unmeasured liveness is not
+#                                                a dead dispatch)
+# ---------------------------------------------------------------------------
+
+_HEAD_SHA = "deadbeef00" * 4
+_OTHER_SHA = "ffffffffffffffffffffffffffffffffffffff"
+
+
+def _write_gate_result(
+    state_dir: Path,
+    *,
+    filename: str,
+    dispatch_id: str,
+    gate: str,
+    pr_number: int,
+    status: str = "pass",
+    commit_sha: str = _HEAD_SHA,
+) -> Path:
+    """Write a decided, complete-evidence ``review_gates/results`` record.
+
+    Mirrors ``test_gate_obligations.py``'s ``_write_result_record`` (this file
+    is deliberately self-contained): the report file is really written so both
+    ``has_complete_evidence`` and the on-disk report check pass, and the
+    default ``commit_sha`` matches the ``_get_pr_head_sha_for_gate`` stub so
+    "usable evidence" is the default shape — pass ``_OTHER_SHA`` for a
+    mismatch or ``""`` for an unverifiable binding.
+    """
+    results_dir = state_dir / "review_gates" / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    report_file = state_dir / "review_gates" / "reports" / f"{filename}.md"
+    report_file.parent.mkdir(parents=True, exist_ok=True)
+    report_file.write_text("# gate report\n\npass\n", encoding="utf-8")
+    payload = {
+        "gate": gate,
+        "dispatch_id": dispatch_id,
+        "pr_number": pr_number,
+        "status": status,
+        "contract_hash": "sha256:deadbeef",
+        "report_path": str(report_file),
+        "commit_sha": commit_sha,
+    }
+    path = results_dir / f"{filename}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _patch_head_sha(monkeypatch, head_sha: str = _HEAD_SHA) -> None:
+    """Hermetic sha binding: no test here may shell out to ``gh pr view``
+    (OI-1571 tak 3 added that call to the evidence lookup)."""
+    monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: head_sha)
+
+
+def _commit_sha_for_shape(rejected_shape: str) -> str:
+    """The commit_sha that makes the evidence record REJECTED in the
+    requested way: a proven mismatch (about a different commit) or an
+    unverifiable binding (empty commit_sha -> ``_classify_sha_binding``
+    answers ``unknown``)."""
+    return _OTHER_SHA if rejected_shape == "mismatch" else ""
+
+
+class TestEvidenceLivenessMatrix:
+    """The five evidence-x-liveness combinations from the rebase dispatch."""
+
+    def test_usable_evidence_fulfils_when_dispatch_live(self, tmp_path, monkeypatch):
+        """Combinatie 1: evidence found + dispatch live -> fulfil.
+
+        The gate already reviewed this dispatch (decided, complete, sha-current
+        evidence); that the dispatch is STILL RUNNING and has not pushed its
+        branch changes nothing about a review that already happened."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260902-oi1532-matrix-found-live"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        _patch_head_sha(monkeypatch)
+        monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: True)
+        result_path = _write_gate_result(
+            state_dir, filename="pr-9901-codex_gate",
+            dispatch_id=dispatch_id, gate="codex_gate", pr_number=9901,
+        )
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_FULFILLED, (
+            "usable evidence fulfils regardless of liveness — the sha check "
+            "said this evidence counts, and that settles it"
+        )
+        assert record["reason"] == "fulfilled_by_existing_evidence"
+        assert record["result_path"] == str(result_path)
+        assert summary["pending_after"] == 0
+        assert summary["outcomes"][0]["action"] == STATUS_FULFILLED
+
+    def test_usable_evidence_fulfils_when_dispatch_dead(self, tmp_path, monkeypatch):
+        """Combinatie 2: evidence found + dispatch dead -> fulfil.
+
+        The OI-1388 rescue, unchanged by the liveness split: a dead dispatch
+        a gate already reviewed is fulfilled on the evidence, never retired
+        as unreviewed."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260902-oi1532-matrix-found-dead"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        _patch_head_sha(monkeypatch)
+        monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: False)
+        result_path = _write_gate_result(
+            state_dir, filename="pr-9902-codex_gate",
+            dispatch_id=dispatch_id, gate="codex_gate", pr_number=9902,
+        )
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_FULFILLED
+        assert record["status"] != STATUS_RETIRED
+        assert record["reason"] == "fulfilled_by_existing_evidence"
+        assert record["result_path"] == str(result_path)
+        assert summary["pending_after"] == 0
+
+    @pytest.mark.parametrize("rejected_shape", ["mismatch", "unverifiable"])
+    def test_rejected_evidence_stays_pending_when_dispatch_live(
+        self, tmp_path, monkeypatch, rejected_shape,
+    ):
+        """Combinatie 3: rejected evidence (sha mismatch OR unverifiable) +
+        dispatch live -> stay PENDING, never retire.
+
+        Levendheid wint van sha-mismatch: the rejected evidence says THIS
+        record does not count; the live dispatch says MORE evidence is still
+        coming (its own gate run may still produce a current verdict).
+        Folding the two into one rejection is exactly the defect."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = f"20260902-oi1532-matrix-{rejected_shape}-live"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        _patch_head_sha(monkeypatch)
+        monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: True)
+        _write_gate_result(
+            state_dir, filename=f"pr-9903-{rejected_shape}-codex_gate",
+            dispatch_id=dispatch_id, gate="codex_gate", pr_number=9903,
+            commit_sha=_commit_sha_for_shape(rejected_shape),
+        )
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_PENDING, (
+            f"a LIVE dispatch stays pending on {rejected_shape} evidence — "
+            "the sha check rejected THIS evidence, it said nothing about "
+            "whether more evidence is coming"
+        )
+        assert record["status"] != STATUS_RETIRED
+        assert record["reason"] == REASON_NO_PR_BRANCH_GONE_LIVE
+        # The rejected evidence is documented, not silently discarded.
+        assert "rejected as rescue evidence" in record["reason_detail"]
+        assert summary["pending_after"] == 1
+        assert summary["outcomes"][0]["action"] == "pending"
+
+    @pytest.mark.parametrize("rejected_shape", ["mismatch", "unverifiable"])
+    def test_rejected_evidence_retires_with_mismatch_detail_when_dispatch_dead(
+        self, tmp_path, monkeypatch, rejected_shape,
+    ):
+        """Combinatie 4: rejected evidence + dispatch dead -> retire, WITH
+        the mismatch detail in the record.
+
+        A dead dispatch produces no more evidence, so nothing can ever
+        resolve the rejection — retire is correct. But the record must say
+        WHY the existing evidence did not count, never silently proceed as
+        if nothing existed at all (OI-1571 tak 3)."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = f"20260902-oi1532-matrix-{rejected_shape}-dead"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        _patch_head_sha(monkeypatch)
+        monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: False)
+        _write_gate_result(
+            state_dir, filename=f"pr-9904-{rejected_shape}-codex_gate",
+            dispatch_id=dispatch_id, gate="codex_gate", pr_number=9904,
+            commit_sha=_commit_sha_for_shape(rejected_shape),
+        )
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_RETIRED, (
+            f"a DEAD dispatch with {rejected_shape} evidence is retired — "
+            "nothing more is coming, so the obligation can never resolve"
+        )
+        assert record["reason"] == REASON_NO_PR_BRANCH_GONE
+        # mismatch_detail in the record — the shape named accurately:
+        # "about a DIFFERENT commit" only for a proven mismatch, "could not
+        # be verified" for an unverifiable binding.
+        assert "rejected as rescue evidence" in record["reason_detail"]
+        if rejected_shape == "mismatch":
+            assert "DIFFERENT commit" in record["reason_detail"]
+            assert "this verdict is about other code" in record["reason_detail"]
+        else:
+            assert "could not be verified" in record["reason_detail"]
+            assert "DIFFERENT commit" not in record["reason_detail"]
+        assert summary["pending_after"] == 0
+
+    @pytest.mark.parametrize("rejected_shape", ["mismatch", "unverifiable"])
+    def test_rejected_evidence_stays_pending_when_liveness_unmeasured(
+        self, tmp_path, monkeypatch, rejected_shape,
+    ):
+        """Combinatie 5: liveness NOT MEASURABLE -> stay PENDING, its OWN branch.
+
+        Identical setup to combinatie 4 minus the liveness answer (no
+        occupancy lock file, real probe -> None). An unmeasured liveness is
+        NOT a dead dispatch: the same rejected evidence that retires a dead
+        dispatch must leave an unmeasured one pending — that distinction is
+        precisely what this PR adds, and folding it into "dood" reintroduces
+        the retire-on-ambiguous-evidence defect."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = f"20260902-oi1532-matrix-{rejected_shape}-unmeasured"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        _patch_head_sha(monkeypatch)
+        # No _dispatch_is_live stub and no lock file: the REAL probe returns
+        # None (unmeasured) — the third state, exercised end to end.
+        _write_gate_result(
+            state_dir, filename=f"pr-9905-{rejected_shape}-codex_gate",
+            dispatch_id=dispatch_id, gate="codex_gate", pr_number=9905,
+            commit_sha=_commit_sha_for_shape(rejected_shape),
+        )
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_PENDING, (
+            f"unmeasured liveness + {rejected_shape} evidence stays pending — "
+            "unmeasured is its own branch, never folded into 'dead'"
+        )
+        assert record["status"] != STATUS_RETIRED
+        assert record["reason"] == REASON_NO_PR_BRANCH_GONE_UNMEASURED
+        assert "rejected as rescue evidence" in record["reason_detail"]
+        assert summary["pending_after"] == 1
+        assert summary["outcomes"][0]["action"] == "pending"

--- a/tests/test_oi1532_live_dispatch_not_retired.py
+++ b/tests/test_oi1532_live_dispatch_not_retired.py
@@ -302,7 +302,7 @@ class TestTakALivenessUnmeasured:
         _patch_resolution(monkeypatch, branch_exists=False)
         # No lock file exists in the temp state dir -> the REAL probe returns
         # None. Do NOT stub _dispatch_is_live: we want to prove the real
-        # three-way branch reaches retire_unmeasured on a missing lock file.
+        # three-way branch reaches stay_pending_unmeasured on a missing lock file.
 
         summary = runner.run(state_dir)
 

--- a/tests/test_oi1532_live_dispatch_not_retired.py
+++ b/tests/test_oi1532_live_dispatch_not_retired.py
@@ -731,3 +731,175 @@ class TestEvidenceLivenessMatrix:
         assert "rejected as rescue evidence" in record["reason_detail"]
         assert summary["pending_after"] == 1
         assert summary["outcomes"][0]["action"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# OI-1587 — the two stay-pending branches OI-1532 INTRODUCED must not
+# reintroduce the unbounded wait Tak B closed. Measured by T0 directly on
+# _pre_execution_decision at 882c5817, threshold _STAY_PENDING_ESCALATION_ATTEMPTS = 96:
+#   branch gone, live=True   att 1/96/960/100000 -> stay_pending_live        (never escalates)
+#   branch gone, live=None   att 1/96/960/100000 -> stay_pending_unmeasured  (never escalates)
+#   branch gone, live=False  att 1/96/960/100000 -> retire
+#   branch exists (Tak B)    att 1 -> stay_pending, att >= 96 -> escalate_stay_pending
+# The attempts check lived only in the branch_exists True/None tak; the two
+# new returns never saw it. The fix bounds stay_pending_unmeasured with the
+# SAME constant (never a second bound — test_threshold_reuses_unresolvable_constant
+# above pins that), and leaves stay_pending_live deliberately unbounded: a held
+# occupancy lock is kernel-enforced positive evidence of a live process and
+# self-corrects the instant the holder exits, so an attempt count must never
+# escalate over a provably-running dispatch.
+# ---------------------------------------------------------------------------
+
+
+class TestTakCNewBranchesBounded:
+    """Bounding the branches OI-1532 added (OI-1587 fix-forward on PR #1729).
+
+    The escalate tests are RED on 882c5817 (the unmeasured branch returned
+    ``stay_pending_unmeasured`` for EVERY attempts value) and GREEN after the
+    fix; the live-branch test is GREEN on both — it pins the deliberate
+    "unbounded, and here is why" decision so it cannot silently drift.
+    """
+
+    _DECISION_DISPATCH_ID = "20260902-oi1587-tak-c"
+
+    @staticmethod
+    def _decision(attempts: int, dispatch_live) -> dict:
+        """Drive the REAL ``_pre_execution_decision`` — the same surface T0
+        measured — with an empty result index (no rescue evidence) and the
+        branch-gone AWAITING resolution split by the given liveness answer."""
+        return runner._pre_execution_decision(
+            TestTakCNewBranchesBounded._DECISION_DISPATCH_ID,
+            "codex_gate",
+            runner.PrResolution(
+                runner.RESOLUTION_AWAITING,
+                owner_repo="Vinix24/vnx-orchestration",
+                branch_exists=False,
+                dispatch_live=dispatch_live,
+                reason=(
+                    "no PR yet for head branch "
+                    f"dispatch/{TestTakCNewBranchesBounded._DECISION_DISPATCH_ID}"
+                ),
+            ),
+            attempts,
+            {},
+        )
+
+    def test_unmeasured_escalates_at_and_past_threshold(self):
+        """RED on 882c5817: returned ``stay_pending_unmeasured`` at every
+        attempts value, including 100000 — an unmeasurable state that never
+        resolves is a measurement defect, not a wait, and must escalate to
+        the loud terminal outcome past the SAME threshold Tak B uses."""
+        threshold = runner._STAY_PENDING_ESCALATION_ATTEMPTS
+        assert self._decision(1, None)["kind"] == "stay_pending_unmeasured"
+        assert self._decision(threshold - 1, None)["kind"] == "stay_pending_unmeasured"
+        for attempts in (threshold, 960, 100000):
+            kind = self._decision(attempts, None)["kind"]
+            assert kind == "escalate_stay_pending_unmeasured", (
+                f"attempts={attempts}: an unmeasured liveness that has failed "
+                f"{attempts} consecutive measurements must escalate loudly — "
+                f"got {kind!r}, i.e. the OI-1532 unmeasured branch reintroduced "
+                "the unbounded wait Tak B closed (OI-1587)"
+            )
+
+    def test_unmeasured_escalation_reuses_the_same_constant(self):
+        """The escalation boundary IS ``_STAY_PENDING_ESCALATION_ATTEMPTS`` —
+        never a second, drift-prone bound: one attempt below it still waits,
+        at it the wait is over."""
+        threshold = runner._STAY_PENDING_ESCALATION_ATTEMPTS
+        assert self._decision(threshold - 1, None)["kind"] == "stay_pending_unmeasured"
+        assert self._decision(threshold, None)["kind"] == "escalate_stay_pending_unmeasured"
+
+    def test_live_stays_pending_at_every_attempt_count(self):
+        """The explicit OI-1587 decision for ``live=True``: DELIBERATELY
+        UNBOUNDED. A held occupancy lock is kernel-enforced positive evidence
+        that a live process owns the dispatch right now, and the kernel
+        releases it the instant the holder exits — the state self-corrects
+        without a timer, and escalating on an attempt count would book a loud
+        terminal outcome over a dispatch that is provably still running (the
+        exact retire-the-live defect OI-1532 fixed, in a new shape)."""
+        threshold = runner._STAY_PENDING_ESCALATION_ATTEMPTS
+        for attempts in (1, threshold - 1, threshold, 960, 100000):
+            kind = self._decision(attempts, True)["kind"]
+            assert kind == "stay_pending_live", (
+                f"attempts={attempts}: a live dispatch (occupancy lock held) "
+                f"must NEVER be escalated or retired on an attempt count — "
+                f"got {kind!r}"
+            )
+
+    def test_unmeasured_escalation_writes_loud_terminal_record(self, tmp_path, monkeypatch):
+        """End-to-end through ``runner.run`` — RED on 882c5817 (the record
+        landed STATUS_PENDING forever). The escalation must book the SAME loud
+        terminal not_executable the other bounded branches book, under its OWN
+        reason that says the liveness MEASUREMENT failed — never a generic
+        timeout that reads as 'the dispatch simply outwaited a PR'."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260902-oi1587-unmeasured-escalate"
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        # One attempt below the threshold so this run crosses it (the runner
+        # increments attempts by 1 before deciding).
+        update_obligation(path, attempts=runner._STAY_PENDING_ESCALATION_ATTEMPTS - 1)
+        _patch_resolution(monkeypatch, branch_exists=False)
+        # No lock file in the temp state dir -> the REAL probe returns None
+        # (unmeasured) — the exact shape of the 262 lock-less pending
+        # obligations measured on the vnx-dev store.
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_NOT_EXECUTABLE, (
+            "an unmeasured liveness past the stay-pending threshold must "
+            "escalate to the loud terminal not_executable — a state that could "
+            "not be measured 96 times in a row is a defect in the measurement, "
+            "not a wait (OI-1587)"
+        )
+        assert record["reason"] == "stay_pending_unmeasured_timeout", (
+            "the escalation reason must name the UNMEASURED liveness, never "
+            "fold into the generic stay_pending_timeout"
+        )
+        assert record["reason_detail"], "reason_detail is required, never empty"
+        assert "could not be measured" in record["reason_detail"]
+        assert summary["pending_after"] == 0, "escalated obligation is terminal, not still open"
+        assert summary["outcomes"][0]["action"] == "not_executable"
+
+    def test_unmeasured_below_threshold_stays_pending_visibly(self, tmp_path, monkeypatch):
+        """Below the threshold the unmeasured branch keeps its OI-1532
+        behaviour: stays pending, visibly labelled, never retired."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260902-oi1587-unmeasured-below"
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        update_obligation(path, attempts=runner._STAY_PENDING_ESCALATION_ATTEMPTS - 2)
+        _patch_resolution(monkeypatch, branch_exists=False)
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_PENDING
+        assert record["reason"] == REASON_NO_PR_BRANCH_GONE_UNMEASURED
+        assert summary["pending_after"] == 1
+
+    def test_unmeasured_escalation_dry_run_parity(self, tmp_path, monkeypatch):
+        """The dry run must forecast the escalation a real run takes (OI-1388
+        defect 2 extended to the new kind) — RED on 882c5817, which forecast
+        ``would_stay_pending_unmeasured`` at every attempts value."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260902-oi1587-unmeasured-dry"
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        update_obligation(path, attempts=runner._STAY_PENDING_ESCALATION_ATTEMPTS - 1)
+        _patch_resolution(monkeypatch, branch_exists=False)
+
+        dry_summary = runner.run(state_dir, write=False)
+
+        assert dry_summary["outcomes"][0]["action"] == "would_escalate_stay_pending_unmeasured"
+        assert dry_summary["pending_after"] == 0, (
+            "an escalation is terminal — the dry run must not count it toward "
+            "the pending backlog"
+        )
+        # A dry run never writes: the record on disk is untouched.
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_PENDING

--- a/tests/test_oi1532_live_dispatch_not_retired.py
+++ b/tests/test_oi1532_live_dispatch_not_retired.py
@@ -1,0 +1,464 @@
+"""tests/test_oi1532_live_dispatch_not_retired.py — OI-1532.
+
+The obligation runner must not retire a LIVE dispatch that has not pushed its
+branch yet, and must not retry a genuine wait FOREVER.
+
+Defect, in one function, two branches, both wrong
+(``scripts/gate_obligation_runner.py::_pre_execution_decision``):
+
+  * Tak A — ``branch_exists is False`` is too aggressive. ``False`` folds two
+    states into one: "branch existed and was deleted" (dispatch dead, retire
+    is correct) and "branch never created because the dispatch is STILL
+    RUNNING" (retire is wrong). Caught live on ``20260830-124500-sidedoor``:
+    ``would_retire`` while the dispatch held an occupancy lock (13 min runtime,
+    pid 82207). The fix splits ``False`` three ways using the dispatch's
+    occupancy lock: dead (retire), alive (stay pending), liveness-unmeasurable
+    (stay pending, visibly — a THIRD state, never a silent default).
+  * Tak B — everything that is not ``False`` waits UNBOUNDED. ``stay_pending``
+    had no attempt bound. Measured on mission-control: 11 obligations on 776
+    attempts (8+ days at the 900s cadence) with nothing alarming. The fix
+    reuses ``_STAY_PENDING_ESCALATION_ATTEMPTS`` (== the existing
+    ``_UNRESOLVABLE_ESCALATION_ATTEMPTS``) so a wait that never produces a PR
+    escalates loudly, never via a second drift-prone bound.
+
+Hard test requirement: a test that is RED on the current tree and GREEN after
+the fix. The liveness probe must NOT measure itself — POSIX advisory locks are
+per-OPEN-FILE-DESCRIPTION, not per-process, so a probe that takes the lock in
+the same process that already holds it would block itself. The live-dispatch
+test holds the occupancy lock in a SEPARATE subprocess while the runner's probe
+runs in the main process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import gate_obligation_runner as runner  # noqa: E402
+from gate_obligations import (  # noqa: E402
+    STATUS_NOT_EXECUTABLE,
+    STATUS_PENDING,
+    STATUS_RETIRED,
+    REASON_NO_PR_BRANCH_GONE,
+    REASON_NO_PR_BRANCH_GONE_LIVE,
+    REASON_NO_PR_BRANCH_GONE_UNMEASURED,
+    obligation_path,
+    register_obligation,
+    update_obligation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror test_gate_obligations.py's fixtures so this file is
+# self-contained (no cross-file import of private helpers).
+# ---------------------------------------------------------------------------
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "vnx-data" / "state"
+    (state_dir / "review_gates" / "requests").mkdir(parents=True, exist_ok=True)
+    (state_dir / "review_gates" / "results").mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _read_obligation(state_dir: Path, dispatch_id: str) -> dict:
+    return json.loads(obligation_path(state_dir, dispatch_id).read_text(encoding="utf-8"))
+
+
+def _patch_resolution(monkeypatch, *, branch_exists, dispatch_live=None) -> None:
+    """Pin PR resolution so no gh/git calls happen.
+
+    ``dispatch_live`` is left to the REAL ``_dispatch_is_live`` unless the test
+    is exercising the subprocess-holder path (which creates a real lock file)
+    or explicitly stubbing it. Pinning ``branch_exists`` is enough to drive the
+    AWAITING branch; the liveness probe then reads the real occupancy lock.
+    """
+    monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+    monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
+    monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
+    monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: branch_exists)
+
+
+# A tiny program that takes an exclusive flock on a given path and holds it
+# until its stdin is closed (or it is killed). Written to a temp file and run
+# as a SUBPROCESS so the lock's open file description belongs to a different
+# process than the runner's probe — the OI-1232 / OI-1532 contract: a probe in
+# the same process that holds the lock measures itself.
+_HOLD_LOCK_SRC = textwrap.dedent(
+    """
+    import fcntl, sys, time
+    path = sys.argv[1]
+    fh = open(path, "a")
+    fcntl.flock(fh, fcntl.LOCK_EX)  # blocking: wait until we win it
+    # Signal the parent we hold the lock, then hold until stdin EOF.
+    sys.stdout.write("HELD\\n")
+    sys.stdout.flush()
+    try:
+        # Block on stdin read; parent closes stdin (or kills us) to release.
+        sys.stdin.read()
+    finally:
+        fcntl.flock(fh, fcntl.LOCK_UN)
+        fh.close()
+    """
+)
+
+
+@pytest.fixture
+def hold_occupancy_lock(tmp_path):
+    """Return a context manager that holds the dispatch's occupancy lock in a
+    SEPARATE subprocess for the duration of the ``with`` block.
+
+    Creates the lock file first (the isolation layer creates it with
+    ``open(..., "a")`` before flock-ing), then spawns a holder subprocess.
+    The holder prints ``HELD`` once it has the lock so the caller knows the
+    probe will see a live holder. On exit the subprocess is terminated and
+    reaped; the kernel releases the lock the instant its process exits.
+    """
+    holder_path = tmp_path / "_hold_lock_src.py"
+    holder_path.write_text(_HOLD_LOCK_SRC, encoding="utf-8")
+
+    holders: list[subprocess.Popen] = []
+
+    def _hold(lock_path: Path):
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        # Create the file the way the isolation layer does (open "a"), so the
+        # probe's ``lock_path.exists()`` check sees it — a missing file reads
+        # as ``None`` (unmeasured), which is NOT what this fixture means to
+        # simulate (a live dispatch always created its worktree/lock).
+        open(lock_path, "a").close()
+        proc = subprocess.Popen(
+            [sys.executable, str(holder_path), str(lock_path)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        # Wait for the holder to confirm it has the lock (or report an error).
+        ready = proc.stdout.readline()
+        if ready != b"HELD\n":
+            err = proc.stderr.read().decode("utf-8", "replace")
+            proc.kill()
+            pytest.fail(f"occupancy holder did not acquire the lock: {err!r} (ready={ready!r})")
+        holders.append(proc)
+        return proc
+
+    yield _hold
+
+    for proc in holders:
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+            proc.wait(timeout=5)
+        except (subprocess.TimeoutExpired, OSError, BrokenPipeError):
+            proc.kill()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Tak A — branch_exists is False, three ways.
+# ---------------------------------------------------------------------------
+
+
+class TestTakALiveDispatchNotRetired:
+    """A dispatch whose branch is gone on GitHub but is STILL RUNNING (its
+    occupancy lock is held by a live process) must NOT be retired.
+
+    RED on unfixed main: ``_pre_execution_decision`` returned ``{"kind":
+    "retire"}`` for ``branch_exists is False`` regardless of liveness, so the
+    obligation landed STATUS_RETIRED while the dispatch was actively running.
+    """
+
+    def test_live_dispatch_stays_pending_not_retired(self, tmp_path, monkeypatch, hold_occupancy_lock):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-live-not-pushed"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        # Hold the occupancy lock in a SEPARATE subprocess — the runner's probe
+        # runs in this process and must see a live holder without measuring
+        # itself (POSIX locks are per-open-file-description, not per-process).
+        lock_path = runner._occupancy_lock_path(state_dir, dispatch_id)
+        holder = hold_occupancy_lock(lock_path)
+
+        try:
+            summary = runner.run(state_dir)
+        finally:
+            # Release the holder so the fixture can clean up.
+            if holder.stdin is not None:
+                holder.stdin.close()
+            holder.wait(timeout=5)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        # The live dispatch must NOT be retired.
+        assert record["status"] == STATUS_PENDING, (
+            "a dispatch that is still running (occupancy lock held by a live "
+            "process) must stay pending — it has not pushed its branch yet, "
+            "NOT died (OI-1532 Tak A)"
+        )
+        assert record["status"] != STATUS_RETIRED
+        assert record["reason"] == REASON_NO_PR_BRANCH_GONE_LIVE, (
+            "the recorded reason must say 'live, not pushed' so the state is "
+            "distinct from a generic wait, not mistaken for a normal no-PR-yet"
+        )
+        assert record["reason_detail"], "reason_detail is required, never empty"
+        assert "still running" in record["reason_detail"]
+        # The runner's outcome action mirrors the pending state.
+        assert summary["pending_after"] == 1
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == "pending"
+
+    def test_live_dispatch_liveness_probe_does_not_measure_itself(self, tmp_path, monkeypatch):
+        """Regression guard for the POSIX-lock footgun: a probe that holds the
+        lock in the SAME process as the check would block itself and read the
+        dispatch as live for the wrong reason (its own hold, not a real
+        dispatch's). This test takes the lock IN-PROCESS and asserts the probe
+        still reads a live holder — proving the probe opens its OWN file
+        description rather than re-entering the holder's. If a future change
+        made the probe reuse the holder's fd, this test would hang or
+        misreport; the separate-subprocess test above is the real proof, this
+        is the cheap unit guard on the probe itself."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-probe-self"
+        import fcntl
+
+        lock_path = runner._occupancy_lock_path(state_dir, dispatch_id)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        # Take the exclusive lock in THIS process.
+        fh = open(lock_path, "a")
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            # The probe opens its OWN fd and asks LOCK_SH | LOCK_NB. An
+            # exclusive holder blocks it -> True (live). The probe must NOT
+            # reuse this fd (which would make a shared request succeed against
+            # our own exclusive lock on the same description — a false negative).
+            live = runner._dispatch_is_live(state_dir, dispatch_id)
+            assert live is True, (
+                "the probe must open its own file description and see the "
+                "in-process exclusive holder as live — if this reads False or "
+                "None, the probe is re-entering the holder's open file "
+                "description and measuring itself (OI-1532 / OI-1232)"
+            )
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+            fh.close()
+
+
+class TestTakADeadDispatchStillRetired:
+    """The existing, correct behaviour must not regress: a dispatch that is
+    dead (branch gone AND no live holder) is still retired."""
+
+    def test_dead_dispatch_retired(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-dead-no-pr"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        # No occupancy lock file exists -> _dispatch_is_live returns None
+        # (unmeasured), NOT False. To simulate a genuinely DEAD dispatch whose
+        # worktree existed (lock file present, no holder), stub the probe to
+        # False. This is the real shape of a dead dispatch that created a
+        # worktree: the file remains after teardown, the kernel released the
+        # lock when the holder exited.
+        monkeypatch.setattr(runner, "_dispatch_is_live", lambda sd, did: False)
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_RETIRED
+        assert record["reason"] == REASON_NO_PR_BRANCH_GONE
+        assert summary["pending_after"] == 0
+
+
+class TestTakALivenessUnmeasured:
+    """The THIRD state: the branch is gone but liveness could not be measured
+    (no occupancy lock file — the dispatch never created a worktree, a
+    dry-run, a hand-registered obligation, or a lane without occupancy locks —
+    or the probe failed). This is NOT dead and NOT alive. The runner must NOT
+    retire (a live dispatch must never be closed on ambiguous evidence) and
+    must record the unmeasured state VISIBLY so it is not mistaken for a
+    normal wait."""
+
+    def test_no_lock_file_stays_pending_unmeasured(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-unmeasured"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        # No lock file exists in the temp state dir -> the REAL probe returns
+        # None. Do NOT stub _dispatch_is_live: we want to prove the real
+        # three-way branch reaches retire_unmeasured on a missing lock file.
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_PENDING, (
+            "liveness-unmeasurable must NOT retire — a live dispatch must "
+            "never be closed on ambiguous evidence (OI-1532 third state)"
+        )
+        assert record["status"] != STATUS_RETIRED
+        assert record["reason"] == REASON_NO_PR_BRANCH_GONE_UNMEASURED, (
+            "the recorded reason must mark the state unmeasured so it is "
+            "distinct from a generic wait and from a confirmed retirement"
+        )
+        assert record["reason_detail"], "reason_detail is required"
+        assert "could not be measured" in record["reason_detail"]
+        assert summary["pending_after"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tak B — the genuine-wait branch must be bounded.
+# ---------------------------------------------------------------------------
+
+
+class TestTakBBoundedWait:
+    """The ``stay_pending`` branch (branch exists / undetermined) used to retry
+    forever. It now escalates loudly past ``_STAY_PENDING_ESCALATION_ATTEMPTS``
+    (which reuses ``_UNRESOLVABLE_ESCALATION_ATTEMPTS`` — never a second bound)."""
+
+    def test_below_threshold_stays_pending(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-wait-below"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        # branch_exists True -> genuine wait, liveness never probed.
+        _patch_resolution(monkeypatch, branch_exists=True)
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_PENDING
+        assert record["attempts"] == 1
+        assert summary["pending_after"] == 1
+
+    def test_at_threshold_escalates_loudly(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-wait-over-threshold"
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        # Bring the obligation to one attempt BELOW the threshold so this run
+        # crosses it (the runner increments attempts by 1 before deciding).
+        update_obligation(path, attempts=runner._STAY_PENDING_ESCALATION_ATTEMPTS - 1)
+        _patch_resolution(monkeypatch, branch_exists=True)
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_NOT_EXECUTABLE, (
+            "a genuine wait that has retried past the stay-pending threshold "
+            "must escalate to a loud terminal not_executable — never retry "
+            "silently forever (OI-1532 Tak B)"
+        )
+        assert record["reason"] == "stay_pending_timeout"
+        assert record["reason_detail"], "reason_detail is required"
+        assert "waited" in record["reason_detail"]
+        assert summary["pending_after"] == 0
+
+    def test_threshold_reuses_unresolvable_constant(self):
+        """The stay-pending bound MUST be the same constant as the unresolvable
+        bound — two bounds that drift out of step is the next defect."""
+        assert runner._STAY_PENDING_ESCALATION_ATTEMPTS is runner._UNRESOLVABLE_ESCALATION_ATTEMPTS
+        assert runner._STAY_PENDING_ESCALATION_ATTEMPTS == runner._UNRESOLVABLE_ESCALATION_ATTEMPTS
+
+    def test_branch_unknown_below_threshold_stays_pending(self, tmp_path, monkeypatch):
+        """branch_exists None (gh could not tell) is also a genuine wait under
+        the same bound — ambiguous evidence never retires, but it no longer
+        waits forever either."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-branch-unknown-below"
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        update_obligation(path, attempts=runner._STAY_PENDING_ESCALATION_ATTEMPTS - 2)
+        _patch_resolution(monkeypatch, branch_exists=None)
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_PENDING
+        assert summary["pending_after"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Dry-run parity — the new kinds must forecast the same action a real run takes.
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunParity:
+    """The dry run must walk the SAME three-way decision tree as a real run for
+    the new OI-1532 branches (OI-1388 defect 2 extended)."""
+
+    def test_live_dispatch_dry_run_forecasts_stay_pending(self, tmp_path, monkeypatch, hold_occupancy_lock):
+        real_dir = _make_state_dir(tmp_path / "real")
+        dry_dir = _make_state_dir(tmp_path / "dry")
+        dispatch_id = "20260830-oi1532-parity-live"
+        for state_dir in (real_dir, dry_dir):
+            register_obligation(
+                state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+            )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        # Hold the lock in a subprocess for BOTH dirs (the probe reads whichever
+        # state_dir it is given). A single holder per dir.
+        real_holder = hold_occupancy_lock(runner._occupancy_lock_path(real_dir, dispatch_id))
+        dry_holder = hold_occupancy_lock(runner._occupancy_lock_path(dry_dir, dispatch_id))
+        try:
+            dry_summary = runner.run(dry_dir, write=False)
+            real_summary = runner.run(real_dir, write=True)
+        finally:
+            for h in (dry_holder, real_holder):
+                if h.stdin is not None:
+                    h.stdin.close()
+                h.wait(timeout=5)
+
+        dry_action = dry_summary["outcomes"][0]["action"]
+        real_action = real_summary["outcomes"][0]["action"]
+        assert dry_action == "would_stay_pending_live"
+        assert real_action == "pending"
+        # Both agree the dispatch is NOT retired.
+        assert dry_action != "would_retire"
+        assert real_action != STATUS_RETIRED
+
+    def test_unmeasured_dry_run_forecasts_stay_pending(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-parity-unmeasured"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        _patch_resolution(monkeypatch, branch_exists=False)
+        # No lock file -> real probe returns None.
+
+        dry_summary = runner.run(state_dir, write=False)
+
+        assert dry_summary["outcomes"][0]["action"] == "would_stay_pending_unmeasured"
+        assert dry_summary["pending_after"] == 1
+
+    def test_over_threshold_dry_run_forecasts_escalation(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260830-oi1532-parity-escalate"
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        update_obligation(path, attempts=runner._STAY_PENDING_ESCALATION_ATTEMPTS - 1)
+        _patch_resolution(monkeypatch, branch_exists=True)
+
+        dry_summary = runner.run(state_dir, write=False)
+
+        assert dry_summary["outcomes"][0]["action"] == "would_escalate_stay_pending"
+        assert dry_summary["pending_after"] == 0

--- a/tests/test_oi1532_live_dispatch_not_retired.py
+++ b/tests/test_oi1532_live_dispatch_not_retired.py
@@ -766,8 +766,15 @@ class TestTakCNewBranchesBounded:
     def _decision(attempts: int, dispatch_live) -> dict:
         """Drive the REAL ``_pre_execution_decision`` — the same surface T0
         measured — with an empty result index (no rescue evidence) and the
-        branch-gone AWAITING resolution split by the given liveness answer."""
+        branch-gone AWAITING resolution split by the given liveness answer.
+
+        ``state_dir`` (#1745/OI-1508) is a required positional now, but the
+        AWAITING branch this test drives never reads it — only the RESOLVED
+        branch's owner/repo fallback does — so a placeholder path that is
+        never touched is correct here, not a real temp dir.
+        """
         return runner._pre_execution_decision(
+            Path("/unused-state-dir-oi1587-tak-c"),
             TestTakCNewBranchesBounded._DECISION_DISPATCH_ID,
             "codex_gate",
             runner.PrResolution(
@@ -781,7 +788,7 @@ class TestTakCNewBranchesBounded:
                 ),
             ),
             attempts,
-            {},
+            runner.GateResultIndex({}, {}),
         )
 
     def test_unmeasured_escalates_at_and_past_threshold(self):


### PR DESCRIPTION
## Summary

`_pre_execution_decision` (`scripts/gate_obligation_runner.py`) had two wrong branches in one function. Both missed the same missing state: **does this dispatch still live**.

**Tak A — `branch_exists is False` is te agressief.** `False` folds two states into one: "branch existed and was deleted" (dispatch dead, retire is correct) and "branch never created because the dispatch is STILL RUNNING" (retire is wrong). Caught live on `20260830-124500-sidedoor`: `would_retire` while the dispatch held an occupancy lock (13 min runtime, pid 82207).

**Tak B — `stay_pending` is onbegrensd.** A genuine wait retried forever with no attempt bound. Measured on mission-control: 11 obligations on 776 attempts (8+ days at the 900s cadence) with nothing alarming.

## Fix

Add the missing state via the dispatch's occupancy lock (`<state_dir>/dispatch_worktree_claims/<safe_id>.occupancy`) — an `fcntl.flock` on an open file description the kernel releases the instant its holder exits. A non-blocking probe answers "is a live process still holding this dispatch" hard.

- **Tak A three-valued**: dead → `retire` (unchanged); alive → `pending` (`no_pr_branch_gone_live`, never retired); liveness-unmeasurable → `pending` (`no_pr_branch_gone_unmeasured`, a THIRD state, never a silent default for either).
- **Tak B bounded**: `stay_pending` escalates loudly past `_STAY_PENDING_ESCALATION_ATTEMPTS`, which **reuses** `_UNRESOLVABLE_ESCALATION_ATTEMPTS` (96 × 900s ≈ 24h) — never a second, drift-prone bound next to the existing two.

The existing branches (evidence-shortcut, `RESOLUTION_UNRESOLVABLE` escalation, temporary-refusal escalation) are untouched.

## Producer-freshness-monitor question (dispatch point 3)

The docstring claims the producer-freshness-monitor catches perenially-pending obligations per gate-key. Measured 30-08:
- **vnx-dev**: monitor runs (heartbeat 06:00, 10 findings, status stale).
- **mission-control**: NO heartbeat, NO NDJSON — the launchd plist resolves to `vnx-dev`, so the monitor never ran there. The 776-attempt wait alarmed nothing for 8 days.

The monitor works where it runs, but it is not a sufficient backstop for Tak B: the runner-side bound is the vangnet that works regardless of whether the monitor is installed. Not overbodig.

## Verification

**RED on pre-fix main** (`/tmp/oi1532_red_demo.py`, pre-fix source restored via `git show HEAD`):
```
status = retired   <- live dispatch (occupancy lock held by subprocess) retired
AssertionError: RED expected pending (live dispatch), got 'retired'
```

**GREEN after fix** (same demo):
```
status = pending   pending_after = 1   outcome action = pending
```

**Grep on field names** found extra test files the import-graph misses:
```
grep -rln "branch_exists|no_pr_branch_gone|_pre_execution_decision|stay_pending" tests/ --include="*.py"
  -> test_oi1392_pr_enforcement_work_ref.py, test_cli_flag_forwarding.py,
     test_per_pr_closure.py, test_closure_verifier*.py (3)
grep -rln "occupancy" tests/ --include="*.py"
  -> test_dispatch_worktree_lifecycle_guards.py
```

**Tests run** (225 passed):
```
pytest tests/test_gate_obligations.py tests/test_gate_obligation_runner.py \
  tests/test_gate_obligation_runner_scope.py tests/test_gate_obligation_retire_backlog.py \
  tests/test_oi1532_live_dispatch_not_retired.py tests/test_gate_recovery_wiring.py \
  tests/test_oi1490_gate_provider_registry.py tests/test_oi1485_gate_execution_depth.py \
  tests/test_oi1392_pr_enforcement_work_ref.py tests/test_gate_recorder_overwrite_guard.py
225 passed
```

**Pre-existing failures (not caused by this diff)**: 10 in `test_per_pr_closure.py` + `test_cli_flag_forwarding.py`, identical on the clean tree (`review_gate_manager.py:339` `strict` kwarg — unrelated).

## Liveness self-measurement guard (dispatch point 1)

POSIX advisory locks are per-OPEN-FILE-DESCRIPTION, not per-process. The live-dispatch test holds the occupancy lock in a **separate subprocess** (`hold_occupancy_lock` fixture) while the runner's probe runs in the main process. A unit guard (`test_live_dispatch_liveness_probe_does_not_measure_itself`) takes the lock in-process and asserts the probe still reads a live holder via its OWN file description — proving it does not re-enter the holder's.

## Documentation

The three states of Tak A and the bound of Tak B are written as a CONTRACT in `docs/operations/PRODUCER_FRESHNESS_MONITOR.md` (operator-directive 30-08), including the measured reason the freshness monitor is not a sufficient backstop.

**Model**: sonnet
**Provider**: claude
**Dispatch-ID**: 20260830-143000-oi1532-levende-dispatch-niet-afboeken

🤖 Generated with [Claude Code](https://claude.com/claude-code)