### PR TITLE
fix(subsystems): LIVE + unmeasured health is not a legal combination (D6b)

### DIFF
--- a/.github/workflows/subsystems-drift.yml
+++ b/.github/workflows/subsystems-drift.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Check ledger drift (deterministic columns only)
         run: make subsystems-check
+
+      - name: Check LIVE status requires measured health (D6b)
+        run: make live-health-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: subsystems-check
+.PHONY: subsystems-check live-health-check
 
 # Diff docs/core/SUBSYSTEMS.md's deterministic columns (subsystem/what/flag/status)
 # against the live `vnx subsystems --md` generator. The dynamic `health` column is
@@ -6,3 +6,9 @@
 # .github/workflows/subsystems-drift.yml.
 subsystems-check:
 	python3 scripts/check_subsystems_drift.py
+
+# Fail when a cockpit subsystem claims LIVE while its own health reads
+# "unknown" -- LIVE + unmeasured is a self-contradiction, not a legal
+# combination (D6b). Wired into .github/workflows/subsystems-drift.yml.
+live-health-check:
+	python3 scripts/check_live_requires_measured_health.py

--- a/docs/core/SUBSYSTEMS.md
+++ b/docs/core/SUBSYSTEMS.md
@@ -13,12 +13,6 @@ This document is the single source of truth for which VNX subsystems are live, p
 | zero-llm-injection | No prompt injection via environment or receipts; strict input boundaries. | — | LIVE | works — red-team tests pass |
 | dispatch-plan | Single-entry dispatch door, dispatch-plan reconciliation. | — | LIVE | works — dispatch tests pass |
 | test-suite | Pytest + integration coverage for kernel and cockpit. | — | LIVE | works — CI green |
-| cheap-recon-scout | Cheap-model scout recon pre-pass in the dispatch door (fail-open). | `VNX_SCOUT_PREPASS` | LIVE | unknown — no probe yet |
-| horizon-planning | Autonomous roadmap auto-next loading (starts work unattended). | `VNX_ROADMAP_AUTOPILOT` | LIVE | unknown — no probe yet |
-| headless-dispatch-routing | Headless dispatch routing mode selector. | `VNX_HEADLESS_ROUTING` | LIVE | unknown — no probe yet |
-| central-db-routing | Central-DB read mode for the runtime coordination store (per-project vs central vs shadow). | `VNX_USE_CENTRAL_DB` | LIVE | unknown — no probe yet |
-| smart-router-staging | Phased smart-router AUTO routing rollout (per-tier enable + deterministic canary fraction). | `VNX_SMART_ROUTER_CANARY_PCT` | LIVE | unknown — no probe yet |
-| claude-tmux-serialization | N-slot serial lock protecting the shared Claude subscription session cap for the claude-tmux dispatch lane. | `VNX_TMUX_MAX_CONCURRENT` | LIVE | unknown — no probe yet |
 | migration-mechanisms | Schema-evolution surfaces (42 SQL files + 6 appliers). Consolidation PARKed pending inventory-lock. | `VNX_MIGRATION_SYSTEM` | PARK-with-trigger | degraded — 42 SQL files + 6 appliers; consolidation PARKed pending inventory-lock (`scripts/lib/migration_inventory.py`, PR-8) |
 | within-db-tenancy | Composite (project_id, id) keys inside per-project DBs. Removal PARKed pending per-table central-DB safety proof. | — | PARK-with-trigger | degraded — keys present; drop deferred (central-store/dual-write/ADR-026 interaction) |
 | docs-bloat | Comparisons, stale archive, marketing docs inflating docs/ count. | — | CUT | degraded — ~288 markdown files, large `_archive/` |
@@ -30,6 +24,12 @@ This document is the single source of truth for which VNX subsystems are live, p
 | dream-consolidation | Nightly memory consolidation + pending review dispatch. | `VNX_DREAM_SCHEDULER_ENABLED` | ACTIVATE-and-measure | unknown — no cycles run |
 | injection-effectiveness-eval-loop | Instrument WHY patterns are ignored before tuning generation. | `VNX_INJECTION_WHY_ENABLED` | ACTIVATE-and-measure | unknown — probe not built yet |
 | cross-project-federation | Cross-project intelligence federation (not yet implemented). | `VNX_USE_FEDERATION` | ACTIVATE-and-measure | unknown — no probe yet |
+| cheap-recon-scout | Cheap-model scout recon pre-pass in the dispatch door (fail-open). | `VNX_SCOUT_PREPASS` | ACTIVATE-and-measure | unknown — no probe yet |
+| horizon-planning | Autonomous roadmap auto-next loading (starts work unattended). | `VNX_ROADMAP_AUTOPILOT` | ACTIVATE-and-measure | unknown — no probe yet |
+| headless-dispatch-routing | Headless dispatch routing mode selector. | `VNX_HEADLESS_ROUTING` | ACTIVATE-and-measure | unknown — no probe yet |
+| central-db-routing | Central-DB read mode for the runtime coordination store (per-project vs central vs shadow). | `VNX_USE_CENTRAL_DB` | ACTIVATE-and-measure | unknown — no probe yet |
+| smart-router-staging | Phased smart-router AUTO routing rollout (per-tier enable + deterministic canary fraction). | `VNX_SMART_ROUTER_CANARY_PCT` | ACTIVATE-and-measure | unknown — no probe yet |
+| claude-tmux-serialization | N-slot serial lock protecting the shared Claude subscription session cap for the claude-tmux dispatch lane. | `VNX_TMUX_MAX_CONCURRENT` | ACTIVATE-and-measure | unknown — no probe yet |
 | plan-gate-panel | 5-model deliberation panel for plan-first enforcement. | `VNX_PLAN_GATE_ENFORCE` | SCOPE | works — panel runs, verdicts recorded |
 | plan-gate-task-class-scope | Restrict panel to complex features; run trivial tracks on a reduced 2-seat panel (scope read-site: plan_gate_enforcement.plan_gate_scope). | `VNX_PLAN_GATE_COMPLEX_ONLY` | SCOPE | works — scope read-site present (light plans run 2 seats) |
 | subsystem-cockpit | SUBSYSTEMS.md + config_registry + vnx subsystems + dashboard tile. | — | COCKPIT | degraded — SSOT exists, probes partial |

--- a/scripts/check_live_requires_measured_health.py
+++ b/scripts/check_live_requires_measured_health.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""CI check: no cockpit subsystem may claim LIVE while its own health reads
+"unknown" (D6b).
+
+`LIVE` means, per ``docs/core/SUBSYSTEMS.md``'s legend, "running and expected
+to stay on" -- a claim of fact. "unknown -- no probe yet" is an admission
+that nobody has ever measured it. The two together said the same thing twice
+with opposite truth values: six subsystems carried exactly that combination
+(cheap-recon-scout, horizon-planning, headless-dispatch-routing,
+central-db-routing, smart-router-staging, claude-tmux-serialization) until
+this dispatch moved them to ``ACTIVATE-and-measure``. This script keeps the
+combination illegal going forward -- it is the "controle die rood wordt"
+this dispatch was asked to leave behind, not just the one-time fix.
+
+Health is resolved the same way ``vnx subsystems`` does (live beacon, else
+the seed value committed in ``docs/core/SUBSYSTEMS.md``) so this check is
+deterministic in a clean CI checkout with no beacon files: it degrades to
+pure seed-health, which is exactly the committed doc text.
+
+Wired via ``make live-health-check`` and
+``.github/workflows/subsystems-drift.yml``.
+
+Exit codes: 0 = no LIVE+unknown rows, 1 = violation found, 2 = internal error.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for sub in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "lib"):
+    s = str(sub)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+sys.path.insert(0, str(_REPO_ROOT))
+
+
+def violations_in_rows(rows: list[dict]) -> list[str]:
+    """Pure filter: subsystem names that are status=LIVE with unmeasured health.
+
+    Split out from ``find_live_unknown_violations`` so the invariant is
+    unit-testable against synthetic rows, without needing a live beacon dir
+    or the committed SUBSYSTEMS.md seed table.
+    """
+    return [
+        row["subsystem"]
+        for row in rows
+        if row["status"] == "LIVE" and row.get("health", "").startswith("unknown")
+    ]
+
+
+def find_live_unknown_violations(repo_root: Path) -> list[str]:
+    """Return subsystem names that are status=LIVE with unmeasured health."""
+    from vnx_cli import _engine
+    from vnx_cli.commands import subsystems as sub_mod
+
+    engine_root = _engine.engine_root()
+    data_dir = _engine.resolve_data_root(repo_root)
+
+    rows = sub_mod.build_rows()
+    seed_health = sub_mod._parse_seed_health(engine_root)
+    sub_mod._attach_health(rows, data_dir, seed_health, use_probe=False)
+
+    return violations_in_rows(rows)
+
+
+def main() -> int:
+    try:
+        violations = find_live_unknown_violations(_REPO_ROOT)
+    except ImportError as exc:
+        print(f"internal error: cannot import subsystems generator: {exc}", file=sys.stderr)
+        return 2
+
+    if not violations:
+        print("OK — no LIVE subsystem claims 'unknown' health.")
+        return 0
+
+    print(
+        "VIOLATION — LIVE status paired with unmeasured health is not a legal "
+        "combination:",
+        file=sys.stderr,
+    )
+    for name in violations:
+        print(f"  {name}: status=LIVE, health=unknown", file=sys.stderr)
+    print(
+        "\nEither: (a) demote to ACTIVATE in scripts/lib/config_registry.py "
+        "until a probe exists, or (b) register an effectiveness probe "
+        "(scripts/lib/effectiveness_probe.py) that measures it.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_live_requires_measured_health.py
+++ b/scripts/check_live_requires_measured_health.py
@@ -35,27 +35,69 @@ for sub in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "lib"):
 sys.path.insert(0, str(_REPO_ROOT))
 
 
-# Health cells read "<category> — <detail>" (e.g. "works — CI green"). These
-# are the categories this check has verified mean "a probe or seed actually
-# produced a reading" (OI-1593): `works`, `degraded`, and `produces-crap` are
-# real probe/seed outcomes; `stale` means the beacon aged out but still holds
-# a prior real reading (health_beacon.py). None of the four says whether
-# LIVE+degraded/produces-crap/stale SHOULD be legal — that is a separate
-# design question this check does not take a position on. It only asserts
-# they are genuinely measured, so they are exempt from the "unmeasured"
-# violation this check exists to catch.
+# Health cells read "<category> — <detail>" (e.g. "works — CI green").
+# ``subsystems._attach_health`` fills this column from ONE OF TWO vocabularies
+# per row (a beacon wins if one exists for the subsystem, else the row falls
+# back to seed prose — see its docstring), and this allowlist must recognize
+# both or it silently only covers whichever one the original author had in
+# view (OI-1596: a version of this list that covered only the seed
+# vocabulary reported LIVE+beacon-`ok` as a VIOLATION with the message
+# "health is unmeasured" — the exact opposite of what had been measured).
 #
-# Everything else falls through to "unmeasured": `unknown` (explicit "no
-# probe yet"), an empty cell, a missing `health` key, and any category this
-# check has never seen before. That last case is deliberate fail-closed
-# behavior — a new beacon category (e.g. a future `absent`) is unmeasured
-# until this allowlist is updated to say otherwise, not until this check
-# happens to not recognize it as a violation.
+#   seed prose (docs/core/SUBSYSTEMS.md health column, parsed by
+#   ``_parse_seed_health``; verified against the committed file on OI-1596):
+#       works, degraded, produces-crap, unknown
+#
+#   beacon (``health_beacon.all_beacons()``'s derived ``health`` field, which
+#   is what ``beacon.get('health', ...)`` in ``_attach_health`` actually
+#   reads; verified against health_beacon.py's docstring and its
+#   ``beacon_summary()`` counts dict, both of which enumerate the same six):
+#       ok, stale, fail, corrupt, unknown, absent
+#
+# A component CAN self-report a raw ``status`` of "degraded" (e.g.
+# ``learning_loop.py``), but ``all_beacons()`` only ever honors a
+# self-reported ok/fail/stale/corrupt — anything else, including "degraded",
+# collapses to "fail" before this check ever sees it (health_beacon.py
+# ``_status_to_health``). So the beacon vocabulary this check actually
+# receives never contains the word "degraded"; that spelling only ever
+# arrives via a seed row.
+#
+# `works`, `degraded`, and `produces-crap` (seed) are real seed outcomes — a
+# human recorded a measurement. `ok` and `fail` (beacon) are likewise
+# genuinely measured: `fail` is measured-and-bad, a SEPARATE design question
+# (may LIVE+fail be legal?) this check does not take a position on, same as
+# it already declines to judge degraded/produces-crap — this check is about
+# *unmeasured*, not about *bad*. `stale` (beacon) means the beacon aged out
+# but still holds a prior real reading. None of these six says whether the
+# LIVE+<category> combination SHOULD be legal — only that it is genuinely
+# measured, so all six are exempt from the "unmeasured" violation this check
+# exists to catch.
+#
+# Everything else falls through to "unmeasured": `unknown` (both
+# vocabularies' explicit "no probe/no recent signal yet"), `absent` (beacon:
+# an expected component that never once wrote), `corrupt` (beacon: the JSON
+# could not be read at all — not a trustworthy reading, so it is treated the
+# same as never having measured, not bundled in with `fail`), an empty cell,
+# a missing `health` key, and any category this check has never seen before.
+# That last case is deliberate fail-closed behavior — a new category is
+# unmeasured until this allowlist is updated to say otherwise, not until
+# this check happens to not recognize it as a violation.
+#
+# Not derived from a shared source: neither vocabulary has one. The seed
+# words are free text in a markdown table, not a validated enum anywhere in
+# code. The beacon side comes closest — ``health_beacon.beacon_summary()``
+# has an inline ``counts`` dict naming the same six categories — but it is
+# not exported as a reusable constant, and only covers the beacon half
+# anyway. Exporting one would mean refactoring health_beacon.py's internals,
+# which is out of scope for this one allowlist; if a shared constant is
+# wanted, do it as its own change.
 _MEASURED_HEALTH_CATEGORIES = frozenset({
     "works",
     "degraded",
     "produces-crap",
     "stale",
+    "ok",
+    "fail",
 })
 
 

--- a/scripts/check_live_requires_measured_health.py
+++ b/scripts/check_live_requires_measured_health.py
@@ -35,6 +35,37 @@ for sub in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "lib"):
 sys.path.insert(0, str(_REPO_ROOT))
 
 
+# Health cells read "<category> — <detail>" (e.g. "works — CI green"). These
+# are the categories this check has verified mean "a probe or seed actually
+# produced a reading" (OI-1593): `works`, `degraded`, and `produces-crap` are
+# real probe/seed outcomes; `stale` means the beacon aged out but still holds
+# a prior real reading (health_beacon.py). None of the four says whether
+# LIVE+degraded/produces-crap/stale SHOULD be legal — that is a separate
+# design question this check does not take a position on. It only asserts
+# they are genuinely measured, so they are exempt from the "unmeasured"
+# violation this check exists to catch.
+#
+# Everything else falls through to "unmeasured": `unknown` (explicit "no
+# probe yet"), an empty cell, a missing `health` key, and any category this
+# check has never seen before. That last case is deliberate fail-closed
+# behavior — a new beacon category (e.g. a future `absent`) is unmeasured
+# until this allowlist is updated to say otherwise, not until this check
+# happens to not recognize it as a violation.
+_MEASURED_HEALTH_CATEGORIES = frozenset({
+    "works",
+    "degraded",
+    "produces-crap",
+    "stale",
+})
+
+
+def _health_category(health: str) -> str:
+    """First token of a health cell, e.g. 'works — CI green' -> 'works'.
+    An empty or missing cell yields '', which is never in
+    ``_MEASURED_HEALTH_CATEGORIES`` and therefore always a violation."""
+    return (health or "").split("—", 1)[0].strip()
+
+
 def violations_in_rows(rows: list[dict]) -> list[str]:
     """Pure filter: subsystem names that are status=LIVE with unmeasured health.
 
@@ -45,7 +76,8 @@ def violations_in_rows(rows: list[dict]) -> list[str]:
     return [
         row["subsystem"]
         for row in rows
-        if row["status"] == "LIVE" and row.get("health", "").startswith("unknown")
+        if row["status"] == "LIVE"
+        and _health_category(row.get("health", "")) not in _MEASURED_HEALTH_CATEGORIES
     ]
 
 

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -84,7 +84,7 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
     "VNX_SCOUT_PREPASS": _e(
         "VNX_SCOUT_PREPASS", "bool", "0", "intelligence",
         "Cheap-model scout recon pre-pass in the door (fail-open).",
-        subsystem="cheap-recon-scout", status="LIVE"),
+        subsystem="cheap-recon-scout", status="ACTIVATE"),
     "VNX_TAGGER_ENABLED": _e(
         "VNX_TAGGER_ENABLED", "bool", "0", "intelligence",
         "Persist-time LLM tagging over the closed VNX vocabulary.",
@@ -108,11 +108,11 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
     "VNX_ROADMAP_AUTOPILOT": _e(
         "VNX_ROADMAP_AUTOPILOT", "bool", "0", "dispatch",
         "Autonomous roadmap auto-next loading (starts work).", approval=True,
-        subsystem="horizon-planning", status="LIVE"),
+        subsystem="horizon-planning", status="ACTIVATE"),
     "VNX_HEADLESS_ROUTING": _e(
         "VNX_HEADLESS_ROUTING", "string", "0", "dispatch",
         "Headless dispatch routing mode.",
-        subsystem="headless-dispatch-routing", status="LIVE"),
+        subsystem="headless-dispatch-routing", status="ACTIVATE"),
     "VNX_DEFAULT_REVIEW_STACK": _e(
         "VNX_DEFAULT_REVIEW_STACK", "string", "gemini_review,codex_gate,claude_github_optional", "gate",
         "Comma-separated default review-gate stack (dispatch 20260823-beta2-e, OI-1435). "
@@ -166,7 +166,7 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "Central-DB read mode (''=per-project | '1'=central | 'shadow'). Process-start routing — "
         "env-only, surfaced read-only: live-toggling would split reads across DBs mid-process.",
         writable=False,
-        subsystem="central-db-routing", status="LIVE"),
+        subsystem="central-db-routing", status="ACTIVATE"),
     "VNX_USE_FEDERATION": _e(
         "VNX_USE_FEDERATION", "bool", "0", "intelligence",
         "Cross-project intelligence federation (NOT yet implemented).",
@@ -250,24 +250,24 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
     "VNX_SMART_ROUTER_TIER_ZERO": _e(
         "VNX_SMART_ROUTER_TIER_ZERO", "bool", "0", "dispatch",
         "Route tier-zero (trivial reformat) dispatches through the smart router.",
-        subsystem="smart-router-staging", status="LIVE"),
+        subsystem="smart-router-staging", status="ACTIVATE"),
     "VNX_SMART_ROUTER_TIER_LOW": _e(
         "VNX_SMART_ROUTER_TIER_LOW", "bool", "0", "dispatch",
         "Route tier-low (script edit) dispatches through the smart router.",
-        subsystem="smart-router-staging", status="LIVE"),
+        subsystem="smart-router-staging", status="ACTIVATE"),
     "VNX_SMART_ROUTER_TIER_MID": _e(
         "VNX_SMART_ROUTER_TIER_MID", "bool", "0", "dispatch",
         "Route tier-mid (multi-file/design) dispatches through the smart router.",
-        subsystem="smart-router-staging", status="LIVE"),
+        subsystem="smart-router-staging", status="ACTIVATE"),
     "VNX_SMART_ROUTER_TIER_HIGH": _e(
         "VNX_SMART_ROUTER_TIER_HIGH", "bool", "0", "dispatch",
         "Route tier-high (architectural/security) dispatches through the smart router.",
-        subsystem="smart-router-staging", status="LIVE"),
+        subsystem="smart-router-staging", status="ACTIVATE"),
     "VNX_SMART_ROUTER_CANARY_PCT": _e(
         "VNX_SMART_ROUTER_CANARY_PCT", "string", "0", "dispatch",
         "Canary fraction (0-100) of an enabled tier's traffic routed via the smart "
         "router; the rest follows the legacy path. Deterministic per dispatch.",
-        subsystem="smart-router-staging", status="LIVE",
+        subsystem="smart-router-staging", status="ACTIVATE",
         # Explicit canonical pick (OI-1385): preserves the pre-existing last-wins winner for
         # this subsystem's 5 flags. Not re-audited by this dispatch — out of scope.
         cockpit_canonical=True),
@@ -283,7 +283,7 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "scoped to this project. The process env var still wins over this "
         "config-store value as an explicit per-session override.",
         approval=True,
-        subsystem="claude-tmux-serialization", status="LIVE"),
+        subsystem="claude-tmux-serialization", status="ACTIVATE"),
 }
 
 # Flag-LESS subsystems from the cockpit ledger (docs/core/SUBSYSTEMS.md) — kernel/meta subsystems

--- a/tests/smart_router/test_staging.py
+++ b/tests/smart_router/test_staging.py
@@ -142,7 +142,10 @@ def test_registry_flags_registered_default_off_with_subsystem():
         entry = cr.CONFIG_REGISTRY[key]
         assert entry.default == "0", f"{key} must default off (rollout starts from zero)"
         assert entry.subsystem == "smart-router-staging"
-        assert entry.status == "LIVE"
+        # D6b (30-08): smart-router-staging carried LIVE with no registered
+        # effectiveness probe (unmeasured) -- moved to ACTIVATE-and-measure,
+        # the cockpit's status for "dormant until a probe exists".
+        assert entry.status == "ACTIVATE"
     canary = cr.CONFIG_REGISTRY[st.CANARY_PCT_KEY]
     assert canary.default == "0"
     assert canary.subsystem == "smart-router-staging"

--- a/tests/test_live_requires_measured_health.py
+++ b/tests/test_live_requires_measured_health.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for scripts/check_live_requires_measured_health.py (D6b).
+"""Tests for scripts/check_live_requires_measured_health.py (D6b + OI-1593).
 
 Pins the invariant this dispatch introduced: a cockpit subsystem may not
 carry status=LIVE while its health reads "unknown". Six subsystems
@@ -7,6 +7,12 @@ carry status=LIVE while its health reads "unknown". Six subsystems
 central-db-routing, smart-router-staging, claude-tmux-serialization) carried
 exactly that combination before this dispatch moved them to
 ACTIVATE-and-measure in scripts/lib/config_registry.py.
+
+OI-1593 hardened the filter from a prefix match on the literal string
+'unknown' to an allowlist of known-measured categories (works, degraded,
+produces-crap, stale). A prefix match let an empty health cell, or any
+future beacon category the filter had never seen, pass LIVE silently —
+exactly the "unmeasured" state this check exists to catch.
 """
 from __future__ import annotations
 
@@ -70,3 +76,41 @@ def test_real_repo_tree_would_have_flagged_the_six_before_the_fix() -> None:
             row["status"] = "LIVE"
 
     assert set(check.violations_in_rows(rows)) == pre_fix_six
+
+
+def test_violations_in_rows_catches_live_with_empty_health() -> None:
+    """OI-1593: an empty health cell does not start with 'unknown', so the
+    old prefix filter passed it silently. Empty means nobody wrote a
+    reading — it must be a violation, same as an explicit 'unknown'."""
+    rows = [
+        {"subsystem": "cheap-recon-scout", "status": "LIVE", "health": ""},
+    ]
+    assert check.violations_in_rows(rows) == ["cheap-recon-scout"]
+
+
+def test_violations_in_rows_catches_live_with_unrecognized_category() -> None:
+    """OI-1593: a beacon category this check has never seen (e.g. a future
+    'absent — no beacon file') must fail closed as a violation, not pass
+    because it happens not to start with 'unknown'."""
+    rows = [
+        {"subsystem": "cheap-recon-scout", "status": "LIVE", "health": "absent — no beacon file"},
+    ]
+    assert check.violations_in_rows(rows) == ["cheap-recon-scout"]
+
+
+def test_violations_in_rows_allows_live_with_works_health() -> None:
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "works — dispatch outcomes routed correctly"},
+    ]
+    assert check.violations_in_rows(rows) == []
+
+
+def test_violations_in_rows_allows_live_with_stale_health() -> None:
+    """OI-1593: 'stale' means a probe DID run and produced a reading that has
+    since aged out — it is measured, just old. Whether LIVE+stale SHOULD be
+    legal is a separate design question this check does not take a position
+    on; it is pinned here as explicitly out of scope for this filter."""
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "stale — ok"},
+    ]
+    assert check.violations_in_rows(rows) == []

--- a/tests/test_live_requires_measured_health.py
+++ b/tests/test_live_requires_measured_health.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_live_requires_measured_health.py (D6b).
+
+Pins the invariant this dispatch introduced: a cockpit subsystem may not
+carry status=LIVE while its health reads "unknown". Six subsystems
+(cheap-recon-scout, horizon-planning, headless-dispatch-routing,
+central-db-routing, smart-router-staging, claude-tmux-serialization) carried
+exactly that combination before this dispatch moved them to
+ACTIVATE-and-measure in scripts/lib/config_registry.py.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_live_requires_measured_health as check  # noqa: E402
+
+
+def test_violations_in_rows_catches_live_with_unknown_health() -> None:
+    rows = [
+        {"subsystem": "cheap-recon-scout", "status": "LIVE", "health": "unknown — no probe yet"},
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "works — dispatch outcomes routed correctly"},
+        {"subsystem": "dream-consolidation", "status": "ACTIVATE", "health": "unknown — no cycles run"},
+    ]
+    assert check.violations_in_rows(rows) == ["cheap-recon-scout"]
+
+
+def test_violations_in_rows_empty_when_no_live_unknown_combo() -> None:
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "works — dispatch outcomes routed correctly"},
+        {"subsystem": "cheap-recon-scout", "status": "ACTIVATE", "health": "unknown — no probe yet"},
+    ]
+    assert check.violations_in_rows(rows) == []
+
+
+def test_real_repo_tree_has_no_live_unknown_violations() -> None:
+    """Regression pin: the six subsystems this dispatch fixed stay fixed."""
+    violations = check.find_live_unknown_violations(REPO_ROOT)
+    assert violations == []
+
+
+def test_real_repo_tree_would_have_flagged_the_six_before_the_fix() -> None:
+    """Proves the check can fail: replaying the pre-fix status values against
+    the real rowset must reproduce exactly the six subsystems named in the
+    dispatch (cheap-recon-scout, horizon-planning, headless-dispatch-routing,
+    central-db-routing, smart-router-staging, claude-tmux-serialization)."""
+    from vnx_cli import _engine
+    from vnx_cli.commands import subsystems as sub_mod
+
+    engine_root = _engine.engine_root()
+    data_dir = _engine.resolve_data_root(REPO_ROOT)
+
+    rows = sub_mod.build_rows()
+    seed_health = sub_mod._parse_seed_health(engine_root)
+    sub_mod._attach_health(rows, data_dir, seed_health, use_probe=False)
+
+    pre_fix_six = {
+        "cheap-recon-scout",
+        "horizon-planning",
+        "headless-dispatch-routing",
+        "central-db-routing",
+        "smart-router-staging",
+        "claude-tmux-serialization",
+    }
+    for row in rows:
+        if row["subsystem"] in pre_fix_six:
+            row["status"] = "LIVE"
+
+    assert set(check.violations_in_rows(rows)) == pre_fix_six

--- a/tests/test_live_requires_measured_health.py
+++ b/tests/test_live_requires_measured_health.py
@@ -114,3 +114,57 @@ def test_violations_in_rows_allows_live_with_stale_health() -> None:
         {"subsystem": "provider-routing", "status": "LIVE", "health": "stale — ok"},
     ]
     assert check.violations_in_rows(rows) == []
+
+
+def test_violations_in_rows_allows_live_with_beacon_ok_health() -> None:
+    """OI-1596: the allowlist only covered the seed-prose vocabulary
+    (works/degraded/produces-crap/stale). A live beacon reporting a bare
+    'ok' — no ' — detail' suffix, since ``_attach_health`` only appends one
+    when a signal is present — used to be reported as a VIOLATION with the
+    message "health is unmeasured", the opposite of what was measured:
+    'ok' is a genuine, healthy reading from ``health_beacon.all_beacons()``."""
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "ok"},
+    ]
+    assert check.violations_in_rows(rows) == []
+
+
+def test_violations_in_rows_allows_live_with_beacon_fail_health() -> None:
+    """OI-1596: 'fail' is measured-and-bad, not unmeasured. Whether
+    LIVE+fail SHOULD be legal is a separate design question this check does
+    not take a position on, same as LIVE+degraded/produces-crap — this check
+    only asserts a reading exists, it never judges whether the reading is
+    good."""
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "fail"},
+    ]
+    assert check.violations_in_rows(rows) == []
+
+
+def test_violations_in_rows_catches_live_with_bare_unknown_beacon_health() -> None:
+    """'unknown' with no ' — detail' suffix (the bare beacon form, e.g. an
+    event-driven beacon past its freshness backstop) must stay a violation —
+    both vocabularies agree 'unknown' means not genuinely measured."""
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "unknown"},
+    ]
+    assert check.violations_in_rows(rows) == ["provider-routing"]
+
+
+def test_violations_in_rows_catches_live_with_bare_absent_beacon_health() -> None:
+    """'absent' (an expected component that never once wrote a beacon) must
+    stay a violation — it is the beacon vocabulary's own "never measured"
+    category, distinct from but just as unmeasured as seed 'unknown'."""
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "absent"},
+    ]
+    assert check.violations_in_rows(rows) == ["provider-routing"]
+
+
+def test_violations_in_rows_catches_live_with_fabricated_category() -> None:
+    """Fail-closed property, independent of any real category: a health
+    string neither vocabulary has ever produced must be a violation."""
+    rows = [
+        {"subsystem": "provider-routing", "status": "LIVE", "health": "frobnicated"},
+    ]
+    assert check.violations_in_rows(rows) == ["provider-routing"]

--- a/vnx_cli/commands/subsystems.py
+++ b/vnx_cli/commands/subsystems.py
@@ -109,12 +109,6 @@ _ROW_ORDER: List[str] = [
     "zero-llm-injection",
     "dispatch-plan",
     "test-suite",
-    "cheap-recon-scout",
-    "horizon-planning",
-    "headless-dispatch-routing",
-    "central-db-routing",
-    "smart-router-staging",
-    "claude-tmux-serialization",
     # PARK-with-trigger / CUT
     "migration-mechanisms",
     "within-db-tenancy",
@@ -128,6 +122,17 @@ _ROW_ORDER: List[str] = [
     "dream-consolidation",
     "injection-effectiveness-eval-loop",
     "cross-project-federation",
+    # D6b (30-08): LIVE claimed for these six despite having no probe — a
+    # status is a written claim, not a measurement (config_registry.py's own
+    # docstring: "no read-site consults them"). "LIVE and unmeasured" is not
+    # a legal combination, so they move here alongside the loop's other
+    # dormant-until-measured subsystems.
+    "cheap-recon-scout",
+    "horizon-planning",
+    "headless-dispatch-routing",
+    "central-db-routing",
+    "smart-router-staging",
+    "claude-tmux-serialization",
     # SCOPE
     "plan-gate-panel",
     "plan-gate-task-class-scope",


### PR DESCRIPTION
## Summary
- Six cockpit subsystems (`cheap-recon-scout`, `horizon-planning`, `headless-dispatch-routing`, `central-db-routing`, `smart-router-staging`, `claude-tmux-serialization`) carried `status=LIVE` in `scripts/lib/config_registry.py` while `docs/core/SUBSYSTEMS.md`'s health column read `unknown — no probe yet` for each — a status claiming "running and expected to stay on" next to an admission that nobody ever measured it.
- Moves all six to `status=ACTIVATE` (rendered `ACTIVATE-and-measure`), regenerates the ledger via `vnx subsystems --md`, and reorders them into the ACTIVATE group in `vnx_cli/commands/subsystems.py:_ROW_ORDER`.
- Adds `scripts/check_live_requires_measured_health.py`, a new CI check that fails whenever a subsystem is `LIVE` with `unknown` health, wired into `.github/workflows/subsystems-drift.yml` alongside the existing ledger-drift check (`make live-health-check`).
- No new probes were built — out of scope per the dispatch. `scripts/lib/effectiveness_probe.py`'s `register_probe` mechanism already exists for whoever picks these six up next.

## Changes
- `scripts/lib/config_registry.py` — 10 `status="LIVE"` → `status="ACTIVATE"` across the 6 subsystems (smart-router-staging has 5 flag entries).
- `vnx_cli/commands/subsystems.py` — moved the 6 subsystem names from the LIVE block to the ACTIVATE-and-measure block in `_ROW_ORDER`.
- `docs/core/SUBSYSTEMS.md` — regenerated deterministic columns (status + row position) for the 6 rows; health text unchanged (still `unknown — no probe yet`, since no probe was built).
- `scripts/check_live_requires_measured_health.py` — new CI check (`violations_in_rows` pure filter + `find_live_unknown_violations` live entrypoint).
- `Makefile` — new `live-health-check` target.
- `.github/workflows/subsystems-drift.yml` — added the new check as a second step.
- `tests/smart_router/test_staging.py` — updated a hardcoded `status == "LIVE"` assertion to `"ACTIVATE"` (the only other test in the repo asserting cockpit status for these flags; swept the rest of `tests/` for the same pattern, found none).
- `tests/test_live_requires_measured_health.py` — new tests: pure-filter unit tests, a regression pin that the real tree has zero violations, and a replay test that re-applies the pre-fix LIVE status to the real rowset and asserts the check reproduces exactly the six named subsystems.

## Verification
- `python3 scripts/check_subsystems_drift.py` → OK, 28 subsystems, no drift.
- `python3 scripts/check_live_requires_measured_health.py` → OK, no violations.
- Demonstrated the check **can fail**: stashed `config_registry.py` back to its pre-fix state and reran the check — it went red and named exactly the six subsystems, then the fix was restored. Also pinned as `test_real_repo_tree_would_have_flagged_the_six_before_the_fix`.
- `python3 -m pytest -q tests/test_config_registry.py tests/vnx_cli/test_subsystems.py tests/smart_router/ tests/test_live_requires_measured_health.py` → 229 passed.
- Swept `tests/` for any other `status == "LIVE"` assertion on these six subsystems/flags — only the one in `test_staging.py` existed, now fixed.

## Open Items
None.

Dispatch-ID: 20260830-090600-d6-architectuurtabel-gegenereerd (D6b)
**Model**: sonnet
**Provider**: claude