### PR TITLE
fix(gate): bind evidence to PR head sha, expire lane_exhausted, retire stale takeover evidence (OI-1569, OI-1571)

### DIFF
--- a/scripts/gate_obligation_reopen_stale_evidence.py
+++ b/scripts/gate_obligation_reopen_stale_evidence.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""gate_obligation_reopen_stale_evidence.py — audited reopen of an obligation
+that was booked fulfilled/failed off evidence about a DIFFERENT commit
+(OI-1571 tak 3).
+
+The gate obligation runner used to book an obligation fulfilled off any
+complete-evidence decided verdict for the same dispatch_id/PR+gate,
+regardless of which commit that verdict actually reviewed
+(``gate_obligation_runner._has_decided_evidence`` gained a sha-binding check
+in this same dispatch — 20260830-153000-oi1569-quota-heeft-geen-tijddimensie
+— but the fix is not retroactive). Any obligation booked BEFORE that fix
+landed can be sitting on a record that is, in fact, unreviewed against its
+PR's current head.
+
+This is a hand-triggered CORRECTION tool, not part of the runner's own
+retry loop: :func:`gate_obligations.update_obligation` is the ONLY place
+state gets mutated, and this script is the ONLY place that state mutation
+happens for THIS specific defect class — a worker or operator hand-editing
+the JSON file directly is exactly what this exists to make unnecessary.
+
+Live measured case (30-08, PR #1719): obligation
+``20260830-133000-oi1453-noemer-is-pass`` (gate=codex_gate) was booked
+``fulfilled``/``resolved_by_gate=glm_gate`` off ``pr-1719-glm_gate.json``, a
+PASS recorded 2026-08-29T11:35:55Z against commit 8101fdf2 — the PR head at
+the time this script was written is 64df9933f6b3fed46070d597965f4415acca83e.
+``vnx pr-ready 1719`` independently confirmed the same fact
+("glm_gate NOT on head").
+
+Safety: this script VERIFIES the mismatch itself before writing anything —
+it never trusts an operator's claim on faith. It refuses (no write, exit 2)
+when:
+  - the obligation is not in a terminal fulfilled/failed state (nothing to
+    reopen),
+  - the obligation's own ``evidence_result_path``/``result_path`` cannot be
+    read,
+  - the PR's current head sha cannot be resolved (``gh`` unavailable) — the
+    mismatch cannot be PROVEN, so nothing is reopened on an unverified claim
+    (the same "third branch, never guess" discipline the runner's own sha
+    check applies),
+  - the evidence's own commit_sha turns out to MATCH the current head after
+    all (there is genuinely nothing to correct).
+
+Usage:
+    python3 scripts/gate_obligation_reopen_stale_evidence.py \\
+        --dispatch-id 20260830-133000-oi1453-noemer-is-pass        # dry run
+    python3 scripts/gate_obligation_reopen_stale_evidence.py \\
+        --dispatch-id 20260830-133000-oi1453-noemer-is-pass --write
+
+Dry run is the default on purpose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+for _p in (SCRIPT_DIR / "lib", SCRIPT_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from gate_obligations import (  # noqa: E402
+    STATUS_FAILED,
+    STATUS_FULFILLED,
+    STATUS_PENDING,
+    obligation_path,
+    update_obligation,
+)
+from gate_executor import _classify_sha_binding  # noqa: E402
+from gate_obligation_runner import _get_pr_head_sha_for_gate  # noqa: E402
+
+
+def _utc_now_iso() -> str:
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class ReopenRefused(RuntimeError):
+    """The obligation cannot be reopened — see the message for why."""
+
+
+def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
+    """Read the obligation and PROVE its evidence is about a different
+    commit than the PR's current head. Never writes. Raises
+    :class:`ReopenRefused` (never returns a half-verified result) when the
+    mismatch cannot be established.
+    """
+    path = obligation_path(state_dir, dispatch_id)
+    if not path.exists():
+        raise ReopenRefused(f"no obligation record for dispatch_id={dispatch_id!r} at {path}")
+    record = json.loads(path.read_text(encoding="utf-8"))
+
+    status = record.get("status")
+    if status not in (STATUS_FULFILLED, STATUS_FAILED):
+        raise ReopenRefused(
+            f"obligation status is {status!r}, not fulfilled/failed — nothing to reopen"
+        )
+
+    evidence_path_str = record.get("evidence_result_path") or record.get("result_path")
+    if not evidence_path_str:
+        raise ReopenRefused("obligation carries no evidence_result_path/result_path to verify")
+    evidence_path = Path(evidence_path_str)
+    if not evidence_path.exists():
+        raise ReopenRefused(f"evidence file does not exist on disk: {evidence_path}")
+    try:
+        evidence_record = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReopenRefused(f"evidence file unreadable: {evidence_path} ({exc})") from exc
+
+    pr_number = record.get("pr_number") or evidence_record.get("pr_number")
+    if not isinstance(pr_number, int) or pr_number <= 0:
+        raise ReopenRefused("obligation has no resolvable pr_number to check the PR head against")
+
+    head_sha = _get_pr_head_sha_for_gate(pr_number)
+    evidence_sha = str(evidence_record.get("commit_sha") or "")
+    binding = _classify_sha_binding(head_sha, evidence_sha)
+
+    if binding == "unknown":
+        raise ReopenRefused(
+            f"sha binding unverifiable (head_sha={head_sha!r}, evidence_sha={evidence_sha!r}) "
+            "— refusing to reopen on an unproven claim"
+        )
+    if binding == "match":
+        raise ReopenRefused(
+            f"evidence commit_sha {evidence_sha!r} MATCHES the current PR #{pr_number} head "
+            f"{head_sha!r} — there is nothing stale to correct"
+        )
+
+    return {
+        "path": path,
+        "record": record,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "evidence_sha": evidence_sha,
+        "evidence_path": str(evidence_path),
+        "resolved_by_gate": record.get("resolved_by_gate") or record.get("fulfilled_by") or record.get("gate"),
+    }
+
+
+def reopen_obligation(
+    state_dir: Path, dispatch_id: str, *, operator_reason: str, write: bool,
+) -> Dict[str, Any]:
+    """Verify the mismatch, then (if ``write``) reopen the obligation to
+    ``STATUS_PENDING`` via the audited :func:`update_obligation` API —
+    never a hand-edit of the JSON file.
+    """
+    proof = verify_stale_evidence(state_dir, dispatch_id)
+    record = proof["record"]
+    reason_detail = (
+        f"reopened by gate_obligation_reopen_stale_evidence.py (OI-1571 tak 3): "
+        f"the obligation was booked {record.get('status')!r} via "
+        f"{proof['resolved_by_gate']!r} off evidence at {proof['evidence_path']} "
+        f"(commit_sha={proof['evidence_sha'][:12]!r}), which is a DIFFERENT "
+        f"commit than PR #{proof['pr_number']}'s current head "
+        f"({proof['head_sha'][:12]!r}) — the gate obligation runner's own "
+        "sha-binding check (this same dispatch) would now refuse this "
+        f"evidence outright. Operator reason: {operator_reason}"
+    )
+    outcome: Dict[str, Any] = {
+        "dispatch_id": dispatch_id,
+        "path": str(proof["path"]),
+        "previous_status": record.get("status"),
+        "pr_number": proof["pr_number"],
+        "head_sha": proof["head_sha"],
+        "evidence_sha": proof["evidence_sha"],
+        "reason_detail": reason_detail,
+        "write": write,
+    }
+    if not write:
+        outcome["action"] = "would_reopen"
+        return outcome
+
+    from review_gate_manager import emit_governance_receipt  # noqa: PLC0415
+
+    # ADR-005: the ledger is canonical, written before the state mutation —
+    # the same order every other durable state-mutation in this fleet uses
+    # (see gate_request_handler._check_ci_gate_requirement_mismatch).
+    emit_governance_receipt(
+        "gate_obligation_reopened_stale_evidence",
+        receipt_kind="review_gate",
+        status="reopened",
+        dispatch_id=dispatch_id,
+        gate=str(record.get("gate") or ""),
+        pr_number=proof["pr_number"],
+        previous_status=record.get("status"),
+        previous_resolved_by_gate=proof["resolved_by_gate"],
+        evidence_commit_sha=proof["evidence_sha"],
+        pr_head_sha=proof["head_sha"],
+        reason_detail=reason_detail,
+    )
+    update_obligation(
+        proof["path"],
+        status=STATUS_PENDING,
+        attempts=0,
+        last_attempt_at=None,
+        resolved_at=None,
+        request_path=None,
+        result_path=None,
+        resolved_by_gate=None,
+        takeover_hops=None,
+        fulfilled_by=None,
+        takeover_gate=None,
+        evidence_result_path=None,
+        reason="reopened_stale_takeover_evidence",
+        reason_detail=reason_detail,
+    )
+    outcome["action"] = "reopened"
+    return outcome
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--state-dir", type=Path, default=None)
+    parser.add_argument("--dispatch-id", required=True)
+    parser.add_argument(
+        "--reason", default="OI-1571 tak 3 remediation — see script docstring for the measured case",
+        help="Operator-supplied audit reason, embedded in the obligation's reason_detail",
+    )
+    parser.add_argument("--write", action="store_true", help="Persist the reopen (default: dry run)")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.state_dir is not None:
+        state_dir = args.state_dir
+    else:
+        import vnx_paths  # noqa: PLC0415
+
+        state_dir = Path(vnx_paths.ensure_env()["VNX_STATE_DIR"])
+    if not state_dir.is_dir():
+        print(f"ERROR: state dir not found: {state_dir}", file=sys.stderr)
+        return 20
+
+    try:
+        outcome = reopen_obligation(
+            state_dir, args.dispatch_id, operator_reason=args.reason, write=args.write,
+        )
+    except ReopenRefused as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(outcome, indent=2))
+    else:
+        print(f"action={outcome['action']} dispatch_id={outcome['dispatch_id']}")
+        print(f"  previous_status={outcome['previous_status']}")
+        print(f"  pr_number={outcome['pr_number']} head_sha={outcome['head_sha'][:12]}")
+        print(f"  evidence_sha={outcome['evidence_sha'][:12]}")
+        if not args.write:
+            print("  DRY RUN — pass --write to persist")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -141,6 +141,7 @@ from gate_status import (  # noqa: E402
     has_complete_evidence,
     is_pass as _gate_is_pass,
 )
+from gate_executor import _classify_sha_binding  # noqa: E402
 
 _LOG = logging.getLogger("gate_obligation_runner")
 
@@ -196,6 +197,16 @@ _TEMPORARY_NOT_EXECUTABLE_REASONS = frozenset({
     "provider_not_installed",
 })
 _TEMPORARY_REFUSAL_ESCALATION_ATTEMPTS = _UNRESOLVABLE_ESCALATION_ATTEMPTS
+
+# OI-1569 Klaar item 8: a genuine gate run measures 91-405s; a quota refusal
+# measures 3-15s; a silent stale-evidence fulfilment (the PR #1719/#1736
+# defect this dispatch fixes) measured 7s. None of duration_seconds (absent
+# on some lanes by design), recorded_at (cannot tell "just written" from
+# "written minutes ago" on its own), or the result file's mtime alone proves
+# which of these a booking is — together they can. 60s is comfortably above
+# the fastest real quota-refusal bucket and comfortably below the fastest
+# genuine-run bucket measured; see _flag_fast_fulfillment_if_evidence_predates_attempt.
+_FAST_FULFILLMENT_MTIME_THRESHOLD_SECONDS = 60
 
 # PR-resolution outcomes. The runner must tell "no PR yet" (a wait) apart from
 # "cannot resolve because the environment is wrong" (a fault) IN THE RECORD,
@@ -598,6 +609,62 @@ def resolve_pr_number(state_dir: Path, record: Dict[str, Any]) -> PrResolution:
 # ---------------------------------------------------------------------------
 
 
+def _get_pr_head_sha_for_gate(pr_number: Optional[int]) -> str:
+    """The PR's current GitHub head commit sha, for OI-1571 tak 3 sha-binding
+    checks (:func:`_has_decided_evidence`).
+
+    A thin wrapper around ``gate_recorder.get_pr_head_sha`` -- the SAME
+    canonical source ``gate_executor._execute_requested_gates`` already uses
+    for its own sha-binding check (OI-1307/B6: gh, never a local ``git
+    rev-parse HEAD``, which would answer for the runner's own checkout, not
+    the PR). A separate, module-level wrapper here (rather than a call
+    inline) so tests can monkeypatch this runner's own resolution
+    independently of gate_executor's identical call. Returns "" for a
+    missing/invalid pr_number -- :func:`gate_executor._classify_sha_binding`
+    already treats an empty sha on either side as ``unknown``, never a
+    ``mismatch``.
+    """
+    if not isinstance(pr_number, int) or pr_number <= 0:
+        return ""
+    from gate_recorder import get_pr_head_sha  # noqa: PLC0415
+
+    return get_pr_head_sha(pr_number)
+
+
+def _flag_fast_fulfillment_if_evidence_predates_attempt(
+    result_file: Path, gate: str, pr_number: int, dispatch_id: str,
+) -> Optional[str]:
+    """OI-1569 Klaar item 8: a fulfilment/failure booked from a result FILE
+    that was not actually touched by this attempt is not provably a fresh
+    run this cycle. A LOUD warning, never a new blocking mechanism — a
+    dispatch with no new commits can legitimately reuse an already-current
+    evidence file, and that must still fulfil — this only makes the shape
+    VISIBLE (log line + returned detail for the outcome) so a silent
+    stale-evidence fulfilment stays observable even if some future change
+    reopens the hole the sha check in :func:`fulfill_obligation` closes.
+
+    Returns None when the file is missing/unreadable or was touched
+    recently enough (age < :data:`_FAST_FULFILLMENT_MTIME_THRESHOLD_SECONDS`)
+    — the overwhelmingly common, unremarkable case.
+    """
+    try:
+        mtime = result_file.stat().st_mtime
+    except OSError:
+        return None
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    age_seconds = datetime.now(timezone.utc).timestamp() - mtime
+    if age_seconds < _FAST_FULFILLMENT_MTIME_THRESHOLD_SECONDS:
+        return None
+    detail = (
+        f"{gate} fulfilment for PR #{pr_number} (dispatch {dispatch_id}) used "
+        f"evidence whose file was last written {age_seconds:.0f}s before this "
+        "attempt resolved — not provably a fresh run this cycle (OI-1569 Klaar item 8)"
+    )
+    _LOG.warning("gate_obligation_runner: %s", detail)
+    return detail
+
+
 def _build_manager(state_dir: Path):
     """Construct a ReviewGateManager pinned to the runner's state dir.
 
@@ -689,9 +756,19 @@ def _index_gate_results(
     return index
 
 
-def _has_decided_evidence(record: Dict[str, Any]) -> bool:
-    """True when ``record`` is a DECIDED pass/fail gate verdict carrying a
-    complete, still-on-disk evidence trail.
+# OI-1571 tak 3: four outcomes for "is this record usable evidence", never
+# collapsed to a bare bool. A record can be structurally decided (complete
+# evidence, on-disk report, a real pass/fail verdict) and STILL not count —
+# because it is evidence about a DIFFERENT commit than the PR head, or
+# because whether it is current or not cannot even be determined.
+_EVIDENCE_NOT_DECIDED = "not_decided"
+_EVIDENCE_USABLE = "usable"
+_EVIDENCE_MISMATCH = "mismatch"
+_EVIDENCE_UNKNOWN_SHA = "unknown_sha"
+
+
+def _has_decided_evidence(record: Dict[str, Any], head_sha: str) -> Tuple[str, str]:
+    """Classify whether ``record`` is USABLE evidence for the PR at ``head_sha``.
 
     "Complete evidence" mirrors ``gate_status.has_complete_evidence``
     (non-empty ``contract_hash`` AND ``report_path`` — the same bar
@@ -702,55 +779,128 @@ def _has_decided_evidence(record: Dict[str, Any]) -> bool:
     any other status that is not a decided pass/fail (incomplete,
     ``unavailable``, or unrecognised) — only :func:`gate_status.is_pass`
     returning True, or a status in :data:`gate_status.FAIL_STATES`, counts.
+    Any of these gaps returns :data:`_EVIDENCE_NOT_DECIDED`.
+
+    OI-1571 tak 3: a record that clears every check above can still be
+    evidence about ANOTHER commit -- measured live on PR #1719 (a glm_gate
+    verdict from the day before, about a since-superseded head) and PR #1736
+    (a codex_gate verdict left on disk by an earlier dispatch against the
+    same PR, picked up unchanged by a later one). This function is the
+    single place that decides that, via
+    :func:`gate_executor._classify_sha_binding` -- the SAME function the
+    merge door and the fresh-execution path already use, never a second sha
+    comparison:
+
+      - ``match``    -> :data:`_EVIDENCE_USABLE`: the ONLY outcome a caller
+        may treat as found.
+      - ``mismatch`` -> :data:`_EVIDENCE_MISMATCH`: provably about a
+        different commit. A caller must reject it exactly as it would
+        reject "no evidence", but the returned detail names both shas so
+        whatever record documents the rejection can carry the reason.
+      - ``unknown``  -> :data:`_EVIDENCE_UNKNOWN_SHA`: the binding itself
+        could not be determined (``head_sha`` or the record's own
+        ``commit_sha`` is empty). A THIRD outcome, distinct from both
+        ``usable`` and ``mismatch`` -- a caller must suspend judgement
+        (never silently accept, never silently refuse) rather than guess
+        which of the two this unverifiable case actually is.
 
     Factored out of :func:`_fulfilling_result` (D2e) so the OI-1388
     evidence-index lookup and the takeover-chain walk
     (:func:`_find_takeover_successor_evidence`, which reads records fresh
     off disk rather than through an index) share exactly ONE "is this
     usable evidence" predicate instead of two that could silently drift
-    apart.
+    apart -- and, since D2e, the declared-gate gating check inside
+    :func:`fulfill_obligation` shares it too: a THIRD direct call site,
+    not just the two above.
     """
     if not has_complete_evidence(record):
-        return False
+        return _EVIDENCE_NOT_DECIDED, "incomplete evidence (contract_hash/report_path)"
     if not Path(str(record.get("report_path"))).exists():
-        return False
+        return _EVIDENCE_NOT_DECIDED, "report_path no longer exists on disk"
     status = _gate_canonical_status(record)
     if status == "not_executable":
-        return False
+        return _EVIDENCE_NOT_DECIDED, "not_executable is never evidence — the gate never ran"
     passed, _reason = _gate_is_pass(record)
-    return passed or status in _GATE_RESULT_FAIL_STATES
+    if not (passed or status in _GATE_RESULT_FAIL_STATES):
+        return _EVIDENCE_NOT_DECIDED, f"status {status!r} is not a decided pass/fail verdict"
+
+    result_sha = str(record.get("commit_sha") or "")
+    binding = _classify_sha_binding(head_sha, result_sha)
+    if binding == "match":
+        return _EVIDENCE_USABLE, "commit_sha matches the PR head"
+    if binding == "mismatch":
+        return _EVIDENCE_MISMATCH, (
+            f"result records commit {result_sha[:8] or '?'} but the PR head is "
+            f"{head_sha[:8] or '?'} — this verdict is about other code"
+        )
+    return _EVIDENCE_UNKNOWN_SHA, (
+        "sha binding unknown — head_sha or the record's commit_sha is missing; "
+        "cannot verify whether this evidence belongs to the current head"
+    )
 
 
 def _fulfilling_result(
     index: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]],
     dispatch_id: str,
     gate: str,
-) -> Optional[Tuple[Path, Dict[str, Any]]]:
-    """Return the (path, record) of a complete-evidence, DECIDED result for
-    ``(dispatch_id, gate)`` — a gate that actually ran and reached a verdict.
+) -> Dict[str, Any]:
+    """Scan the ``(dispatch_id, gate)`` bucket for a complete-evidence,
+    DECIDED, sha-CURRENT result — a gate that actually ran, reached a
+    verdict, and is provably about the PR's current head.
 
     OI-1388 defect 1: a terminal retirement/escalation must never overwrite
-    evidence that a gate already produced. "Usable evidence" is
-    :func:`_has_decided_evidence` — four distinct non-evidence states are
-    rejected there: a result that is entirely absent (empty index bucket,
-    checked here), one whose evidence fields are empty strings, one whose
-    ``report_path`` points at a file that no longer exists, and one whose
-    verdict itself is not decided (BETA3-C2).
+    evidence that a gate already produced. OI-1571 tak 3 tightens "already
+    produced" to also mean "still about the current commit" — each
+    candidate's PR head is resolved fresh via
+    :func:`_get_pr_head_sha_for_gate` off the CANDIDATE record's own
+    ``pr_number`` (never the caller's obligation, which by construction
+    could not resolve one — that is exactly why this rescue path exists).
 
-    The caller determines PASS vs. FAIL on the returned record via
+    Returns a dict, never a bare ``Optional[Tuple]`` (OI-1571 tak 3: an
+    UNVERIFIABLE candidate must not collapse into "nothing found" — that
+    would silently retire/escalate over evidence that might still be
+    current):
+
+      - ``{"kind": "found", "entry": (path, record)}`` — sha-matching,
+        decided evidence. The only outcome a caller may fulfil/fail on.
+      - ``{"kind": "unverifiable", "entry": (path, record), "detail": ...}``
+        — decided evidence exists but its sha binding could not be
+        verified. A caller must suspend judgement, not retire/escalate.
+      - ``{"kind": "absent", "detail": Optional[str]}`` — nothing decided
+        and current was found. ``detail`` carries the reason for the first
+        MISMATCH seen (both shas), when one was, so a caller's
+        retire/escalate record can document why a candidate was rejected
+        rather than silently proceeding as if nothing existed at all.
+
+    The caller determines PASS vs. FAIL on a ``"found"`` entry via
     :func:`gate_status.is_pass` — this function only answers "does usable
     evidence exist", never "what should the obligation be stamped".
     """
+    unverifiable: Optional[Tuple[Path, Dict[str, Any], str]] = None
+    mismatch_detail: Optional[str] = None
     for entry, record in index.get((dispatch_id, gate), []):
-        if _has_decided_evidence(record):
-            return entry, record
-    return None
+        candidate_pr = record.get("pr_number")
+        head_sha = (
+            _get_pr_head_sha_for_gate(candidate_pr) if isinstance(candidate_pr, int) else ""
+        )
+        kind, detail = _has_decided_evidence(record, head_sha)
+        if kind == _EVIDENCE_USABLE:
+            return {"kind": "found", "entry": (entry, record)}
+        if kind == _EVIDENCE_UNKNOWN_SHA and unverifiable is None:
+            unverifiable = (entry, record, detail)
+        if kind == _EVIDENCE_MISMATCH and mismatch_detail is None:
+            mismatch_detail = detail
+    if unverifiable is not None:
+        entry, record, detail = unverifiable
+        return {"kind": "unverifiable", "entry": (entry, record), "detail": detail}
+    return {"kind": "absent", "detail": mismatch_detail}
 
 
 def _find_takeover_successor_evidence(
     manager: Any,
     declared_gate: str,
     pr_number: int,
+    head_sha: str,
 ) -> Optional[Tuple[str, Path, Dict[str, Any], List[str]]]:
     """D2e (dispatch 20260830-120000-d2e-takeover-keten-bewijs): walk the
     review-gate takeover chain FORWARD from ``declared_gate``, reading each
@@ -793,6 +943,15 @@ def _find_takeover_successor_evidence(
     separate dispatch, E2) walks off the end of ``chain`` here exactly the
     same way a chain that never produced any evidence at all does, and
     both correctly return ``None``.
+
+    OI-1571 tak 3: a successor's own record can ALSO be decided/complete
+    but about a different commit (the live PR #1719 case: a glm_gate PASS
+    from the day before) or sha-unverifiable. Both are rejected here via
+    :func:`_has_decided_evidence` exactly like an incomplete/undecided
+    record — the walk simply keeps going. The caller
+    (:func:`fulfill_obligation`) is the one that must not silently retire a
+    dispatch just because THIS walk found nothing usable; the walk itself
+    only ever answers "found" or "found nothing", same as before D2e.
     """
     from gate_request_handler import _build_review_gate_takeover_chain  # noqa: PLC0415
 
@@ -811,7 +970,8 @@ def _find_takeover_successor_evidence(
             continue
         if not isinstance(candidate_record, dict):
             continue
-        if not _has_decided_evidence(candidate_record):
+        kind, _detail = _has_decided_evidence(candidate_record, head_sha)
+        if kind != _EVIDENCE_USABLE:
             continue
         return current, candidate_path, candidate_record, hops
     return None
@@ -846,10 +1006,10 @@ def _terminal_evidence_contradictions(
         if not gate or gate == NO_GATE_KEY:
             continue
         dispatch_id = str(record.get("dispatch_id") or path.stem)
-        evidence = _fulfilling_result(result_index, dispatch_id, gate)
-        if evidence is None:
+        lookup = _fulfilling_result(result_index, dispatch_id, gate)
+        if lookup["kind"] != "found":
             continue
-        evidence_path, _evidence_record = evidence
+        evidence_path, _evidence_record = lookup["entry"]
         reason = record.get("reason")
         contradictions.append(
             {
@@ -916,12 +1076,16 @@ def _pre_execution_decision(
       - ``stay_pending``               — genuine wait (branch alive / undetermined)
       - ``retire``                     — dead dispatch, no rescuing evidence
       - ``fulfill_by_evidence``        — OI-1388 defect 1: a complete-evidence
-        DECIDED PASS already exists for this dispatch_id + gate; carried as
-        ``decision["evidence"] = (path, record)``
+        DECIDED PASS, sha-current with the PR head, already exists for this
+        dispatch_id + gate; carried as ``decision["evidence"] = (path, record)``
       - ``fulfill_by_failed_evidence`` — BETA3-C2: same rescue, but the
         existing evidence is a DECIDED FAIL — never booked as
         ``fulfill_by_evidence``, or the obligation would launder a rejection
         into a clean pass; also carries ``decision["evidence"]``
+      - ``sha_unverifiable``           — OI-1571 tak 3: a complete, decided
+        result exists but its sha binding to the PR head could not be
+        verified. NEITHER a rescue NOR a retire/escalate — a third outcome
+        that suspends judgement; carries ``decision["detail"]``
       - ``attempt_gate``               — PR resolved: the caller must actually
         run the gate to learn the outcome (only the real run does this)
 
@@ -929,22 +1093,30 @@ def _pre_execution_decision(
     evidence here — :func:`_fulfilling_result` rejects those itself, so a
     dispatch whose only "evidence" is a never-ran gate falls straight through
     to ``retire``/``escalate``/``unresolvable`` exactly as if no result
-    existed at all.
+    existed at all. A DECIDED result about a DIFFERENT commit (OI-1571 tak 3
+    ``mismatch``) is rejected the same way, but the retire/escalate decision
+    carries ``decision["mismatch_detail"]`` when one was seen, so whatever
+    record documents the retirement/escalation can also document why the
+    rejected evidence did not count.
     """
     if resolution.status == RESOLUTION_UNRESOLVABLE:
-        evidence = _fulfilling_result(result_index, dispatch_id, gate)
-        if evidence is not None:
-            return _evidence_decision(evidence)
+        lookup = _fulfilling_result(result_index, dispatch_id, gate)
+        if lookup["kind"] == "found":
+            return _evidence_decision(lookup["entry"])
+        if lookup["kind"] == "unverifiable":
+            return {"kind": "sha_unverifiable", "detail": lookup["detail"]}
         if attempts >= _UNRESOLVABLE_ESCALATION_ATTEMPTS:
-            return {"kind": "escalate"}
+            return {"kind": "escalate", "mismatch_detail": lookup.get("detail")}
         return {"kind": "unresolvable"}
 
     if resolution.status == RESOLUTION_AWAITING:
         if resolution.branch_exists is False:
-            evidence = _fulfilling_result(result_index, dispatch_id, gate)
-            if evidence is not None:
-                return _evidence_decision(evidence)
-            return {"kind": "retire"}
+            lookup = _fulfilling_result(result_index, dispatch_id, gate)
+            if lookup["kind"] == "found":
+                return _evidence_decision(lookup["entry"])
+            if lookup["kind"] == "unverifiable":
+                return {"kind": "sha_unverifiable", "detail": lookup["detail"]}
+            return {"kind": "retire", "mismatch_detail": lookup.get("detail")}
         return {"kind": "stay_pending"}
 
     return {"kind": "attempt_gate"}
@@ -955,6 +1127,7 @@ _DRY_RUN_ACTION_LABELS: Dict[str, str] = {
     "escalate": "would_escalate_not_executable",
     "fulfill_by_evidence": "would_stamp",
     "fulfill_by_failed_evidence": "would_stamp_failed",
+    "sha_unverifiable": "would_stay_pending_sha_unverifiable",
     "retire": "would_retire",
     "stay_pending": "would_stay_pending",
     "attempt_gate": "would_fulfill",
@@ -1007,10 +1180,16 @@ def _dry_run_outcome(
             f"verdict — never a clean pass ({evidence_path})"
         )
         outcome["result_path"] = str(evidence_path)
+    elif decision["kind"] == "sha_unverifiable":
+        outcome["detail"] = decision.get("detail")
     elif decision["kind"] == "retire":
         outcome["detail"] = resolution.reason or "dispatch died without ever producing a PR; branch gone"
+        if decision.get("mismatch_detail"):
+            outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
     elif decision["kind"] in ("unresolvable", "escalate"):
         outcome["detail"] = resolution.reason
+        if decision.get("mismatch_detail"):
+            outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
     return outcome
 
 
@@ -1078,6 +1257,9 @@ def fulfill_obligation(
                 "a dispatch a gate already reviewed must never be retired or "
                 "escalated as unreviewed"
             ),
+            fulfilled_by=gate,
+            takeover_gate=None,
+            evidence_result_path=str(evidence_path),
         )
         outcome["action"] = STATUS_FULFILLED
         outcome["detail"] = (
@@ -1120,6 +1302,9 @@ def fulfill_obligation(
                 "BETA3-C2: the gate DID review this, so the obligation is "
                 "discharged, but a rejection must never be booked as fulfilled"
             ),
+            fulfilled_by=gate,
+            takeover_gate=None,
+            evidence_result_path=str(evidence_path),
         )
         outcome["action"] = STATUS_FAILED
         outcome["detail"] = (
@@ -1130,19 +1315,51 @@ def fulfill_obligation(
         outcome["result_path"] = updated.get("result_path")
         return outcome
 
+    if decision["kind"] == "sha_unverifiable":
+        # OI-1571 tak 3: a complete, decided result exists for this
+        # dispatch+gate, but whether it belongs to the PR's CURRENT head
+        # could not be verified (head_sha or the record's own commit_sha is
+        # missing). Neither the OI-1388 rescue (that requires a confirmed
+        # MATCH) nor a retire/escalate (that would silently discard evidence
+        # that might still be current) applies — a third outcome that
+        # suspends judgement and stays pending, loud about why, so the next
+        # run gets another chance to verify it.
+        update_obligation(
+            path,
+            status=STATUS_PENDING,
+            attempts=attempts,
+            last_attempt_at=now,
+            reason="sha_binding_unverifiable",
+            reason_detail=(
+                f"{gate} has existing complete evidence for dispatch "
+                f"{dispatch_id} but its sha binding to the PR head could not "
+                f"be verified ({decision.get('detail')}) — suspending "
+                "judgement (OI-1571 tak 3) rather than silently accepting or "
+                "discarding it; will re-check on the next run"
+            ),
+        )
+        outcome["detail"] = "existing evidence found but its sha binding is unverifiable"
+        return outcome
+
     if decision["kind"] in ("unresolvable", "escalate"):
         # The environment is wrong (repo unattributable, gh unusable): a fault,
         # not a wait. Record it in a state distinct from ``pending`` so a
         # misconfigured obligation can never masquerade as "not yet". It stays
         # retryable — the env may be fixed — until it crosses the escalation
         # threshold, where it becomes the loud terminal not_executable.
+        mismatch_note = (
+            f" A prior {gate} result exists for this dispatch but is about a "
+            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
+            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
+            if decision.get("mismatch_detail") else ""
+        )
         update_obligation(
             path,
             status=STATUS_UNRESOLVABLE,
             attempts=attempts,
             last_attempt_at=now,
             reason="unresolvable_repo",
-            reason_detail=resolution.reason,
+            reason_detail=f"{resolution.reason}{mismatch_note}",
         )
         outcome["action"] = "unresolvable"
         outcome["detail"] = resolution.reason
@@ -1159,7 +1376,7 @@ def fulfill_obligation(
                     f"environment is misconfigured: {resolution.reason}. Fix "
                     "the project attribution (VNX_PROJECT_ID / "
                     "~/.vnx/projects.json / the checkout's git origin remote) "
-                    "and reset this obligation to pending."
+                    f"and reset this obligation to pending.{mismatch_note}"
                 ),
             )
             outcome["action"] = "not_executable"
@@ -1170,6 +1387,12 @@ def fulfill_obligation(
         # gone from origin — nothing will ever gate this obligation.
         # Terminal, distinct from `fulfilled` (no gate ever reviewed it).
         branch_name = f"dispatch/{dispatch_id}"
+        mismatch_note = (
+            f" A prior {gate} result exists for this dispatch but is about a "
+            f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
+            "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
+            if decision.get("mismatch_detail") else ""
+        )
         update_obligation(
             path,
             status=STATUS_RETIRED,
@@ -1182,7 +1405,7 @@ def fulfill_obligation(
                 f"dispatch {dispatch_id} never produced a PR and its head "
                 f"branch {branch_name} no longer exists on "
                 f"{resolution.owner_repo or 'the resolved repo'} — nothing "
-                f"left for {gate} to guard"
+                f"left for {gate} to guard.{mismatch_note}"
             ),
         )
         outcome["action"] = STATUS_RETIRED
@@ -1206,6 +1429,12 @@ def fulfill_obligation(
     # decision["kind"] == "attempt_gate": a PR is resolved — actually run it.
     pr_number = resolution.pr_number
     owner_repo = resolution.owner_repo or _resolve_github_owner_repo(state_dir)
+    # OI-1571 tak 3: resolved ONCE for this attempt and reused for every sha
+    # check below (the declared gate's own record, the takeover walk, and
+    # the final terminal fallback) — never re-fetched per check, and never a
+    # second implementation of "what is the PR head" (gate_executor's own
+    # fresh-execution sha check uses the exact same source).
+    head_sha = _get_pr_head_sha_for_gate(pr_number)
 
     branch = (
         str(record.get("branch") or "").strip()
@@ -1257,9 +1486,22 @@ def fulfill_obligation(
         # verdict: when it is, the existing handling below books it exactly
         # as it does today, and a successor is never even looked at (D2e:
         # "bewijs bij de gedeclareerde poort zelf wordt gevonden zoals nu").
+        #
+        # OI-1571 tak 3: "decided" now also means sha-CURRENT. A stale-but-
+        # complete record left on disk by an EARLIER dispatch against the
+        # same PR (measured live, PR #1736: an older dispatch's codex_gate
+        # PASS survived untouched because this attempt's codex run never
+        # overwrote it) used to satisfy the old bool check and skip the
+        # takeover walk entirely — declared_kind/declared_detail are reused
+        # below, after the walk, so a MISMATCH/UNKNOWN_SHA declared record
+        # is never silently trusted by the unconditional fallback either.
+        declared_kind, declared_detail = (
+            _has_decided_evidence(result_data, head_sha) if result_data is not None
+            else (_EVIDENCE_NOT_DECIDED, "no result record on disk yet")
+        )
         takeover_hit = None
-        if not (result_data is not None and _has_decided_evidence(result_data)):
-            takeover_hit = _find_takeover_successor_evidence(manager, gate, pr_number)
+        if declared_kind != _EVIDENCE_USABLE:
+            takeover_hit = _find_takeover_successor_evidence(manager, gate, pr_number, head_sha)
 
         if takeover_hit is not None:
             successor_gate, successor_path, successor_record, hops = takeover_hit
@@ -1287,6 +1529,9 @@ def fulfill_obligation(
                 result_path=str(successor_path),
                 resolved_by_gate=successor_gate,
                 takeover_hops=hops,
+                fulfilled_by=successor_gate,
+                takeover_gate=successor_gate,
+                evidence_result_path=str(successor_path),
                 reason=reason,
                 reason_detail=reason_detail,
             )
@@ -1414,7 +1659,72 @@ def fulfill_obligation(
                 outcome["detail"] = escalation_detail
             return outcome
 
+        # OI-1571 tak 3: reached only when the declared gate's OWN on-disk
+        # record looks decided enough to fall straight through to the
+        # unconditional booking below (its status is a pass/known-terminal
+        # shape) -- but "looks decided" is not "is current". A MISMATCH or
+        # UNKNOWN_SHA declared_kind here means the takeover walk above ALSO
+        # found nothing usable (a match would have short-circuited via
+        # takeover_hit, or declared_kind itself would already be USABLE and
+        # skip this branch entirely) -- so this is the dead end: neither the
+        # declared gate's own evidence nor any successor's is provably about
+        # the current head. Never fall through to the unconditional
+        # STATUS_FULFILLED default on that basis (measured live, PR #1736: a
+        # stale codex_gate PASS from an earlier dispatch against the same PR
+        # booked fulfilled with zero takeover, zero rescue markers).
+        if declared_kind == _EVIDENCE_MISMATCH:
+            update_obligation(
+                path,
+                status=STATUS_PENDING,
+                pr_number=pr_number,
+                branch=branch,
+                attempts=attempts,
+                last_attempt_at=now,
+                request_path=str(manager._request_path(gate, pr_number)),
+                result_path=str(result_file),
+                reason="stale_evidence_sha_mismatch",
+                reason_detail=(
+                    f"{gate}'s own result for PR #{pr_number} is decided but "
+                    f"about a DIFFERENT commit than the PR head "
+                    f"({declared_detail}) and no takeover successor produced "
+                    "current evidence either — staying pending, never booking "
+                    "a verdict about other code (OI-1571 tak 3)"
+                ),
+            )
+            outcome["action"] = "pending"
+            outcome["detail"] = declared_detail
+            return outcome
+
+        if declared_kind == _EVIDENCE_UNKNOWN_SHA:
+            update_obligation(
+                path,
+                status=STATUS_PENDING,
+                pr_number=pr_number,
+                branch=branch,
+                attempts=attempts,
+                last_attempt_at=now,
+                request_path=str(manager._request_path(gate, pr_number)),
+                result_path=str(result_file),
+                reason="sha_binding_unverifiable",
+                reason_detail=(
+                    f"{gate}'s own result for PR #{pr_number} is decided but "
+                    f"its sha binding to the PR head could not be verified "
+                    f"({declared_detail}) and no takeover successor produced "
+                    "verifiable evidence either — suspending judgement "
+                    "(OI-1571 tak 3) rather than silently accepting or "
+                    "refusing it"
+                ),
+            )
+            outcome["action"] = "pending"
+            outcome["detail"] = declared_detail
+            return outcome
+
         terminal = result_status if result_status in TERMINAL_STATUSES else STATUS_FULFILLED
+        fast_fulfillment_warning = None
+        if terminal in (STATUS_FULFILLED, STATUS_FAILED):
+            fast_fulfillment_warning = _flag_fast_fulfillment_if_evidence_predates_attempt(
+                result_file, gate, pr_number, dispatch_id,
+            )
         updated = update_obligation(
             path,
             status=terminal,
@@ -1427,6 +1737,11 @@ def fulfill_obligation(
             result_path=str(result_file),
             reason=None if not result.get("has_required_failure") else "required_failure",
             reason_detail=None if terminal == STATUS_FULFILLED else f"result status: {result_status}",
+            fulfilled_by=gate if terminal in (STATUS_FULFILLED, STATUS_FAILED) else None,
+            takeover_gate=None,
+            evidence_result_path=(
+                str(result_file) if terminal in (STATUS_FULFILLED, STATUS_FAILED) else None
+            ),
         )
         # Mirror the status actually persisted to disk — never a hardcoded
         # "fulfilled" label, which would lie about a not_executable/failed
@@ -1436,6 +1751,8 @@ def fulfill_obligation(
         outcome["request_path"] = updated.get("request_path")
         outcome["result_path"] = updated.get("result_path")
         outcome["has_required_failure"] = bool(result.get("has_required_failure"))
+        if fast_fulfillment_warning:
+            outcome["fast_fulfillment_warning"] = fast_fulfillment_warning
         return outcome
     except Exception as exc:  # noqa: BLE001 — a gate that cannot run is a loud registered outcome
         result_payload = _record_loud_not_executable(
@@ -1537,7 +1854,10 @@ def run(
         if not write:
             outcome = _dry_run_outcome(state_dir, path, record, result_index)
             outcomes.append(outcome)
-            if outcome["action"] in ("would_stay_pending", "would_stay_unresolvable", "would_fulfill"):
+            if outcome["action"] in (
+                "would_stay_pending", "would_stay_unresolvable", "would_fulfill",
+                "would_stay_pending_sha_unverifiable",
+            ):
                 pending_after += 1
             continue
         outcome = fulfill_obligation(state_dir, path, record, result_index=result_index)

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -220,6 +220,96 @@ def _scan_seat_failure_text(result: Dict[str, Any], manager: "Optional[GateReque
     return "no_response", (field_text or "no detail recorded")
 
 
+# OI-1569 tak 1+2 (dispatch 20260830-153000-oi1569-quota-heeft-geen-tijddimensie):
+# a lane_exhausted classification had no time dimension at all -- a quota
+# refusal is inherently temporary, but the walk in _dispatch_review_seat
+# reads it as a permanent property of the lane. Measured live: once EVERY
+# gate in the configured chain (codex_gate -> kimi_gate -> glm_gate ->
+# deepseek_gate) has a lane_exhausted record on file, the walk always lands
+# on _chain_exhausted_result and NOTHING ever gets a fresh attempt again --
+# PR #1719 stayed blocked on a 10:13 record five hours later, at 15:08, with
+# five OTHER PRs completing real codex runs in between (no provider outage).
+# This constant is the deliberately simple fix: a lane_exhausted record
+# older than this TTL no longer counts as "still exhausted" -- the walk
+# stops at that hop and re-dispatches it fresh, exactly as it would for a
+# gate with no prior failure at all. Retrying too early is cheap (a
+# still-exhausted gate re-records lane_exhausted in 3-15s, per the dispatch's
+# own measurements) -- a short, simple TTL is safer than a long one or a
+# parsed reset-time from provider-specific prose.
+_LANE_EXHAUSTION_TTL_SECONDS = 3600
+
+
+def _seat_failure_age_seconds(recorded_at: Any) -> Optional[float]:
+    """Age, in seconds, of a gate result's ``recorded_at`` timestamp.
+
+    Returns None -- not 0, not a huge sentinel -- when ``recorded_at`` is
+    missing, not a string, or not a parseable ISO8601 timestamp. OI-1569 tak
+    1+2's third branch (see :func:`_lane_exhausted_or_expired`) depends on
+    this distinction: "no usable timestamp" must never silently read as
+    either "just recorded" (age 0) or "ancient" (a huge sentinel) -- both
+    would smuggle a specific answer into what is actually unknown.
+    """
+    if not isinstance(recorded_at, str) or not recorded_at.strip():
+        return None
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    text = recorded_at.strip()
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    return max(0.0, (now - parsed).total_seconds())
+
+
+def _lane_exhausted_or_expired(result: Dict[str, Any]) -> str:
+    """Recency-gate a ``lane_exhausted`` classification (OI-1569 tak 1+2).
+
+    Three outcomes, never two -- collapsing the third into either of the
+    first two is exactly the defect this exists to fix:
+
+      - the record's ``recorded_at`` is recent (age < TTL): still
+        exhausted -- returns ``'lane_exhausted'`` unchanged, the walk keeps
+        skipping this hop.
+      - ``recorded_at`` is old: EXPIRED -- a quota refusal is not a
+        permanent lane property. Returns ``'lane_exhausted_expired'``
+        (anything other than the literal ``'lane_exhausted'`` already stops
+        the caller's walk and re-dispatches this gate).
+      - the record has no usable ``recorded_at`` at all: THIS IS ITS OWN
+        BRANCH, not "still exhausted" and not "expired" -- logged loudly
+        (an operator must be able to see an unverifiable-age record, never
+        have it pass through silently either way) and returns
+        ``'lane_exhausted_unknown_age'``. Behaviourally this also stops the
+        walk (the safe default when staleness cannot be proven is to allow
+        a retry, never to perpetuate an unverifiable block forever) -- but
+        it is a NAMED, distinct outcome so the two cases stay
+        distinguishable in logs and tests.
+    """
+    age_seconds = _seat_failure_age_seconds(result.get("recorded_at"))
+    if age_seconds is None:
+        logger.warning(
+            "gate_request_handler: lane_exhausted record for gate=%s pr=%s has "
+            "no usable recorded_at (%r) -- cannot verify staleness; treating "
+            "as retry-eligible rather than perpetuating an unverifiable block "
+            "(OI-1569 tak 1+2)",
+            result.get("gate", "?"), result.get("pr_number", "?"), result.get("recorded_at"),
+        )
+        return "lane_exhausted_unknown_age"
+    if age_seconds >= _LANE_EXHAUSTION_TTL_SECONDS:
+        logger.info(
+            "gate_request_handler: lane_exhausted record for gate=%s pr=%s is "
+            "%.0fs old (TTL=%ds) -- treating as EXPIRED, re-dispatching fresh "
+            "(OI-1569 tak 1+2)",
+            result.get("gate", "?"), result.get("pr_number", "?"),
+            age_seconds, _LANE_EXHAUSTION_TTL_SECONDS,
+        )
+        return "lane_exhausted_expired"
+    return "lane_exhausted"
+
+
 class GateRequestHandlerMixin:
     """Mixin providing gate request creation methods for ReviewGateManager."""
 
@@ -405,6 +495,19 @@ class GateRequestHandlerMixin:
                                      payment/quota code, or a permanent
                                      not_executable refusal with a
                                      provider-owned reason). Take over.
+            'lane_exhausted_expired' / 'lane_exhausted_unknown_age' --
+                                     OI-1569 tak 1+2: a marker WAS found, but
+                                     the recency gate below (see
+                                     :func:`_lane_exhausted_or_expired`)
+                                     refuses to keep treating it as a
+                                     currently-exhausted lane. Any value that
+                                     is not the literal string
+                                     'lane_exhausted' already stops the
+                                     caller's chain walk and re-dispatches
+                                     this seat -- these two names exist so
+                                     the reason is loud and distinguishable
+                                     in logs, never to be pattern-matched by
+                                     a caller.
             'unreadable_verdict' -- toestand 2: a response existed, the
                                      verdict block did not parse. Abstain --
                                      never take over.
@@ -423,7 +526,7 @@ class GateRequestHandlerMixin:
             # over FROM a seat that was never real would misattribute cause.
             if result.get("reason") == "gate_runner_missing":
                 return "ok"
-            return "lane_exhausted"
+            return _lane_exhausted_or_expired(result)
         if status != "unavailable":
             return "ok"
         reason = result.get("reason", "")
@@ -440,6 +543,8 @@ class GateRequestHandlerMixin:
         # msg='Expecting value: line 1' beside raw='Error code: 403'; a
         # msg-keyed check reads toestand 2 while the raw body says toestand 1.
         state, _detail = _scan_seat_failure_text(result, self)
+        if state == "lane_exhausted":
+            return _lane_exhausted_or_expired(result)
         return state
 
     def _read_lane_log_or_report_text(self, result: Dict[str, Any]) -> str:

--- a/tests/test_beta3_e1_review_gate_chain.py
+++ b/tests/test_beta3_e1_review_gate_chain.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -58,6 +59,15 @@ for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
         sys.path.insert(0, _p)
 
 import config_registry as cr  # noqa: E402
+
+# OI-1569 tak 1+2: _classify_review_seat_failure now recency-gates a
+# lane_exhausted classification (gate_request_handler._lane_exhausted_or_expired,
+# TTL 3600s) -- a fixture's recorded_at must be FRESH relative to whenever the
+# suite actually runs, or these marker-discrimination fixtures would silently
+# start exercising the recency branch instead of the thing they are named
+# for. Computed once at collection time, not hardcoded, so this file never
+# goes stale the way the hand-dated 2026-08-26/08-22 fixtures below did.
+_FRESH_RECORDED_AT = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @pytest.fixture(autouse=True)
@@ -203,6 +213,7 @@ for _provider in ("codex", "kimi", "glm", "deepseek"):
     PROVIDER_CASES.append((_provider, "real_exhaustion", {
         "gate": _gate, "status": "unavailable", "reason": "dispatch_error",
         "residual_risk": _REAL_EXHAUSTION_TEXT[_provider],
+        "recorded_at": _FRESH_RECORDED_AT,
     }, "lane_exhausted"))
     PROVIDER_CASES.append((_provider, "parse_miss", {
         "gate": _gate, "status": "unavailable", "reason": "parse_error",
@@ -266,6 +277,7 @@ _PR1691_RESULT = {
     "contract_hash": "",
     "provider": "glm",
     "branch": "fix/pr1691",
+    "recorded_at": _FRESH_RECORDED_AT,
 }
 
 
@@ -333,7 +345,12 @@ _PR1696_REAL_CODEX_RECORD = {
     "advisory_findings": [],
     "required_reruns": ["codex_gate"],
     "residual_risk": "Gate exit_nonzero. Re-run required.",
-    "recorded_at": "2026-08-26T18:01:55Z",
+    # OI-1569 tak 1+2: recorded_at is FRESH (not the original 26-08 capture
+    # time) so this record exercises the marker-discrimination it is named
+    # for, not the separate recency gate (gate_request_handler.
+    # _lane_exhausted_or_expired) added later. Every other field stays the
+    # verbatim measured shape.
+    "recorded_at": _FRESH_RECORDED_AT,
     "branch": "dispatch/20260826-beta3-f-uitval-overschrijft-verdict-niet",
     "commit_sha": "ed3bdd97caf88094a4854067beed38594dc03d59",
 }
@@ -497,11 +514,13 @@ def test_three_step_chain_carries_full_path_in_annotation(manager_env, monkeypat
         "gate": "codex_gate", "pr_number": pr_number, "status": "unavailable",
         "reason": "dispatch_error",
         "residual_risk": _REAL_EXHAUSTION_TEXT["codex"],
+        "recorded_at": _FRESH_RECORDED_AT,
     })
     _write_result(manager_env["results_dir"], pr_number, "kimi_gate", {
         "gate": "kimi_gate", "pr_number": pr_number, "status": "unavailable",
         "reason": "dispatch_error",
         "residual_risk": _REAL_EXHAUSTION_TEXT["kimi"],
+        "recorded_at": _FRESH_RECORDED_AT,
     })
 
     with _patch_governance_receipt():
@@ -614,10 +633,12 @@ def test_chain_runs_empty_is_named_terminal_state(manager_env, monkeypatch):
     _write_result(manager_env["results_dir"], pr_number, "kimi_gate", {
         "gate": "kimi_gate", "pr_number": pr_number, "status": "unavailable",
         "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["kimi"],
+        "recorded_at": _FRESH_RECORDED_AT,
     })
     _write_result(manager_env["results_dir"], pr_number, "glm_gate", {
         "gate": "glm_gate", "pr_number": pr_number, "status": "unavailable",
         "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["glm"],
+        "recorded_at": _FRESH_RECORDED_AT,
     })
 
     with _patch_governance_receipt():
@@ -971,7 +992,9 @@ _PR1696_REAL_GLM_RESULT = {
         "a review outcome"
     ),
     "failure_reason": "",
-    "recorded_at": "2026-08-26T20:18:37Z",
+    # OI-1569 tak 1+2: fresh, not the original 26-08 capture time -- see the
+    # matching note on _PR1696_REAL_CODEX_RECORD above.
+    "recorded_at": _FRESH_RECORDED_AT,
     "evidence_source": "live",
     "branch": "dispatch/20260826-beta3-f-uitval-overschrijft-verdict-niet",
     "commit_sha": "cfcd8d3181e18452949bc2130149ffc40018eb62",
@@ -1164,3 +1187,130 @@ def test_derived_dispatch_id_path_escape_is_refused(manager_env, monkeypatch, ca
 def _patch_governance_receipt():
     from unittest.mock import patch
     return patch("governance_receipts.emit_governance_receipt")
+
+
+# ---------------------------------------------------------------------------
+# OI-1569 tak 1+2 (dispatch 20260830-153000-oi1569-quota-heeft-geen-tijddimensie):
+# _classify_review_seat_failure had no time dimension -- a lane_exhausted
+# classification, once recorded, blocked the takeover walk from ever
+# re-attempting that gate again. Measured live: PR #1719's codex_gate
+# obligation stayed pending on a 10:13 record five hours later (15:08), with
+# five OTHER PRs completing real codex runs in between -- no provider
+# outage, just a classification with no way to expire.
+#
+# _lane_exhausted_or_expired (gate_request_handler.py) is the fix: THREE
+# outcomes, matching the same "never collapse the third branch" discipline
+# as the sha-binding fix in gate_obligation_runner.py.
+# ---------------------------------------------------------------------------
+
+from datetime import timedelta  # noqa: E402
+
+import gate_request_handler  # noqa: E402
+
+
+def test_recent_lane_exhausted_stays_lane_exhausted():
+    """A record recorded well inside the TTL still classifies as
+    lane_exhausted -- the walk keeps skipping this hop, unchanged."""
+    record = {
+        "gate": "codex_gate", "pr_number": 1719, "status": "unavailable",
+        "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["codex"],
+        "recorded_at": _FRESH_RECORDED_AT,
+    }
+    manager = _make_manager()
+    assert manager._classify_review_seat_failure(record) == "lane_exhausted"
+
+
+def test_stale_lane_exhausted_expires_and_stops_the_walk():
+    """RED on unfixed main (measured 2026-08-30): a lane_exhausted record
+    older than the TTL used to classify as 'lane_exhausted' forever, so
+    _dispatch_review_seat's walk always skipped past it -- once every gate
+    in the chain had one, NOTHING ever got a fresh attempt again (PR #1719,
+    #1728). GREEN here: an expired record classifies as something other
+    than the literal 'lane_exhausted', which already stops the walk and
+    re-dispatches this exact gate."""
+    old = (
+        datetime.now(timezone.utc) - timedelta(seconds=gate_request_handler._LANE_EXHAUSTION_TTL_SECONDS + 60)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    record = {
+        "gate": "codex_gate", "pr_number": 1719, "status": "unavailable",
+        "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["codex"],
+        "recorded_at": old,
+    }
+    manager = _make_manager()
+    classification = manager._classify_review_seat_failure(record)
+    assert classification != "lane_exhausted", (
+        f"an expired lane_exhausted record must not classify as still-exhausted, got {classification!r}"
+    )
+    assert classification == "lane_exhausted_expired"
+
+
+def test_stale_lane_exhausted_actually_reattempts_the_gate(manager_env, monkeypatch):
+    """Integration proof: with an EXPIRED codex_gate record on disk and no
+    successor configured, request_reviews must dispatch codex_gate itself
+    again -- never fall into _chain_exhausted_result on a stale record."""
+    monkeypatch.chdir(manager_env["project_root"])
+    monkeypatch.setenv("VNX_REVIEW_GATE_TAKEOVER_CHAIN", "codex_gate")
+    old = (
+        datetime.now(timezone.utc) - timedelta(seconds=gate_request_handler._LANE_EXHAUSTION_TTL_SECONDS + 60)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    pr_number = 9503
+    _write_result(manager_env["results_dir"], pr_number, "codex_gate", {
+        "gate": "codex_gate", "pr_number": pr_number, "status": "unavailable",
+        "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["codex"],
+        "recorded_at": old,
+    })
+    manager = _make_manager()
+
+    with _patch_governance_receipt():
+        result = manager.request_reviews(
+            pr_number=pr_number,
+            branch="fix/stale-exhaustion-retry",
+            review_stack=["codex_gate"],
+            risk_class="medium",
+            changed_files=["scripts/foo.py"],
+            mode="per_pr",
+            dispatch_id="oi1569-stale-retry-test",
+        )
+
+    seat = result["requested"][0]
+    assert seat["gate"] == "codex_gate", (
+        f"an expired lane_exhausted record must re-dispatch the ORIGINAL gate, got {seat['gate']!r}"
+    )
+    assert not seat.get("takeover"), "a re-attempt of the same gate is not a takeover"
+
+
+def test_lane_exhausted_with_no_recorded_at_is_the_third_branch_not_silently_either_extreme(caplog):
+    """The third branch: a record with NO usable recorded_at at all must not
+    silently read as 'still exhausted' (perpetuating an unverifiable block
+    forever) NOR silently read the same as a confirmed expiry -- it gets its
+    own named outcome, loud in the log."""
+    record = {
+        "gate": "codex_gate", "pr_number": 1719, "status": "unavailable",
+        "reason": "dispatch_error", "residual_risk": _REAL_EXHAUSTION_TEXT["codex"],
+        # no recorded_at at all
+    }
+    manager = _make_manager()
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        classification = manager._classify_review_seat_failure(record)
+    assert classification == "lane_exhausted_unknown_age"
+    assert classification not in ("lane_exhausted", "lane_exhausted_expired")
+    assert "no usable recorded_at" in caplog.text
+
+
+def test_age_seconds_helper_three_states():
+    """_seat_failure_age_seconds itself: missing, unparseable, and a real
+    ISO8601 timestamp (with and without the Z suffix) are all handled, and
+    the missing/unparseable cases both return None -- never 0, never a huge
+    sentinel that would smuggle a specific answer into "unknown"."""
+    assert gate_request_handler._seat_failure_age_seconds(None) is None
+    assert gate_request_handler._seat_failure_age_seconds("") is None
+    assert gate_request_handler._seat_failure_age_seconds("not-a-timestamp") is None
+    assert gate_request_handler._seat_failure_age_seconds(12345) is None
+
+    recent = datetime.now(timezone.utc) - timedelta(seconds=30)
+    age = gate_request_handler._seat_failure_age_seconds(recent.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    assert age is not None and 25 <= age <= 45
+
+    age_iso = gate_request_handler._seat_failure_age_seconds(recent.isoformat())
+    assert age_iso is not None and 25 <= age_iso <= 45

--- a/tests/test_dlv5_review_gate_takeover.py
+++ b/tests/test_dlv5_review_gate_takeover.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -44,6 +45,12 @@ VNX_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+# OI-1569 tak 1+2: _classify_review_seat_failure now recency-gates a
+# lane_exhausted classification (TTL 3600s) -- the fixtures below must carry
+# a FRESH recorded_at, or this file's takeover assertions would start
+# exercising the recency branch instead of the takeover mechanism they test.
+_FRESH_RECORDED_AT = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @pytest.fixture
@@ -116,7 +123,7 @@ _KIMI_LANE_EXHAUSTED_RESULT = {
         "contact us via api-feedback@moonshot.cn', "
         "'type': 'access_terminated_error'}}"
     ),
-    "recorded_at": "2026-08-22T09:51:00Z",
+    "recorded_at": _FRESH_RECORDED_AT,
     "branch": "fix/takeover-test",
     "commit_sha": "a" * 40,
 }

--- a/tests/test_gate_obligation_reopen_stale_evidence.py
+++ b/tests/test_gate_obligation_reopen_stale_evidence.py
@@ -1,0 +1,199 @@
+"""tests/test_gate_obligation_reopen_stale_evidence.py — OI-1571 tak 3: the
+audited, one-off correction tool for an obligation booked fulfilled/failed
+off evidence about a DIFFERENT commit, before the runner's own sha-binding
+check existed.
+
+Live measured shape (PR #1719, 30-08): obligation
+``20260830-133000-oi1453-noemer-is-pass`` booked fulfilled via
+``resolved_by_gate=glm_gate`` off a glm_gate PASS recorded against an OLDER
+commit than the PR's current head. This script is the ONLY audited place
+that state mutation happens — never a hand-edit of the JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import gate_obligation_reopen_stale_evidence as reopener  # noqa: E402
+from gate_obligations import (  # noqa: E402
+    STATUS_FULFILLED,
+    STATUS_PENDING,
+    obligation_path,
+    register_obligation,
+    update_obligation,
+)
+
+_HEAD_SHA = "64df9933f6b3fed46070d597965f4415acca83e"
+_STALE_SHA = "8101fdf2dabcc29190710f9f62aed6bb451859d1"
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "vnx-data" / "state"
+    (state_dir / "review_gates" / "results").mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _write_evidence(state_dir: Path, *, commit_sha: str, gate: str = "glm_gate", pr_number: int = 1719) -> Path:
+    path = state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+    path.write_text(
+        json.dumps({
+            "gate": gate, "pr_number": pr_number, "status": "pass",
+            "contract_hash": "sha256:deadbeef", "report_path": "/tmp/does-not-need-to-exist.md",
+            "commit_sha": commit_sha, "recorded_at": "2026-08-29T11:35:55Z",
+        }),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _seed_takeover_fulfilled_obligation(state_dir: Path, dispatch_id: str, evidence_path: Path) -> Path:
+    path = register_obligation(
+        state_dir, dispatch_id=dispatch_id, gate="codex_gate",
+        project_id="vnx-dev", pr_number=1719,
+    )
+    update_obligation(
+        path,
+        status=STATUS_FULFILLED,
+        resolved_at="2026-08-30T13:10:19Z",
+        result_path=str(evidence_path),
+        evidence_result_path=str(evidence_path),
+        resolved_by_gate="glm_gate",
+        fulfilled_by="glm_gate",
+        takeover_gate="glm_gate",
+        reason="fulfilled_by_takeover_evidence",
+    )
+    return path
+
+
+class TestVerifyStaleEvidence:
+    def test_refuses_when_sha_actually_matches(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        evidence_path = _write_evidence(state_dir, commit_sha=_HEAD_SHA)
+        _seed_takeover_fulfilled_obligation(state_dir, "d-matching", evidence_path)
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+
+        with pytest.raises(reopener.ReopenRefused, match="MATCHES"):
+            reopener.verify_stale_evidence(state_dir, "d-matching")
+
+    def test_refuses_when_head_sha_unresolvable(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        evidence_path = _write_evidence(state_dir, commit_sha=_STALE_SHA)
+        _seed_takeover_fulfilled_obligation(state_dir, "d-unresolvable", evidence_path)
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: "")
+
+        with pytest.raises(reopener.ReopenRefused, match="unverifiable"):
+            reopener.verify_stale_evidence(state_dir, "d-unresolvable")
+
+    def test_refuses_when_obligation_not_terminal(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="d-still-pending", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1719,
+        )
+        with pytest.raises(reopener.ReopenRefused, match="not fulfilled/failed"):
+            reopener.verify_stale_evidence(state_dir, "d-still-pending")
+
+    def test_refuses_when_dispatch_id_unknown(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        with pytest.raises(reopener.ReopenRefused, match="no obligation record"):
+            reopener.verify_stale_evidence(state_dir, "d-does-not-exist")
+
+    def test_proves_mismatch_and_returns_both_shas(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        evidence_path = _write_evidence(state_dir, commit_sha=_STALE_SHA)
+        _seed_takeover_fulfilled_obligation(state_dir, "d-1719-shape", evidence_path)
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+
+        proof = reopener.verify_stale_evidence(state_dir, "d-1719-shape")
+        assert proof["head_sha"] == _HEAD_SHA
+        assert proof["evidence_sha"] == _STALE_SHA
+        assert proof["resolved_by_gate"] == "glm_gate"
+
+
+class TestReopenObligation:
+    def test_dry_run_never_writes(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        evidence_path = _write_evidence(state_dir, commit_sha=_STALE_SHA)
+        path = _seed_takeover_fulfilled_obligation(state_dir, "d-dry-run", evidence_path)
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+
+        outcome = reopener.reopen_obligation(
+            state_dir, "d-dry-run", operator_reason="test", write=False,
+        )
+        assert outcome["action"] == "would_reopen"
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_FULFILLED, "a dry run must never mutate the record"
+
+    def test_write_reopens_via_the_audited_api_and_emits_a_receipt(self, tmp_path, monkeypatch):
+        """RED on unfixed main (measured 2026-08-30: this script did not
+        exist): the live PR #1719 obligation stayed fulfilled forever with
+        no code path to correct it — a worker's only option was a hand-edit,
+        which is exactly what this tool exists to make unnecessary."""
+        state_dir = _make_state_dir(tmp_path)
+        evidence_path = _write_evidence(state_dir, commit_sha=_STALE_SHA)
+        path = _seed_takeover_fulfilled_obligation(state_dir, "d-write-reopen", evidence_path)
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+
+        with patch("review_gate_manager.emit_governance_receipt") as mock_emit:
+            outcome = reopener.reopen_obligation(
+                state_dir, "d-write-reopen", operator_reason="OI-1571 PR #1719 correction", write=True,
+            )
+
+        assert outcome["action"] == "reopened"
+        assert mock_emit.called, "the ledger event must be emitted before the mutation (ADR-005)"
+        emit_kwargs = mock_emit.call_args.kwargs
+        assert emit_kwargs["dispatch_id"] == "d-write-reopen"
+        assert emit_kwargs["pr_head_sha"] == _HEAD_SHA
+        assert emit_kwargs["evidence_commit_sha"] == _STALE_SHA
+
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_PENDING
+        assert record["attempts"] == 0
+        assert record["resolved_at"] is None
+        assert record["resolved_by_gate"] is None
+        assert record["fulfilled_by"] is None
+        assert _STALE_SHA[:12] in record["reason_detail"]
+        assert _HEAD_SHA[:12] in record["reason_detail"]
+        assert "OI-1571 PR #1719 correction" in record["reason_detail"]
+
+    def test_write_refused_without_writing_when_evidence_still_matches(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        evidence_path = _write_evidence(state_dir, commit_sha=_HEAD_SHA)
+        path = _seed_takeover_fulfilled_obligation(state_dir, "d-no-op", evidence_path)
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+
+        with pytest.raises(reopener.ReopenRefused):
+            reopener.reopen_obligation(state_dir, "d-no-op", operator_reason="test", write=True)
+
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_FULFILLED
+
+
+class TestCli:
+    def test_main_refused_exits_2(self, tmp_path, capsys):
+        state_dir = _make_state_dir(tmp_path)
+        rc = reopener.main(["--state-dir", str(state_dir), "--dispatch-id", "d-nonexistent"])
+        assert rc == 2
+        assert "REFUSED" in capsys.readouterr().err
+
+    def test_main_dry_run_reports_would_reopen(self, tmp_path, monkeypatch, capsys):
+        state_dir = _make_state_dir(tmp_path)
+        evidence_path = _write_evidence(state_dir, commit_sha=_STALE_SHA)
+        _seed_takeover_fulfilled_obligation(state_dir, "d-cli-dry-run", evidence_path)
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+
+        rc = reopener.main(["--state-dir", str(state_dir), "--dispatch-id", "d-cli-dry-run"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "action=would_reopen" in out
+        assert "DRY RUN" in out

--- a/tests/test_gate_obligation_runner.py
+++ b/tests/test_gate_obligation_runner.py
@@ -11,7 +11,9 @@ message instead of writing to a fabricated or unattributable store.
 from __future__ import annotations
 
 import json
+import os
 import sys
+import time
 import types
 from pathlib import Path
 
@@ -276,11 +278,25 @@ def _make_state_dir(tmp_path: Path) -> Path:
     return state_dir
 
 
-def _patch_manager(monkeypatch, manager: "_FakeReviewGateManager") -> None:
+# OI-1571 tak 3: attempt_gate now resolves a PR head sha up front for every
+# obligation it processes. The default here is an arbitrary fixed sentinel
+# most tests never need to match against anything — _patch_manager stubs
+# _get_pr_head_sha_for_gate to this value purely for hermeticity (no test in
+# this file may shell out to a real `gh pr view`). Tests that DO care about
+# sha binding (TestTakeoverChainEvidence) stamp their fake managers' result
+# records with this same value so "the happy path still works" stays the
+# default, and override it locally to build a mismatch.
+_DEFAULT_TEST_HEAD_SHA = "deadbeef00" * 4
+
+
+def _patch_manager(
+    monkeypatch, manager: "_FakeReviewGateManager", *, head_sha: str = _DEFAULT_TEST_HEAD_SHA,
+) -> None:
     """Hermetic patch: no git, no gh, no real gate — only the fake manager."""
     monkeypatch.setattr(runner, "_build_manager", lambda state_dir: manager)
     monkeypatch.setattr(runner, "_branch_from_github", lambda pr, owner_repo: None)
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda state_dir: "Vinix24/vnx-orchestration")
+    monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: head_sha)
     fake_rgm = types.ModuleType("review_gate_manager")
     fake_rgm._compute_changed_files = lambda branch: ["scripts/lib/foo.py"]
     monkeypatch.setitem(sys.modules, "review_gate_manager", fake_rgm)
@@ -431,12 +447,17 @@ class _TakeoverFakeReviewGateManager:
     def __init__(
         self, state_dir: Path, *, target_gate: "str | None", status: str,
         report_path: Path, contract_hash: str = "sha256:deadbeef",
+        commit_sha: str = "deadbeef00" * 4,
     ) -> None:
         self.state_dir = Path(state_dir)
         self.target_gate = target_gate
         self.status = status
         self.report_path = report_path
         self.contract_hash = contract_hash
+        # OI-1571 tak 3: matches _patch_manager's default _get_pr_head_sha_for_gate
+        # stub so "the successor's evidence is current" is the default shape
+        # -- pass a different value to build a mismatch/unverifiable record.
+        self.commit_sha = commit_sha
         self.calls = []
 
     def _request_path(self, gate: str, pr_number: int) -> Path:
@@ -464,6 +485,7 @@ class _TakeoverFakeReviewGateManager:
                 "status": self.status,
                 "contract_hash": self.contract_hash,
                 "report_path": str(self.report_path),
+                "commit_sha": self.commit_sha,
             }),
             encoding="utf-8",
         )
@@ -609,3 +631,308 @@ class TestTakeoverChainEvidence:
         outcome = summary["outcomes"][0]
         assert outcome["action"] == STATUS_FULFILLED
         assert "resolved_by_gate" not in outcome
+        # OI-1571 tak 3, Klaar item 4: even the non-takeover fulfilment path
+        # must fill fulfilled_by/takeover_gate/evidence_result_path.
+        assert record["fulfilled_by"] == "codex_gate"
+        assert record["takeover_gate"] is None
+        assert record["evidence_result_path"] == record["result_path"]
+
+
+# ---------------------------------------------------------------------------
+# OI-1571 tak 3 (dispatch 20260830-153000-oi1569-quota-heeft-geen-tijddimensie):
+# _has_decided_evidence never checked commit_sha, so evidence for a DIFFERENT
+# commit than the PR's current head could still fulfil an obligation.
+#
+# TWO independently measured live shapes, both fixed by the SAME predicate
+# (_has_decided_evidence(record, head_sha)), never two separate checks:
+#
+#   1. KRUIS-POORT (PR #1719): a codex-declared obligation booked fulfilled
+#      via _find_takeover_successor_evidence off a glm_gate record from a
+#      PRIOR commit -- the takeover-chain walk never checked the successor's
+#      sha either.
+#   2. ZELFDE-POORT (PR #1736): a codex-declared obligation booked fulfilled
+#      off codex_gate's OWN result file, left on disk by an EARLIER dispatch
+#      against the same PR and never overwritten by this attempt (the
+#      gate_recorder overwrite guard preserves a decided verdict rather than
+#      let a less-decided fresh attempt replace it -- see gate_executor.py's
+#      OI-1488 note) -- the declared-gate gating check never checked sha
+#      either, so it never even looked at the takeover chain.
+# ---------------------------------------------------------------------------
+
+
+class _NoOpReviewGateManager:
+    """A ``request_and_execute`` that writes ONLY request records and
+    touches NO result file at all -- mirrors the real overwrite guard
+    (gate_recorder) refusing to let a fresh, less-decided attempt replace an
+    existing decided verdict: from this runner's point of view, the result
+    file on disk after the call is EXACTLY what it was before the call.
+    """
+
+    def __init__(self, state_dir: Path) -> None:
+        self.state_dir = Path(state_dir)
+        self.calls = []
+
+    def _request_path(self, gate: str, pr_number: int) -> Path:
+        return self.state_dir / "review_gates" / "requests" / f"pr-{pr_number}-{gate}.json"
+
+    def _result_path(self, gate: str, pr_number: int) -> Path:
+        return self.state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+
+    def request_and_execute(self, *, pr_number, branch, review_stack, risk_class,
+                             changed_files, mode, dispatch_id=""):
+        self.calls.append(
+            {"pr_number": pr_number, "branch": branch, "review_stack": list(review_stack)}
+        )
+        for gate in review_stack:
+            self._request_path(gate, pr_number).write_text(
+                json.dumps({"gate": gate, "pr_number": pr_number, "status": "requested"}),
+                encoding="utf-8",
+            )
+        return {"pr_number": pr_number, "branch": branch, "gates": [], "has_required_failure": False}
+
+
+def _seed_decided_gate_result(
+    state_dir: Path, gate: str, pr_number: int, *, commit_sha: str, report_path: Path,
+    status: str = "pass", contract_hash: str = "sha256:deadbeef",
+) -> None:
+    """Pre-seed a gate's OWN result record as a DECIDED, complete-evidence
+    verdict for ``commit_sha`` -- the shape a genuinely-reviewed commit
+    leaves behind, used here to build a STALE record for an OLDER commit
+    than the one :func:`_patch_manager`'s stub reports as the PR head.
+    """
+    (state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json").write_text(
+        json.dumps({
+            "gate": gate, "pr_number": pr_number, "status": status,
+            "contract_hash": contract_hash, "report_path": str(report_path),
+            "commit_sha": commit_sha,
+        }),
+        encoding="utf-8",
+    )
+
+
+class TestShaBindingBlocksStaleEvidence:
+    @pytest.fixture(autouse=True)
+    def _clean_takeover_chain_env(self, monkeypatch):
+        monkeypatch.delenv("VNX_REVIEW_GATE_TAKEOVER_CHAIN", raising=False)
+        monkeypatch.delenv("VNX_OVERRIDE_VNX_REVIEW_GATE_TAKEOVER_CHAIN", raising=False)
+
+    def test_kruis_poort_stale_takeover_successor_evidence_never_fulfills(self, tmp_path, monkeypatch):
+        """(a) kruis-poort, PR #1719 shape: codex's own record stays stuck
+        unavailable (lane_exhausted), and the takeover successor (glm_gate)
+        DOES carry complete, decided evidence -- but for an OLDER commit
+        than the PR's current head. Must NOT fulfil."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260830-oi1571-kruis-poort", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1719,
+        )
+        _seed_stuck_gate_result(state_dir, "codex_gate", 1719)
+        report_file = state_dir / "unified_reports" / "glm-gate-pr1719.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("glm_gate report body", encoding="utf-8")
+
+        manager = _TakeoverFakeReviewGateManager(
+            state_dir, target_gate="glm_gate", status="pass", report_path=report_file,
+            commit_sha="ffffffffffffffffffffffffffffffffffffff",  # a DIFFERENT commit than the head
+        )
+        _patch_manager(monkeypatch, manager)  # head_sha defaults to "deadbeef00" * 4
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 1, (
+            "stale takeover evidence (wrong commit) must never fulfil the obligation"
+        )
+        record = _read_obligation(state_dir, "20260830-oi1571-kruis-poort")
+        assert record["status"] == STATUS_PENDING
+        assert "resolved_by_gate" not in record
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == "pending"
+
+    def test_kruis_poort_matching_sha_still_fulfills(self, tmp_path, monkeypatch):
+        """Control for (a): the exact same shape, but the successor's
+        commit_sha matches the PR head -- must still fulfil via takeover
+        (never a false negative introduced by the sha check)."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260830-oi1571-kruis-poort-match", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1720,
+        )
+        _seed_stuck_gate_result(state_dir, "codex_gate", 1720)
+        report_file = state_dir / "unified_reports" / "glm-gate-pr1720.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("glm_gate report body", encoding="utf-8")
+
+        manager = _TakeoverFakeReviewGateManager(
+            state_dir, target_gate="glm_gate", status="pass", report_path=report_file,
+            # default commit_sha matches _patch_manager's default head_sha
+        )
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 0
+        record = _read_obligation(state_dir, "20260830-oi1571-kruis-poort-match")
+        assert record["status"] == STATUS_FULFILLED
+        assert record["resolved_by_gate"] == "glm_gate"
+
+    def test_zelfde_poort_stale_declared_gate_evidence_never_fulfills(self, tmp_path, monkeypatch):
+        """(b) zelfde-poort, PR #1736 shape: codex_gate's OWN result record
+        is a DECIDED, complete-evidence PASS -- but left on disk by an
+        EARLIER dispatch against the same PR, for an OLDER commit. This
+        attempt's manager.request_and_execute does not overwrite it (mirrors
+        the real overwrite guard). Must NOT fulfil off it, and the takeover
+        chain must actually be consulted (no successor exists here either,
+        so it stays pending)."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260830-oi1571-zelfde-poort", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1736,
+        )
+        report_file = state_dir / "unified_reports" / "codex-gate-pr1736-earlier-dispatch.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("codex_gate report body from an earlier dispatch", encoding="utf-8")
+        _seed_decided_gate_result(
+            state_dir, "codex_gate", 1736,
+            commit_sha="ffffffffffffffffffffffffffffffffffffff",  # a DIFFERENT, OLDER commit
+            report_path=report_file,
+        )
+
+        manager = _NoOpReviewGateManager(state_dir)
+        _patch_manager(monkeypatch, manager)  # head_sha defaults to "deadbeef00" * 4
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 1, (
+            "a same-gate result left on disk for a DIFFERENT commit must "
+            "never silently fulfil the obligation"
+        )
+        record = _read_obligation(state_dir, "20260830-oi1571-zelfde-poort")
+        assert record["status"] == STATUS_PENDING
+        assert record["reason"] == "stale_evidence_sha_mismatch"
+        assert "fulfilled_by" not in record
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == "pending"
+
+    def test_zelfde_poort_matching_sha_still_fulfills(self, tmp_path, monkeypatch):
+        """Control for (b): codex_gate's own record is decided, complete,
+        AND for the current head -- must fulfil directly, exactly as
+        test_declared_gate_evidence_still_found_directly_when_present
+        already proves for the takeover-chain-untouched case; this control
+        additionally proves it through the _NoOpReviewGateManager shape."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260830-oi1571-zelfde-poort-match", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1737,
+        )
+        report_file = state_dir / "unified_reports" / "codex-gate-pr1737.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("codex_gate report body", encoding="utf-8")
+        _seed_decided_gate_result(
+            state_dir, "codex_gate", 1737,
+            commit_sha="deadbeef00" * 4,  # matches _patch_manager's default head_sha
+            report_path=report_file,
+        )
+
+        manager = _NoOpReviewGateManager(state_dir)
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 0
+        record = _read_obligation(state_dir, "20260830-oi1571-zelfde-poort-match")
+        assert record["status"] == STATUS_FULFILLED
+        assert record["fulfilled_by"] == "codex_gate"
+
+    def test_unknown_sha_binding_suspends_judgement_third_branch(self, tmp_path, monkeypatch):
+        """The third branch: the declared gate's own record is decided and
+        complete, but its commit_sha is EMPTY (unverifiable) -- must neither
+        silently accept (fulfil) nor silently refuse (retire/escalate). It
+        must stay pending with a reason that names the third branch
+        explicitly, distinct from both the happy path and the mismatch path.
+        """
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260830-oi1571-unknown-sha", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1738,
+        )
+        report_file = state_dir / "unified_reports" / "codex-gate-pr1738.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("codex_gate report body", encoding="utf-8")
+        _seed_decided_gate_result(
+            state_dir, "codex_gate", 1738, commit_sha="", report_path=report_file,
+        )
+
+        manager = _NoOpReviewGateManager(state_dir)
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert summary["pending_after"] == 1
+        record = _read_obligation(state_dir, "20260830-oi1571-unknown-sha")
+        assert record["status"] == STATUS_PENDING
+        assert record["reason"] == "sha_binding_unverifiable"
+
+
+# ---------------------------------------------------------------------------
+# OI-1569 Klaar item 8: a loud tripwire, not just a code comment, for the
+# exact measured signature of a silent stale-evidence fulfilment — a
+# terminal booking whose evidence FILE predates the attempt that used it.
+# The sha check above already prevents the specific PR #1719/#1736 defect
+# from fulfilling silently; this is a second, independent, cheap safety net
+# that stays useful even if some future change reopens a different hole.
+# ---------------------------------------------------------------------------
+
+
+class TestFastFulfillmentTripwire:
+    def test_evidence_file_touched_by_this_attempt_is_silent(self, tmp_path, monkeypatch):
+        """Control: the overwhelmingly common case — the result file is
+        freshly written by THIS attempt — must never trip the warning."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260830-oi1569-fresh-evidence", gate="ci_gate",
+            project_id="vnx-dev", pr_number=9670,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        outcome = summary["outcomes"][0]
+        assert "fast_fulfillment_warning" not in outcome
+
+    def test_stale_result_file_trips_the_warning(self, tmp_path, monkeypatch):
+        """RED on unfixed main (measured 2026-08-30: no such check existed
+        at all): a result file whose mtime predates this attempt by well
+        over the threshold, but whose commit_sha still happens to match the
+        PR head (so the sha check alone does not intercept it — this is a
+        deliberately independent second signal), must trip a LOUD,
+        observable warning on the outcome."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260830-oi1569-stale-evidence", gate="codex_gate",
+            project_id="vnx-dev", pr_number=9671,
+        )
+        report_file = state_dir / "unified_reports" / "codex-gate-pr9671.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("codex_gate report body", encoding="utf-8")
+        result_path = state_dir / "review_gates" / "results" / "pr-9671-codex_gate.json"
+        result_path.write_text(
+            json.dumps({
+                "gate": "codex_gate", "pr_number": 9671, "status": "pass",
+                "contract_hash": "sha256:deadbeef", "report_path": str(report_file),
+                "commit_sha": _DEFAULT_TEST_HEAD_SHA,
+            }),
+            encoding="utf-8",
+        )
+        old_mtime = time.time() - (runner._FAST_FULFILLMENT_MTIME_THRESHOLD_SECONDS + 120)
+        os.utime(result_path, (old_mtime, old_mtime))
+
+        manager = _NoOpReviewGateManager(state_dir)
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_FULFILLED, "the sha still matches, so this must still fulfil"
+        assert "fast_fulfillment_warning" in outcome
+        assert "not provably a fresh run this cycle" in outcome["fast_fulfillment_warning"]

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -1332,6 +1332,29 @@ def test_build_role_without_gate_is_refused_even_with_empty_paths(tmp_path, monk
 # ---------------------------------------------------------------------------
 
 
+# OI-1571 tak 3: _has_decided_evidence now requires a sha binding MATCH
+# before any evidence-discriminator test below counts as "found". This is
+# the shared head sha every _write_result_record call below stamps by
+# default, matched by the autouse _stub_pr_head_sha fixture just below it —
+# neither of these tests is about sha binding (that gets its own dedicated
+# coverage in test_gate_obligation_runner.py's TestTakeoverChainEvidence),
+# so both sides default to a fixed, matching sentinel rather than each test
+# individually mocking a gh call.
+_DEFAULT_TEST_HEAD_SHA = "deadbeef00" * 4
+
+
+@pytest.fixture(autouse=True)
+def _stub_pr_head_sha(monkeypatch):
+    """Hermetic default: no test in this file exercises real gh access, and
+    without this every attempt_gate/_fulfilling_result path would shell out
+    to ``gh pr view`` for a synthetic pr_number (OI-1571 tak 3 added this
+    call). Returns :data:`_DEFAULT_TEST_HEAD_SHA` for every pr_number,
+    matching the ``commit_sha`` :func:`_write_result_record` stamps by
+    default.
+    """
+    monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: _DEFAULT_TEST_HEAD_SHA)
+
+
 def _write_result_record(
     state_dir: Path,
     *,
@@ -1343,6 +1366,7 @@ def _write_result_record(
     contract_hash: str = "sha256:deadbeef",
     report_path: str | None = "__auto__",
     status: str = "pass",
+    commit_sha: str = _DEFAULT_TEST_HEAD_SHA,
 ) -> Path:
     """Write a ``review_gates/results/<filename>.json`` record.
 
@@ -1358,6 +1382,11 @@ def _write_result_record(
     "complete evidence" record for any verdict — pass, a decided fail
     (``failed``/``errored``/``blocked``), or ``not_executable`` — to pin the
     evidence discriminator's verdict-aware split.
+
+    ``commit_sha`` (OI-1571 tak 3, default :data:`_DEFAULT_TEST_HEAD_SHA`)
+    matches what the autouse ``_stub_pr_head_sha`` fixture returns for every
+    pr_number — pass a different value (or ``""``) to build a
+    mismatched/unverifiable record for a test that specifically wants one.
     """
     results_dir = Path(state_dir) / "review_gates" / "results"
     results_dir.mkdir(parents=True, exist_ok=True)
@@ -1374,6 +1403,7 @@ def _write_result_record(
         "status": status,
         "contract_hash": contract_hash,
         "report_path": report_path or "",
+        "commit_sha": commit_sha,
     }
     path = results_dir / f"{filename}.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -1471,7 +1501,7 @@ def test_evidence_discriminator_missing_record_is_not_evidence(tmp_path):
     """Bucket 1 of 4: no result record at all for this dispatch_id+gate."""
     state_dir = _make_state_dir(tmp_path)
     index = runner._index_gate_results(state_dir)
-    assert runner._fulfilling_result(index, "no-such-dispatch", "codex_gate") is None
+    assert runner._fulfilling_result(index, "no-such-dispatch", "codex_gate")["kind"] == "absent"
 
 
 def test_evidence_discriminator_empty_contract_hash_is_not_evidence(tmp_path):
@@ -1482,7 +1512,7 @@ def test_evidence_discriminator_empty_contract_hash_is_not_evidence(tmp_path):
         gate="codex_gate", pr_number=1, contract_hash="",
     )
     index = runner._index_gate_results(state_dir)
-    assert runner._fulfilling_result(index, "d-empty-hash", "codex_gate") is None
+    assert runner._fulfilling_result(index, "d-empty-hash", "codex_gate")["kind"] == "absent"
 
 
 def test_evidence_discriminator_empty_report_path_is_not_evidence(tmp_path):
@@ -1493,7 +1523,7 @@ def test_evidence_discriminator_empty_report_path_is_not_evidence(tmp_path):
         gate="codex_gate", pr_number=2, report_path="",
     )
     index = runner._index_gate_results(state_dir)
-    assert runner._fulfilling_result(index, "d-empty-report", "codex_gate") is None
+    assert runner._fulfilling_result(index, "d-empty-report", "codex_gate")["kind"] == "absent"
 
 
 def test_evidence_discriminator_nonexistent_report_file_is_not_evidence(tmp_path):
@@ -1506,7 +1536,7 @@ def test_evidence_discriminator_nonexistent_report_file_is_not_evidence(tmp_path
         report_path=str(state_dir / "review_gates" / "reports" / "ghost.md"),
     )
     index = runner._index_gate_results(state_dir)
-    assert runner._fulfilling_result(index, "d-ghost-report", "codex_gate") is None
+    assert runner._fulfilling_result(index, "d-ghost-report", "codex_gate")["kind"] == "absent"
 
 
 def test_evidence_discriminator_finds_complete_evidence(tmp_path):
@@ -1518,9 +1548,9 @@ def test_evidence_discriminator_finds_complete_evidence(tmp_path):
         gate="codex_gate", pr_number=4,
     )
     index = runner._index_gate_results(state_dir)
-    found = runner._fulfilling_result(index, "d-complete", "codex_gate")
-    assert found is not None
-    found_path, found_record = found
+    lookup = runner._fulfilling_result(index, "d-complete", "codex_gate")
+    assert lookup["kind"] == "found"
+    found_path, found_record = lookup["entry"]
     assert found_path == result_path
     assert found_record["dispatch_id"] == "d-complete"
 
@@ -1547,7 +1577,7 @@ def test_evidence_discriminator_rejects_not_executable_even_with_complete_eviden
         gate="codex_gate", pr_number=5, status="not_executable",
     )
     index = runner._index_gate_results(state_dir)
-    assert runner._fulfilling_result(index, "d-not-executable", "codex_gate") is None
+    assert runner._fulfilling_result(index, "d-not-executable", "codex_gate")["kind"] == "absent"
 
 
 def test_evidence_discriminator_rejects_undecided_status_even_with_complete_evidence(tmp_path):
@@ -1561,7 +1591,7 @@ def test_evidence_discriminator_rejects_undecided_status_even_with_complete_evid
         gate="codex_gate", pr_number=6, status="unavailable",
     )
     index = runner._index_gate_results(state_dir)
-    assert runner._fulfilling_result(index, "d-undecided", "codex_gate") is None
+    assert runner._fulfilling_result(index, "d-undecided", "codex_gate")["kind"] == "absent"
 
 
 def test_evidence_discriminator_accepts_decided_fail_as_evidence(tmp_path):
@@ -1575,9 +1605,9 @@ def test_evidence_discriminator_accepts_decided_fail_as_evidence(tmp_path):
         gate="codex_gate", pr_number=7, status="failed",
     )
     index = runner._index_gate_results(state_dir)
-    found = runner._fulfilling_result(index, "d-decided-fail", "codex_gate")
-    assert found is not None
-    found_path, _found_record = found
+    lookup = runner._fulfilling_result(index, "d-decided-fail", "codex_gate")
+    assert lookup["kind"] == "found"
+    found_path, _found_record = lookup["entry"]
     assert found_path == result_path
 
 
@@ -1744,6 +1774,7 @@ def test_contradiction_flags_already_retired_obligation_with_reason_none(tmp_pat
     )
     result_path = _write_result_record(
         state_dir, filename="pr-1-codex_gate", dispatch_id="d-already-retired", gate="codex_gate",
+        pr_number=1,
     )
 
     summary = runner.run(state_dir, write=False)
@@ -1775,6 +1806,7 @@ def test_contradiction_flags_already_not_executable_obligation(tmp_path):
     )
     _write_result_record(
         state_dir, filename="pr-2-ci_gate", dispatch_id="d-already-not-exec", gate="ci_gate",
+        pr_number=2,
     )
 
     summary = runner.run(state_dir, write=True)
@@ -1802,6 +1834,7 @@ def test_contradiction_bucket_distinguishes_empty_from_missing_reason(tmp_path):
     )
     _write_result_record(
         state_dir, filename="pr-3-codex_gate", dispatch_id="d-empty-reason", gate="codex_gate",
+        pr_number=3,
     )
 
     summary = runner.run(state_dir, write=False)
@@ -1857,6 +1890,7 @@ def test_contradiction_scan_covers_full_store_not_just_scope(tmp_path):
     )
     _write_result_record(
         state_dir, filename="pr-5-codex_gate", dispatch_id="20260101-out-of-scope", gate="codex_gate",
+        pr_number=5,
     )
 
     summary = runner.run(state_dir, write=False, since="2026-08-01")


### PR DESCRIPTION
## Summary

Three tracks, one PR (they all touch `gate_obligation_runner.py`'s evidence predicate or the takeover chain it reads):

- **OI-1571 tak 3 (BLOCKER)**: `_has_decided_evidence` never checked `commit_sha`, so a complete-evidence decided verdict about a **different commit** than the PR's current head could still fulfil an obligation. Measured live on PR #1719 (cross-gate, via the D2e takeover chain: a stale glm_gate PASS from the day before) and PR #1736 (same-gate: a codex_gate record left by an earlier dispatch, never overwritten by a later one). The predicate now classifies `match`/`mismatch`/`unknown` via the existing `gate_executor._classify_sha_binding` (never a second sha comparison), and every caller — the OI-1388 rescue path (`_fulfilling_result`), the takeover-chain walk (`_find_takeover_successor_evidence`), and the declared-gate gating check inside `fulfill_obligation` — treats `unknown` as a **third branch** that suspends judgement instead of silently accepting or refusing. `fulfilled_by`/`takeover_gate`/`evidence_result_path` are now stamped on every fulfilment path.
- **OI-1569 tak 1+2**: the `lane_exhausted` classification had no time dimension. Once every gate in the review-gate takeover chain had a `lane_exhausted` record on file, `_dispatch_review_seat`'s walk always landed on `_chain_exhausted_result` and nothing ever got a fresh attempt again — PR #1719's codex_gate obligation stayed blocked on a 10:13 record five hours later while five other PRs completed real codex runs in between (no provider outage). `_classify_review_seat_failure` now recency-gates a `lane_exhausted` result (TTL 3600s) via `_lane_exhausted_or_expired`, with its own named branch for a record with no usable `recorded_at` at all.
- **Loud tripwire**: a fulfilment/failure whose evidence file predates the attempt that used it by more than 60s now gets an explicit warning + outcome field (`fast_fulfillment_warning`), independent of the sha check — a second, cheap safety net.
- **Audited correction**: `scripts/gate_obligation_reopen_stale_evidence.py`, a one-off tool that re-verifies a sha mismatch itself before reopening an obligation to `pending` via the existing audited `update_obligation` API. Run against the live store to reopen `20260830-133000-oi1453-noemer-is-pass` (PR #1719), which this defect had booked `fulfilled`.

## Test plan

- [x] Red-before-fix confirmed via `git stash` on the two source files, for all new tests (kruis-poort, zelfde-poort, unknown-sha, lane-exhaustion expiry/unknown-age, fast-fulfillment tripwire, reopen tool) — all failed pre-fix (behavioral assertion or `AttributeError` on the not-yet-existing helper), all pass post-fix.
- [x] `tests/test_gate_obligation_runner.py`, `tests/test_gate_obligations.py`, `tests/test_beta3_e1_review_gate_chain.py`, `tests/test_dlv5_review_gate_takeover.py`, `tests/test_gate_obligation_reopen_stale_evidence.py` — full green.
- [x] Neighbour sweep: every test file importing `gate_request_handler` or `gate_obligation_runner` (19 + 5 files) — 650 passed, 1 pre-existing unrelated failure (`test_gate_dispatch_id.py::test_request_reviews_propagates_dispatch_id_to_claude_github`, confirmed red on unfixed main too via the same stash check).
- [x] Live correction applied and verified: `~/.vnx-data/vnx-dev/state/review_gates/obligations/20260830-133000-oi1453-noemer-is-pass.json` is back to `pending`, with a `gate_obligation_reopened_stale_evidence` receipt in `t0_receipts.ndjson`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)