### PR TITLE
fix(tests): state_writer completion wait measures progress, not wall-clock total (OI-1598)

### DIFF
--- a/tests/test_state_writer.py
+++ b/tests/test_state_writer.py
@@ -18,30 +18,109 @@ import state_writer as SW  # noqa: E402
 _THREADS = 100
 _WRITES_PER_THREAD = 100
 
-# Per-write completion budget in seconds. The measured unloaded cost of one
-# append_locked call is ~0.08ms (the full workload runs in ~0.8s), so the
-# 12ms allowance is ~150x headroom: generous enough for a loaded shared
-# runner to finish, tight enough that a genuine lock regression (a thread
-# blocked forever) still trips the assert. The old fixed 10s join was sized
-# for an unloaded machine and false-failed on the CI runner (OI-1005).
+# Per-write completion budget in seconds, used ONLY as a reference value in
+# the OI-1598 proof below (and to size the OI-1598 slow-runner delay) — it
+# is no longer used to compute a pass/fail deadline. The measured unloaded
+# cost of one append_locked call is ~0.08ms, so 12ms is ~150x headroom.
+# That per-write constant is exactly the defect OI-1598 fixes: a budget
+# scaled by workload size (_THREADS * _WRITES_PER_THREAD * this constant)
+# is still a FIXED per-write time assumption, so it still false-fails when
+# the runner itself (not just the workload) is slower than assumed — CI
+# measured one run ~80% slower than another and it blew even the scaled
+# budget while making progress the whole time. The wait logic below no
+# longer measures total time at all; it measures whether writes are still
+# landing. The old fixed 10s join (pre-dating the scaled budget) was sized
+# for an unloaded machine and false-failed the same way, one layer earlier
+# (OI-1005).
 _PER_WRITE_BUDGET_S = 0.012
 
+# How long the wait tolerates ZERO completions across ALL threads before
+# calling it a stall. Deliberately NOT scaled to workload size — that
+# scaling is the bug class this fixes. It only has to be orders of
+# magnitude above any single flock+fsync cycle we simulate (unloaded
+# ~0.08ms; the injected slow-runner delays below top out in the tens of
+# ms) so real progress on a slow-but-healthy runner never trips it, while
+# a genuine deadlock still fails in seconds rather than tying up CI.
+_STALL_WINDOW_S = 3.0
 
-def _wait_for_threads(
-    threads: list[threading.Thread], *, completion_budget: float
-) -> list[threading.Thread]:
-    """Join every thread within one shared completion budget.
 
-    Each join gets whatever remains of the budget, so the deadline is a
-    wall-clock hang-detector rather than a per-thread allowance: a
-    slow-but-progressing runner finishes (all threads do identical work and
-    start together), a deadlocked thread blocks forever and trips the
-    deadline. Returns the threads still alive when the budget expires.
+class _ProgressCounter:
+    """Thread-safe monotonic counter of completed writes.
+
+    A lock-guarded int is the cheapest counter that's actually reliable
+    across threads: the lock costs nanoseconds against the ~80us-1.5ms
+    flock+fsync cycle it counts, so it can't skew the thing it measures.
     """
-    deadline = time.monotonic() + completion_budget
-    for thread in threads:
-        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+
+    def __init__(self) -> None:
+        self._value = 0
+        self._lock = threading.Lock()
+
+    def increment(self) -> None:
+        with self._lock:
+            self._value += 1
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+
+def _wait_for_progress(
+    threads: list[threading.Thread],
+    *,
+    progress: _ProgressCounter,
+    total: int,
+    stall_window: float,
+) -> list[threading.Thread]:
+    """Wait for every thread to finish, judging health by progress, not time.
+
+    Polls the shared completion counter instead of comparing elapsed
+    wall-clock time to a deadline: as long as SOME write lands within each
+    `stall_window`, the wait keeps going no matter how long the whole run
+    takes, so a slower machine just takes longer without failing. Only a
+    genuine stall — nothing completes for a full `stall_window` — ends the
+    wait early. Returns the threads still alive when either all `total`
+    writes have landed and every thread has exited, or the stall window
+    elapses without a new completion.
+    """
+    poll_interval = min(0.05, stall_window / 10)
+    last_seen = progress.value
+    last_progress_at = time.monotonic()
+    while any(thread.is_alive() for thread in threads):
+        if progress.value >= total:
+            # All writes landed; give any thread still unwinding from its
+            # last call a real chance to exit before checking is_alive().
+            for thread in threads:
+                thread.join(timeout=stall_window)
+            break
+        time.sleep(poll_interval)
+        seen = progress.value
+        if seen > last_seen:
+            last_seen = seen
+            last_progress_at = time.monotonic()
+        elif time.monotonic() - last_progress_at > stall_window:
+            break
     return [thread for thread in threads if thread.is_alive()]
+
+
+def _slow_append_factory(delay_s: float):
+    """Wrap the real append_locked with a delay held inside its lock.
+
+    The delay must sit inside the same sentinel lock append_locked uses so
+    it actually serializes (a delay before the lock would run in parallel
+    across threads and change nothing) — this is how a slow-runner's
+    per-operation cost is faithfully simulated.
+    """
+    real_append = SW.append_locked
+
+    def _slow_append(data_path: Path, record: dict) -> None:
+        sentinel = SW._sentinel_path(data_path)
+        with sentinel.open("a+", encoding="utf-8") as sentinel_fh:
+            fcntl.flock(sentinel_fh.fileno(), fcntl.LOCK_EX)
+            time.sleep(delay_s)
+        real_append(data_path, record)
+
+    return _slow_append
 
 
 def test_append_locked_writes_single_record(tmp_path: Path):
@@ -95,11 +174,13 @@ def test_append_locked_without_skip_if_returns_true(tmp_path: Path):
 def test_append_locked_concurrent_100_threads_100_writes(tmp_path: Path):
     path = tmp_path / "state.ndjson"
     start = threading.Event()
+    progress = _ProgressCounter()
 
     def _worker(index: int) -> None:
         start.wait(timeout=5)
         for seq in range(_WRITES_PER_THREAD):
             SW.append_locked(path, {"thread": index, "seq": seq})
+            progress.increment()
 
     threads = [
         threading.Thread(target=_worker, args=(index,), daemon=True)
@@ -112,18 +193,19 @@ def test_append_locked_concurrent_100_threads_100_writes(tmp_path: Path):
     start.set()
 
     # The writes are serialized by append_locked's flock, so the workload is
-    # _THREADS * _WRITES_PER_THREAD sequential flock+fsync cycles. A fixed
-    # 10s join was tuned to an unloaded machine and false-failed on a loaded
-    # shared runner (OI-1005). The per-write-scaled budget below waits long
-    # enough for a slow-but-progressing runner while a genuine lock
-    # regression (a thread blocked forever) still trips the assert.
-    completion_budget = _THREADS * _WRITES_PER_THREAD * _PER_WRITE_BUDGET_S
-    alive = _wait_for_threads(threads, completion_budget=completion_budget)
+    # _THREADS * _WRITES_PER_THREAD sequential flock+fsync cycles. Waiting on
+    # progress rather than a wall-clock deadline means a slow-but-advancing
+    # runner just takes longer instead of false-failing (OI-1005, OI-1598);
+    # a genuine lock regression (a thread blocked forever) still trips the
+    # stall window below.
+    total = _THREADS * _WRITES_PER_THREAD
+    alive = _wait_for_progress(
+        threads, progress=progress, total=total, stall_window=_STALL_WINDOW_S
+    )
     assert not alive, (
-        f"{len(alive)} worker thread(s) did not finish within "
-        f"{completion_budget:.0f}s ({_THREADS} threads x {_WRITES_PER_THREAD} "
-        f"writes, {_PER_WRITE_BUDGET_S * 1000:.0f}ms allowance per write). "
-        "Either the runner is pathologically slow or append_locked deadlocked"
+        f"{len(alive)} worker thread(s) made no progress for "
+        f"{_STALL_WINDOW_S:.0f}s ({progress.value}/{total} writes landed). "
+        "append_locked likely deadlocked"
     )
 
     lines = path.read_text(encoding="utf-8").splitlines()
@@ -143,34 +225,22 @@ def test_oi1005_slow_runner_fits_scaled_budget_but_not_fixed_join(
     on a run that was merely slow. Simulate that runner by inflating
     append_locked's per-write cost to ~1.5ms (measured unloaded: ~0.08ms):
     the pure-sleep component alone is ~15s serialized, past the old 10s cap,
-    before any contention overhead. The scaled budget must let the workload
-    finish; if the wait logic reverts to a fixed <=10s join, this test turns
-    red.
+    before any contention overhead. The progress-based wait must let the
+    workload finish regardless of total elapsed time; if the wait logic
+    reverts to a fixed <=10s join, this test turns red.
     """
     path = tmp_path / "state.ndjson"
     start = threading.Event()
+    progress = _ProgressCounter()
     simulated_delay_s = 0.0015
-    real_append = SW.append_locked
 
-    def _slow_append(data_path: Path, record: dict) -> None:
-        # Faithful slow-runner simulation. append_locked's work is
-        # serialized by its flock critical section, so the injected delay
-        # must sit inside that section to actually slow the workload down
-        # (a delay before the lock would run in parallel across the 100
-        # threads and change nothing). Hold the same sentinel lock
-        # append_locked uses, sleep, then release and delegate.
-        sentinel = SW._sentinel_path(data_path)
-        with sentinel.open("a+", encoding="utf-8") as sentinel_fh:
-            fcntl.flock(sentinel_fh.fileno(), fcntl.LOCK_EX)
-            time.sleep(simulated_delay_s)
-        real_append(data_path, record)
-
-    monkeypatch.setattr(SW, "append_locked", _slow_append)
+    monkeypatch.setattr(SW, "append_locked", _slow_append_factory(simulated_delay_s))
 
     def _worker(index: int) -> None:
         start.wait(timeout=5)
         for seq in range(_WRITES_PER_THREAD):
             SW.append_locked(path, {"thread": index, "seq": seq})
+            progress.increment()
 
     threads = [
         threading.Thread(target=_worker, args=(index,), daemon=True)
@@ -190,11 +260,14 @@ def test_oi1005_slow_runner_fits_scaled_budget_but_not_fixed_join(
         "fixed 10s join to be a valid slow-runner reproduction"
     )
 
-    completion_budget = _THREADS * _WRITES_PER_THREAD * _PER_WRITE_BUDGET_S
-    alive = _wait_for_threads(threads, completion_budget=completion_budget)
+    total = _THREADS * _WRITES_PER_THREAD
+    alive = _wait_for_progress(
+        threads, progress=progress, total=total, stall_window=_STALL_WINDOW_S
+    )
     assert not alive, (
-        f"{len(alive)} worker thread(s) did not finish within "
-        f"{completion_budget:.0f}s under simulated load"
+        f"{len(alive)} worker thread(s) made no progress for "
+        f"{_STALL_WINDOW_S:.0f}s under simulated load "
+        f"({progress.value}/{total} writes landed)"
     )
 
     lines = path.read_text(encoding="utf-8").splitlines()
@@ -204,15 +277,99 @@ def test_oi1005_slow_runner_fits_scaled_budget_but_not_fixed_join(
         assert isinstance(parsed, dict)
 
 
-def test_oi1005_wait_for_threads_detects_a_genuine_hang():
-    """The completion wait must still catch a real lock regression.
+def test_oi1598_progress_wait_tolerates_a_slow_runner_that_breaks_scaled_budget(
+    tmp_path: Path, monkeypatch
+):
+    """Regression for OI-1598.
 
-    A thread that blocks forever is returned when the budget expires, so a
-    red run of the concurrent test keeps meaning "append_locked deadlocked"
-    rather than "the runner was slow" (OI-1005).
+    OI-1005's fix scaled the completion budget to the workload size
+    (_THREADS * _WRITES_PER_THREAD * _PER_WRITE_BUDGET_S), but that budget
+    is still a FIXED per-write time assumption — it moved the problem from
+    "vast getal" to "vast getal per eenheid werk" without closing it. CI
+    measured one suite run ~80% slower than a prior one (2244.91s vs
+    1252.84s wall-clock) and it blew even the scaled budget while making
+    progress the entire time (98 threads still had unfinished writes, not
+    zero).
+
+    This is the direct proof, not just a claim: inject a per-write delay
+    ABOVE _PER_WRITE_BUDGET_S so the OLD scaled-budget assertion is
+    provably false for THIS run's own measured elapsed time, then show the
+    progress-based wait still succeeds because writes keep landing. Small
+    workload on purpose (5x5, not 100x100) — the inequality that matters
+    (per-write delay > per-write budget) holds independent of workload
+    size, so this stays fast while proving the same failure mode.
+    """
+    path = tmp_path / "state.ndjson"
+    start = threading.Event()
+    progress = _ProgressCounter()
+    threads_n, writes_n = 5, 5
+    total = threads_n * writes_n
+    # 3x _PER_WRITE_BUDGET_S: comfortably above the old per-write allowance
+    # (so the old scaled-budget assertion is guaranteed false below) while
+    # comfortably below _STALL_WINDOW_S (so the new wait still sees steady
+    # progress, not a stall).
+    slow_delay_s = _PER_WRITE_BUDGET_S * 3
+
+    monkeypatch.setattr(SW, "append_locked", _slow_append_factory(slow_delay_s))
+
+    def _worker(index: int) -> None:
+        start.wait(timeout=5)
+        for seq in range(writes_n):
+            SW.append_locked(path, {"thread": index, "seq": seq})
+            progress.increment()
+
+    threads = [
+        threading.Thread(target=_worker, args=(index,), daemon=True)
+        for index in range(threads_n)
+    ]
+
+    for thread in threads:
+        thread.start()
+
+    run_start = time.monotonic()
+    start.set()
+
+    alive = _wait_for_progress(
+        threads, progress=progress, total=total, stall_window=_STALL_WINDOW_S
+    )
+    elapsed = time.monotonic() - run_start
+
+    old_scaled_budget = total * _PER_WRITE_BUDGET_S
+    print(
+        f"OI-1598 proof: elapsed={elapsed:.3f}s, old scaled budget="
+        f"{old_scaled_budget:.3f}s -> old assertion (elapsed <= budget) "
+        f"would be {elapsed <= old_scaled_budget}; new progress assertion "
+        f"(not alive) is {not alive}"
+    )
+
+    # The OLD assertion, applied to this exact run, must be provably red.
+    assert elapsed > old_scaled_budget, (
+        f"elapsed {elapsed:.3f}s must exceed the old scaled budget "
+        f"{old_scaled_budget:.3f}s for this to prove OI-1598's failure "
+        "mode: increase slow_delay_s relative to _PER_WRITE_BUDGET_S"
+    )
+    # The NEW assertion, on the same run, must be green.
+    assert not alive, (
+        f"{len(alive)} thread(s) made no progress for {_STALL_WINDOW_S:.0f}s "
+        f"even though the injected per-write delay ({slow_delay_s * 1000:.0f}ms) "
+        "alone should not stall progress"
+    )
+    assert progress.value == total
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == total
+
+
+def test_oi1598_wait_for_progress_detects_a_genuine_hang():
+    """The progress-based wait must still catch a real lock regression.
+
+    A thread that blocks forever makes zero progress, so it's returned
+    when the stall window expires — a red run keeps meaning "append_locked
+    deadlocked" rather than "the runner was slow" (OI-1005, OI-1598).
     """
     release = threading.Event()
     entered = threading.Event()
+    progress = _ProgressCounter()
 
     def _blocked() -> None:
         entered.set()
@@ -222,7 +379,9 @@ def test_oi1005_wait_for_threads_detects_a_genuine_hang():
     thread.start()
     entered.wait(timeout=5)
 
-    alive = _wait_for_threads([thread], completion_budget=0.5)
+    alive = _wait_for_progress(
+        [thread], progress=progress, total=1, stall_window=0.5
+    )
     release.set()
     thread.join(timeout=5)
 


### PR DESCRIPTION
## Summary

OI-1598: `test_oi1005_slow_runner_fits_scaled_budget_but_not_fixed_join` false-failed on a slower CI runner (run `33634351880` on #1741: 2244.91s vs a prior run's 1252.84s, ~80% slower). Root cause: the OI-1005 fix scaled the completion budget to workload size (`_THREADS * _WRITES_PER_THREAD * _PER_WRITE_BUDGET_S`), but that's still a *fixed per-write time* assumption — it moved the bug from "vast getal" to "vast getal per eenheid werk" without closing the class. A slower machine (not just a bigger workload) still blows it.

Replaces the wall-clock deadline with a stall-window over a shared progress counter (`_wait_for_progress` + `_ProgressCounter`, tests-only): the wait only fails when **no write lands for `_STALL_WINDOW_S` (3s)**, regardless of total elapsed time. A slow-but-progressing runner just takes longer; a genuine deadlock still trips the window quickly.

## Changes

- `tests/test_state_writer.py`:
  - Added `_ProgressCounter` (lock-guarded int, cheap relative to the flock+fsync cycle it counts) and `_wait_for_progress` (stall-window wait), replacing `_wait_for_threads` (wall-clock deadline).
  - `test_append_locked_concurrent_100_threads_100_writes` and `test_oi1005_slow_runner_fits_scaled_budget_but_not_fixed_join` now wait on progress instead of a scaled deadline. The OI-1005 protection (a fixed <=10s join is insufficient for the 100×100 workload) is preserved via its existing arithmetic proof (`assert serialized_workload > 10.0`).
  - Added `test_oi1598_progress_wait_tolerates_a_slow_runner_that_breaks_scaled_budget`: a small, fast (5×5) dedicated proof that empirically shows, on the same run, the OLD scaled-budget assertion is false while the NEW progress assertion is true.
  - Renamed `test_oi1005_wait_for_threads_detects_a_genuine_hang` → `test_oi1598_wait_for_progress_detects_a_genuine_hang`, updated to the new function; still proves a genuine hang is caught.
  - `scripts/lib/state_writer.py` untouched — the fix is entirely in how the test waits, not in the module under test.

## Verification

`python3 -m pytest tests/test_state_writer.py -v -s` — 10 passed in ~23s. Proof output from the new OI-1598 test:
```
OI-1598 proof: elapsed=1.017s, old scaled budget=0.300s -> old assertion (elapsed <= budget) would be False; new progress assertion (not alive) is True
```

Red-run proof (temporarily reverted `_wait_for_progress` to the pre-OI-1005 fixed `<=10s` join, ran, then restored — not committed):
```
FAILED tests/test_state_writer.py::test_oi1005_slow_runner_fits_scaled_budget_but_not_fixed_join
AssertionError: 100 worker thread(s) made no progress for 3s under simulated load (4774/10000 writes landed)
```
The other two tests still passed under that revert (small workload finishes within 10s regardless; a genuine hang is still caught by any join-based wait eventually) — consistent with the defect being specifically about false-failing on slow-but-progressing large workloads, not about missing true positives.

Sanity run of related state_writer test files: `pytest tests/test_state_writer.py tests/test_state_writer_compact_backfill_migration.py tests/test_state_writer_caller_migration.py -q` — 16 passed.

**Second location (per dispatch instruction):** grepped for other tests asserting a wall-clock total (join/timeout/deadline in seconds) instead of progress, and for the same *workload-scaled* budget shape specifically (`grep -rlnE "completion_budget|_BUDGET_S\b" tests/`, verified it catches this file). No other test scales a completion deadline with workload size the way this one did. `tests/test_path_parity_hook.py:51` (`_HOOK_BUDGET_SECONDS = 5.0`) asserts a fixed wall-clock budget for a single SessionStart-hook subprocess call — same "assert on total, not progress" pattern, but a single atomic operation (no workload to measure progress against), so it's a different, lower-risk shape. A number of concurrency tests (`test_dispatch_broker.py`, `test_dual_writer.py`, `test_oi1486_concurrent_result_writers.py`, `test_pool_manager_integration.py`, `test_dispatch_worktree_identity_race.py`, `test_coordination_lock_retry.py`, etc.) use fixed `thread.join(timeout=N)` calls, but on 2 threads with large fixed margins (5-90s) rather than a workload-scaled budget on 100 threads — same general class, much lower risk, not fixed here per the dispatch's "meld, fix niet" instruction.

## Open Items

None

**Dispatch-ID**: 20260902-oi1598-meet-voortgang-niet-totaaltijd
**Model**: claude-sonnet-5
**Provider**: claude