### PR TITLE
fix(gate): merge door reads takeover provenance from the successor's own record (OI-1576)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -379,6 +379,42 @@ def _find_gate_result(
 # takeover-provenance route (OI-1576) may speak for it.
 _DECIDED_VERDICT_STATES = _GATE_PASS_STATES | _GATE_FAIL_STATES
 
+# Glob metacharacters that would change the meaning of a pr_id-derived glob
+# pattern (e.g. turn it into a wildcard match instead of a literal prefix).
+_GLOB_UNSAFE_CHARS = frozenset("*?[]")
+
+
+def _pr_scoped_json_candidates(results_dir: Path, pr_id: str) -> List[Path]:
+    """Cheap filename pre-filter for ``_find_takeover_successor_results`` (OI-1599 advisory).
+
+    Every gate-result writer (``gate_recorder.result_file_path`` and the
+    legacy ``pr-{n}-{gate}.json`` fallback it replaced) stamps the SAME
+    ``pr_id``/``pr_number`` value into both the filename and the record's own
+    ``pr_id`` field — there is no writer that names a file for one PR and
+    stamps another PR's id inside it. That means a file whose name cannot
+    possibly carry this ``pr_id`` can be skipped before it is ever opened,
+    without weakening ``_record_matches_scope``'s own pr_id check in any way:
+    the two checks agree by construction.
+
+    Three literal prefixes cover every writer observed in the live store:
+    ``{pr_id}-...json`` (contract writer, slug == bare pr_id), ``pr-{pr_id}-...json``
+    (legacy writer), and ``{slug}-...json`` where ``slug`` strips dashes the
+    same way ``_find_gate_result`` does — covering a dash-bearing pr_id even
+    though every current caller passes a bare digit string.
+
+    Falls back to the unfiltered ``*.json`` scan when ``pr_id`` is empty or
+    contains a glob metacharacter: a prefix filter must never risk silently
+    dropping a record it cannot express as a safe literal glob.
+    """
+    if not pr_id or any(ch in _GLOB_UNSAFE_CHARS for ch in pr_id):
+        return sorted(results_dir.glob("*.json"))
+    slug = pr_id.lower().replace("-", "")
+    patterns = {f"{pr_id}-*.json", f"pr-{pr_id}-*.json", f"{slug}-*.json"}
+    matches: set = set()
+    for pattern in patterns:
+        matches.update(results_dir.glob(pattern))
+    return sorted(matches)
+
 
 def _find_takeover_successor_results(
     gate: str,
@@ -422,7 +458,7 @@ def _find_takeover_successor_results(
     provenance_notes: List[str] = []
     if not results_dir.exists():
         return candidates, provenance_notes
-    for path in sorted(results_dir.glob("*.json")):
+    for path in _pr_scoped_json_candidates(results_dir, pr_id):
         try:
             data = json.loads(_read_text(path))
         except (json.JSONDecodeError, OSError):

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
@@ -27,6 +27,9 @@ from review_contract import ReviewContract
 from codex_final_gate import enforce_codex_gate
 from codex_severity_translator import translate_findings as translate_codex_findings
 from gate_status import (
+    FAIL_STATES as _GATE_FAIL_STATES,
+    PASS_STATES as _GATE_PASS_STATES,
+    canonical_status as gate_canonical_status,
     has_complete_evidence as gate_has_complete_evidence,
     is_pass as gate_is_pass,
     is_terminal as gate_is_terminal,
@@ -283,6 +286,47 @@ def _matches_required_field(supplied: Optional[str], actual: Optional[str]) -> b
     return (actual or "") == supplied
 
 
+def _record_matches_scope(
+    data: Dict[str, Any],
+    pr_id: str,
+    branch: Optional[str],
+    project_id: Optional[str],
+    head_sha: Optional[str],
+) -> bool:
+    """Shared scope matcher for gate result records.
+
+    Used by both ``_find_gate_result`` (the declared gate's own record) and
+    ``_find_takeover_successor_results`` (OI-1576 provenance route) so the two
+    read paths can never drift apart on what counts as in-scope evidence.
+    """
+    # Offline test-run records must never count as evidence for a real PR.
+    # The writer (kimi_gate --diff-file) stamps them test_run: true. Reject
+    # before any pr_id/branch matching so a synthetic pr_id (0, 1, 2)
+    # cannot align with a real contract.
+    if _is_test_run_record(data):
+        return False
+    # PR-scoped AND matching: if data carries pr_id it must match the queried pr_id.
+    # This prevents a result from a different PR satisfying a closure check even when
+    # the filename-based lookup finds a contract for the correct PR name.
+    data_pr_id = data.get("pr_id")
+    if data_pr_id and data_pr_id != pr_id:
+        return False
+    # ADR-007: project_id must be present and match when caller supplies one.
+    if project_id is not None:
+        data_pid = (data.get("project_id") or "").strip()
+        if not data_pid or data_pid != project_id:
+            return False
+    # ADR-005: branch must be present and match when caller supplies one.
+    # A branch-less result is stale evidence from a prior feature.
+    if not _matches_required_field(branch, data.get("branch")):
+        return False
+    # OI-1307: head sha must be present and match when caller supplies one —
+    # same strictness as branch (a result without commit_sha is stale).
+    if not _matches_required_field(head_sha, data.get("commit_sha")):
+        return False
+    return True
+
+
 def _find_gate_result(
     gate: str,
     pr_id: str,
@@ -305,32 +349,7 @@ def _find_gate_result(
     """
 
     def _accept(data: Dict[str, Any]) -> bool:
-        # Offline test-run records must never count as evidence for a real PR.
-        # The writer (kimi_gate --diff-file) stamps them test_run: true. Reject
-        # before any pr_id/branch matching so a synthetic pr_id (0, 1, 2)
-        # cannot align with a real contract.
-        if _is_test_run_record(data):
-            return False
-        # PR-scoped AND matching: if data carries pr_id it must match the queried pr_id.
-        # This prevents a result from a different PR satisfying a closure check even when
-        # the filename-based lookup finds a contract for the correct PR name.
-        data_pr_id = data.get("pr_id")
-        if data_pr_id and data_pr_id != pr_id:
-            return False
-        # ADR-007: project_id must be present and match when caller supplies one.
-        if project_id is not None:
-            data_pid = (data.get("project_id") or "").strip()
-            if not data_pid or data_pid != project_id:
-                return False
-        # ADR-005: branch must be present and match when caller supplies one.
-        # A branch-less result is stale evidence from a prior feature.
-        if not _matches_required_field(branch, data.get("branch")):
-            return False
-        # OI-1307: head sha must be present and match when caller supplies one —
-        # same strictness as branch (a result without commit_sha is stale).
-        if not _matches_required_field(head_sha, data.get("commit_sha")):
-            return False
-        return True
+        return _record_matches_scope(data, pr_id, branch, project_id, head_sha)
 
     pr_slug = pr_id.lower().replace("-", "")
     # Contract-based results: {pr_slug}-{gate}-contract.json
@@ -352,6 +371,167 @@ def _find_gate_result(
         except (json.JSONDecodeError, OSError):
             continue
     return None
+
+
+# A record whose coerced status is in this set reached its own verdict
+# (pass/fail). Anything else — unavailable, not_executable, pending, ... —
+# means the gate never produced a decision, which is exactly when the
+# takeover-provenance route (OI-1576) may speak for it.
+_DECIDED_VERDICT_STATES = _GATE_PASS_STATES | _GATE_FAIL_STATES
+
+
+def _find_takeover_successor_results(
+    gate: str,
+    pr_id: str,
+    results_dir: Path,
+    branch: Optional[str] = None,
+    project_id: Optional[str] = None,
+    head_sha: Optional[str] = None,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """OI-1576: successor records that name ``gate`` in their OWN takeover_path.
+
+    The gate chain slides forward (codex unavailable -> kimi not executable ->
+    glm takes over and writes a valid verdict under its OWN name). The runner
+    walks that chain; the merge door does NOT — it reads the provenance FIELD
+    the successor record carries about itself, so no reader ever has to
+    reconstruct the chain from other records again.
+
+    A record is a provenance candidate for declared gate ``gate`` when, and
+    only when:
+
+      1. it carries ``takeover: true`` AND a non-empty ``takeover_path``
+      2. an element of ``takeover_path`` has ``gate == <declared gate>``
+      3. it is in scope for this PR under the SAME matcher the declared-gate
+         lookup uses (``_record_matches_scope``: test_run rejection, pr_id,
+         project_id, branch, and the head-sha binding from #1740)
+
+    The record's OWN status is never inspected here — that is the caller's
+    invariant chain — and a chain step's status inside someone's
+    ``takeover_path`` is never consulted either: two records may legitimately
+    disagree about a gate that ran twice (live #1729: deepseek's path calls
+    glm_gate not_executable while glm_gate's own record says pass), and each
+    record speaks only for itself.
+
+    Returns ``(candidates, provenance_notes)``. ``provenance_notes`` names any
+    record that claims ``takeover: true`` but carries an empty or absent
+    ``takeover_path``: that is a THIRD outcome — not "no takeover", not
+    "proven provenance" — and the caller must refuse it as provenance evidence
+    with a message that the provenance could not be determined.
+    """
+    candidates: List[Dict[str, Any]] = []
+    provenance_notes: List[str] = []
+    if not results_dir.exists():
+        return candidates, provenance_notes
+    for path in sorted(results_dir.glob("*.json")):
+        try:
+            data = json.loads(_read_text(path))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        record_gate = (data.get("gate") or "").strip()
+        # The declared gate's own record was already evaluated by the caller;
+        # this route only ever looks at OTHER gates' records.
+        if not record_gate or record_gate == gate:
+            continue
+        if data.get("takeover") is not True:
+            continue
+        if not _record_matches_scope(data, pr_id, branch, project_id, head_sha):
+            continue
+        takeover_path = data.get("takeover_path")
+        if not isinstance(takeover_path, list) or not takeover_path:
+            provenance_notes.append(
+                f"{record_gate} (bestand {path.name}) claimt overname maar draagt "
+                "een lege of afwezige takeover_path"
+            )
+            continue
+        path_gates = [
+            str(step.get("gate") or "").strip()
+            for step in takeover_path
+            if isinstance(step, dict)
+        ]
+        if gate not in path_gates:
+            continue
+        candidates.append(data)
+    return candidates, provenance_notes
+
+
+def _merge_door_record_verdict(
+    result: Dict[str, Any],
+    gate_label: str,
+    pr_id: str,
+) -> Dict[str, Any]:
+    """Run the merge door's invariant chain against one gate result record.
+
+    The SAME five invariants for the declared gate's own record and for an
+    OI-1576 takeover successor — ``gate_label`` is the record's own gate name,
+    so messages always name the evidence actually being judged.
+    """
+    if not gate_is_terminal(result):
+        status = result.get("status", "unknown")
+        return {
+            "verdict": "NO-GO",
+            "message": f"{gate_label} resultaat is niet terminaal (status={status}): bewijs onvolledig",
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate_label,
+        }
+    if not gate_has_complete_evidence(result):
+        return {
+            "verdict": "NO-GO",
+            "message": f"{gate_label} resultaat mist contract_hash en/of report_path: bewijs onvolledig",
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate_label,
+        }
+    report_path = Path(result["report_path"])
+    if not report_path.exists():
+        return {
+            "verdict": "NO-GO",
+            "message": f"{gate_label} report_path bestaat niet: {report_path}",
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate_label,
+        }
+    passed, reason = gate_is_pass(result)
+    if not passed:
+        return {
+            "verdict": "NO-GO",
+            "message": f"{gate_label} staat merge niet toe — {reason}",
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate_label,
+        }
+    # Invariant 7: a passing verdict whose report still carries blocking
+    # indicators is a contradiction, not evidence.
+    try:
+        report_content = report_path.read_text(encoding="utf-8")
+    except OSError:
+        return {
+            "verdict": "NO-GO",
+            "message": f"{gate_label} report_path onleesbaar: {report_path}",
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate_label,
+        }
+    if _count_report_blocking_indicators(report_content) > 0:
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                f"{gate_label} resultaat zegt pass maar het rapport bevat blocking-indicatoren "
+                "— bewijs spreekt zichzelf tegen"
+            ),
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate_label,
+        }
+    return {
+        "verdict": "GO",
+        "message": f"{gate_label} resultaat aanwezig en passing voor {pr_id}",
+        "overridden": False,
+        "override_reason": None,
+        "gate": gate_label,
+    }
 
 
 def check_review_gate_for_merge(
@@ -384,10 +564,75 @@ def check_review_gate_for_merge(
     non-empty subset so an empty-hash result can never green-light a merge.
     The override escape hatch lives in the caller (``pr_merge._run_review_gate``),
     mirroring how the CI gate keeps its override in ``check_ci_run_for_head``.
+
+    OI-1576: when the declared gate never reached its own verdict (record
+    absent, or a non-verdict status like ``unavailable``/``not_executable`` —
+    the chain slid forward), a SUCCESSOR record that names the declared gate
+    in its own ``takeover_path`` counts as evidence, under the SAME invariants
+    (``_merge_door_record_verdict``) plus the SAME scope/sha binding
+    (``_record_matches_scope``). The door reads the provenance FIELD the
+    successor carries about itself; it never walks the chain through other
+    records. A decided verdict at the declared gate (pass or fail) always
+    stands on its own and is never overridden by a successor.
     """
     result = _find_gate_result(
         gate, pr_id, results_dir, branch=branch, project_id=project_id, head_sha=head_sha
     )
+    if result is not None and gate_canonical_status(result) in _DECIDED_VERDICT_STATES:
+        # The declared gate reached its own verdict: it stands on its own.
+        # This is also what keeps the walking-reader trap closed — a step
+        # status in someone else's takeover_path can never disqualify a gate
+        # that carries its own decided record (live #1729: deepseek's path
+        # called glm_gate not_executable while glm_gate itself passed).
+        return _merge_door_record_verdict(result, gate, pr_id)
+
+    # The declared gate produced no decided verdict. Consult successor
+    # records that name this gate in their OWN takeover_path (OI-1576).
+    successors, provenance_notes = _find_takeover_successor_results(
+        gate, pr_id, results_dir, branch=branch, project_id=project_id, head_sha=head_sha
+    )
+    first_failure: Optional[Dict[str, Any]] = None
+    for successor in successors:
+        successor_gate = (successor.get("gate") or "").strip() or gate
+        verdict = _merge_door_record_verdict(successor, successor_gate, pr_id)
+        if verdict["verdict"] == "GO":
+            return {
+                "verdict": "GO",
+                "message": (
+                    f"{gate} bewezen via overname: {successor_gate} draagt {gate} in "
+                    f"zijn takeover_path en is zelf passing voor {pr_id}"
+                ),
+                "overridden": False,
+                "override_reason": None,
+                "gate": gate,
+                "evidence_gate": successor_gate,
+            }
+        if first_failure is None:
+            first_failure = verdict
+    if first_failure is not None:
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                f"overname-route voor {gate}: {first_failure['message']}"
+            ),
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate,
+        }
+    if provenance_notes:
+        # Third branch: takeover claimed but provenance not determinable.
+        # Not "no takeover", not "proven provenance" — a refusal that says
+        # exactly what could not be established.
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                f"overnamebewijs voor {gate} op {pr_id} geweigerd: herkomst niet "
+                f"vast te stellen ({'; '.join(provenance_notes)})"
+            ),
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate,
+        }
     if result is None:
         return {
             "verdict": "NO-GO",
@@ -396,71 +641,7 @@ def check_review_gate_for_merge(
             "override_reason": None,
             "gate": gate,
         }
-    if not gate_is_terminal(result):
-        status = result.get("status", "unknown")
-        return {
-            "verdict": "NO-GO",
-            "message": f"{gate} resultaat is niet terminaal (status={status}): bewijs onvolledig",
-            "overridden": False,
-            "override_reason": None,
-            "gate": gate,
-        }
-    if not gate_has_complete_evidence(result):
-        return {
-            "verdict": "NO-GO",
-            "message": f"{gate} resultaat mist contract_hash en/of report_path: bewijs onvolledig",
-            "overridden": False,
-            "override_reason": None,
-            "gate": gate,
-        }
-    report_path = Path(result["report_path"])
-    if not report_path.exists():
-        return {
-            "verdict": "NO-GO",
-            "message": f"{gate} report_path bestaat niet: {report_path}",
-            "overridden": False,
-            "override_reason": None,
-            "gate": gate,
-        }
-    passed, reason = gate_is_pass(result)
-    if not passed:
-        return {
-            "verdict": "NO-GO",
-            "message": f"{gate} staat merge niet toe — {reason}",
-            "overridden": False,
-            "override_reason": None,
-            "gate": gate,
-        }
-    # Invariant 7: a passing verdict whose report still carries blocking
-    # indicators is a contradiction, not evidence.
-    try:
-        report_content = report_path.read_text(encoding="utf-8")
-    except OSError:
-        return {
-            "verdict": "NO-GO",
-            "message": f"{gate} report_path onleesbaar: {report_path}",
-            "overridden": False,
-            "override_reason": None,
-            "gate": gate,
-        }
-    if _count_report_blocking_indicators(report_content) > 0:
-        return {
-            "verdict": "NO-GO",
-            "message": (
-                f"{gate} resultaat zegt pass maar het rapport bevat blocking-indicatoren "
-                "— bewijs spreekt zichzelf tegen"
-            ),
-            "overridden": False,
-            "override_reason": None,
-            "gate": gate,
-        }
-    return {
-        "verdict": "GO",
-        "message": f"{gate} resultaat aanwezig en passing voor {pr_id}",
-        "overridden": False,
-        "override_reason": None,
-        "gate": gate,
-    }
+    return _merge_door_record_verdict(result, gate, pr_id)
 
 
 # Request-side states for the optional Claude GitHub review gate that record

--- a/tests/test_oi1576_merge_door_takeover_evidence.py
+++ b/tests/test_oi1576_merge_door_takeover_evidence.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""OI-1576: the merge door must read takeover provenance from the successor's
+OWN record.
+
+Measured on main 0faeccce against the vnx-dev store (PR #1729): the gate chain
+slid forward — codex_gate unavailable, kimi_gate not executable, glm_gate took
+over and wrote a valid PASS under its OWN name, carrying
+``takeover: true`` + a ``takeover_path`` whose first element is the declared
+gate (``codex_gate``). ``gate_obligation_runner`` walks that chain since #1740,
+but the merge door (``pr_merge`` ->
+``closure_verifier.check_review_gate_for_merge`` -> ``_find_gate_result``) only
+ever looked for a record NAMED after the declared gate — NO-GO while glm had
+in fact reviewed and passed the head commit.
+
+The fix is read-side only: a successor record counts as evidence for declared
+gate X when, and only when:
+
+  1. the record carries ``takeover: true`` AND a non-empty ``takeover_path``
+  2. an element of ``takeover_path`` has ``gate == X``
+  3. the record's OWN status is a pass — never a chain step's status
+  4. every invariant the door already enforces still holds (terminal, complete
+     evidence, report on disk, gate_is_pass, no blocking indicators, the
+     head-sha binding from #1740)
+
+A record with ``takeover: true`` but an empty/absent ``takeover_path`` is a
+THIRD outcome — not "no takeover", not "proven provenance" — and is refused
+with a message that the provenance could not be determined.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier
+
+# Mirrored from the live vnx-dev store records for PR #1729.
+PR_ID = "1729"
+BRANCH = "dispatch/20260830-143000-oi1532-levende-dispatch-niet-afboeken"
+HEAD_SHA = "aa1b8ebf151bf87a3f98c647d0c97d63e59aa197"
+STALE_SHA = "e9c9e3d579473569d5204c10d5bf4d346bef1ba2"
+
+CLEAN_REPORT = "# Gate report\n\nAll findings reviewed, nothing blocking.\n"
+
+
+def _write_result(results_dir: Path, gate: str, data: dict) -> Path:
+    """Write a result record under the writer's real naming (pr-<n>-<gate>.json)."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / f"pr-{PR_ID}-{gate}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _report_file(tmp_path: Path, content: str = CLEAN_REPORT) -> Path:
+    report = tmp_path / "report.md"
+    report.write_text(content, encoding="utf-8")
+    return report
+
+
+def _declared_unavailable() -> dict:
+    """pr-1729-codex_gate.json as measured: unavailable, recorded on a stale sha."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": PR_ID,
+        "status": "unavailable",
+        "contract_hash": "",
+        "report_path": "",
+        "branch": BRANCH,
+        "commit_sha": STALE_SHA,
+    }
+
+
+def _successor(report: Path, **overrides) -> dict:
+    """pr-1729-glm_gate.json as measured before the later direct run overwrote it:
+    a pass under the successor's own name, naming its own provenance."""
+    data = {
+        "gate": "glm_gate",
+        "pr_id": PR_ID,
+        "status": "pass",
+        "blocking_count": 0,
+        "blocking_findings": [],
+        "contract_hash": "15270d8bdfc53bcf",
+        "report_path": str(report),
+        "branch": BRANCH,
+        "commit_sha": HEAD_SHA,
+        "takeover": True,
+        "takeover_from": "kimi_gate",
+        "takeover_path": [
+            {"gate": "codex_gate", "status": "unavailable"},
+            {"gate": "kimi_gate", "status": "not_executable"},
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def _check(results_dir: Path, gate: str = "codex_gate", head_sha: str = HEAD_SHA) -> dict:
+    return closure_verifier.check_review_gate_for_merge(
+        PR_ID, gate, results_dir, branch=BRANCH, head_sha=head_sha
+    )
+
+
+class TestSuccessorEvidenceAccepted:
+    def test_declared_unavailable_successor_pass_is_go(self, tmp_path):
+        """The live #1729 shape: declared codex_gate unavailable on a stale sha,
+        glm_gate pass on the head sha with codex_gate in its takeover_path."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        _write_result(results_dir, "glm_gate", _successor(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO"
+        assert verdict["gate"] == "codex_gate"
+        assert verdict["evidence_gate"] == "glm_gate"
+        assert "overname" in verdict["message"]
+
+    def test_successor_without_own_pass_is_no_go(self, tmp_path):
+        """Requirement 3: the successor's OWN status decides — a successor that
+        is not itself a pass is NO-GO even with a perfect takeover_path."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        _write_result(
+            results_dir, "glm_gate", _successor(report, status="fail", blocking_count=1)
+        )
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "glm_gate" in verdict["message"]
+
+    def test_successor_sha_mismatch_is_no_go(self, tmp_path):
+        """The sha-binding from #1740 applies to takeover evidence too: a
+        successor pass recorded against a different commit is stale evidence."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        _write_result(
+            results_dir, "glm_gate", _successor(report, commit_sha=STALE_SHA)
+        )
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+
+    def test_successor_with_blocking_report_is_no_go(self, tmp_path):
+        """Invariant 7 applies to takeover evidence too: a passing record whose
+        report carries blocking indicators contradicts itself."""
+        results_dir = tmp_path / "results"
+        report = _report_file(
+            tmp_path,
+            content='# Gate report\n\n```json\n{"verdict": "fail", "findings": []}\n```\n',
+        )
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        _write_result(results_dir, "glm_gate", _successor(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "blocking" in verdict["message"]
+
+    def test_successor_missing_contract_hash_is_no_go(self, tmp_path):
+        """Complete-evidence invariant applies to takeover evidence too."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        _write_result(results_dir, "glm_gate", _successor(report, contract_hash=""))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "contract_hash" in verdict["message"]
+
+
+class TestThirdBranchProvenanceNotDeterminable:
+    def test_takeover_true_empty_path_is_no_go(self, tmp_path):
+        """takeover: true with an EMPTY takeover_path can prove nothing — refused
+        with 'herkomst niet vast te stellen', a third outcome, not a third value."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        _write_result(results_dir, "glm_gate", _successor(report, takeover_path=[]))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "herkomst niet vast te stellen" in verdict["message"]
+
+    def test_takeover_true_missing_path_is_no_go(self, tmp_path):
+        """Same third branch when takeover_path is absent from the record."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        record = _successor(report)
+        del record["takeover_path"]
+        _write_result(results_dir, "glm_gate", record)
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "herkomst niet vast te stellen" in verdict["message"]
+
+
+class TestUnrelatedRecordsNeverTakeOver:
+    def test_plain_pass_for_other_gate_is_no_go(self, tmp_path):
+        """A passing record that makes no takeover claim is not evidence for
+        the declared gate — no random pass may take over."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        record = _successor(report)
+        del record["takeover"]
+        del record["takeover_from"]
+        del record["takeover_path"]
+        _write_result(results_dir, "glm_gate", record)
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+
+    def test_takeover_path_without_declared_gate_is_no_go(self, tmp_path):
+        """A takeover record whose path never passes through the declared gate
+        proves a DIFFERENT takeover, not this one."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(
+            results_dir,
+            "glm_gate",
+            _successor(
+                report,
+                takeover_path=[{"gate": "kimi_gate", "status": "not_executable"}],
+            ),
+        )
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+
+
+class TestContradictionTrap:
+    def test_path_step_status_never_disqualifies_declared_gates_own_pass(self, tmp_path):
+        """The walking-reader trap (live in the #1729 store):
+        pr-1729-deepseek_gate.json's takeover_path names glm_gate as
+        not_executable, while pr-1729-glm_gate.json itself says pass. Glm ran
+        twice — once as a chain step the runner could not drive, once as a
+        direct script run. A record's OWN status decides; the status of a step
+        in someone else's path must never disqualify it."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        glm_record = {
+            "gate": "glm_gate",
+            "pr_id": PR_ID,
+            "status": "pass",
+            "blocking_count": 0,
+            "blocking_findings": [],
+            "contract_hash": "15270d8bdfc53bcf",
+            "report_path": str(report),
+            "branch": BRANCH,
+            "commit_sha": HEAD_SHA,
+        }
+        _write_result(results_dir, "glm_gate", glm_record)
+        deepseek_record = _successor(
+            report,
+            gate="deepseek_gate",
+            status="not_executable",
+            takeover_from="glm_gate",
+            takeover_path=[
+                {"gate": "codex_gate", "status": "unavailable"},
+                {"gate": "kimi_gate", "status": "not_executable"},
+                {"gate": "glm_gate", "status": "not_executable"},
+            ],
+        )
+        _write_result(results_dir, "deepseek_gate", deepseek_record)
+
+        verdict = _check(results_dir, gate="glm_gate")
+
+        assert verdict["verdict"] == "GO"
+        assert "evidence_gate" not in verdict

--- a/tests/test_oi1576_merge_door_takeover_evidence.py
+++ b/tests/test_oi1576_merge_door_takeover_evidence.py
@@ -285,3 +285,93 @@ class TestContradictionTrap:
 
         assert verdict["verdict"] == "GO"
         assert "evidence_gate" not in verdict
+
+
+class TestFilenameFilterPreservesEvidence:
+    """OI-1599 advisory: ``_find_takeover_successor_results`` now pre-filters
+    the results_dir glob by filename (``_pr_scoped_json_candidates``) before
+    opening/parsing a single record — the glm_gate advisory on cd0e3112 flags
+    the unconditional ``*.json`` scan as a merge-time cost that grows with the
+    (monotonically growing) results directory.
+
+    The only real risk of that change is a filename the filter skips that
+    still carries valid evidence. Every test below drives the PUBLIC
+    ``check_review_gate_for_merge`` path (never the private filter helper
+    directly), so the SAME test runs unmodified against the pre-change code
+    (which never filters by filename — it always scans everything) and the
+    post-change code. Both must pass identically; a test that only passes
+    post-change would prove the filter self-consistent, not that it preserved
+    what the unfiltered scan used to find.
+    """
+
+    def test_successor_found_regardless_of_filename_convention(self, tmp_path):
+        """The two real writer conventions — legacy ``pr-<n>-<gate>.json``
+        (``_write_result``) and contract-style ``<slug>-<gate>-contract.json``
+        (``gate_recorder.result_file_path`` when ``pr_id`` is set) — must both
+        still be found as takeover evidence, not just whichever one a test
+        helper happens to default to."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir(parents=True)
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        # Contract-style filename instead of the legacy pr-<n>-<gate>.json.
+        contract_path = results_dir / f"{PR_ID}-glm_gate-contract.json"
+        contract_path.write_text(json.dumps(_successor(report)), encoding="utf-8")
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO"
+        assert verdict["evidence_gate"] == "glm_gate"
+
+    def test_successor_found_among_many_other_pr_noise_files(self, tmp_path):
+        """Hundreds of OTHER PRs' records sit in the same results_dir (the
+        live vnx-dev store measured 522 files across 419 distinct pr_ids on
+        2026-09-02). None of that noise — written under both naming
+        conventions — may hide this PR's own successor evidence."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir(parents=True)
+        report = _report_file(tmp_path)
+        for other_pr in range(1000, 1050):
+            noise = _declared_unavailable()
+            noise["pr_id"] = str(other_pr)
+            noise["gate"] = "glm_gate"
+            (results_dir / f"pr-{other_pr}-glm_gate.json").write_text(
+                json.dumps(noise), encoding="utf-8"
+            )
+            (results_dir / f"{other_pr}-glm_gate-contract.json").write_text(
+                json.dumps(noise), encoding="utf-8"
+            )
+        _write_result(results_dir, "codex_gate", _declared_unavailable())
+        _write_result(results_dir, "glm_gate", _successor(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO"
+        assert verdict["evidence_gate"] == "glm_gate"
+
+    def test_pr_id_with_glob_metacharacter_falls_back_to_full_scan(self, tmp_path):
+        """A pr_id containing a glob metacharacter is never produced by any
+        real caller (every one passes ``str(pr_number)``), but the filter
+        must still resolve correctly rather than silently mis-globbing and
+        losing evidence for it."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir(parents=True)
+        report = _report_file(tmp_path)
+        weird_pr_id = "17[29]"
+        declared = _declared_unavailable()
+        declared["pr_id"] = weird_pr_id
+        (results_dir / "weird-codex_gate.json").write_text(
+            json.dumps(declared), encoding="utf-8"
+        )
+        successor = _successor(report)
+        successor["pr_id"] = weird_pr_id
+        (results_dir / "weird-glm_gate.json").write_text(
+            json.dumps(successor), encoding="utf-8"
+        )
+
+        verdict = closure_verifier.check_review_gate_for_merge(
+            weird_pr_id, "codex_gate", results_dir, branch=BRANCH, head_sha=HEAD_SHA
+        )
+
+        assert verdict["verdict"] == "GO"
+        assert verdict["evidence_gate"] == "glm_gate"


### PR DESCRIPTION
## Summary

The gate chain slides forward under load: codex falls over, kimi isn't drivable, glm takes over and writes a valid PASS under its OWN name, carrying `takeover_path` back to the declared gate. `gate_obligation_runner.py` has walked that chain since #1740; the merge door (`pr_merge` → `closure_verifier.check_review_gate_for_merge` → `_find_gate_result`) did not — it only ever matched a record named after the declared gate. Measured live on PR #1729: `codex_gate` recorded `unavailable`, `glm_gate` recorded `pass` with `codex_gate` in its `takeover_path`, and the merge door returned NO-GO.

## Changes

- `scripts/closure_verifier.py`
  - Extracted the shared scope matcher `_record_matches_scope` (test_run rejection, pr_id, project_id, branch, #1740 sha binding) out of `_find_gate_result` so a new read path can reuse it verbatim instead of drifting.
  - Added `_find_takeover_successor_results(gate, ...)`: returns records that carry `takeover: true`, a non-empty `takeover_path` naming `gate`, and are in scope for the PR — plus a list of provenance-notes for records that claim a takeover but cannot prove it (empty/absent `takeover_path`).
  - Extracted the door's five invariants (terminal, complete evidence, report on disk, `gate_is_pass`, no blocking indicators in the report) into `_merge_door_record_verdict`, reused for both the declared gate's own record and a successor's.
  - `check_review_gate_for_merge`: when the declared gate never reached a decided verdict (absent, or a non-verdict status like `unavailable`/`not_executable`), falls back to a successor record naming the declared gate in its own `takeover_path`. A decided verdict on the declared gate (pass or fail) always stands on its own — never overridden by a successor. A `takeover: true` record with no provable path is refused as a distinct third outcome ("herkomst niet vast te stellen"), not silently treated as proof or as absence.
- `tests/test_oi1576_merge_door_takeover_evidence.py` (new) — 10 cases mirroring the live #1729 store shapes: successor-pass accepted, successor's own non-pass rejected (even with a perfect path), successor sha-mismatch rejected, successor blocking-report / missing-contract-hash rejected, both takeover-true-but-unprovable-path shapes refused with the exact message, unrelated/unpathed passes never take over, and the live contradiction trap (deepseek's path calls `glm_gate` `not_executable` while `glm_gate`'s own record says pass — the record's own status must decide).

## Second-reader sweep (OI-1576 is exactly "reader A fixed, reader B wasn't")

Grepped the tree for other readers matching gate results by name without considering takeover provenance:

- `scripts/lib/pr_readiness.py` — verdict already delegates to `check_review_gate_for_merge` (now fixed); its own `_find_gate_result` call is diagnostic-only (record_sha/report_path annotation), not the go/no-go. No change needed.
- `scripts/roadmap_manager.py:402` (`_gates_incomplete`) — calls `closure_verifier._find_gate_result` directly for feature-advancement blocking. Same bug class, **not fixed here** — out of the declared scope (the merge door only).
- `scripts/headless_orchestrator.py:494-522` — reads `review_gates/results/pr-{n}-{gate}.json` by exact gate name and calls `is_pass` directly for feature-unblocking. Same bug class, **not fixed here**.
- `scripts/gate_reanchor_cli.py`, `scripts/review_gate_manager.py`, `scripts/lib/chain_state_projection.py`, `scripts/lib/prior_round_injector.py` — checked, out of pattern (re-anchoring a named gate's own record, request-time takeover already handled inline, prior-round findings injection, or dead/superseded module with no consumer besides its own test).

## Test plan

- [x] `tests/test_oi1576_merge_door_takeover_evidence.py` — red on unmodified `closure_verifier.py` (6/10 failed, reproducing the exact #1729 bug), green after the fix (10/10)
- [x] Targeted suite for every file owning `check_review_gate_for_merge`/`_find_gate_result`/`_find_takeover_successor` behavior (14 files, 267 tests incl. the new 10): 7 pre-existing failures confirmed present on unmodified main too (unrelated — `test_claude_github_review_linkage.py`, `test_gate_evidence_accuracy.py::TestVerdictOnlyReportPathEnforcement`), 0 new failures, 0 regressions
- [x] `python3 -m py_compile scripts/closure_verifier.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)