### PR TITLE
fix(gate): PR-producing dispatch stamps its PR number onto the gate obligation (OI-1599)

### DIFF
--- a/scripts/lib/report_body_contract.py
+++ b/scripts/lib/report_body_contract.py
@@ -59,11 +59,31 @@ def build_directive(dispatch_id: str, *, pr_id: "str | None" = None) -> str:
 
     Workers use the exact headings listed. Validator also accepts common
     aliases (## Files Modified, ## Test Results, ## Work Completed, ## Evidence).
+
+    OI-1599: the ``**PR_Ref**`` request below is UNCONDITIONAL — it does not
+    gate on ``pr_id``, unlike the ``## PR`` section above it. ``pr_id`` is only
+    non-None when a PR already existed BEFORE this dispatch ran; a dispatch
+    that creates a brand-new PR cannot know its number until ``gh pr create``
+    runs mid-dispatch, so gating the request on ``pr_id`` (as the ``## PR``
+    section does) would never ask exactly the dispatches that most need
+    asking. This is a request, not a requirement: it adds no heading
+    ``validate_body()`` checks for, so a report that never produces a PR is
+    never marked invalid for omitting it, and no existing report is retroactively
+    broken by this change.
     """
     sections = list(_REQUIRED_SECTIONS)
     if pr_id:
         sections.append("## PR")
     sections_formatted = "\n".join(f"- `{s}`" for s in sections)
+    pr_ref_note = (
+        "\nIf this dispatch creates or updates a pull request, also stamp its "
+        "number as a bold field within the first 3000 characters of your report "
+        "(or as frontmatter `pr_ref`): `**PR_Ref**: #1234`. This is how the "
+        "receipt converter links the PR to this dispatch's review-gate "
+        "obligation — without it the obligation can never be matched to a PR "
+        "that did not exist yet when the dispatch was registered. Omit this "
+        "field entirely when this dispatch does not produce a PR.\n"
+    )
     return (
         f"{_DIRECTIVE_SENTINEL}\n\n"
         "## Report Body Contract\n\n"
@@ -72,6 +92,7 @@ def build_directive(dispatch_id: str, *, pr_id: "str | None" = None) -> str:
         "are also accepted by the validator):\n\n"
         f"{sections_formatted}\n\n"
         "Each section must be non-empty. `## Open Items` may contain \"None\" explicitly.\n"
+        f"{pr_ref_note}"
     )
 
 

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -640,26 +640,40 @@ def _parse_pr_number(pr_ref: Optional[str]) -> Optional[int]:
         return None
 
 
-def _verify_pr_exists(pr_number: int, *, timeout: int = 15) -> bool:
+def _verify_pr_exists(
+    pr_number: int, *, timeout: int = 15, expected_head_ref: Optional[str] = None,
+) -> bool:
     """Return True when *pr_number* resolves to a real PR on GitHub.
 
-    Uses ``gh pr view <n> --json state`` so existence is MEASURED against the
-    remote — never taken from a report at face value (OI-1203: a number the
-    worker types into its own report is a claim, not evidence).  Returns False
-    on any error (missing ``gh``, non-zero exit, unparseable output, timeout).
+    Uses ``gh pr view <n> --json state,headRefName`` so existence is MEASURED
+    against the remote — never taken from a report at face value (OI-1203: a
+    number the worker types into its own report is a claim, not evidence).
+    Returns False on any error (missing ``gh``, non-zero exit, unparseable
+    output, timeout).
+
+    ``expected_head_ref`` (OI-1599): when set, the PR must ALSO carry this
+    exact ``headRefName`` or the check fails. Plain existence is not enough
+    once the caller is about to bind this PR number to a SPECIFIC dispatch's
+    gate obligation — a real PR that merely happens to share the typed number
+    but belongs to a different branch must never be adopted, or the merge
+    gate would later read gate evidence for the wrong PR.
     """
     gh = shutil.which("gh")
     if not gh:
         return False
     try:
         result = subprocess.run(
-            [gh, "pr", "view", str(pr_number), "--json", "state"],
+            [gh, "pr", "view", str(pr_number), "--json", "state,headRefName"],
             capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
             return False
         data = json.loads(result.stdout or "{}")
-        return isinstance(data, dict)
+        if not isinstance(data, dict):
+            return False
+        if expected_head_ref is not None and data.get("headRefName") != expected_head_ref:
+            return False
+        return True
     except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         return False
 
@@ -752,7 +766,7 @@ def _run_fail_closed_checks(
     return violations
 
 
-def build_receipt_from_report(
+def _build_receipt_from_report_core(
     report_path: Path, text: str, *, state_dir: Optional[Path] = None
 ) -> Optional[Dict[str, Any]]:
     """Build a minimal governed receipt dict from report content.
@@ -1042,6 +1056,127 @@ def build_receipt_from_report(
         route_dec = _load_route_decision(dispatch_id, state_dir)
         if route_dec:
             receipt["route_decision"] = route_dec
+    return receipt
+
+
+# ---------------------------------------------------------------------------
+# Obligation PR-link (OI-1599)
+# ---------------------------------------------------------------------------
+#
+# The dispatch door registers a review-gate obligation BEFORE the worker runs
+# (gate_obligations.register_obligation, called from dispatch_cli.run_dispatch)
+# — a dispatch that creates a NEW PR cannot know its PR number at that point,
+# so the obligation lands with pr_number=None. pr_merge._resolve_declared_gate
+# joins on pr_number and finds nothing for these obligations, so the merge
+# gate refuses PRs that carry real, evidenced gate passes (OI-1508 / OI-1599,
+# measured 2026-09-02: 286 of 591 obligations pr_number-less, all pending).
+# scripts/gate_obligation_runner.py would close this gap later, but is not
+# scheduled for every project (only mission-control's launchd label is
+# loaded). This converter already resolves dispatch_id, state_dir and the
+# report's own declared pr_ref for every report it processes — completing the
+# link here needs no second channel, only asking the worker for the number
+# (report_body_contract.build_directive) and reading what it wrote back.
+
+_PR_LINK_LINKED = "linked"
+_PR_LINK_UNREPORTED = "unreported"
+_PR_LINK_REFUSED = "refused"
+
+
+def _resolve_pr_link(
+    dispatch_id: Optional[str], merged: Dict[str, Any], state_dir: Optional[Path],
+) -> Tuple[str, Optional[str]]:
+    """Best-effort: stamp this dispatch's PR number onto its gate obligation.
+
+    Returns ``(pr_link, reason)``. ``pr_link`` is exactly one of
+    ``"linked"``, ``"unreported"``, ``"refused"`` — never a boolean, and
+    never a fourth value: a dispatch with no obligation record at all is not
+    a failure of this mechanism (it is a dispatch that never declared a
+    gate), so it is folded into ``"refused"`` with reason ``"no_obligation"``
+    rather than invented as a distinct state. ``reason`` is populated only
+    for ``"refused"``.
+
+    The obligation is stamped (``pr_number`` + ``branch``) ONLY when all four
+    hold:
+      a. the report carries a ``pr_ref`` that parses to an integer;
+      b. ``gh pr view`` confirms that PR exists;
+      c. its ``headRefName`` is ``dispatch/<dispatch_id>`` — otherwise a
+         mistyped or stale number would bind a stranger's PR to this
+         obligation, and the merge gate would later read gate evidence for
+         the WRONG PR;
+      d. the obligation is still ``pending`` and carries no ``pr_number`` yet
+         — an existing link is never overwritten and a terminal status is
+         never reopened.
+
+    Never raises: obligation linking is best-effort relative to the receipt
+    write path, the same contract ``register_obligation`` keeps at the door.
+    """
+    pr_ref = str(merged.get("pr_ref") or "").strip() if merged else ""
+    if not pr_ref:
+        return _PR_LINK_UNREPORTED, None
+    if not dispatch_id or state_dir is None:
+        return _PR_LINK_REFUSED, "no_dispatch_id_or_state_dir"
+
+    try:
+        sys.path.insert(0, str(_LIB_DIR))
+        from gate_obligations import obligation_path, update_obligation, STATUS_PENDING
+
+        path = obligation_path(state_dir, dispatch_id)
+        if not path.exists():
+            return _PR_LINK_REFUSED, "no_obligation"
+
+        pr_number = _parse_pr_number(pr_ref)
+        if pr_number is None:
+            return _PR_LINK_REFUSED, f"unparseable_pr_ref:{pr_ref}"
+
+        expected_branch = f"dispatch/{dispatch_id}"
+        if not _verify_pr_exists(pr_number, expected_head_ref=expected_branch):
+            return _PR_LINK_REFUSED, f"pr_not_verified_or_wrong_branch:{pr_number}"
+
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return _PR_LINK_REFUSED, f"obligation_unreadable:{exc}"
+
+        if record.get("status") != STATUS_PENDING:
+            return _PR_LINK_REFUSED, f"obligation_not_pending:{record.get('status')}"
+        if record.get("pr_number") is not None:
+            return _PR_LINK_REFUSED, "obligation_already_linked"
+
+        update_obligation(path, pr_number=pr_number, branch=expected_branch)
+        return _PR_LINK_LINKED, None
+    except Exception as exc:  # noqa: BLE001 — best-effort, mirrors register_obligation
+        logger.warning(
+            "report_to_receipt_converter: obligation pr_link failed dispatch=%s pr_ref=%s: %s",
+            dispatch_id, pr_ref, exc,
+        )
+        return _PR_LINK_REFUSED, f"exception:{type(exc).__name__}"
+
+
+def build_receipt_from_report(
+    report_path: Path, text: str, *, state_dir: Optional[Path] = None
+) -> Optional[Dict[str, Any]]:
+    """Build a governed receipt dict from report content (see
+    :func:`_build_receipt_from_report_core` for the full return-shape
+    contract) and, best-effort, complete the OI-1599 obligation PR-link.
+
+    Every receipt this returns (regardless of event_type — task_complete,
+    task_failed, or report_contract_invalid all count, since a PR can exist
+    independent of whether the report itself passed every check) carries a
+    ``pr_link`` field: ``"linked"``, ``"unreported"``, or ``"refused"`` (see
+    :func:`_resolve_pr_link`). ``None`` results (no dispatch_id resolvable at
+    all) pass through untouched — there is nothing to link.
+    """
+    receipt = _build_receipt_from_report_core(report_path, text, state_dir=state_dir)
+    if receipt is None:
+        return receipt
+
+    fm = parse_frontmatter(text)
+    body = _extract_body_fields(text)
+    merged: Dict[str, Any] = {**body, **fm}
+    pr_link, pr_link_reason = _resolve_pr_link(receipt.get("dispatch_id"), merged, state_dir)
+    receipt["pr_link"] = pr_link
+    if pr_link_reason:
+        receipt["pr_link_reason"] = pr_link_reason
     return receipt
 
 

--- a/tests/test_report_body_contract.py
+++ b/tests/test_report_body_contract.py
@@ -239,6 +239,42 @@ def test_build_directive_excludes_pr_when_not_set():
 
 
 # ---------------------------------------------------------------------------
+# OI-1599 — the PR_Ref request is unconditional, unlike the ## PR heading
+# ---------------------------------------------------------------------------
+
+def test_build_directive_requests_pr_ref_even_without_pr_id():
+    """A dispatch that will create a BRAND NEW PR has no pr_id yet at
+    dispatch time — the door cannot know the PR's number until ``gh pr
+    create`` runs mid-dispatch. If the request were gated on pr_id (like the
+    ``## PR`` heading is), exactly the dispatches that most need to report
+    their PR number would never be asked."""
+    d = build_directive("test-dispatch-004")
+    assert "**PR_Ref**" in d
+
+
+def test_build_directive_requests_pr_ref_when_pr_id_also_set():
+    """The request stays present when pr_id IS already known — the ## PR
+    heading and the PR_Ref bold-field request are independent asks."""
+    d = build_directive("test-dispatch-005", pr_id="PR-9")
+    assert "**PR_Ref**" in d
+    assert "## PR" in d
+
+
+def test_build_directive_pr_ref_request_does_not_add_a_required_heading():
+    """The PR_Ref instruction must not turn into a NEW required section —
+    a report that never produces a PR must still validate cleanly."""
+    d = build_directive("test-dispatch-006")
+    body = _canonical_body()
+    result = validate_body(body)
+    assert result.valid is True, f"missing={result.missing}"
+    # And the directive text itself carries no NEW "## " heading — the
+    # PR_Ref ask is a bold field, not a section header.
+    import re
+    headings = set(re.findall(r"^## .+", d, re.MULTILINE))
+    assert headings == {"## Report Body Contract"}
+
+
+# ---------------------------------------------------------------------------
 # CI assertion: no unified_reports body contains the old placeholder string
 # ---------------------------------------------------------------------------
 

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -3001,3 +3001,282 @@ class TestConvertDispatchIdsRejectsUnsafeIds:
 
         assert stats.new_count == 1
         assert stats.malformed_count == 0
+
+
+# ---------------------------------------------------------------------------
+# OI-1599: obligation PR-link — a dispatch that creates a NEW PR cannot know
+# its number when the door registers the obligation, so the obligation lands
+# with pr_number=None and the merge gate can never find it. This converter
+# already resolves dispatch_id/state_dir/pr_ref for every report it
+# processes, so it completes the link once the worker's own report names the
+# PR it opened.
+# ---------------------------------------------------------------------------
+
+from gate_obligations import (  # noqa: E402
+    STATUS_FULFILLED,
+    STATUS_PENDING,
+    obligation_path,
+    register_obligation,
+)
+
+
+def _register_pending_obligation(
+    state_dir: Path, dispatch_id: str, *, gate: str = "codex_gate",
+) -> Path:
+    path = register_obligation(state_dir, dispatch_id=dispatch_id, gate=gate)
+    assert path is not None
+    return path
+
+
+def _read_obligation(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestObligationPrLinkOldCodeRegression:
+    def test_old_code_never_sets_pr_link_key_at_all(self, tmp_path, state_dir, monkeypatch):
+        """OI-1599 regression proof: on the code as it stood before this fix,
+        build_receipt_from_report() had no notion of ``pr_link`` at all — the
+        key is simply absent from the returned dict, so bracket-access raises
+        KeyError (a behavioral failure, not an import/attribute accident).
+        This test asserts the NEW contract; it is included here (rather than
+        run against a checked-out old revision) so both states are visible in
+        one file — flip the assertion to `not in receipt` and it is exactly
+        what failed before this dispatch's changes landed.
+        """
+        dispatch_id = "20260902-oi1599-old-code-check"
+        _register_pending_obligation(state_dir, dispatch_id)
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#4242")
+        monkeypatch.setattr(
+            "report_to_receipt_converter._verify_pr_exists",
+            lambda *a, **kw: True,
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        # KeyError here is exactly what the pre-fix code produced — this line
+        # is the "fails on old code, passes on new" proof required by the
+        # dispatch verification contract.
+        assert receipt["pr_link"] == "linked"
+
+
+class TestObligationPrLinkThreeBranches:
+    def test_unreported_when_report_has_no_pr_ref(self, tmp_path, state_dir):
+        """Branch 1: no pr_ref in the report → 'unreported', obligation untouched."""
+        dispatch_id = "20260902-oi1599-unreported"
+        obl_path = _register_pending_obligation(state_dir, dispatch_id)
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id)
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "unreported"
+        assert "pr_link_reason" not in receipt
+        record = _read_obligation(obl_path)
+        assert record["pr_number"] is None
+        assert record["branch"] is None
+        assert record["status"] == STATUS_PENDING
+
+    def test_linked_when_pr_ref_verified_and_obligation_pending(
+        self, tmp_path, state_dir, monkeypatch,
+    ):
+        """Branch 2: a pr_ref that verifies against a pending, unlinked
+        obligation gets stamped — pr_number + branch land on the record."""
+        dispatch_id = "20260902-oi1599-linked"
+        obl_path = _register_pending_obligation(state_dir, dispatch_id)
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#4242")
+
+        seen_calls = []
+
+        def _fake_verify(pr_number, *, timeout=15, expected_head_ref=None):
+            seen_calls.append((pr_number, expected_head_ref))
+            return pr_number == 4242 and expected_head_ref == f"dispatch/{dispatch_id}"
+
+        monkeypatch.setattr("report_to_receipt_converter._verify_pr_exists", _fake_verify)
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "linked"
+        assert "pr_link_reason" not in receipt
+        assert seen_calls == [(4242, f"dispatch/{dispatch_id}")]
+        record = _read_obligation(obl_path)
+        assert record["pr_number"] == 4242
+        assert record["branch"] == f"dispatch/{dispatch_id}"
+        # Linking never touches status — the gate has not reviewed anything yet.
+        assert record["status"] == STATUS_PENDING
+
+    def test_refused_when_pr_ref_present_but_unverifiable(
+        self, tmp_path, state_dir, monkeypatch,
+    ):
+        """Branch 3: a pr_ref that fails verification → 'refused' with a
+        reason, obligation left completely unchanged."""
+        dispatch_id = "20260902-oi1599-refused"
+        obl_path = _register_pending_obligation(state_dir, dispatch_id)
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#9999")
+        monkeypatch.setattr(
+            "report_to_receipt_converter._verify_pr_exists",
+            lambda *a, **kw: False,
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "refused"
+        assert "pr_not_verified_or_wrong_branch" in receipt["pr_link_reason"]
+        record = _read_obligation(obl_path)
+        assert record["pr_number"] is None
+        assert record["branch"] is None
+
+
+class TestObligationPrLinkFourConditions:
+    """The four AND-ed conditions gating a real stamp (OI-1599 dispatch §2)."""
+
+    def test_condition_c_head_ref_mismatch_is_refused_not_linked(
+        self, tmp_path, state_dir, monkeypatch,
+    ):
+        """(c) A PR that exists but belongs to a DIFFERENT branch must never
+        be adopted — otherwise a mistyped/stale number binds a stranger's PR
+        to this obligation and the merge gate reads gate evidence for the
+        wrong PR."""
+        dispatch_id = "20260902-oi1599-headref-mismatch"
+        obl_path = _register_pending_obligation(state_dir, dispatch_id)
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#777")
+
+        def _fake_run(cmd, **kw):
+            class _R:
+                returncode = 0
+                stdout = json.dumps({
+                    "state": "OPEN",
+                    "headRefName": "dispatch/some-other-dispatch",
+                })
+            return _R()
+
+        monkeypatch.setattr("report_to_receipt_converter.shutil.which", lambda _n: "/usr/bin/gh")
+        monkeypatch.setattr("report_to_receipt_converter.subprocess.run", _fake_run)
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "refused"
+        record = _read_obligation(obl_path)
+        assert record["pr_number"] is None
+
+    def test_condition_c_head_ref_match_is_linked(self, tmp_path, state_dir, monkeypatch):
+        """(c) Same PR, but headRefName DOES match this dispatch's branch —
+        the stamp proceeds. Positive control for the mismatch test above."""
+        dispatch_id = "20260902-oi1599-headref-match"
+        obl_path = _register_pending_obligation(state_dir, dispatch_id)
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#777")
+
+        def _fake_run(cmd, **kw):
+            class _R:
+                returncode = 0
+                stdout = json.dumps({
+                    "state": "OPEN",
+                    "headRefName": f"dispatch/{dispatch_id}",
+                })
+            return _R()
+
+        monkeypatch.setattr("report_to_receipt_converter.shutil.which", lambda _n: "/usr/bin/gh")
+        monkeypatch.setattr("report_to_receipt_converter.subprocess.run", _fake_run)
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "linked"
+        record = _read_obligation(obl_path)
+        assert record["pr_number"] == 777
+        assert record["branch"] == f"dispatch/{dispatch_id}"
+
+    def test_condition_d_existing_link_is_never_overwritten(
+        self, tmp_path, state_dir, monkeypatch,
+    ):
+        """(d) An obligation that already carries a pr_number must not be
+        re-stamped by a second (possibly wrong) pr_ref."""
+        dispatch_id = "20260902-oi1599-no-overwrite"
+        obl_path = _register_pending_obligation(state_dir, dispatch_id)
+        from gate_obligations import update_obligation
+        update_obligation(obl_path, pr_number=111, branch=f"dispatch/{dispatch_id}")
+
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#222")
+        monkeypatch.setattr(
+            "report_to_receipt_converter._verify_pr_exists",
+            lambda *a, **kw: True,
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "refused"
+        assert receipt["pr_link_reason"] == "obligation_already_linked"
+        record = _read_obligation(obl_path)
+        assert record["pr_number"] == 111  # unchanged, not overwritten with 222
+
+    def test_condition_d_terminal_status_is_never_reopened(
+        self, tmp_path, state_dir, monkeypatch,
+    ):
+        """(d) A terminal obligation (e.g. already fulfilled by a gate run)
+        must never be touched by a late-arriving pr_ref."""
+        dispatch_id = "20260902-oi1599-no-reopen"
+        obl_path = _register_pending_obligation(state_dir, dispatch_id)
+        from gate_obligations import update_obligation
+        update_obligation(obl_path, status=STATUS_FULFILLED)
+
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#333")
+        monkeypatch.setattr(
+            "report_to_receipt_converter._verify_pr_exists",
+            lambda *a, **kw: True,
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "refused"
+        assert "obligation_not_pending" in receipt["pr_link_reason"]
+        record = _read_obligation(obl_path)
+        assert record["status"] == STATUS_FULFILLED
+        assert record["pr_number"] is None
+
+    def test_no_obligation_record_is_silent_refused_not_a_fourth_value(
+        self, tmp_path, state_dir,
+    ):
+        """A dispatch with NO obligation at all (never declared a gate) is
+        not an error and not a fourth pr_link value — it folds into
+        'refused' with a distinct reason, and nothing is written to disk."""
+        dispatch_id = "20260902-oi1599-no-obligation"
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, pr_ref="#555")
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+
+        assert receipt is not None
+        assert receipt["pr_link"] == "refused"
+        assert receipt["pr_link_reason"] == "no_obligation"
+        assert not obligation_path(state_dir, dispatch_id).exists()


### PR DESCRIPTION
## Summary

The dispatch door registers a review-gate obligation *before* the worker runs (`gate_obligations.register_obligation`, called from `dispatch_cli.run_dispatch`). A dispatch that creates a **new** PR cannot know its PR number at that point — `gh pr create` runs mid-dispatch — so the obligation lands with `pr_number=null`. `pr_merge._resolve_declared_gate` joins on `pr_number`, finds nothing, and the merge gate refuses PRs that carry real, evidenced gate passes. Measured 2026-09-02: 286 of 591 obligations in the vnx-dev store are `pr_number`-less, all `status=pending` (OI-1508).

The obligation runner would eventually close this gap, but it isn't scheduled for every project (only mission-control's launchd label loads). This PR closes it at the one channel that already exists for every dispatch: the worker's own completion report.

## Changes

- `scripts/lib/report_body_contract.py`: `build_directive()` now **unconditionally** asks the worker to stamp `**PR_Ref**: #1234` (bold field, first 3000 chars, or frontmatter `pr_ref`) — not gated on `pr_id` like the existing `## PR` heading, since a new-PR dispatch has no `pr_id` yet. This is a request, not a new required section: `validate_body()` is untouched, so no existing report becomes invalid and a non-PR dispatch never struggles.
- `scripts/lib/report_to_receipt_converter.py`:
  - `_verify_pr_exists()` gains an optional `expected_head_ref` — when set, the PR must carry that exact `headRefName` or the check fails.
  - New `_resolve_pr_link()`: best-effort, stamps `pr_number`+`branch` on the pending obligation only when all four hold — a parseable `pr_ref`, a verified PR, `headRefName == dispatch/<id>`, and the obligation is still `pending` with no `pr_number` yet (never overwrites a link, never reopens a terminal status).
  - `build_receipt_from_report()` now wraps the existing builder and stamps every receipt with `pr_link`: `linked` / `unreported` / `refused` (never a boolean; a dispatch with no obligation at all folds into `refused` — it's not a fourth value, just a dispatch that never declared a gate).

Both existing call sites of `build_directive()` (`dispatch_prepare.py:111`, `tmux_interactive_dispatch.py:945`) inherit the fix automatically — no plumbing changes needed there.

## Verification

Targeted suite (scope per dispatch instruction — full suite NOT run):
```
python3 -m pytest tests/test_report_to_receipt_converter.py tests/test_gate_obligations.py \
  tests/test_report_body_contract.py tests/test_dispatch_prepare.py \
  tests/test_dispatch_push_verified.py tests/test_report_parser_model_provider.py \
  tests/test_worker_heartbeat_silence.py -q
# 379 passed
```

**Old-code-fails / new-code-passes proof** — reverted `scripts/lib/report_to_receipt_converter.py` and `scripts/lib/report_body_contract.py` to the pre-fix `HEAD` (test files kept at the new revision), then ran only the new test classes:
```
python3 -m pytest tests/test_report_to_receipt_converter.py -q -k "ObligationPrLink"
# 9 failed, 160 deselected — every failure is KeyError: 'pr_link' (behavioral, not
# ImportError/AttributeError): the old code never set the key at all.
```
Restored the fix, reran the same targeted suite: **379 passed** (see command above).

New tests cover all three `pr_link` branches (`unreported`, `linked`, `refused`) plus the four stamping conditions from the dispatch instruction — in particular the `headRefName` mismatch check (condition c, with a positive control) and the never-overwrite / never-reopen rule (condition d) — in `TestObligationPrLinkThreeBranches` and `TestObligationPrLinkFourConditions` (`tests/test_report_to_receipt_converter.py`), plus two directive tests in `tests/test_report_body_contract.py` confirming the PR_Ref request is unconditional and adds no new required heading.

End-to-end measurement against this PR's own obligation record follows in a follow-up comment once the PR number is known (this dispatch is its own proof, per the dispatch instruction).

## Open Items

None

**Dispatch-ID**: 20260902-oi1599-verplichting-krijgt-pr-r2
**Model**: sonnet
**Provider**: claude