### PR TITLE
fix(gate): RESOLVED branch checks evidence and PR state before gating (OI-1508)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -122,6 +122,8 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 from gate_obligations import (  # noqa: E402
     NO_GATE_KEY,
     REASON_NO_PR_BRANCH_GONE,
+    REASON_PR_CLOSED,
+    REASON_PR_MERGED,
     STATUS_FAILED,
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
@@ -444,6 +446,32 @@ def _branch_exists_on_github(dispatch_id: str, owner_repo: str) -> Optional[bool
         "(rc=%s) — treating as unknown, not gone: %s",
         branch, proc.returncode, combined.strip(),
     )
+    return None
+
+
+def _pr_state_from_github(pr_number: int, owner_repo: str) -> Optional[str]:
+    """Whether a resolved PR is ``OPEN``, ``MERGED``, or ``CLOSED`` on GitHub.
+
+    OI-1508: the RESOLVED branch of :func:`_pre_execution_decision` knows a
+    PR number but nothing about its live disposition — measuring it here is
+    the read-only ``gh pr view <n> --json state`` call that the RESOLVED
+    branch was missing entirely, unconditionally treating every resolved PR
+    as still open and re-attempting the gate on it.
+
+    Returns the state string on a definite answer, ``None`` when it cannot
+    be determined (gh missing, timeout, network error, or an unrecognised
+    response) — mirrors :func:`_branch_exists_on_github`: a caller may only
+    retire on a definite ``MERGED``/``CLOSED``, never on ``None`` (OI-1388:
+    ambiguous evidence must never close an obligation).
+    """
+    data = _gh_json(
+        ["pr", "view", str(pr_number), "--json", "state"],
+        owner_repo=owner_repo,
+    )
+    if isinstance(data, dict):
+        state = data.get("state")
+        if isinstance(state, str) and state.strip():
+            return state.strip().upper()
     return None
 
 
@@ -1054,6 +1082,7 @@ def _evidence_decision(evidence: Tuple[Path, Dict[str, Any]]) -> Dict[str, Any]:
 
 
 def _pre_execution_decision(
+    state_dir: Path,
     dispatch_id: str,
     gate: str,
     resolution: PrResolution,
@@ -1068,13 +1097,33 @@ def _pre_execution_decision(
     (OI-1388 defect 2). Every input here is already read-only-derivable: PR
     resolution and the branch-existence check both happen inside
     :func:`resolve_pr_number` via read-only ``gh`` calls (safe in a dry run),
-    and the evidence lookup is a local file read.
+    the evidence lookup is a local file read, and the RESOLVED branch's own
+    ``gh pr view`` state check (:func:`_pr_state_from_github`, OI-1508) is
+    read-only too — ``state_dir`` is only needed to resolve an owner/repo
+    that :func:`resolve_pr_number` did not already attach to ``resolution``
+    (it only does when a PR was actually found via GitHub search; a
+    ``pr_number`` sourced from the record itself or dispatch metadata
+    carries no owner/repo at all).
 
     Returns ``{"kind": ..., ...}`` where ``kind`` is one of:
-      - ``unresolvable``               — env fault, stays retryable (below threshold)
-      - ``escalate``                   — env fault, past threshold: terminal escalation
+      - ``unresolvable``               — env fault, stays retryable (below
+        threshold). OI-1508: also reused by the RESOLVED branch when a
+        known PR's live state (open/merged/closed) could not be determined
+        — the same class of fault (the environment cannot answer a
+        required question) even though the PR number itself is known;
+        deliberately NOT a new status vocabulary member every other
+        consumer of ``STATUS_*`` would need to learn about. Carries
+        ``decision["detail"]`` naming what could not be determined.
+      - ``escalate``                   — env fault, past threshold: terminal
+        escalation. Same OI-1508 reuse as ``unresolvable`` above.
       - ``stay_pending``               — genuine wait (branch alive / undetermined)
-      - ``retire``                     — dead dispatch, no rescuing evidence
+      - ``retire``                     — dead dispatch, no rescuing evidence.
+        OI-1508: also returned by the RESOLVED branch when ``gh`` confirms
+        the PR is MERGED or CLOSED (never on OPEN, and never without first
+        checking for rescuing evidence) — carries
+        ``decision["retire_reason"]`` (``REASON_PR_MERGED``/
+        ``REASON_PR_CLOSED``) so the caller can distinguish it from the
+        pre-existing "branch gone, no PR ever" retirement.
       - ``fulfill_by_evidence``        — OI-1388 defect 1: a complete-evidence
         DECIDED PASS, sha-current with the PR head, already exists for this
         dispatch_id + gate; carried as ``decision["evidence"] = (path, record)``
@@ -1086,8 +1135,10 @@ def _pre_execution_decision(
         result exists but its sha binding to the PR head could not be
         verified. NEITHER a rescue NOR a retire/escalate — a third outcome
         that suspends judgement; carries ``decision["detail"]``
-      - ``attempt_gate``               — PR resolved: the caller must actually
-        run the gate to learn the outcome (only the real run does this)
+      - ``attempt_gate``               — PR resolved AND (for a RESOLVED
+        resolution) confirmed OPEN, or no evidence-check applies at all:
+        the caller must actually run the gate to learn the outcome (only
+        the real run does this)
 
     ``not_executable`` and any other undecided status are never returned as
     evidence here — :func:`_fulfilling_result` rejects those itself, so a
@@ -1098,6 +1149,14 @@ def _pre_execution_decision(
     carries ``decision["mismatch_detail"]`` when one was seen, so whatever
     record documents the retirement/escalation can also document why the
     rejected evidence did not count.
+
+    OI-1508: before this fix, ``resolution.status == RESOLUTION_RESOLVED``
+    returned ``attempt_gate`` unconditionally — never checking for existing
+    evidence, never checking whether the PR was still open. Measured live
+    against the central store: 258 obligations would re-run a gate
+    (110-880s each) that in most cases had already merged or closed, and at
+    least 19 of them already carried a DECIDED PASS this branch was
+    silently discarding.
     """
     if resolution.status == RESOLUTION_UNRESOLVABLE:
         lookup = _fulfilling_result(result_index, dispatch_id, gate)
@@ -1119,7 +1178,51 @@ def _pre_execution_decision(
             return {"kind": "retire", "mismatch_detail": lookup.get("detail")}
         return {"kind": "stay_pending"}
 
-    return {"kind": "attempt_gate"}
+    # resolution.status == RESOLUTION_RESOLVED (OI-1508): a PR is known, but
+    # that alone never used to be checked against existing evidence or the
+    # PR's live state — see the docstring measurement above.
+    lookup = _fulfilling_result(result_index, dispatch_id, gate)
+    if lookup["kind"] == "found":
+        return _evidence_decision(lookup["entry"])
+    if lookup["kind"] == "unverifiable":
+        return {"kind": "sha_unverifiable", "detail": lookup["detail"]}
+
+    pr_number = resolution.pr_number
+    owner_repo = resolution.owner_repo or _resolve_github_owner_repo(state_dir)
+    pr_state = (
+        _pr_state_from_github(pr_number, owner_repo)
+        if pr_number and owner_repo else None
+    )
+    if pr_state == "OPEN":
+        return {"kind": "attempt_gate"}
+    if pr_state in ("MERGED", "CLOSED"):
+        retire_reason = REASON_PR_MERGED if pr_state == "MERGED" else REASON_PR_CLOSED
+        return {
+            "kind": "retire",
+            "retire_reason": retire_reason,
+            "mismatch_detail": lookup.get("detail"),
+        }
+
+    # PR state could not be determined (gh missing/timed out/unrecognised
+    # response, or the owner/repo itself could not be resolved) — a THIRD
+    # outcome, distinct from both "confirmed open" (attempt_gate) and
+    # "confirmed merged/closed" (retire). OI-1388: ambiguous evidence must
+    # never retire an obligation; an unqueryable PR state must not silently
+    # gate on it either, since it might just as well already be closed.
+    if pr_number and owner_repo:
+        detail = (
+            f"PR #{pr_number} state on {owner_repo} could not be determined "
+            "(gh unreachable, timed out, or returned an unrecognised "
+            "response) — cannot safely retire or gate it"
+        )
+    else:
+        detail = (
+            "PR resolved but its owner/repo could not be determined to "
+            "query PR state — cannot safely retire or gate it"
+        )
+    if attempts >= _UNRESOLVABLE_ESCALATION_ATTEMPTS:
+        return {"kind": "escalate", "detail": detail, "mismatch_detail": lookup.get("detail")}
+    return {"kind": "unresolvable", "detail": detail}
 
 
 _DRY_RUN_ACTION_LABELS: Dict[str, str] = {
@@ -1163,7 +1266,7 @@ def _dry_run_outcome(
 
     attempts = int(record.get("attempts") or 0) + 1
     resolution = resolve_pr_number(state_dir, record)
-    decision = _pre_execution_decision(dispatch_id, gate, resolution, attempts, result_index)
+    decision = _pre_execution_decision(state_dir, dispatch_id, gate, resolution, attempts, result_index)
     outcome: Dict[str, Any] = {
         "dispatch_id": dispatch_id,
         "gate": gate,
@@ -1183,11 +1286,28 @@ def _dry_run_outcome(
     elif decision["kind"] == "sha_unverifiable":
         outcome["detail"] = decision.get("detail")
     elif decision["kind"] == "retire":
-        outcome["detail"] = resolution.reason or "dispatch died without ever producing a PR; branch gone"
+        # OI-1508: retire_reason distinguishes the RESOLVED branch's own
+        # merged/closed retirement from the pre-existing "branch gone, no
+        # PR ever" retirement — resolution.reason is unset for the former
+        # (RESOLUTION_RESOLVED never populates it), so it must not be used
+        # as the fallback text there.
+        retire_reason = decision.get("retire_reason")
+        if retire_reason in (REASON_PR_MERGED, REASON_PR_CLOSED):
+            state_word = "merged" if retire_reason == REASON_PR_MERGED else "closed without merge"
+            outcome["detail"] = (
+                f"PR #{resolution.pr_number} is {state_word} and no rescuing "
+                f"{gate} evidence was found"
+            )
+        else:
+            outcome["detail"] = resolution.reason or "dispatch died without ever producing a PR; branch gone"
         if decision.get("mismatch_detail"):
             outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
     elif decision["kind"] in ("unresolvable", "escalate"):
-        outcome["detail"] = resolution.reason
+        # OI-1508: decision["detail"] carries the RESOLVED branch's own
+        # "PR state undeterminable" message when present — resolution.reason
+        # is unset for RESOLUTION_RESOLVED, so it is only the fallback for
+        # the pre-existing RESOLUTION_UNRESOLVABLE origin of this branch.
+        outcome["detail"] = decision.get("detail") or resolution.reason
         if decision.get("mismatch_detail"):
             outcome["detail"] = f"{outcome['detail']} (rejected mismatched evidence: {decision['mismatch_detail']})"
     return outcome
@@ -1230,7 +1350,7 @@ def fulfill_obligation(
     now = utc_now_iso()
 
     resolution = resolve_pr_number(state_dir, record)
-    decision = _pre_execution_decision(dispatch_id, gate, resolution, attempts, result_index)
+    decision = _pre_execution_decision(state_dir, dispatch_id, gate, resolution, attempts, result_index)
 
     if decision["kind"] == "fulfill_by_evidence":
         # OI-1388 defect 1: a gate already produced a complete-evidence PASS
@@ -1347,6 +1467,13 @@ def fulfill_obligation(
         # misconfigured obligation can never masquerade as "not yet". It stays
         # retryable — the env may be fixed — until it crosses the escalation
         # threshold, where it becomes the loud terminal not_executable.
+        #
+        # OI-1508: decision["detail"] carries the RESOLVED branch's own "PR
+        # state undeterminable" message when this kind originated there —
+        # resolution.reason is unset for RESOLUTION_RESOLVED (only
+        # RESOLUTION_UNRESOLVABLE/RESOLUTION_AWAITING populate it), so it is
+        # only the fallback for this block's pre-existing origin.
+        reason_source = decision.get("detail") or resolution.reason
         mismatch_note = (
             f" A prior {gate} result exists for this dispatch but is about a "
             f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
@@ -1359,10 +1486,10 @@ def fulfill_obligation(
             attempts=attempts,
             last_attempt_at=now,
             reason="unresolvable_repo",
-            reason_detail=f"{resolution.reason}{mismatch_note}",
+            reason_detail=f"{reason_source}{mismatch_note}",
         )
         outcome["action"] = "unresolvable"
-        outcome["detail"] = resolution.reason
+        outcome["detail"] = reason_source
         if decision["kind"] == "escalate":
             update_obligation(
                 path,
@@ -1373,7 +1500,7 @@ def fulfill_obligation(
                 reason="unresolvable_timeout",
                 reason_detail=(
                     f"PR unresolved after {attempts} attempts because the "
-                    f"environment is misconfigured: {resolution.reason}. Fix "
+                    f"environment is misconfigured: {reason_source}. Fix "
                     "the project attribution (VNX_PROJECT_ID / "
                     "~/.vnx/projects.json / the checkout's git origin remote) "
                     f"and reset this obligation to pending.{mismatch_note}"
@@ -1383,16 +1510,41 @@ def fulfill_obligation(
         return outcome
 
     if decision["kind"] == "retire":
-        # OI-1388: the dispatch never produced a PR AND its head branch is
-        # gone from origin — nothing will ever gate this obligation.
-        # Terminal, distinct from `fulfilled` (no gate ever reviewed it).
-        branch_name = f"dispatch/{dispatch_id}"
         mismatch_note = (
             f" A prior {gate} result exists for this dispatch but is about a "
             f"DIFFERENT commit ({decision['mismatch_detail']}) and was "
             "rejected as rescue evidence, never silently reused (OI-1571 tak 3)."
             if decision.get("mismatch_detail") else ""
         )
+        retire_reason = decision.get("retire_reason", REASON_NO_PR_BRANCH_GONE)
+        if retire_reason in (REASON_PR_MERGED, REASON_PR_CLOSED):
+            # OI-1508: the RESOLVED branch's own retirement — gh confirmed
+            # the PR is no longer open, and the evidence lookup above this
+            # branch found no rescuing verdict. Never fires on an OPEN PR
+            # (that stays attempt_gate) and never without that lookup.
+            state_word = "merged" if retire_reason == REASON_PR_MERGED else "closed without merge"
+            update_obligation(
+                path,
+                status=STATUS_RETIRED,
+                pr_number=resolution.pr_number,
+                attempts=attempts,
+                last_attempt_at=now,
+                resolved_at=now,
+                reason=retire_reason,
+                reason_detail=(
+                    f"PR #{resolution.pr_number} for dispatch {dispatch_id} is "
+                    f"{state_word} and no rescuing {gate} evidence was found — "
+                    f"nothing left for {gate} to guard.{mismatch_note}"
+                ),
+            )
+            outcome["action"] = STATUS_RETIRED
+            outcome["detail"] = f"PR #{resolution.pr_number} is {state_word} — retired"
+            return outcome
+
+        # OI-1388: the dispatch never produced a PR AND its head branch is
+        # gone from origin — nothing will ever gate this obligation.
+        # Terminal, distinct from `fulfilled` (no gate ever reviewed it).
+        branch_name = f"dispatch/{dispatch_id}"
         update_obligation(
             path,
             status=STATUS_RETIRED,

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -91,6 +91,32 @@ runner fulfils them:
      file no longer exists) does NOT count — that is a third, distinct
      outcome (chain walked, nothing usable found anywhere), never conflated
      with either "found at the declared gate" or "found via takeover".
+  10. OI-1612: items 7-9's evidence lookup was keyed ONLY on
+      ``(dispatch_id, gate)`` — matching a result record only when its OWN
+      ``dispatch_id`` field equals the obligation's. That join holds for a
+      result THIS runner just wrote itself (``request_and_execute`` stamps
+      the obligation's ``dispatch_id`` onto whatever it produces), but a gate
+      result file is written per ``(pr_number, gate)`` regardless of who ran
+      it — a manually-triggered poortrun, a takeover successor, or any other
+      process writes its OWN dispatch_id (the poortrun's, not the build
+      dispatch's) into that same slot. Measured live: 345 of 524 results on
+      vnx-dev carry a dispatch_id, and it is essentially always the
+      poortrun's — the dispatch_id join for a RESOLVED obligation (a PR
+      already known) could structurally never match pre-existing evidence
+      from any run other than this runner's own, and ``would_stamp`` stayed
+      at 0 across the whole store. The evidence index now also keys on
+      ``(pr_number, gate)`` (gate results are one-per-(pr_number, gate),
+      never one-per-dispatch — the same convention item 9 already documents
+      for ``manager._result_path``), and the RESOLVED branch of
+      :func:`_pre_execution_decision` looks evidence up by ITS OWN resolved
+      ``pr_number`` in addition to ``dispatch_id``. AWAITING/UNRESOLVABLE
+      obligations have no ``pr_number`` to look up by definition (that is
+      exactly why the dispatch_id join existed in the first place) and keep
+      using the dispatch_id-only lookup unchanged. The sha-binding check
+      (item 9's :func:`_has_decided_evidence`) is untouched either way — a
+      pr_number-matched candidate is rejected exactly as a dispatch_id-
+      matched one is when its ``commit_sha`` does not match the PR's current
+      head.
 
 Scheduling: launchd ``com.vnx.gate-obligation-runner.plist`` (StartInterval
 900s); also safe to run manually at any time — fulfilment is idempotent
@@ -114,7 +140,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
@@ -754,21 +780,51 @@ def _record_loud_not_executable(
     )
 
 
-def _index_gate_results(
-    state_dir: Path,
-) -> Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]]:
-    """Index ``review_gates/results`` records by ``(dispatch_id, gate)``.
+class GateResultIndex(NamedTuple):
+    """Two views over ``review_gates/results``, built once per :func:`run` call.
+
+    ``by_dispatch`` keys on ``(dispatch_id, gate)`` — the join that holds for
+    a result THIS runner wrote itself (``manager.request_and_execute(...,
+    dispatch_id=dispatch_id)`` stamps the obligation's own dispatch_id onto
+    whatever it produces). AWAITING/UNRESOLVABLE obligations have no
+    ``pr_number`` at all, so this is the only lookup available to them.
+
+    ``by_pr`` keys on ``(pr_number, gate)`` — a gate result file is written
+    one-per-(pr_number, gate) regardless of which poortrun produced it (the
+    same convention :func:`_find_takeover_successor_evidence`'s docstring
+    already documents via ``manager._result_path(gate, pr_number)``). OI-1612:
+    this is the join a RESOLVED obligation (``pr_number`` already known)
+    actually needs — its own ``dispatch_id`` almost never equals the
+    dispatch_id a pre-existing result record carries, because that field
+    records the POORTRUN that produced the result, not the build dispatch the
+    obligation was declared for.
+    """
+
+    by_dispatch: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]]
+    by_pr: Dict[Tuple[int, str], List[Tuple[Path, Dict[str, Any]]]]
+
+
+def _index_gate_results(state_dir: Path) -> GateResultIndex:
+    """Index ``review_gates/results`` records by ``(dispatch_id, gate)`` AND
+    by ``(pr_number, gate)`` — see :class:`GateResultIndex`.
 
     Built once per :func:`run` call so the OI-1388 evidence discriminator
     (defect 1) costs O(results) instead of O(obligations * results). A
     malformed/unreadable result file is skipped, never raised — the same
     tolerance :func:`fulfill_obligation` already applies when it reads a
     result file's status back after invoking a gate.
+
+    OI-1612: a record is indexed by whichever key(s) it actually carries — a
+    record with a ``pr_number`` but no ``dispatch_id`` (179 of 524, measured
+    live) used to be skipped entirely; it now lands in ``by_pr`` even though
+    ``by_dispatch`` has nothing for it. A record needs at least ``gate`` and
+    one of ``dispatch_id``/``pr_number`` to be indexed at all.
     """
     results_dir = Path(state_dir) / "review_gates" / "results"
-    index: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]] = {}
+    by_dispatch: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]] = {}
+    by_pr: Dict[Tuple[int, str], List[Tuple[Path, Dict[str, Any]]]] = {}
     if not results_dir.is_dir():
-        return index
+        return GateResultIndex(by_dispatch, by_pr)
     for entry in sorted(results_dir.glob("*.json")):
         try:
             record = json.loads(entry.read_text(encoding="utf-8"))
@@ -776,12 +832,16 @@ def _index_gate_results(
             continue
         if not isinstance(record, dict):
             continue
-        dispatch_id = str(record.get("dispatch_id") or "")
         gate = str(record.get("gate") or "")
-        if not dispatch_id or not gate:
+        if not gate:
             continue
-        index.setdefault((dispatch_id, gate), []).append((entry, record))
-    return index
+        dispatch_id = str(record.get("dispatch_id") or "")
+        if dispatch_id:
+            by_dispatch.setdefault((dispatch_id, gate), []).append((entry, record))
+        pr_number = record.get("pr_number")
+        if isinstance(pr_number, int):
+            by_pr.setdefault((pr_number, gate), []).append((entry, record))
+    return GateResultIndex(by_dispatch, by_pr)
 
 
 # OI-1571 tak 3: four outcomes for "is this record usable evidence", never
@@ -868,13 +928,24 @@ def _has_decided_evidence(record: Dict[str, Any], head_sha: str) -> Tuple[str, s
 
 
 def _fulfilling_result(
-    index: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]],
+    index: GateResultIndex,
     dispatch_id: str,
     gate: str,
+    pr_number: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Scan the ``(dispatch_id, gate)`` bucket for a complete-evidence,
-    DECIDED, sha-CURRENT result — a gate that actually ran, reached a
-    verdict, and is provably about the PR's current head.
+    """Scan for a complete-evidence, DECIDED, sha-CURRENT result — a gate
+    that actually ran, reached a verdict, and is provably about the PR's
+    current head.
+
+    OI-1612: candidates come from BOTH of :class:`GateResultIndex`'s views —
+    ``index.by_dispatch[(dispatch_id, gate)]`` (a result THIS runner wrote
+    itself for this exact obligation) and, when ``pr_number`` is given,
+    ``index.by_pr[(pr_number, gate)]`` (any result for this PR+gate,
+    regardless of which poortrun's dispatch_id it carries — see
+    :class:`GateResultIndex`). A record present in both is scanned once, not
+    twice. ``pr_number`` is only available for a RESOLVED obligation; the
+    AWAITING/UNRESOLVABLE callers pass ``None`` and get exactly the
+    pre-OI-1612 dispatch_id-only behaviour.
 
     OI-1388 defect 1: a terminal retirement/escalation must never overwrite
     evidence that a gate already produced. OI-1571 tak 3 tightens "already
@@ -883,6 +954,9 @@ def _fulfilling_result(
     :func:`_get_pr_head_sha_for_gate` off the CANDIDATE record's own
     ``pr_number`` (never the caller's obligation, which by construction
     could not resolve one — that is exactly why this rescue path exists).
+    This sha check applies identically to every candidate regardless of
+    which index found it — a pr_number-matched candidate about a different
+    commit is rejected exactly like a dispatch_id-matched one would be.
 
     Returns a dict, never a bare ``Optional[Tuple]`` (OI-1571 tak 3: an
     UNVERIFIABLE candidate must not collapse into "nothing found" — that
@@ -904,9 +978,18 @@ def _fulfilling_result(
     :func:`gate_status.is_pass` — this function only answers "does usable
     evidence exist", never "what should the obligation be stamped".
     """
+    candidates: List[Tuple[Path, Dict[str, Any]]] = list(index.by_dispatch.get((dispatch_id, gate), []))
+    if isinstance(pr_number, int):
+        seen_paths = {path for path, _record in candidates}
+        for entry in index.by_pr.get((pr_number, gate), []):
+            path, _record = entry
+            if path not in seen_paths:
+                candidates.append(entry)
+                seen_paths.add(path)
+
     unverifiable: Optional[Tuple[Path, Dict[str, Any], str]] = None
     mismatch_detail: Optional[str] = None
-    for entry, record in index.get((dispatch_id, gate), []):
+    for entry, record in candidates:
         candidate_pr = record.get("pr_number")
         head_sha = (
             _get_pr_head_sha_for_gate(candidate_pr) if isinstance(candidate_pr, int) else ""
@@ -1007,7 +1090,7 @@ def _find_takeover_successor_evidence(
 
 def _terminal_evidence_contradictions(
     obligations: List[Tuple[Path, Dict[str, Any]]],
-    result_index: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]],
+    result_index: GateResultIndex,
 ) -> List[Dict[str, Any]]:
     """Report ALREADY-terminal obligations whose evidence contradicts them.
 
@@ -1024,6 +1107,12 @@ def _terminal_evidence_contradictions(
     the two statuses this dispatch's fix intercepts pre-write. A ``no_gate``
     obligation (``gate == NO_GATE_KEY``) never had a gate to review it, so it
     is excluded — there is no dispatch_id+gate result to contradict it.
+
+    OI-1612: the lookup also passes the obligation's own ``pr_number`` (when
+    the record carries one) so this diagnostic surfaces the SAME class of
+    contradiction the pre-execution rescue now catches — a terminal record
+    whose evidence carries a poortrun's own dispatch_id rather than the
+    obligation's.
     """
     contradictions: List[Dict[str, Any]] = []
     for path, record in obligations:
@@ -1034,7 +1123,11 @@ def _terminal_evidence_contradictions(
         if not gate or gate == NO_GATE_KEY:
             continue
         dispatch_id = str(record.get("dispatch_id") or path.stem)
-        lookup = _fulfilling_result(result_index, dispatch_id, gate)
+        obligation_pr_number = record.get("pr_number")
+        lookup = _fulfilling_result(
+            result_index, dispatch_id, gate,
+            pr_number=obligation_pr_number if isinstance(obligation_pr_number, int) else None,
+        )
         if lookup["kind"] != "found":
             continue
         evidence_path, _evidence_record = lookup["entry"]
@@ -1087,7 +1180,7 @@ def _pre_execution_decision(
     gate: str,
     resolution: PrResolution,
     attempts: int,
-    result_index: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]],
+    result_index: GateResultIndex,
 ) -> Dict[str, Any]:
     """Decide what happens to an obligation before any gate is actually run.
 
@@ -1181,7 +1274,17 @@ def _pre_execution_decision(
     # resolution.status == RESOLUTION_RESOLVED (OI-1508): a PR is known, but
     # that alone never used to be checked against existing evidence or the
     # PR's live state — see the docstring measurement above.
-    lookup = _fulfilling_result(result_index, dispatch_id, gate)
+    #
+    # OI-1612: this is the ONE branch that can pass pr_number into the
+    # lookup — the dispatch_id-only join could structurally never find
+    # pre-existing evidence here (see GateResultIndex/_fulfilling_result):
+    # resolution.pr_number is already known, so the lookup also checks
+    # index.by_pr[(pr_number, gate)], which is how a poortrun's own
+    # differently-named dispatch_id no longer hides its evidence from this
+    # obligation.
+    lookup = _fulfilling_result(
+        result_index, dispatch_id, gate, pr_number=resolution.pr_number,
+    )
     if lookup["kind"] == "found":
         return _evidence_decision(lookup["entry"])
     if lookup["kind"] == "unverifiable":
@@ -1241,7 +1344,7 @@ def _dry_run_outcome(
     state_dir: Path,
     path: Path,
     record: Dict[str, Any],
-    result_index: Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]],
+    result_index: GateResultIndex,
 ) -> Dict[str, Any]:
     """Report the action a real run would take for one obligation — never writes.
 
@@ -1318,7 +1421,7 @@ def fulfill_obligation(
     path: Path,
     record: Dict[str, Any],
     *,
-    result_index: Optional[Dict[Tuple[str, str], List[Tuple[Path, Dict[str, Any]]]]] = None,
+    result_index: Optional[GateResultIndex] = None,
 ) -> Dict[str, Any]:
     """Attempt fulfilment of one pending obligation.
 

--- a/tests/test_gate_obligation_runner.py
+++ b/tests/test_gate_obligation_runner.py
@@ -27,10 +27,15 @@ for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
 import vnx_paths  # noqa: E402
 import gate_obligation_runner as runner  # noqa: E402
 from gate_obligations import (  # noqa: E402
+    REASON_NO_PR_BRANCH_GONE,
+    REASON_PR_CLOSED,
+    REASON_PR_MERGED,
     STATUS_FAILED,
     STATUS_FULFILLED,
     STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
+    STATUS_RETIRED,
+    STATUS_UNRESOLVABLE,
     obligation_path,
     register_obligation,
     update_obligation,
@@ -291,12 +296,26 @@ _DEFAULT_TEST_HEAD_SHA = "deadbeef00" * 4
 
 def _patch_manager(
     monkeypatch, manager: "_FakeReviewGateManager", *, head_sha: str = _DEFAULT_TEST_HEAD_SHA,
+    pr_state: "str | None" = "OPEN",
 ) -> None:
-    """Hermetic patch: no git, no gh, no real gate — only the fake manager."""
+    """Hermetic patch: no git, no gh, no real gate — only the fake manager.
+
+    ``pr_state`` (OI-1508) stubs the RESOLVED branch's own ``gh pr view``
+    state check to a fixed answer — default ``"OPEN"`` so every test in this
+    file that registers an obligation WITH a ``pr_number`` (a RESOLVED
+    resolution) keeps reaching ``attempt_gate`` exactly as before this fix,
+    unless a test overrides it to exercise the new retire/undetermined
+    outcomes.
+    """
     monkeypatch.setattr(runner, "_build_manager", lambda state_dir: manager)
     monkeypatch.setattr(runner, "_branch_from_github", lambda pr, owner_repo: None)
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda state_dir: "Vinix24/vnx-orchestration")
     monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: head_sha)
+    # raising=False: on unfixed pre-OI-1508 code this attribute does not
+    # exist yet — the RED proof for OI-1508 must fail on BEHAVIOR (the gate
+    # manager gets called when it must not be), never on this shared test
+    # helper's own AttributeError.
+    monkeypatch.setattr(runner, "_pr_state_from_github", lambda pr_number, owner_repo: pr_state, raising=False)
     fake_rgm = types.ModuleType("review_gate_manager")
     fake_rgm._compute_changed_files = lambda branch: ["scripts/lib/foo.py"]
     monkeypatch.setitem(sys.modules, "review_gate_manager", fake_rgm)
@@ -936,3 +955,256 @@ class TestFastFulfillmentTripwire:
         assert outcome["action"] == STATUS_FULFILLED, "the sha still matches, so this must still fulfil"
         assert "fast_fulfillment_warning" in outcome
         assert "not provably a fresh run this cycle" in outcome["fast_fulfillment_warning"]
+
+
+# ---------------------------------------------------------------------------
+# OI-1508: the RESOLVED branch of _pre_execution_decision used to return
+# {"kind": "attempt_gate"} unconditionally — never checking for existing
+# evidence, never checking whether the PR was still open. Measured live
+# against the central store: 258 obligations would re-run a gate (110-880s
+# each), 95 of them already carrying their own pr_number, at least 19 of
+# those already with a DECIDED PASS on disk, and a 40-PR sample coming back
+# 36 MERGED / 4 CLOSED / 0 OPEN.
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedBranchChecksEvidenceBeforeGating:
+    """RED on unfixed main (measured 2026-09-02, the OI-1508 defect): a
+    RESOLVED obligation (``pr_number`` already known) with a pre-existing
+    DECIDED PASS for the same dispatch_id+gate still called the gate
+    manager and booked the obligation via the unconditional "attempt_gate"
+    path, never even looking at the evidence already on disk.
+
+    Driven through the stable :func:`runner.run` entry point rather than
+    calling ``_pre_execution_decision`` directly — the OI-1508 fix adds a
+    ``state_dir`` parameter to that function, so a direct call would fail
+    unfixed code on a signature mismatch (an interface error) instead of on
+    the actual regression. Through ``run()`` the RED run fails on OBSERVED
+    BEHAVIOR: the gate manager gets invoked when it must not be, and the
+    booked reason differs.
+    """
+
+    def test_pre_existing_pass_evidence_is_stamped_without_gating(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1508-resolved-evidence", gate="codex_gate",
+            project_id="vnx-dev", pr_number=50001,
+        )
+        report_file = state_dir / "unified_reports" / "codex-gate-pr50001.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("codex_gate report body", encoding="utf-8")
+        result_path = state_dir / "review_gates" / "results" / "pr-50001-codex_gate.json"
+        result_path.write_text(
+            json.dumps({
+                "gate": "codex_gate", "pr_number": 50001,
+                "dispatch_id": "20260902-oi1508-resolved-evidence",
+                "status": "pass", "contract_hash": "sha256:deadbeef",
+                "report_path": str(report_file), "commit_sha": _DEFAULT_TEST_HEAD_SHA,
+            }),
+            encoding="utf-8",
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager)
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == [], (
+            "existing evidence must be found BEFORE the RESOLVED branch "
+            "gates — a gate must never be re-run when a decided verdict "
+            "already exists for this dispatch+gate (OI-1508)"
+        )
+        record = _read_obligation(state_dir, "20260902-oi1508-resolved-evidence")
+        assert record["status"] == STATUS_FULFILLED
+        assert record["reason"] == "fulfilled_by_existing_evidence"
+        assert record["result_path"] == str(result_path)
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_FULFILLED
+
+
+class TestResolvedBranchPreExecutionDecision:
+    """Direct unit coverage of every outcome the RESOLVED branch of
+    ``_pre_execution_decision`` can now reach (OI-1508) — one test per tak,
+    a positive alongside each negative so every individual check can fail
+    on its own: bewijs-aanwezig-pass, bewijs-aanwezig-fail,
+    sha-onverifieerbaar, PR-open, PR-merged, PR-closed, and
+    PR-status-onbepaalbaar.
+    """
+
+    GATE = "codex_gate"
+    DISPATCH_ID = "20260902-oi1508-branch-coverage"
+    PR_NUMBER = 50100
+    OWNER_REPO = "Vinix24/vnx-orchestration"
+    HEAD_SHA = _DEFAULT_TEST_HEAD_SHA
+
+    def _resolution(self) -> "runner.PrResolution":
+        return runner.PrResolution(
+            runner.RESOLUTION_RESOLVED, pr_number=self.PR_NUMBER, owner_repo=self.OWNER_REPO,
+        )
+
+    def _seed_evidence(self, state_dir: Path, *, status: str, commit_sha: str = "__default__") -> Path:
+        report_file = state_dir / "unified_reports" / f"{self.GATE}-pr{self.PR_NUMBER}.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("report body", encoding="utf-8")
+        result_path = state_dir / "review_gates" / "results" / f"pr-{self.PR_NUMBER}-{self.GATE}.json"
+        result_path.write_text(
+            json.dumps({
+                "gate": self.GATE, "pr_number": self.PR_NUMBER, "dispatch_id": self.DISPATCH_ID,
+                "status": status, "contract_hash": "sha256:deadbeef",
+                "report_path": str(report_file),
+                "commit_sha": self.HEAD_SHA if commit_sha == "__default__" else commit_sha,
+            }),
+            encoding="utf-8",
+        )
+        return result_path
+
+    def _decide(self, state_dir: Path, monkeypatch, *, attempts: int = 1) -> dict:
+        monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: self.HEAD_SHA)
+        index = runner._index_gate_results(state_dir)
+        return runner._pre_execution_decision(
+            state_dir, self.DISPATCH_ID, self.GATE, self._resolution(), attempts, index,
+        )
+
+    # -- bewijs-aanwezig-pass ----------------------------------------------
+
+    def test_evidence_present_pass_rescues_instead_of_gating(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        self._seed_evidence(state_dir, status="pass")
+        decision = self._decide(state_dir, monkeypatch)
+        assert decision["kind"] == "fulfill_by_evidence"
+
+    # -- bewijs-aanwezig-fail -----------------------------------------------
+
+    def test_evidence_present_fail_discharges_without_a_clean_pass(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        self._seed_evidence(state_dir, status="failed")
+        decision = self._decide(state_dir, monkeypatch)
+        assert decision["kind"] == "fulfill_by_failed_evidence"
+
+    # -- sha-onverifieerbaar --------------------------------------------------
+
+    def test_evidence_present_unverifiable_sha_suspends_judgement(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        self._seed_evidence(state_dir, status="pass", commit_sha="")
+        decision = self._decide(state_dir, monkeypatch)
+        assert decision["kind"] == "sha_unverifiable"
+
+    # -- PR-open --------------------------------------------------------------
+
+    def test_pr_open_still_attempts_the_gate(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        monkeypatch.setattr(runner, "_pr_state_from_github", lambda pr, owner_repo: "OPEN")
+        decision = self._decide(state_dir, monkeypatch)
+        assert decision["kind"] == "attempt_gate"
+
+    # -- PR-merged --------------------------------------------------------------
+
+    def test_pr_merged_retires_with_pr_merged_reason(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        monkeypatch.setattr(runner, "_pr_state_from_github", lambda pr, owner_repo: "MERGED")
+        decision = self._decide(state_dir, monkeypatch)
+        assert decision["kind"] == "retire"
+        assert decision["retire_reason"] == REASON_PR_MERGED
+
+    # -- PR-closed --------------------------------------------------------------
+
+    def test_pr_closed_retires_with_pr_closed_reason(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        monkeypatch.setattr(runner, "_pr_state_from_github", lambda pr, owner_repo: "CLOSED")
+        decision = self._decide(state_dir, monkeypatch)
+        assert decision["kind"] == "retire"
+        assert decision["retire_reason"] == REASON_PR_CLOSED
+
+    # -- PR-status-onbepaalbaar ---------------------------------------------
+
+    def test_pr_state_undetermined_neither_retires_nor_gates(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        monkeypatch.setattr(runner, "_pr_state_from_github", lambda pr, owner_repo: None)
+        decision = self._decide(state_dir, monkeypatch, attempts=1)
+        assert decision["kind"] == "unresolvable"
+        assert decision["detail"] is not None and "could not be determined" in decision["detail"]
+
+    def test_pr_state_undetermined_escalates_past_threshold(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        monkeypatch.setattr(runner, "_pr_state_from_github", lambda pr, owner_repo: None)
+        decision = self._decide(
+            state_dir, monkeypatch, attempts=runner._UNRESOLVABLE_ESCALATION_ATTEMPTS,
+        )
+        assert decision["kind"] == "escalate"
+
+
+class TestResolvedBranchRetireIntegration:
+    """End-to-end (through ``runner.run``) proof that a merged/closed PR
+    without rescuing evidence is actually retired on disk, and that the
+    boundary is hard: an OPEN PR is NEVER retired, regardless of age."""
+
+    def test_merged_pr_without_evidence_is_retired(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1508-merged-retire", gate="codex_gate",
+            project_id="vnx-dev", pr_number=50002,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="MERGED")
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == [], "a merged PR must never re-fire the gate"
+        record = _read_obligation(state_dir, "20260902-oi1508-merged-retire")
+        assert record["status"] == STATUS_RETIRED
+        assert record["reason"] == REASON_PR_MERGED
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_RETIRED
+
+    def test_closed_pr_without_evidence_is_retired(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1508-closed-retire", gate="codex_gate",
+            project_id="vnx-dev", pr_number=50003,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="CLOSED")
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == [], "a closed PR must never re-fire the gate"
+        record = _read_obligation(state_dir, "20260902-oi1508-closed-retire")
+        assert record["status"] == STATUS_RETIRED
+        assert record["reason"] == REASON_PR_CLOSED
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_RETIRED
+
+    def test_open_pr_is_never_retired_gate_still_runs(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1508-open-control", gate="codex_gate",
+            project_id="vnx-dev", pr_number=50004,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="OPEN")
+
+        summary = runner.run(state_dir)
+
+        assert len(manager.calls) == 1, "an OPEN PR must still be gated"
+        record = _read_obligation(state_dir, "20260902-oi1508-open-control")
+        assert record["status"] == STATUS_FULFILLED
+        assert record["status"] != STATUS_RETIRED
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_FULFILLED
+
+    def test_undetermined_pr_state_stays_unresolvable_never_retired(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1508-undetermined", gate="codex_gate",
+            project_id="vnx-dev", pr_number=50005,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state=None)
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == [], "an undeterminable PR state must never gate"
+        record = _read_obligation(state_dir, "20260902-oi1508-undetermined")
+        assert record["status"] == STATUS_UNRESOLVABLE
+        assert record["status"] != STATUS_RETIRED
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == "unresolvable"

--- a/tests/test_gate_obligation_runner.py
+++ b/tests/test_gate_obligation_runner.py
@@ -919,13 +919,24 @@ class TestFastFulfillmentTripwire:
         outcome = summary["outcomes"][0]
         assert "fast_fulfillment_warning" not in outcome
 
-    def test_stale_result_file_trips_the_warning(self, tmp_path, monkeypatch):
-        """RED on unfixed main (measured 2026-08-30: no such check existed
-        at all): a result file whose mtime predates this attempt by well
-        over the threshold, but whose commit_sha still happens to match the
-        PR head (so the sha check alone does not intercept it — this is a
-        deliberately independent second signal), must trip a LOUD,
-        observable warning on the outcome."""
+    def test_stale_result_file_is_rescued_pre_execution_since_oi_1612(self, tmp_path, monkeypatch):
+        """Superseded by OI-1612: before that fix, this exact record (no
+        ``dispatch_id`` field at all — only ``pr_number``) was INVISIBLE to
+        the pre-execution evidence lookup (dispatch_id-only join), so the
+        RESOLVED branch always fell through to ``attempt_gate``, called the
+        (no-op) manager, and read this same stale file back — which is what
+        the mtime tripwire below used to catch as its only signal.
+
+        OI-1612 indexes this record by ``(pr_number, gate)`` too, so the
+        pre-execution rescue now finds and books it BEFORE ``attempt_gate``
+        is ever reached — exactly the same class of wasted re-run OI-1508
+        eliminated for the dispatch_id-matching case. The gate manager must
+        never be invoked at all; the old mtime-staleness path this test used
+        to exercise is now provably unreachable for a RESOLVED obligation
+        with a pre-existing sha-matching decided result, since RESOLVED is
+        the only resolution that ever reaches ``attempt_gate`` and it always
+        supplies the same ``pr_number`` the pre-execution rescue now checks.
+        """
         state_dir = _make_state_dir(tmp_path)
         register_obligation(
             state_dir, dispatch_id="20260830-oi1569-stale-evidence", gate="codex_gate",
@@ -953,8 +964,16 @@ class TestFastFulfillmentTripwire:
 
         outcome = summary["outcomes"][0]
         assert outcome["action"] == STATUS_FULFILLED, "the sha still matches, so this must still fulfil"
-        assert "fast_fulfillment_warning" in outcome
-        assert "not provably a fresh run this cycle" in outcome["fast_fulfillment_warning"]
+        assert outcome["detail"] == (
+            "rescued by the OI-1388 evidence discriminator — a gate had "
+            "already reviewed and approved this dispatch"
+        )
+        assert manager.calls == [], (
+            "OI-1612: pre-existing pr_number-matched evidence must be "
+            "rescued BEFORE the gate manager is ever invoked — never "
+            "re-attempted just because its dispatch_id does not match"
+        )
+        assert "fast_fulfillment_warning" not in outcome
 
 
 # ---------------------------------------------------------------------------
@@ -1208,3 +1227,301 @@ class TestResolvedBranchRetireIntegration:
         assert record["status"] != STATUS_RETIRED
         outcome = summary["outcomes"][0]
         assert outcome["action"] == "unresolvable"
+
+
+# ---------------------------------------------------------------------------
+# OI-1612: the OI-1388 evidence index joined on (dispatch_id, gate) alone.
+# A gate result record's dispatch_id names the POORTRUN that produced it,
+# never the build dispatch the obligation was declared for — item 9's
+# ``manager.request_and_execute(..., dispatch_id=dispatch_id)`` is the ONE
+# exception, a result THIS runner writes for itself. For a RESOLVED
+# obligation (pr_number already known), the old join could therefore never
+# match a pre-existing result written by any OTHER process — measured live
+# on vnx-dev: would_stamp stayed at 0 across 593 and 594 obligations, even
+# though 345 of 524 results carried a dispatch_id (just never the right
+# one). The fix also indexes results by (pr_number, gate) and has the
+# RESOLVED branch of _pre_execution_decision look up by pr_number in
+# addition to dispatch_id — AWAITING/UNRESOLVABLE, which never have a
+# pr_number to look up by, are unchanged.
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceIndexJoinsOnPrNumber:
+    """RED on #1745 (dispatch_id-only join) / GREEN on OI-1612 for the exact
+    live case measured on vnx-dev: obligation
+    ``20260902-oi1599-verplichting-krijgt-pr-r2`` (glm_gate, PR #1744) vs.
+    result record ``pr-1744-glm_gate.json``, written under the poortrun's OWN
+    dispatch_id (``glm-gate-pr1744-1788369563``), never the obligation's.
+    """
+
+    GATE = "glm_gate"
+    PR_NUMBER = 1744
+    OBLIGATION_DISPATCH_ID = "20260902-oi1599-verplichting-krijgt-pr-r2"
+    POORTRUN_DISPATCH_ID = "glm-gate-pr1744-1788369563"
+    HEAD_SHA = _DEFAULT_TEST_HEAD_SHA
+
+    def _seed_result(
+        self,
+        state_dir: Path,
+        *,
+        dispatch_id: str,
+        pr_number: int = PR_NUMBER,
+        gate: str = GATE,
+        status: str = "pass",
+        commit_sha: "str | None" = "__default__",
+        filename: "str | None" = None,
+    ) -> Path:
+        commit_sha = self.HEAD_SHA if commit_sha == "__default__" else commit_sha
+        filename = filename or f"pr-{pr_number}-{gate}"
+        report_file = state_dir / "unified_reports" / f"{filename}.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("report body", encoding="utf-8")
+        result_path = state_dir / "review_gates" / "results" / f"{filename}.json"
+        result_path.write_text(
+            json.dumps({
+                "gate": gate, "pr_number": pr_number, "dispatch_id": dispatch_id,
+                "status": status, "contract_hash": "sha256:deadbeef",
+                "report_path": str(report_file), "commit_sha": commit_sha,
+            }),
+            encoding="utf-8",
+        )
+        return result_path
+
+    # -- the live case: RED on #1745, GREEN on OI-1612 (also condition a) --
+
+    def test_pr_number_matched_evidence_rescues_when_dispatch_id_differs(self, tmp_path, monkeypatch):
+        """The exact vnx-dev case (r2 / pr-1744-glm_gate). PR merged, so the
+        ONLY thing standing between retire and fulfil is whether the
+        evidence lookup can find this record at all — a poortrun's OWN
+        dispatch_id, never the obligation's, is exactly what #1745 could not
+        join on."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id=self.OBLIGATION_DISPATCH_ID, gate=self.GATE,
+            project_id="vnx-dev", pr_number=self.PR_NUMBER,
+        )
+        self._seed_result(state_dir, dispatch_id=self.POORTRUN_DISPATCH_ID)
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="MERGED")
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == [], (
+            "existing pr_number-matched evidence must be found BEFORE the "
+            "RESOLVED branch retires or re-gates"
+        )
+        record = _read_obligation(state_dir, self.OBLIGATION_DISPATCH_ID)
+        assert record["status"] == STATUS_FULFILLED, (
+            f"expected fulfilled via the OI-1612 rescue, got {record['status']!r} "
+            f"(reason={record.get('reason')!r}) — on #1745 this stays RETIRED "
+            "because the dispatch_id-only join never finds a poortrun's own "
+            "result record"
+        )
+        assert record["status"] != STATUS_RETIRED
+        assert record["reason"] == "fulfilled_by_existing_evidence"
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_FULFILLED
+
+    # -- condition b: AWAITING/UNRESOLVABLE keep working via dispatch_id ---
+
+    def test_awaiting_branch_still_rescues_via_dispatch_id_match(self, tmp_path, monkeypatch):
+        """Control for condition (b): an AWAITING obligation (no PR found,
+        dead branch) has no pr_number to look up by at all — it must keep
+        finding evidence exactly the way it did before OI-1612, via a
+        dispatch_id match."""
+        state_dir = _make_state_dir(tmp_path)
+        dispatch_id = "20260902-oi1612-awaiting-dispatch-id-match"
+        register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", project_id="vnx-dev",
+        )
+        monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+        monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda sd: "Vinix24/vnx-orchestration")
+        monkeypatch.setattr(runner, "_pr_from_github", lambda did, owner_repo: None)
+        monkeypatch.setattr(runner, "_branch_exists_on_github", lambda did, owner_repo: False)
+        monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: self.HEAD_SHA)
+        self._seed_result(
+            state_dir, dispatch_id=dispatch_id, gate="codex_gate", pr_number=50200,
+            filename="pr-50200-codex_gate",
+        )
+
+        summary = runner.run(state_dir)
+
+        record = _read_obligation(state_dir, dispatch_id)
+        assert record["status"] == STATUS_FULFILLED
+        assert record["status"] != STATUS_RETIRED
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_FULFILLED
+
+    def test_fulfilling_result_without_pr_number_ignores_by_pr_index(self, tmp_path, monkeypatch):
+        """Direct boundary proof for (b): when a caller passes no
+        ``pr_number`` (exactly what the AWAITING/UNRESOLVABLE call sites
+        do), a record only reachable via ``index.by_pr`` must NOT be found —
+        even though the SAME gate result would be found if ``pr_number``
+        were supplied. Proves those two call sites cannot accidentally start
+        matching on pr_number just because the index now carries one."""
+        monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: self.HEAD_SHA)
+        state_dir = _make_state_dir(tmp_path)
+        self._seed_result(
+            state_dir, dispatch_id="", pr_number=50201, gate="codex_gate",
+            filename="pr-50201-codex_gate",
+        )
+        index = runner._index_gate_results(state_dir)
+
+        no_pr = runner._fulfilling_result(index, "some-other-dispatch-id", "codex_gate")
+        assert no_pr["kind"] == "absent"
+
+        with_pr = runner._fulfilling_result(
+            index, "some-other-dispatch-id", "codex_gate", pr_number=50201,
+        )
+        assert with_pr["kind"] == "found"
+
+    # -- condition c: a pr_number-only record (no dispatch_id) must not be -
+    # silently skipped anymore ----------------------------------------------
+
+    def test_index_places_dispatch_id_less_record_under_by_pr(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        self._seed_result(
+            state_dir, dispatch_id="", pr_number=50202, gate="codex_gate",
+            filename="pr-50202-codex_gate",
+        )
+        index = runner._index_gate_results(state_dir)
+        assert index.by_pr.get((50202, "codex_gate"))
+        assert index.by_dispatch == {}
+
+    def test_record_without_dispatch_id_or_pr_number_is_never_indexed(self, tmp_path):
+        """Negative control for (c): a record needs at least ONE of
+        dispatch_id/pr_number (plus gate) to be indexed at all — a record
+        carrying neither must still be invisible, exactly as before
+        OI-1612."""
+        state_dir = _make_state_dir(tmp_path)
+        report_file = state_dir / "unified_reports" / "orphan.md"
+        report_file.parent.mkdir(parents=True, exist_ok=True)
+        report_file.write_text("report body", encoding="utf-8")
+        result_path = state_dir / "review_gates" / "results" / "orphan-codex_gate.json"
+        result_path.write_text(
+            json.dumps({
+                "gate": "codex_gate", "pr_number": None, "dispatch_id": "",
+                "status": "pass", "contract_hash": "sha256:deadbeef",
+                "report_path": str(report_file), "commit_sha": self.HEAD_SHA,
+            }),
+            encoding="utf-8",
+        )
+        index = runner._index_gate_results(state_dir)
+        assert index.by_dispatch == {}
+        assert index.by_pr == {}
+
+    # -- condition d: pr_number-matched evidence about a DIFFERENT commit --
+    # is still rejected, unchanged -------------------------------------------
+
+    def test_pr_number_matched_evidence_with_wrong_sha_is_not_rescued(self, tmp_path, monkeypatch):
+        """Negative: same live shape as the RED/GREEN case above, except the
+        pr_number-matched record is about a DIFFERENT commit. The
+        pr_number-based lookup must not bypass the sha binding check — this
+        must still retire, exactly as the mismatched-evidence path already
+        did before OI-1612."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1612-wrong-sha", gate=self.GATE,
+            project_id="vnx-dev", pr_number=self.PR_NUMBER,
+        )
+        self._seed_result(
+            state_dir, dispatch_id="glm-gate-pr1744-other-run",
+            commit_sha="c0ffee00" * 5,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="MERGED")
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == [], "a merged PR must never re-fire the gate"
+        record = _read_obligation(state_dir, "20260902-oi1612-wrong-sha")
+        assert record["status"] == STATUS_RETIRED
+        assert record["status"] != STATUS_FULFILLED
+        assert "rejected as rescue evidence" in record["reason_detail"], (
+            "the retired obligation's own record must document that a "
+            "pr_number-matched candidate existed but was rejected on its "
+            "sha binding, not silently ignored"
+        )
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_RETIRED
+
+    def test_pr_number_matched_evidence_with_matching_sha_is_rescued(self, tmp_path, monkeypatch):
+        """Positive control alongside (d): identical setup with the correct
+        sha must fulfil — proves the rejection above is about the sha, not
+        some other accidental difference."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1612-right-sha", gate=self.GATE,
+            project_id="vnx-dev", pr_number=self.PR_NUMBER,
+        )
+        self._seed_result(state_dir, dispatch_id="glm-gate-pr1744-other-run-2")
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="MERGED")
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == []
+        record = _read_obligation(state_dir, "20260902-oi1612-right-sha")
+        assert record["status"] == STATUS_FULFILLED
+        outcome = summary["outcomes"][0]
+        assert outcome["action"] == STATUS_FULFILLED
+
+    # -- condition e: two obligations sharing a PR share the SAME evidence -
+    # legitimately (one file is the single source of truth for that
+    # (pr_number, gate)) — and share the SAME sha rejection too ------------
+
+    def test_two_obligations_same_pr_both_rescued_by_shared_evidence(self, tmp_path, monkeypatch):
+        """Positive: obligation A and obligation B both declare glm_gate
+        against the SAME PR (a re-dispatched fix-forward, e.g. #1729's three
+        obligations) — the single per-(pr_number, gate) result file is
+        legitimate evidence for BOTH, since it genuinely reflects the state
+        of that one PR; this is sharing, not stealing."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1612-shared-a", gate=self.GATE,
+            project_id="vnx-dev", pr_number=self.PR_NUMBER,
+        )
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1612-shared-b", gate=self.GATE,
+            project_id="vnx-dev", pr_number=self.PR_NUMBER,
+        )
+        self._seed_result(state_dir, dispatch_id="glm-gate-pr1744-shared-run")
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="MERGED")
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == []
+        record_a = _read_obligation(state_dir, "20260902-oi1612-shared-a")
+        record_b = _read_obligation(state_dir, "20260902-oi1612-shared-b")
+        assert record_a["status"] == STATUS_FULFILLED
+        assert record_b["status"] == STATUS_FULFILLED
+        assert record_a["result_path"] == record_b["result_path"]
+
+    def test_two_obligations_same_pr_neither_rescued_by_mismatched_evidence(self, tmp_path, monkeypatch):
+        """Negative alongside (e): sharing a pr_number must never let EITHER
+        obligation bypass the sha check — both must be rejected identically
+        when the shared record is about a different commit."""
+        state_dir = _make_state_dir(tmp_path)
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1612-shared-mismatch-a", gate=self.GATE,
+            project_id="vnx-dev", pr_number=self.PR_NUMBER,
+        )
+        register_obligation(
+            state_dir, dispatch_id="20260902-oi1612-shared-mismatch-b", gate=self.GATE,
+            project_id="vnx-dev", pr_number=self.PR_NUMBER,
+        )
+        self._seed_result(
+            state_dir, dispatch_id="glm-gate-pr1744-shared-mismatch-run",
+            commit_sha="badc0de0" * 5,
+        )
+        manager = _FakeReviewGateManager(state_dir, result_status="pass")
+        _patch_manager(monkeypatch, manager, pr_state="MERGED")
+
+        summary = runner.run(state_dir)
+
+        assert manager.calls == []
+        record_a = _read_obligation(state_dir, "20260902-oi1612-shared-mismatch-a")
+        record_b = _read_obligation(state_dir, "20260902-oi1612-shared-mismatch-b")
+        assert record_a["status"] == STATUS_RETIRED
+        assert record_b["status"] == STATUS_RETIRED

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -191,11 +191,18 @@ class _FakeManager(GateReportGeneratorMixin):
         return {"pr_number": pr_number, "branch": branch, "gates": [], "has_required_failure": False}
 
 
-def _patch_manager(monkeypatch, manager: "_FakeManager") -> None:
-    """Hermetic patch: no git, no gh, no real gate — only the fake manager."""
+def _patch_manager(monkeypatch, manager: "_FakeManager", *, pr_state: str = "OPEN") -> None:
+    """Hermetic patch: no git, no gh, no real gate — only the fake manager.
+
+    ``pr_state`` (OI-1508) stubs the RESOLVED branch's own ``gh pr view``
+    state check to a fixed answer — default ``"OPEN"`` so every test in this
+    file that registers an obligation WITH a ``pr_number`` (a RESOLVED
+    resolution) keeps reaching ``attempt_gate`` exactly as before this fix.
+    """
     monkeypatch.setattr(runner, "_build_manager", lambda state_dir: manager)
     monkeypatch.setattr(runner, "_branch_from_github", lambda pr, owner_repo: None)
     monkeypatch.setattr(runner, "_resolve_github_owner_repo", lambda state_dir: "Vinix24/vnx-orchestration")
+    monkeypatch.setattr(runner, "_pr_state_from_github", lambda pr_number, owner_repo: pr_state, raising=False)
     fake_rgm = types.ModuleType("review_gate_manager")
     fake_rgm._compute_changed_files = lambda branch: ["scripts/lib/foo.py"]
     # _write_not_executable_result (mixed into _FakeManager, real production


### PR DESCRIPTION
## Summary
- `_pre_execution_decision`'s RESOLVED branch returned `{"kind": "attempt_gate"}` unconditionally — never checking for existing evidence, never checking whether the PR was still open. Measured live against the central store: 258 obligations would re-run a gate (110-880s each), 95 with `pr_number` already known, at least 19 already carrying a decided PASS on disk, and a 40-PR sample coming back 36 MERGED / 4 CLOSED / 0 OPEN.
- The RESOLVED branch now runs the same `_fulfilling_result` evidence lookup the AWAITING/UNRESOLVABLE branches already do before deciding anything.
- New read-only `_pr_state_from_github` (`gh pr view --json state`) checks the PR's live state: OPEN still gates (`attempt_gate`, unchanged), MERGED/CLOSED retires (`REASON_PR_MERGED`/`REASON_PR_CLOSED`, only when no rescuing evidence was found), and an undeterminable state reuses the existing `unresolvable`/`escalate` vocabulary (bounded retry, then loud terminal escalation) rather than inventing a new `STATUS_*` member every consumer would need to learn about.
- The other two branches of `_pre_execution_decision` (UNRESOLVABLE, AWAITING) are untouched.

## Test plan
- [x] `tests/test_gate_obligation_runner.py` — 44 passed (31 pre-existing + 13 new: RED/GREEN proof, one test per outcome the RESOLVED branch can reach, and end-to-end retire/open/undetermined integration tests)
- [x] `tests/test_gate_obligations.py` — 66 passed (unchanged, `_patch_manager` extended to stub the new PR-state check hermetically)
- [x] `tests/test_gate_obligation_retire_backlog.py`, `tests/test_gate_obligation_reopen_stale_evidence.py`, `tests/test_gate_obligation_runner_scope.py` — 40 passed, untouched by this change
- [x] RED confirmed against unfixed code (source-only `git stash`): the designated proof test fails on **behavior** (`manager.calls` non-empty — the gate got re-invoked despite existing evidence), not ImportError/AttributeError
- [x] Dry run over the real vnx-dev store from this worktree (`VNX_PROJECT_ID=vnx-dev python3 scripts/gate_obligation_runner.py --no-write --json`) — see dispatch report for before/after `action_counts`
- [x] Grep swept the tree for a second place making this decision — none found (`RESOLUTION_RESOLVED`/`resolve_pr_number`/`_pre_execution_decision` only live in `gate_obligation_runner.py`; `gate_obligation_retire_backlog.py` is an independent one-time script with its own bulk `gh pr list` classifier)

Dispatch-ID: 20260902-oi1508-resolved-tak-ziet-bewijs