### PR TITLE
feat(docs): generate the architecture component table, don't hand-edit it (D6a)

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -269,6 +269,24 @@ jobs:
             -p no:cacheprovider \
             --basetemp=/tmp/vnx_pytest_safe
 
+      - name: Architecture doc drift guard (D6a)
+        run: |
+          set -euo pipefail
+          # Fail CI when docs/core/00_VNX_ARCHITECTURE.md's generated
+          # "Supervised Components" / "Hooks" sections drift from the live
+          # start_all() registry / .claude/settings.json wiring. See D6
+          # (dispatch 20260830-090600) — the doc used to hand-list 15
+          # "Active Components" with no relationship to what actually runs.
+          python3 "$GITHUB_WORKSPACE/scripts/generate_architecture_doc.py"
+
+      - name: Run architecture doc drift guard unit tests
+        run: |
+          set -euo pipefail
+          pytest -q \
+            "$GITHUB_WORKSPACE/tests/test_architecture_doc_drift.py" \
+            -p no:cacheprovider \
+            --basetemp=/tmp/vnx_pytest_safe
+
       - name: Status vocabulary drift guard
         run: |
           set -euo pipefail

--- a/docs/core/00_VNX_ARCHITECTURE.md
+++ b/docs/core/00_VNX_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # VNX Orchestration System - Complete Architecture
 
 **Status**: Active
-**Last Updated**: 2026-06-22
+**Last Updated**: 2026-08-30
 **Owner**: T-MANAGER
 **Purpose**: Single source of truth for VNX system architecture, components, and data flow.
 
@@ -828,22 +828,72 @@ project-root/
 
 ## Current System Status (VNX 1.0.0)
 
-### Active Components ✅
-- Smart Tap V7 (JSON/Markdown auto-translation)
-- Dispatcher V8 Minimal (Native skills, multi-provider, 87% token reduction)
-- Receipt Processor V4 (Report → receipt → T0 delivery, adoption tracking)
-- Heartbeat ACK Monitor (ACK processing + timeout tracking)
-- Queue Popup Watcher (dispatch review UI)
-- Dashboard Generator (Real-time metrics → `dashboard_status.json`)
-- Unified State Manager V2 (state consolidation, 5s cycle)
-- Intelligence Daemon (real-time intelligence updates)
-- Recommendations Engine (T0 dispatch suggestions, 30s cycle, max 5 pending — G-L8)
-- VNX Supervisor (Health monitoring, 10s checks, auto-restart)
-- Quality Advisory Pipeline (file size warnings on every completion)
-- PR Queue Manager (parallel PRs, staging → promote workflow)
-- Operator Dashboard (vanilla HTML/JS + `serve_dashboard.py`, attention model, jump command)
-- Worker Intelligence Injection (`userpromptsubmit_worker_intelligence_inject.sh` — T1-T3)
-- Nightly Intelligence Pipeline (`nightly_intelligence_pipeline.sh`, 02:00, 4-phase ordered)
+### Supervised Components (generated — do not hand-edit; regenerate with `python3 scripts/generate_architecture_doc.py --write`)
+
+Every row below is a daemon `vnx_supervisor_simple.sh`'s `start_all()` actually
+starts, read live via `scripts/lib/daemon_register.py` (shared with
+`docs/core/DAEMON_LIVENESS.md` — one register, not two). A daemon renamed or
+removed in `start_all()` fails this file's generation instead of silently
+going stale here.
+
+Running/absent state is deliberately **not** stored in this file — it
+changes by the minute, and a committed "✅ Active" checkmark is exactly the
+claim that drifted (measured 2026-08-30: 0 of these 9 processes were running
+while all 15 old checklist items still said "Active"). Check current
+liveness with `bash scripts/vnx_supervisor_simple.sh status` or
+`python3 -c "import sys; sys.path.insert(0,'scripts/lib'); import daemon_register as d; print(d.measure_daemon_liveness())"`.
+
+<!-- BEGIN GENERATED: supervised-components -->
+- Dispatcher (native skills, multi-provider dispatch). — `dispatcher_minimal.sh` — `scripts/vnx_supervisor_simple.sh:198`
+- Smart Tap (JSON/Markdown auto-translation). — `smart_tap_json_translator.sh` — `scripts/vnx_supervisor_simple.sh:204`
+- Receipt Processor (report -> receipt -> T0 delivery, adoption tracking). — `receipt_processor.sh` — `scripts/vnx_supervisor_simple.sh:205`
+- Heartbeat ACK Monitor (ACK processing + timeout tracking). — `heartbeat_ack_monitor.py` — `scripts/vnx_supervisor_simple.sh:210`
+- Queue Watcher (dispatch review popup; falls back to auto-accept when VNX_QUEUE_POPUP_ENABLED=0). — `queue_popup_watcher.sh` or `queue_auto_accept.sh` (conditional) — `scripts/vnx_supervisor_simple.sh:212`
+- Dashboard Generator (real-time metrics -> dashboard_status.json). — `generate_valid_dashboard.sh` — `scripts/vnx_supervisor_simple.sh:217`
+- Unified State Manager (state consolidation, 5s cycle). — `unified_state_manager.py` — `scripts/vnx_supervisor_simple.sh:218`
+- Intelligence Daemon (real-time intelligence updates). — `intelligence_daemon.py` — `scripts/vnx_supervisor_simple.sh:219`
+- Recommendations Engine (T0 dispatch suggestions, max 5 pending). — `recommendations_engine_daemon.sh` — `scripts/vnx_supervisor_simple.sh:220`
+<!-- END GENERATED: supervised-components -->
+
+### Hooks Wired in `.claude/settings.json` (generated — do not hand-edit; regenerate with `python3 scripts/generate_architecture_doc.py --write`)
+
+<!-- BEGIN GENERATED: hooks -->
+- **PreToolUse**: `pretooluse_block_raw_claude_spawn.sh`, `pretooluse_block_subagent.sh`
+- **SessionEnd**: `session_reconcile_cleanup.sh`, `build_current_state.py`, `build_doc_indexes.py`
+- **SessionStart**: `session_reconcile_autoclose.sh`, `build_t0_state_hook.sh`, `tmux_signal_session_ready.sh`, `path_parity_check.sh`, `monitor_tripwire.sh`, `sessionstart.sh`, `hookpin_check.sh`
+- **Stop**: `stop_report_hook.sh`, `tmux_signal_stop_receipt.sh`, `session_stop_rotation.py`
+- **UserPromptSubmit**: `tmux_signal_prompt_received.sh`
+<!-- END GENERATED: hooks -->
+
+`scripts/userpromptsubmit_worker_intelligence_inject.sh` is intentionally
+absent above: it exists on disk but no hook event in `.claude/settings.json`
+references it (verified 2026-08-30 — `grep -c
+userpromptsubmit_worker_intelligence_inject .claude/settings.json` is 0; its
+only other reference in the tree is its own test,
+`tests/test_learning_feature.py`). It is dead code or a pending wiring
+change, not an active component — the previous "Worker Intelligence
+Injection" checklist entry was wrong.
+
+### Not Continuously Supervised
+
+These are real components but are neither `start_all()` daemons nor
+`.claude/settings.json` hooks, so the two generated sections above correctly
+omit them. Listed by hand — not generated — so they don't silently
+disappear from this document:
+
+- **VNX Supervisor** — the process that runs `start_all()` itself
+  (`scripts/vnx_supervisor_simple.sh`); tracked by its own PID file
+  (`$VNX_PIDS_DIR/vnx_supervisor.pid`), not a `start_all()` entry.
+- **Quality Advisory Pipeline** — `scripts/lib/quality_advisory.py`,
+  imported and invoked inline by `scripts/append_receipt.py` on every
+  receipt write. A feature of Receipt Processor, not an independent process.
+- **PR Queue Manager** — `scripts/pr_queue_manager.py`, invoked on demand
+  via `bin/vnx`; not a persistent daemon.
+- **Operator Dashboard** — `dashboard/serve_dashboard.py`, launched via
+  `dashboard/launch-dashboard.sh`; not part of `start_all()` or `start.sh`.
+- **Nightly Intelligence Pipeline** — `scripts/nightly_intelligence_pipeline.sh`,
+  cron-scheduled (`scripts/install_nightly_crons.sh:28`, `0 4 * * *`), not
+  supervisor-managed.
 
 ### Deprecated Components (not started by supervisor)
 - ACK Dispatcher V2 (`ack_dispatcher_v2.sh`) — replaced by `heartbeat_ack_monitor.py`

--- a/scripts/generate_architecture_doc.py
+++ b/scripts/generate_architecture_doc.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate/check the "Supervised Components" and "Hooks" sections of
+``docs/core/00_VNX_ARCHITECTURE.md`` (D6).
+
+The generated content is spliced between HTML-comment markers so the rest of
+the (still hand-written) document is untouched. Generation logic lives in
+``scripts/lib/architecture_components.py``; this script only reads the
+committed file, renders the two sections, and either diffs (default -- CI
+mode) or writes (``--write``) the result.
+
+Usage:
+  python3 scripts/generate_architecture_doc.py            # check, exit 1 on drift
+  python3 scripts/generate_architecture_doc.py --write     # regenerate in place
+
+Wired via ``make architecture-doc-check`` and
+``.github/workflows/architecture-doc-drift.yml``.
+
+Exit codes: 0 = in sync (or written), 1 = drift detected, 2 = internal error.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for sub in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "lib"):
+    s = str(sub)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+DOC_PATH = _REPO_ROOT / "docs" / "core" / "00_VNX_ARCHITECTURE.md"
+
+_MARKERS = ("supervised-components", "hooks")
+
+
+def _marker_re(name: str) -> "re.Pattern[str]":
+    begin = re.escape(f"<!-- BEGIN GENERATED: {name} -->")
+    end = re.escape(f"<!-- END GENERATED: {name} -->")
+    return re.compile(f"({begin})(.*?)({end})", re.DOTALL)
+
+
+def splice_block(text: str, name: str, new_body: str) -> str:
+    """Replace the content between a marker pair with *new_body*.
+
+    Raises ``ValueError`` if the marker pair is not found -- a missing
+    marker means the doc was hand-edited out from under the generator,
+    which must fail loudly rather than silently skip the section.
+    """
+    pattern = _marker_re(name)
+    if not pattern.search(text):
+        raise ValueError(
+            f"marker pair 'BEGIN/END GENERATED: {name}' not found in {DOC_PATH} "
+            "-- the doc was edited out from under the generator."
+        )
+    return pattern.sub(lambda m: f"{m.group(1)}\n{new_body}\n{m.group(3)}", text, count=1)
+
+
+def render(committed_text: str) -> str:
+    import architecture_components as ac
+
+    daemon_rows = ac.build_daemon_rows()
+    hook_rows = ac.build_hook_rows()
+
+    text = splice_block(committed_text, "supervised-components", ac.render_daemon_md(daemon_rows))
+    text = splice_block(text, "hooks", ac.render_hooks_md(hook_rows))
+    return text
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    write = "--write" in args
+
+    try:
+        committed_text = DOC_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"internal error: cannot read {DOC_PATH}: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        generated_text = render(committed_text)
+    except (ValueError, ImportError, OSError) as exc:
+        print(f"internal error: {exc}", file=sys.stderr)
+        return 2
+
+    if write:
+        DOC_PATH.write_text(generated_text, encoding="utf-8")
+        print(f"wrote {DOC_PATH}")
+        return 0
+
+    if generated_text == committed_text:
+        print(f"OK — {DOC_PATH} generated sections match the live registry.")
+        return 0
+
+    print(
+        f"DRIFT — {DOC_PATH}'s generated sections do not match the live "
+        "registry. Regenerate with:\n"
+        "  python3 scripts/generate_architecture_doc.py --write\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/architecture_components.py
+++ b/scripts/lib/architecture_components.py
@@ -1,0 +1,153 @@
+"""architecture_components — generates the "Supervised Components" and
+"Hooks" sections of ``docs/core/00_VNX_ARCHITECTURE.md`` from the real
+startup registry and the real hook wiring, instead of a hand-maintained
+checklist that silently drifts (D6, dispatch 20260830-090600).
+
+The old doc hand-listed 15 "Active Components", carrying a stale
+``Last Updated`` stamp. Two measured examples of the drift this caused:
+``Smart Tap V7`` / ``Unified State Manager V2`` named launcher-era aliases
+that no longer match the scripts ``start_all()`` actually runs
+(``smart_tap_json_translator.sh`` / ``unified_state_manager.py`` -- no "v7"
+or "v2" in either filename), and "Worker Intelligence Injection" claimed a
+hook (``userpromptsubmit_worker_intelligence_inject.sh``) that
+``.claude/settings.json`` never wires -- its only other reference in the
+tree is its own test.
+
+Two independently-generated sections, each sourced from the one place that
+actually decides the fact it displays:
+  - Supervised Components: ``daemon_register.read_daemon_register()`` (D2),
+    which itself parses ``vnx_supervisor_simple.sh``'s ``start_all()`` -- the
+    only place that decides which processes VNX starts. D6 reads this same
+    module rather than parsing ``start_all()`` a second time, so there is
+    exactly one register, not two (D2's own dispatch note).
+  - Hooks: ``.claude/settings.json``'s own ``hooks`` block -- the only place
+    that decides which hook scripts Claude Code actually runs.
+
+``DAEMON_DESCRIPTIONS`` is a curated map to prose, checked both ways by
+``build_daemon_rows``: a daemon in the live register with no entry here, or
+an entry here for a daemon no longer in the register, is a build error --
+the table stays a checked map, not a hand list that can silently drift from
+the registry it is supposed to describe.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import daemon_register  # noqa: E402
+import project_root  # noqa: E402
+
+SUPERVISOR_RELATIVE_PATH = "scripts/vnx_supervisor_simple.sh"
+SETTINGS_RELATIVE_PATH = ".claude/settings.json"
+
+# name (daemon_register.DaemonSpec.name) -> doc prose. Every start_all() daemon
+# must have exactly one entry; every entry must name a real daemon (see
+# build_daemon_rows). Names, not scripts, are the key: queue_watcher's two
+# candidate scripts (VNX_QUEUE_POPUP_ENABLED branch) share one description.
+DAEMON_DESCRIPTIONS: Dict[str, str] = {
+    "dispatcher": "Dispatcher (native skills, multi-provider dispatch).",
+    "smart_tap": "Smart Tap (JSON/Markdown auto-translation).",
+    "receipt_processor": "Receipt Processor (report -> receipt -> T0 delivery, adoption tracking).",
+    "heartbeat_ack_monitor": "Heartbeat ACK Monitor (ACK processing + timeout tracking).",
+    "queue_watcher": (
+        "Queue Watcher (dispatch review popup; falls back to auto-accept when "
+        "VNX_QUEUE_POPUP_ENABLED=0)."
+    ),
+    "dashboard": "Dashboard Generator (real-time metrics -> dashboard_status.json).",
+    "state_manager": "Unified State Manager (state consolidation, 5s cycle).",
+    "intelligence_daemon": "Intelligence Daemon (real-time intelligence updates).",
+    "recommendations_engine": "Recommendations Engine (T0 dispatch suggestions, max 5 pending).",
+}
+
+
+def build_daemon_rows(supervisor_script: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """One row per daemon ``start_all()`` declares, in declaration order.
+
+    Raises ``ValueError`` when ``DAEMON_DESCRIPTIONS`` and the live register
+    disagree in either direction -- a daemon renamed or removed in
+    ``start_all()`` must not silently vanish from (or linger in) the
+    generated doc; it must fail generation instead (dispatch requirement).
+    """
+    register = daemon_register.read_daemon_register(supervisor_script)
+
+    live_names = {spec.name for spec in register}
+    stale_descriptions = set(DAEMON_DESCRIPTIONS) - live_names
+    if stale_descriptions:
+        raise ValueError(
+            "architecture_components.DAEMON_DESCRIPTIONS names daemons no "
+            f"longer in start_all(): {sorted(stale_descriptions)} -- remove "
+            "the stale entry, or the daemon was renamed and this key must "
+            "follow it."
+        )
+    missing_descriptions = live_names - set(DAEMON_DESCRIPTIONS)
+    if missing_descriptions:
+        raise ValueError(
+            f"start_all() declares daemons with no description: "
+            f"{sorted(missing_descriptions)} -- add an entry to "
+            "architecture_components.DAEMON_DESCRIPTIONS before it can render."
+        )
+
+    return [
+        {
+            "name": spec.name,
+            "description": DAEMON_DESCRIPTIONS[spec.name],
+            "scripts": spec.scripts,
+            "conditional": spec.conditional,
+            "line": spec.line,
+        }
+        for spec in register
+    ]
+
+
+def render_daemon_md(rows: List[Dict[str, Any]]) -> str:
+    lines = []
+    for row in rows:
+        scripts = " or ".join(f"`{s}`" for s in row["scripts"])
+        cond = " (conditional)" if row["conditional"] else ""
+        cite = f"{SUPERVISOR_RELATIVE_PATH}:{row['line']}"
+        lines.append(f"- {row['description']} — {scripts}{cond} — `{cite}`")
+    return "\n".join(lines)
+
+
+# Matches a bare filename with a known hook-script extension, no path
+# separators -- deliberately loose (a command string is shell, not a path
+# grammar) since only the basename is needed to prove wiring.
+_SCRIPT_BASENAME_RE = re.compile(r"[\w-]+\.(?:sh|py)")
+
+
+def build_hook_rows(settings_path: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """One row per Claude Code hook event in ``.claude/settings.json``,
+    listing every script basename actually referenced by that event's
+    commands (declaration order, deduplicated)."""
+    path = Path(settings_path) if settings_path else (
+        project_root.resolve_project_root(__file__) / SETTINGS_RELATIVE_PATH
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    rows: List[Dict[str, Any]] = []
+    for event, matcher_blocks in data.get("hooks", {}).items():
+        scripts: List[str] = []
+        for block in matcher_blocks:
+            for hook in block.get("hooks", []):
+                command = hook.get("command", "")
+                for match in _SCRIPT_BASENAME_RE.finditer(command):
+                    name = match.group(0)
+                    if name not in scripts:
+                        scripts.append(name)
+        rows.append({"event": event, "scripts": scripts})
+    return rows
+
+
+def render_hooks_md(rows: List[Dict[str, Any]]) -> str:
+    lines = []
+    for row in sorted(rows, key=lambda r: r["event"]):
+        scripts = ", ".join(f"`{s}`" for s in row["scripts"]) or "_none wired_"
+        lines.append(f"- **{row['event']}**: {scripts}")
+    return "\n".join(lines)

--- a/scripts/lib/architecture_components.py
+++ b/scripts/lib/architecture_components.py
@@ -126,8 +126,14 @@ def build_hook_rows(settings_path: Optional[Path] = None) -> List[Dict[str, Any]
     """One row per Claude Code hook event in ``.claude/settings.json``,
     listing every script basename actually referenced by that event's
     commands (declaration order, deduplicated)."""
+    # No __file__ anchor (central-mode path gate, shape 3a): a central install
+    # runs this module from the read-only keystone checkout, so anchoring on
+    # __file__ would resolve the keystone's settings.json, not the project's.
+    # CWD-first resolution matches build_daemon_rows' own default and
+    # generate_architecture_doc.py, which both run with the project checkout
+    # as CWD.
     path = Path(settings_path) if settings_path else (
-        project_root.resolve_project_root(__file__) / SETTINGS_RELATIVE_PATH
+        project_root.resolve_project_root() / SETTINGS_RELATIVE_PATH
     )
     data = json.loads(path.read_text(encoding="utf-8"))
 

--- a/scripts/lib/daemon_register.py
+++ b/scripts/lib/daemon_register.py
@@ -30,6 +30,28 @@ liveness genuinely cannot be measured (psutil unavailable, or process
 enumeration itself raised), not a silent default toward either of the other
 two. Conflating "could not check" with "not running" would be exactly the
 kind of loud-but-wrong claim this dispatch exists to prevent.
+
+This module has three distinct ways of failing to produce a register, and
+each gets its own loud handling instead of being lumped together (D2b):
+
+  1. **The source is gone** — ``start_all()`` itself cannot be found in the
+     supervisor script (missing function, renamed, file moved).
+     ``read_daemon_register()`` raises ``ValueError``.
+  2. **The source exists but the parse finds nothing** — ``start_all()`` is
+     there, but zero ``start_process`` lines matched (e.g. the shell switched
+     from double to single quotes and the regex silently stopped matching).
+     This is NOT the same as an intentionally empty register: it is a failed
+     parse wearing an empty register's clothes. ``read_daemon_register()``
+     raises ``ValueError`` here too — a structurally-found-but-semantically-
+     empty result is exactly as untrustworthy as a missing function, and
+     collapsing it into "zero daemons expected" is the bug this dispatch
+     closes (a real register going from nine entries to zero, silently,
+     reported ``overall: "ok"``).
+  3. **The measurement itself cannot run** — process enumeration raises, or
+     psutil is unavailable. ``measure_daemon_liveness()`` returns
+     ``overall: "unknown"`` via ``_all_unknown()`` rather than raising,
+     because by this point a caller already has a real register and wants a
+     best-effort answer, not an exception.
 """
 from __future__ import annotations
 
@@ -73,16 +95,30 @@ class DaemonSpec:
 
 
 def _default_supervisor_script() -> Path:
-    root = project_root.resolve_project_root(__file__)
+    # No __file__ anchor (central-mode path gate, shape 3a): a central install
+    # runs this module from the read-only keystone checkout, so anchoring on
+    # __file__ would resolve the keystone's supervisor script, not the
+    # project's. CWD-first resolution matches every caller of this default —
+    # build_t0_state.py and generate_daemon_liveness_md.py both run with the
+    # project checkout as CWD.
+    root = project_root.resolve_project_root()
     return root / _SUPERVISOR_RELATIVE_PATH
 
 
 def read_daemon_register(supervisor_script: Optional[Path] = None) -> Tuple[DaemonSpec, ...]:
     """Parse ``start_all()`` in ``vnx_supervisor_simple.sh`` into daemon specs.
 
-    Raises ``ValueError`` if the file is unreadable or ``start_all()`` cannot
-    be found — callers that need a best-effort/non-raising read (e.g.
-    ``measure_daemon_liveness``) catch this themselves.
+    Raises ``ValueError`` if the file is unreadable, ``start_all()`` cannot be
+    found, OR ``start_all()`` is found but parses to zero entries — the third
+    failure mode (see module docstring): a structural change to the shell
+    (e.g. a quote-style edit that the ``start_process`` regex no longer
+    matches) can silently turn a real, populated register into an empty one
+    without raising anything on its own. An empty parse result is
+    indistinguishable from "this project runs no daemons" unless it is
+    treated as a failure — so it is. Callers that need a best-effort/
+    non-raising read (e.g. ``measure_daemon_liveness``) catch ``ValueError``
+    themselves; they do not receive a legitimately-empty register through
+    this path.
     """
     path = Path(supervisor_script) if supervisor_script else _default_supervisor_script()
     text = path.read_text(encoding="utf-8")
@@ -135,6 +171,13 @@ def read_daemon_register(supervisor_script: Optional[Path] = None) -> Tuple[Daem
             entry["scripts"].append(script)
         if if_depth > 0:
             entry["conditional"] = True
+
+    if not specs:
+        raise ValueError(
+            f"start_all() found in {path} but yielded zero start_process "
+            "entries — a failed parse (e.g. a quote-style change the regex "
+            "no longer matches), not an empty register"
+        )
 
     return tuple(
         DaemonSpec(

--- a/scripts/lib/daemon_register.py
+++ b/scripts/lib/daemon_register.py
@@ -1,0 +1,241 @@
+"""Daemon register — the single source of truth for VNX's supervised daemons (D2).
+
+D2 dispatch measured four candidate registers before picking one:
+
+  - ``scripts/vnx_supervisor_simple.sh``'s ``start_all()`` — ten ``start_process``
+    calls, one commented out, two behind a ``VNX_QUEUE_POPUP_ENABLED`` branch,
+    two resolved through shell variables. **This is the source**: it is the
+    only place that actually decides which processes VNX starts.
+  - the same file's ``status()`` — a second, hand-duplicated list derived from
+    the first. Rejected: a derived copy, not the source.
+  - ``scripts/commands/start.sh`` — carries two more hand-duplicated fallback
+    lists. Rejected for the same reason.
+  - ``subsystem_health.known_subsystems()`` — 28 cockpit subsystem names that
+    do not know about daemons at all (overlap with the nine daemons: two).
+    Rejected: wrong register entirely.
+
+``read_daemon_register()`` parses ``start_all()`` directly instead of
+hand-maintaining a Python list — a hand-kept list drifts from the shell
+function exactly the way ``docs/core/ARCHITECTURE.md`` already had (the
+D2 dispatch's own finding). D6 (architecture-doc generation) reads this same
+module so there is exactly one register, not two.
+
+``measure_daemon_liveness()`` is the second half: for each register entry,
+determine whether a matching process is actually running right now, using a
+single ``psutil.process_iter()`` pass (already a project dependency — see
+``scripts/intelligence_daemon_monitor.py``) rather than one ``pgrep`` subprocess
+per daemon. A daemon's state is one of three, not two: ``"running"``,
+``"absent"``, or ``"unknown"`` — "unknown" is its own branch for when
+liveness genuinely cannot be measured (psutil unavailable, or process
+enumeration itself raised), not a silent default toward either of the other
+two. Conflating "could not check" with "not running" would be exactly the
+kind of loud-but-wrong claim this dispatch exists to prevent.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import project_root  # noqa: E402
+
+_SUPERVISOR_RELATIVE_PATH = Path("scripts") / "vnx_supervisor_simple.sh"
+
+_VAR_ASSIGN_RE = re.compile(r'^([A-Z_][A-Z0-9_]*)="([^"]*)"\s*$')
+_START_PROCESS_RE = re.compile(r'^start_process\s+"([^"]*)"\s+"([^"]*)"')
+_FUNC_START_RE = re.compile(r'^start_all\s*\(\)\s*\{')
+_IF_RE = re.compile(r'^if\b')
+
+
+@dataclass(frozen=True)
+class DaemonSpec:
+    """One daemon as declared by ``start_all()``.
+
+    ``scripts`` carries every candidate script name observed for this daemon
+    name — normally one, but ``queue_watcher`` has two (the
+    ``VNX_QUEUE_POPUP_ENABLED`` branch selects between
+    ``queue_popup_watcher.sh`` and ``queue_auto_accept.sh``). Liveness
+    matching treats these as alternatives: the daemon is "running" if a
+    process matching ANY of its scripts is found.
+    """
+
+    name: str
+    scripts: Tuple[str, ...]
+    conditional: bool = False
+    line: Optional[int] = None
+
+
+def _default_supervisor_script() -> Path:
+    root = project_root.resolve_project_root(__file__)
+    return root / _SUPERVISOR_RELATIVE_PATH
+
+
+def read_daemon_register(supervisor_script: Optional[Path] = None) -> Tuple[DaemonSpec, ...]:
+    """Parse ``start_all()`` in ``vnx_supervisor_simple.sh`` into daemon specs.
+
+    Raises ``ValueError`` if the file is unreadable or ``start_all()`` cannot
+    be found — callers that need a best-effort/non-raising read (e.g.
+    ``measure_daemon_liveness``) catch this themselves.
+    """
+    path = Path(supervisor_script) if supervisor_script else _default_supervisor_script()
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    variables: Dict[str, str] = {}
+    for line in lines:
+        m = _VAR_ASSIGN_RE.match(line.strip())
+        if m:
+            variables[m.group(1)] = m.group(2)
+
+    def _resolve(token: str) -> str:
+        if token.startswith("$"):
+            return variables.get(token[1:], token)
+        return token
+
+    body_start = None
+    for i, line in enumerate(lines):
+        if _FUNC_START_RE.match(line.strip()):
+            body_start = i + 1
+            break
+    if body_start is None:
+        raise ValueError(f"start_all() not found in {path}")
+
+    # Bash functions in this file never nest braces inside start_all() (the
+    # if/else/fi conditional does not use braces), so the first bare "}" line
+    # reliably closes the function.
+    specs: "dict[str, Dict[str, Any]]" = {}
+    if_depth = 0
+    for offset, line in enumerate(lines[body_start:]):
+        stripped = line.strip()
+        if stripped == "}":
+            break
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _IF_RE.match(stripped):
+            if_depth += 1
+            continue
+        if stripped == "fi":
+            if_depth = max(0, if_depth - 1)
+            continue
+        m = _START_PROCESS_RE.match(stripped)
+        if not m:
+            continue
+        name = _resolve(m.group(1))
+        script = _resolve(m.group(2))
+        line_no = body_start + offset + 1
+        entry = specs.setdefault(name, {"scripts": [], "conditional": False, "line": line_no})
+        if script not in entry["scripts"]:
+            entry["scripts"].append(script)
+        if if_depth > 0:
+            entry["conditional"] = True
+
+    return tuple(
+        DaemonSpec(
+            name=name,
+            scripts=tuple(entry["scripts"]),
+            conditional=entry["conditional"],
+            line=entry["line"],
+        )
+        for name, entry in specs.items()
+    )
+
+
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _all_unknown(register: Sequence[DaemonSpec], *, reason: str) -> Dict[str, Any]:
+    daemons = {
+        spec.name: {"expected": True, "state": "unknown", "pid": None, "since": None}
+        for spec in register
+    }
+    return {"overall": "unknown", "daemons": daemons, "reason": reason}
+
+
+def measure_daemon_liveness(
+    register: Optional[Sequence[DaemonSpec]] = None,
+    *,
+    supervisor_script: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Measure whether each registered daemon currently has a running process.
+
+    Returns ``{"overall": "ok"|"fail"|"unknown", "daemons": {name: {...}}}``.
+    ``overall`` is ``"fail"`` when at least one expected daemon is confirmed
+    absent (a real, measured problem — the exact "nine daemons show 0
+    processes and nothing says so" case this dispatch closes), ``"unknown"``
+    when liveness could not be measured at all (psutil unavailable, or
+    process enumeration itself raised — never silently reported as "ok").
+    """
+    if register is None:
+        try:
+            register = read_daemon_register(supervisor_script)
+        except (OSError, ValueError) as exc:
+            return {"overall": "unknown", "daemons": {}, "reason": f"register unreadable: {exc}"}
+
+    try:
+        import psutil
+    except ImportError as exc:
+        return _all_unknown(register, reason=f"psutil unavailable: {exc}")
+
+    matches: Dict[str, Tuple[Optional[int], Optional[float]]] = {}
+    try:
+        for proc in psutil.process_iter(["pid", "cmdline", "create_time"]):
+            try:
+                info = proc.info
+                cmdline = info.get("cmdline") or []
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+            if not cmdline:
+                continue
+            # Exact basename match per argv token, NOT a substring search over
+            # the joined command line: a `claude -p <prompt>` worker process
+            # (this dispatch's own process, or a sibling worker's) carries its
+            # full instruction text as a single argv element, and that prose
+            # routinely NAMES these very script filenames (e.g. this file's
+            # own docstring/dispatch instructions). A substring match against
+            # that blob self-matches every daemon as "running" on the wrong
+            # PID -- measured directly while building this module (all nine
+            # matched the current `claude -p` worker PID). Basename equality
+            # on a single token only matches the real
+            # `nohup python /.../heartbeat_ack_monitor.py &` invocation shape.
+            basenames = {Path(tok).name for tok in cmdline if tok}
+            for spec in register:
+                if spec.name in matches:
+                    continue
+                if any(script in basenames for script in spec.scripts):
+                    matches[spec.name] = (info.get("pid"), info.get("create_time"))
+    except Exception as exc:  # vnx-silent-except: process enumeration is best-effort; a failure mid-scan must still yield "unknown", not a false "absent"
+        return _all_unknown(register, reason=f"process enumeration failed: {exc}")
+
+    daemons: Dict[str, Any] = {}
+    absent = False
+    for spec in register:
+        hit = matches.get(spec.name)
+        if hit is not None:
+            pid, create_time = hit
+            daemons[spec.name] = {
+                "expected": True,
+                "state": "running",
+                "pid": pid,
+                "since": _iso(create_time) if create_time else None,
+            }
+        else:
+            absent = True
+            daemons[spec.name] = {
+                "expected": True,
+                "state": "absent",
+                "pid": None,
+                "since": None,
+            }
+
+    return {"overall": "fail" if absent else "ok", "daemons": daemons}
+
+
+__all__ = ["DaemonSpec", "read_daemon_register", "measure_daemon_liveness"]

--- a/tests/test_architecture_doc_drift.py
+++ b/tests/test_architecture_doc_drift.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/architecture_components.py and
+scripts/generate_architecture_doc.py (D6a).
+
+docs/core/00_VNX_ARCHITECTURE.md used to hand-list 15 "Active Components".
+Two measured drift examples this dispatch fixes: "Smart Tap V7" / "Unified
+State Manager V2" named launcher-era aliases start_all() no longer runs
+(smart_tap_json_translator.sh / unified_state_manager.py -- no v7/v2 in
+either filename), and "Worker Intelligence Injection" claimed a hook that
+.claude/settings.json never wires. These tests pin: the generated daemon
+table is sourced from start_all() (via daemon_register.read_daemon_register,
+D2) with no stale aliases; the generated hooks table is sourced from
+.claude/settings.json and correctly excludes the unwired script; a daemon
+that the registry and the doc's description map disagree about fails
+generation instead of silently drifting; and the committed doc's generated
+sections match the live registry right now.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+import architecture_components as ac  # noqa: E402
+import generate_architecture_doc as gen  # noqa: E402
+import check_docs_file_line_refs as line_refs_check  # noqa: E402
+
+DOC_PATH = REPO_ROOT / "docs" / "core" / "00_VNX_ARCHITECTURE.md"
+
+
+# ---------------------------------------------------------------------------
+# Daemon rows sourced from start_all() (via daemon_register, D2)
+# ---------------------------------------------------------------------------
+
+def test_daemon_rows_cover_every_start_all_daemon():
+    rows = ac.build_daemon_rows()
+    names = {row["name"] for row in rows}
+    assert names == {
+        "dispatcher", "smart_tap", "receipt_processor", "heartbeat_ack_monitor",
+        "queue_watcher", "dashboard", "state_manager", "intelligence_daemon",
+        "recommendations_engine",
+    }
+
+
+def test_daemon_rows_carry_a_start_all_citation_line():
+    rows = ac.build_daemon_rows()
+    for row in rows:
+        assert row["line"], f"{row['name']} has no citation line into start_all()"
+
+
+def test_rendered_daemon_md_has_no_stale_v7_v2_aliases():
+    """Regression: the old doc's "Smart Tap V7" / "Unified State Manager V2"
+    named scripts start_all() does not run. The real scripts carry no
+    version suffix (smart_tap_json_translator.sh, unified_state_manager.py)."""
+    rendered = ac.render_daemon_md(ac.build_daemon_rows())
+    assert "V7" not in rendered
+    assert "V2" not in rendered
+    assert "smart_tap_json_translator.sh" in rendered
+    assert "unified_state_manager.py" in rendered
+
+
+def test_stale_daemon_description_fails_generation():
+    """A DAEMON_DESCRIPTIONS entry for a daemon start_all() no longer
+    declares must fail generation, not silently vanish from the doc."""
+    original = dict(ac.DAEMON_DESCRIPTIONS)
+    try:
+        ac.DAEMON_DESCRIPTIONS["a_daemon_that_does_not_exist"] = "ghost"
+        with pytest.raises(ValueError, match="no longer in start_all"):
+            ac.build_daemon_rows()
+    finally:
+        ac.DAEMON_DESCRIPTIONS.clear()
+        ac.DAEMON_DESCRIPTIONS.update(original)
+
+
+def test_undescribed_live_daemon_fails_generation():
+    """A daemon start_all() declares with no DAEMON_DESCRIPTIONS entry must
+    fail generation, not render with a missing description."""
+    original = dict(ac.DAEMON_DESCRIPTIONS)
+    try:
+        del ac.DAEMON_DESCRIPTIONS["dispatcher"]
+        with pytest.raises(ValueError, match="no description"):
+            ac.build_daemon_rows()
+    finally:
+        ac.DAEMON_DESCRIPTIONS.clear()
+        ac.DAEMON_DESCRIPTIONS.update(original)
+
+
+# ---------------------------------------------------------------------------
+# Hook rows sourced from .claude/settings.json
+# ---------------------------------------------------------------------------
+
+def test_hook_rows_exclude_unwired_worker_intelligence_injection():
+    """Regression: userpromptsubmit_worker_intelligence_inject.sh is not
+    referenced by any hook event in .claude/settings.json (measured 30-08:
+    grep -c on the file is 0)."""
+    rows = ac.build_hook_rows()
+    all_scripts = {name for row in rows for name in row["scripts"]}
+    assert "userpromptsubmit_worker_intelligence_inject.sh" not in all_scripts
+
+
+def test_hook_rows_include_the_real_userpromptsubmit_hook():
+    rows = ac.build_hook_rows()
+    by_event = {row["event"]: row["scripts"] for row in rows}
+    assert "tmux_signal_prompt_received.sh" in by_event.get("UserPromptSubmit", [])
+
+
+# ---------------------------------------------------------------------------
+# The committed docs/core/00_VNX_ARCHITECTURE.md matches the live registry
+# ---------------------------------------------------------------------------
+
+def test_committed_doc_generated_sections_match_live_registry():
+    committed_text = DOC_PATH.read_text(encoding="utf-8")
+    assert gen.render(committed_text) == committed_text
+
+
+def test_committed_doc_no_longer_claims_a_static_active_components_list():
+    """The hand-maintained '### Active Components ✅' checklist (the section
+    this dispatch replaced) must not reappear."""
+    committed_text = DOC_PATH.read_text(encoding="utf-8")
+    assert "### Active Components" not in committed_text
+    assert "### Supervised Components" in committed_text
+
+
+def test_splice_block_raises_on_missing_markers():
+    with pytest.raises(ValueError, match="marker pair"):
+        gen.splice_block("no markers here", "supervised-components", "x")
+
+
+def test_docs_file_line_refs_check_passes_on_the_generated_citations():
+    """The generated daemon rows embed scripts/vnx_supervisor_simple.sh:NN
+    citations; the existing docs file:line-ref CI check must accept them
+    (D6a deliberately reuses that check instead of building a second one)."""
+    paths = line_refs_check.tracked_rel_paths(REPO_ROOT)
+    violations = line_refs_check.check_docs(REPO_ROOT / "docs", REPO_ROOT, paths)
+    assert violations == []


### PR DESCRIPTION
## Summary
- `docs/core/00_VNX_ARCHITECTURE.md` hand-listed 15 "Active Components ✅" under a `Last Updated: 2026-06-22` stamp. Two measured drift examples: "Smart Tap V7" / "Unified State Manager V2" named launcher-era aliases `start_all()` no longer runs (the real scripts are `smart_tap_json_translator.sh` / `unified_state_manager.py`, no version suffix), and "Worker Intelligence Injection" claimed a hook (`userpromptsubmit_worker_intelligence_inject.sh`) that `.claude/settings.json` never wires (`grep -c` on the file is 0; its only other reference in the tree is its own test).
- Replaces the hand list with two **generated** sections, spliced between HTML comment markers so the rest of the doc stays hand-written:
  - **Supervised Components** — sourced from `scripts/lib/daemon_register.py`'s `read_daemon_register()` (D2), which itself parses `vnx_supervisor_simple.sh`'s `start_all()` — the only place that decides which processes VNX starts. Each row cites its real `scripts/vnx_supervisor_simple.sh:NN` line.
  - **Hooks Wired in `.claude/settings.json`** — sourced from the file itself, grouped by event.
- A component the doc's description map and the live registry disagree about **fails generation loudly** (`ValueError`) instead of silently drifting in either direction — proven both ways (stale description, missing description) in `tests/test_architecture_doc_drift.py`.
- Live running/absent PID state is deliberately **not** stored in the committed doc (SUBSYSTEMS.md precedent: dynamic data would force a recommit every re-run for no reason). The doc instead points readers at how to check it live (`vnx_supervisor_simple.sh status` / `daemon_register.measure_daemon_liveness()`).
- The remaining 5 of the old 15 items (VNX Supervisor itself, Quality Advisory Pipeline, PR Queue Manager, Operator Dashboard, Nightly Intelligence Pipeline) are neither `start_all()` daemons nor `.claude/settings.json` hooks — they're listed by hand in a new "Not Continuously Supervised" section (with real citations) instead of silently disappearing.

## Changes
- `scripts/lib/daemon_register.py` — **new, copied verbatim from D2 (PR #1732, open)**. See coordination note below.
- `scripts/lib/architecture_components.py` — new: `build_daemon_rows()` / `render_daemon_md()` (daemon table, with the fail-loud description-map check), `build_hook_rows()` / `render_hooks_md()` (hooks table).
- `scripts/generate_architecture_doc.py` — new: splices the two generated sections into the committed doc between `<!-- BEGIN/END GENERATED: ... -->` markers; default mode diffs and exits 1 on drift, `--write` regenerates in place.
- `docs/core/00_VNX_ARCHITECTURE.md` — `### Active Components ✅` replaced by `### Supervised Components` (generated) + `### Hooks Wired in .claude/settings.json` (generated) + `### Not Continuously Supervised` (hand-written, cited); `Last Updated` bumped to 2026-08-30.
- `.github/workflows/vnx-ci.yml` — new step right after the existing "Docs file:line reference guard" (reusing that check for citation validity instead of building a second doc-checker, per the dispatch's own instruction), plus its unit-test step.
- `tests/test_architecture_doc_drift.py` — new: daemon-row coverage, no-stale-alias regression (V7/V2), fail-loud invariant (both directions), hook-row exclusion regression (the unwired script), committed-doc-matches-generator regression, and a direct run of `check_docs_file_line_refs.py`'s own checker against the new citations.

## Verification
- `python3 scripts/generate_architecture_doc.py` → OK, matches live registry.
- `python3 scripts/ci/check_docs_file_line_refs.py` → OK, every citation (including the new `scripts/vnx_supervisor_simple.sh:NN` ones) resolves and is in bounds.
- Demonstrated the drift check **can fail**: hand-edited a generated line (added back "V8 Minimal" to the Dispatcher row) → check went red with the exact drift message; reverted, check went green again.
- Demonstrated the fail-loud invariant **can fail** both directions: injected a stale `DAEMON_DESCRIPTIONS` entry (`ValueError: ... no longer in start_all()`), and deleted a live daemon's description (`ValueError: ... no description`).
- `python3 -m pytest -q tests/test_architecture_doc_drift.py tests/test_ci_check_docs_file_line_refs.py` → 37 passed.
- Grepped `tests/` for `00_VNX_ARCHITECTURE`, `Active Components`, `start_all`, `check_docs_file_line_refs` — no other pre-existing test references this doc or section; no coverage lost.

## Open Items
- **Merge-order dependency on D2 (PR #1732):** `scripts/lib/daemon_register.py` is copied verbatim from D2 rather than depended on, because this dispatch's branch forks from `main` (where D2 hasn't landed yet) and per this dispatch's own instructions D2's branch must not be merged into this one to resolve it. The copy is byte-identical to D2's file. Recommend merging D2 first — whichever of the two PRs lands second will see a no-op or a trivially-resolved conflict on that one file.
- `docs/core/10_JSON_DISPATCH_FORMAT.md` and `docs/core/technical/DISPATCHER_SYSTEM.md` still say "Smart Tap V7" in prose (not a generated status table) — out of scope for this dispatch, which is scoped to `00_VNX_ARCHITECTURE.md`'s component table.

Dispatch-ID: 20260830-090600-d6-architectuurtabel-gegenereerd (D6a)
**Model**: sonnet
**Provider**: claude