### PR TITLE
fix(hooks): sessionstart.sh reads the central store, not just repo-local .vnx-data

### DIFF
--- a/docs/governance/decisions/ADR-026-per-project-store-with-governance-federation.md
+++ b/docs/governance/decisions/ADR-026-per-project-store-with-governance-federation.md
@@ -56,6 +56,16 @@ Concrete rules:
 
 Migration scoping + the precise reclaim plan are in `claudedocs/2026-06-27-store-model-research-SYNTHESIS.md` and `claudedocs/2026-06-27-sales-copilot-vnx-cutover-PLAN.md`. The panel reports are at `~/.vnx-data/vnx-dev/unified_reports/20260627-storemodel-{deepseek,kimi,codex,glm}.md`.
 
+## Conformance
+
+Hooks that read or write VNX runtime state must resolve the per-project CENTRAL store — never a repo-local guess. Each of the following hit the same repo-local-vs-central split-brain and was fixed the same way, shelling out to the canonical Python resolver (`vnx_paths.resolve_paths()['VNX_STATE_DIR']`), or its bash lockstep mirror `scripts/lib/vnx_paths.sh`:
+
+- `scripts/hooks/path_parity_check.sh` (OI-852).
+- `scripts/hooks/build_t0_state_hook.sh` (OI-859) — writes `t0_state.json` there.
+- `hooks/sessionstart.sh` (D4, 2026-08-30) — reads `terminal_state_*.json` / `open_items.json` from there for the T0 SessionStart briefing. The prior version only walked repo-local `.vnx-data/state` / `.claude/vnx-data/state` candidates up from `$PWD`; once a checkout had no repo-local `.vnx-data` (the normal case post-cutover), it silently showed an empty-looking "No open items data" briefing instead of the real central-store content. Regression coverage: `tests/test_sessionstart_hook_central_store.py`. A resolved-but-absent store is now a loud `VNX STATE STORE NOT FOUND` in the injected context, not indistinguishable from a genuinely empty one.
+
+Any new hook that reads or writes VNX runtime state must resolve through the same resolver rather than re-deriving a repo-local guess.
+
 ## See also
 
 - ADR-007 — Multi-tenant project_id stamping (the rule this ADR preserves; this ADR amends only the store form).

--- a/hooks/sessionstart.sh
+++ b/hooks/sessionstart.sh
@@ -59,20 +59,37 @@ case "$TERMINAL" in
     # Gather live terminal states (best-effort, 2s timeout)
     T0_TERMINAL_STATES=""
     T0_OPEN_ITEMS=""
-    # Resolve VNX paths for state files
-    _VNX_STATE_DIR=""
-    for _candidate in ".vnx-data/state" ".claude/vnx-data/state"; do
-      _search="$PWD"
-      for _ in 1 2 3 4 5; do
-        if [ -d "$_search/$_candidate" ]; then
-          _VNX_STATE_DIR="$_search/$_candidate"
-          break 2
-        fi
-        _search="$(dirname "$_search")"
-      done
-    done
 
-    if [ -n "$_VNX_STATE_DIR" ]; then
+    # ── Resolve the CENTRAL state dir (ADR-026), same resolver as the runtime ──
+    # The old resolver only checked ".vnx-data/state" / ".claude/vnx-data/state"
+    # up to 5 levels above $PWD — both repo-local candidates. ADR-026 makes the
+    # per-project CENTRAL store (~/.vnx-data/<project_id>/state) canonical, so
+    # a checkout with no repo-local .vnx-data (the normal case since the
+    # central-store cutover) silently found nothing, and this hook injected a
+    # plausible-looking "No open items data" briefing while recent_receipts,
+    # tracks, pr_queue and strategic_state were actually just unreachable
+    # (fail-open). path_parity_check.sh (OI-852) and build_t0_state_hook.sh
+    # (OI-859) hit the identical repo-local-vs-central split-brain and both
+    # fixed it the same way: shell out to the canonical Python resolver
+    # (vnx_paths.resolve_paths), which stays worktree/CWD-agnostic and in
+    # lockstep with the runtime — never a second hand-rolled resolver.
+    # Anchored on this hook's OWN file location (not $PWD), so resolution
+    # doesn't depend on which terminal directory happened to be current.
+    _VNX_STATE_DIR=""
+    _HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)" || _HOOK_DIR=""
+    if [ -n "$_HOOK_DIR" ] && [ -f "$_HOOK_DIR/../scripts/lib/vnx_paths.py" ]; then
+      _VNX_PY="$_HOOK_DIR/../.venv/bin/python"
+      [ -x "$_VNX_PY" ] || _VNX_PY="/opt/homebrew/opt/python@3.12/bin/python3.12"
+      [ -x "$_VNX_PY" ] || _VNX_PY="python3"
+      _VNX_STATE_DIR="$("$_VNX_PY" -c "
+import sys
+sys.path.insert(0, '$_HOOK_DIR/../scripts/lib')
+from vnx_paths import resolve_paths
+print(resolve_paths()['VNX_STATE_DIR'])
+" 2>/dev/null || true)"
+    fi
+
+    if [ -n "$_VNX_STATE_DIR" ] && [ -d "$_VNX_STATE_DIR" ]; then
       # Terminal states from shadow state files
       for _t in T1 T2 T3; do
         _sf="$_VNX_STATE_DIR/terminal_state_${_t}.json"
@@ -97,6 +114,17 @@ case "$TERMINAL" in
           fi
         fi
       fi
+
+      T0_STATE_SECTION="Terminals:
+$(echo -e "${T0_TERMINAL_STATES:-No terminal state data}")
+${T0_OPEN_ITEMS:-No open items data}"
+    else
+      # Not-found is a DIFFERENT state than found-but-empty (a genuinely
+      # measured zero). Say so explicitly instead of falling through to a
+      # "No open items data" default that would read as an ordinary quiet
+      # project instead of an unresolved store — the exact fail-open this
+      # fix closes.
+      T0_STATE_SECTION="VNX STATE STORE NOT FOUND — terminal states, open items, receipts and PR queue are UNAVAILABLE this session (UNMEASURED, not zero). Resolved path: ${_VNX_STATE_DIR:-<resolution failed: vnx_paths.py unreachable from here>}. Expected under ADR-026 at ~/.vnx-data/<project_id>/state — verify the receipt processor has run for this project."
     fi
 
     # ── T0 Orchestrator playbook body (in-context injection) ────────────
@@ -126,9 +154,7 @@ Operator-only skills (not model-invocable): @t0-orchestrator @architect
 Full registry: skills/skills.yaml (repo) or \$VNX_SKILLS_DIR/skills.yaml (consumer)
 Use /t0-orchestrator for orchestration decisions and receipt processing
 
-Terminals:
-$(echo -e "${T0_TERMINAL_STATES:-No terminal state data}")
-${T0_OPEN_ITEMS:-No open items data}
+$T0_STATE_SECTION
 
 CRITICAL: After every completion receipt, check quality advisory + open items before proceeding.
 Skills must NOT use @ prefix in Role field. Skill registry: skills/skills.yaml (repo) or \$VNX_SKILLS_DIR/skills.yaml (consumer).${T0_SKILL_BODY:+

--- a/tests/test_sessionstart_hook_central_store.py
+++ b/tests/test_sessionstart_hook_central_store.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""tests/test_sessionstart_hook_central_store.py — D4: sessionstart.sh reads
+the CENTRAL store (ADR-026), not only a repo-local ".vnx-data/state".
+
+Defect: hooks/sessionstart.sh:64-73 (pre-fix) resolved the T0 state dir by
+walking up from $PWD checking only ".vnx-data/state" and
+".claude/vnx-data/state" — both repo-local candidates. ADR-026
+(docs/governance/decisions/ADR-026-per-project-store-with-governance-federation.md)
+makes the per-project CENTRAL store (~/.vnx-data/<project_id>/state) the
+canonical location. A checkout with no repo-local ".vnx-data" (the normal
+case since the central-store cutover) silently found nothing, and the hook
+injected a plausible-looking "No open items data" / "No terminal state data"
+briefing instead of surfacing that recent_receipts/tracks/pr_queue/
+strategic_state were all actually unreachable — a fail-open.
+
+These tests exercise the real hook (bash + the real vnx_paths resolver)
+against a project directory that deliberately carries NO repo-local
+".vnx-data" anywhere in its tree — the exact defect scenario — and assert:
+
+1. The hook still finds and reads the CENTRAL store (same resolver the
+   runtime uses: vnx_paths.resolve_paths()), same OI-852/OI-859 class fix as
+   scripts/hooks/path_parity_check.sh and scripts/hooks/build_t0_state_hook.sh.
+2. When the store genuinely cannot be resolved/found, the hook says so
+   LOUDLY ("VNX STATE STORE NOT FOUND") instead of falling through to the
+   ordinary "No open items data" / "No terminal state data" defaults — a
+   third state, not a silent zero (niet-gemeten is een derde tak).
+
+Isolation: real per-project central store lookups go through VNX_DATA_HOME
+(redirected at a tmp_path) exactly like tests/test_path_parity_hook.py — the
+whole point is exercising the same "no repo-local state, no explicit
+VNX_STATE_DIR" code path production hits.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "hooks" / "sessionstart.sh"
+LIB = REPO / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import vnx_paths  # noqa: E402
+
+_VNX_ENV_VARS = (
+    "VNX_DATA_DIR",
+    "VNX_STATE_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_DATA_HOME",
+    "VNX_PROJECT_ID",
+    "VNX_HOME",
+    "VNX_BIN",
+    "VNX_EXECUTABLE",
+    "VNX_CANONICAL_ROOT",
+    "VNX_PROJECT_ROOT",
+)
+
+
+def _clean_env(monkeypatch) -> None:
+    for var in _VNX_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_terminal_project(tmp_path: Path, name: str = "project") -> Path:
+    """A T0 terminal dir with NO repo-local .vnx-data anywhere in its tree —
+    the exact pre-fix defect scenario."""
+    root = tmp_path / name
+    (root / ".vnx").mkdir(parents=True)
+    t0_dir = root / ".claude" / "terminals" / "T0"
+    t0_dir.mkdir(parents=True)
+    return t0_dir
+
+
+def _run_hook(cwd: Path, env: dict) -> dict:
+    r = subprocess.run(
+        ["bash", str(HOOK)],
+        capture_output=True, text=True, cwd=str(cwd), env=env, timeout=10,
+    )
+    assert r.returncode == 0, f"hook must exit 0: rc={r.returncode}\nstdout={r.stdout}\nstderr={r.stderr}"
+    return json.loads(r.stdout)
+
+
+class TestCentralStoreResolution:
+    def test_finds_central_store_without_repo_local_vnx_data(self, tmp_path, monkeypatch):
+        """The exact defect (Klaar-wanneer bullet 3): a project dir with NO
+        repo-local .vnx-data/state must still resolve to the central
+        per-project store (ADR-026) and read real terminal-state / open-items
+        content from it."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+
+        isolated_home = tmp_path / "vnx-data-home"
+        monkeypatch.setenv("VNX_DATA_HOME", str(isolated_home))
+
+        env = dict(os.environ)
+        expected_state_dir = Path(vnx_paths.resolve_paths()["VNX_STATE_DIR"])
+        repo_local_fallback = REPO / ".vnx-data" / "state"
+        assert expected_state_dir != repo_local_fallback, (
+            "central resolver coincides with the repo-local fallback on this "
+            "machine -- this test cannot distinguish the fix from the old bug"
+        )
+
+        expected_state_dir.mkdir(parents=True, exist_ok=True)
+        (expected_state_dir / "terminal_state_T1.json").write_text(
+            json.dumps({"status": "busy", "current_task": "UNIQUE-TASK-MARKER-9f2a"}),
+            encoding="utf-8",
+        )
+        (expected_state_dir / "open_items.json").write_text(
+            json.dumps({"items": [
+                {"status": "open", "severity": "blocker", "id": "OI-1", "title": "UNIQUE-OI-MARKER-7b3c"},
+            ]}),
+            encoding="utf-8",
+        )
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "UNIQUE-TASK-MARKER-9f2a" in ctx, ctx
+        assert "UNIQUE-OI-MARKER-7b3c" in ctx, ctx
+        assert "VNX STATE STORE NOT FOUND" not in ctx
+
+        # Regression guard: the old repo-local candidates must never have
+        # been consulted or created as a side effect of this run.
+        assert not (t0_dir.parent.parent.parent / ".vnx-data").exists()
+
+    def test_loud_warning_when_store_not_found(self, tmp_path, monkeypatch):
+        """Not-found is a third state, not a silent zero: when the resolved
+        central path does not exist on disk (no dispatch/receipt-processor
+        has ever run for this project), the hook must say so LOUDLY, never
+        fall through to the ordinary "No open items data" / "No terminal
+        state data" defaults — those must read as "measured: empty", not
+        "unmeasured"."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+
+        isolated_home = tmp_path / "vnx-data-home-empty"
+        monkeypatch.setenv("VNX_DATA_HOME", str(isolated_home))
+        env = dict(os.environ)
+
+        expected_state_dir = Path(vnx_paths.resolve_paths()["VNX_STATE_DIR"])
+        assert not expected_state_dir.exists(), "precondition: central dir must not pre-exist"
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "VNX STATE STORE NOT FOUND" in ctx, ctx
+        assert "UNMEASURED" in ctx, ctx
+        assert "No open items data" not in ctx
+        assert "No terminal state data" not in ctx
+
+    def test_hook_is_valid_bash(self):
+        result = subprocess.run(["bash", "-n", str(HOOK)], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

`hooks/sessionstart.sh` resolved the T0 state dir by walking up from `$PWD`
checking only two repo-local candidates (`.vnx-data/state`,
`.claude/vnx-data/state`, up to 5 levels). ADR-026 makes the per-project
CENTRAL store (`~/.vnx-data/<project_id>/state`) canonical, so a checkout
with no repo-local `.vnx-data` (the normal case since the central-store
cutover) silently found nothing — the hook then injected a plausible-looking
"No open items data" briefing while `recent_receipts`/`tracks`/`pr_queue`/
`strategic_state` were actually just unreachable (fail-open).

- Resolves via the same resolver the runtime uses (`vnx_paths.resolve_paths()`),
  the identical OI-852/OI-859-class fix already applied to
  `scripts/hooks/path_parity_check.sh` and `scripts/hooks/build_t0_state_hook.sh`.
  Anchored on the hook's own file location (not `$PWD`), so resolution doesn't
  depend on which terminal directory happened to be current.
- A resolved-but-absent store now surfaces a loud `VNX STATE STORE NOT FOUND`
  in the injected context, distinct from the ordinary "no data" defaults —
  "not found" and "measured empty" are no longer the same message.
- No other repo-local-only path assumption was found elsewhere in this hook
  (the `PROJECT_ROOT` walk for the T0 skill-body injection is intentionally
  repo-local per ADR-026: "skills are orthogonal to the store").
- ADR-026 gets a new "Conformance" section cross-referencing all three hooks
  that must resolve through this same central-store resolver.

## Test plan

- [x] `tests/test_sessionstart_hook_central_store.py` (new): red on the
      pre-fix hook, green after — verified by checking out the prior version
      and re-running before restoring the fix.
  - central store found (no repo-local `.vnx-data` anywhere) → real
    terminal-state/open-items content is read
  - central store resolved but absent on disk → loud `VNX STATE STORE NOT FOUND`
  - `bash -n` validity
- [x] `tests/test_sessionstart_hook.py`, `tests/test_sessionstart_hook_dead_vars.py`,
      `tests/test_t0_role_audit_static.py`, `tests/test_path_parity_hook.py` — all
      pass unchanged (41 total across the targeted set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)