### PR TITLE
fix(gate): human_gate_queue filters on the deliverable marker, not state alone (OI-1609 p3)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -686,6 +686,27 @@ def _build_tracks_from_db(state_dir: Path, project_id: str) -> Dict[str, Any]:
 # metadata_json, created_at, project_id) so the query never trips on
 # later-migration-only columns (e.g. output_kind/output_ref) on a store that
 # hasn't run the out-of-band migration yet.
+#
+# state='proposed' is NOT unique to deliverables (OI-1609 point 3). Every
+# door-accepted dispatch also lands with state='proposed' — dispatch_cli.py's
+# _persist_dispatch_row deliberately uses it ("'proposed' is invisible to
+# [the claim/stuck/ghost sweeps] — the same state the deliverable layer
+# uses") and, per OI-1609 point 2 (separate dispatch), a plain dispatch
+# should leave 'proposed' once claimed but today does not. Selecting on
+# state alone therefore surfaced ~670 already-run dispatches alongside ~54
+# real deliverables (measured 2026-09-03 on vnx-dev). The `dlv-` id prefix
+# and a non-null `track` are correlated *observations* of that bug, not the
+# actual marker, and a non-null `track` would also disappear the day
+# _persist_dispatch_row starts stamping track_id-derived track values.
+#
+# The actual structural discriminator is `metadata_json.deliverable == true`
+# — the field `cmd_deliverable_add` (planning_cli.py) stamps on every row it
+# creates (`metadata_dict = {"title": title, "deliverable": True}`).
+# `_persist_dispatch_row` never writes metadata_json at all, so a plain
+# dispatch's row always parses to `{}` here. Filtering on this marker keeps
+# the reader correct independent of OI-1609 point 2 landing: it does not
+# rely on plain dispatches leaving 'proposed', so it stays correct before
+# and after that transition is fixed.
 
 _HUMAN_GATE_QUEUE_SQL = (
     "SELECT dispatch_id, track, metadata_json, created_at "
@@ -695,12 +716,18 @@ _HUMAN_GATE_QUEUE_SQL = (
 
 
 def _build_human_gate_queue(state_dir: Path, project_id: str) -> List[Dict[str, Any]]:
-    """Proposed deliverables/dispatches waiting on an operator promote decision.
+    """Proposed deliverables waiting on an operator promote decision.
 
     Read-only and additive: never mutates state, never promotes. Degrades to
     an empty list (never raises) on unavailable identity, a missing/premigration
     DB, or a locked/malformed DB — this is advisory surfacing, not a gate, so a
     degraded read must not block SessionStart.
+
+    Only rows carrying ``metadata_json.deliverable == true`` are returned —
+    see the discriminator note above the SQL. A plain door-accepted dispatch
+    that happens to also sit at state='proposed' is not a decision an
+    operator owes; it is excluded even though it matches the SQL WHERE
+    clause.
     """
     pid = (project_id or "").strip()
     if not pid:
@@ -724,6 +751,8 @@ def _build_human_gate_queue(state_dir: Path, project_id: str) -> List[Dict[str, 
             meta = json.loads(row.get("metadata_json") or "{}")
         except (TypeError, ValueError):
             meta = {}
+        if not (isinstance(meta, dict) and meta.get("deliverable") is True):
+            continue
         title = meta.get("title") if isinstance(meta, dict) else None
         queue.append({
             "id": row.get("dispatch_id"),

--- a/tests/test_human_gate_queue.py
+++ b/tests/test_human_gate_queue.py
@@ -176,6 +176,43 @@ def test_reader_scopes_to_project_id(
     assert {item["id"] for item in queue_b} == {"dlv-b"}
 
 
+def test_reader_excludes_plain_dispatch_at_proposed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OI-1609 point 3: a plain door-accepted dispatch also lands at
+    state='proposed' (dispatch_cli.py._persist_dispatch_row) — not just
+    deliverables. It has no `dlv-` id, no track, and no metadata_json
+    (row.get("metadata_json") parses to "{}", same as the DB default).
+    That is not a decision an operator owes and must not surface here,
+    regardless of what state OI-1609 point 2 (the state-transition fix,
+    out of scope for this dispatch) eventually leaves it in.
+    """
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    db_path = _make_dispatches_db(state_dir)
+    _insert_dispatch(
+        db_path,
+        dispatch_id="20260903-plain-dispatch-abcdef",
+        project_id=_PROJECT_ID,
+        state="proposed",
+        track=None,
+        title=None,
+    )
+    _insert_dispatch(
+        db_path,
+        dispatch_id="dlv-real-deliverable",
+        project_id=_PROJECT_ID,
+        state="proposed",
+        track="kickoff-human-gate-queue",
+        title="Ship the human gate queue",
+    )
+
+    queue = bts._build_human_gate_queue(state_dir, _PROJECT_ID)
+
+    ids = {item["id"] for item in queue}
+    assert "20260903-plain-dispatch-abcdef" not in ids
+    assert ids == {"dlv-real-deliverable"}
+
+
 def test_reader_no_proposed_items_is_empty_list(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- `_build_human_gate_queue` (`scripts/build_t0_state.py`) selected every `dispatches` row at `state='proposed'`. That state is not unique to deliverables: `dispatch_cli.py::_persist_dispatch_row` deliberately parks every door-accepted dispatch there too ("'proposed' is invisible to the claim/stuck/ghost sweeps — the same state the deliverable layer uses"). On `vnx-dev` this surfaced ~670 already-run dispatches as open operator decisions alongside ~54 real deliverables.
- Fix: filter on the actual structural marker — `metadata_json.deliverable == true`, the field `cmd_deliverable_add` (`planning_cli.py`) stamps on every deliverable row. `_persist_dispatch_row` never writes `metadata_json` at all, so a plain dispatch always parses to `{}`. This is chosen over the `dlv-` id prefix or a non-null `track` because those are correlated observations of the same underlying bug, not the authoritative field — a non-null `track` would silently break the moment `_persist_dispatch_row` starts stamping a `track` value too.
- This does not depend on OI-1609 point 2 (the separate state-transition fix) landing: the filter stays correct whether or not plain dispatches keep sitting at `proposed`.

## Changes
- `scripts/build_t0_state.py`: `_build_human_gate_queue` now excludes any `proposed` row whose `metadata_json` does not carry `deliverable: true`. Comment block above `_HUMAN_GATE_QUEUE_SQL` (lines ~676-711) and the function docstring updated to document the discriminator and why the SQL's `state='proposed'` filter alone is insufficient. No SQL/query-shape change — filtering happens in the existing per-row metadata parse.
- `tests/test_human_gate_queue.py`: new regression test `test_reader_excludes_plain_dispatch_at_proposed` — inserts one plain dispatch row (`track=None`, no `dlv-` id, `metadata_json='{}'`, `state='proposed'`) alongside one real deliverable, asserts the plain row is excluded and the deliverable still surfaces.

## Verification
- New test, run against pre-fix code (temporarily reverted `scripts/build_t0_state.py` via `git checkout`, test file untouched): **1 failed, 12 passed** — `test_reader_excludes_plain_dispatch_at_proposed` failed on current/main behavior, confirming RED on the documented bug.
- Same suite after restoring the fix: `python3 -m pytest tests/test_human_gate_queue.py -v` → **13 passed**.
- Full neighbor suite: `python3 -m pytest tests/test_human_gate_queue.py tests/test_build_t0_state.py tests/test_build_t0_state_register_reader.py tests/test_build_t0_state_central.py -v` → **61 passed**.
- `python3 -m py_compile scripts/build_t0_state.py tests/test_human_gate_queue.py` → OK.
- Unrelated pre-existing failure noted and confirmed NOT caused by this change: `tests/test_build_t0_state_exception_handling.py::TestRunsClean::test_build_t0_state_runs_clean_on_main` fails identically (`migration auto_apply failed: no such column: project_id`) on a clean `git stash` of this change — an environment/migration issue in this worktree, out of scope for this dispatch.
- **`t0_state.json` size, real measurement against the live `~/.vnx-data/vnx-dev/state` store** (not a projection): ran the actual builder (`PYTHONPATH=scripts/lib python3 scripts/build_t0_state.py --output <tmp file>`, cleaned up after):
  - **Before** (live file, generated 2026-09-03 07:32, pre-fix code): 516,848 bytes total; `human_gate_queue` section ≈90,024 bytes (724 items).
  - **After** (fixed reader, actual builder run 2026-09-03 12:47): 445,038 bytes total; `human_gate_queue` section 12,273 bytes (**54 items**, matching the real deliverable count).
  - Net: −71,810 bytes total (−13.9%), `human_gate_queue` section −86.4%.

## Open Items
None.

Dispatch-ID: 20260903-oi1609-p3-gate-queue-toont-dispatches
**Model**: sonnet
**Provider**: claude