### PR TITLE
fix(gate): thread task_class/read_only into phantom_guard so the review exemption fires (OI-1614)

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -447,12 +447,29 @@ def govern(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome:
     # check in dispatch_envelope._govern. Best-effort: never fatal to govern (a guard failure must
     # not lose the report). guard_at_govern abstains on an unresolvable ref (never false-rejects).
     try:
-        from phantom_guard import record_phantom_if_any  # noqa: PLC0415
+        from phantom_guard import PhantomDecisionContext, record_phantom_if_any  # noqa: PLC0415
         _tok = raw.token_usage or {}
         record_phantom_if_any(
             dispatch_id=spec.dispatch_id,
-            role=spec.role,
-            status=(raw.receipt.get("status") if isinstance(raw.receipt, dict) else None),
+            context=PhantomDecisionContext(
+                role=spec.role,
+                # OI-1614: GovernSpec already carries task_class (chain-link,
+                # dispatch-20260802-model-ssot-en-ketenlink) — it was simply never
+                # forwarded to the guard, which is why a research/review dispatch on
+                # the tmux lane's govern()-time backstop was rejected despite the
+                # guard's own task_class exemption being correct all along.
+                task_class=spec.task_class,
+                # No caller on this lane currently computes an explicit read_only
+                # signal — GovernSpec carries no such field. Explicit None (not an
+                # omitted keyword) records that this lane looked and found nothing,
+                # not that it forgot to ask (see PhantomDecisionContext docstring).
+                read_only=None,
+                status=(raw.receipt.get("status") if isinstance(raw.receipt, dict) else None),
+                # Not pre-captured on this lane (unlike the provider lane) —
+                # guard_at_govern resolves it below from worktree_path/base_sha (a
+                # LIVE worktree here, not yet torn down).
+                worktree_diff=None,
+            ),
             token_usage=(int(_tok.get("input", 0) or 0) + int(_tok.get("output", 0) or 0)) or None,
             worktree_path=spec.worktree_path,
             base_sha=spec.base_sha,

--- a/scripts/lib/envelope_govern.py
+++ b/scripts/lib/envelope_govern.py
@@ -545,7 +545,7 @@ def _govern(
     # a corrective failed receipt. worktree_path is unavailable on EnvelopeSpec, so the guard derives
     # the dispatch/<id> branch (isolated dispatches) or abstains (never false-rejects). Non-fatal.
     try:
-        from phantom_guard import record_phantom_if_any  # noqa: PLC0415
+        from phantom_guard import PhantomDecisionContext, record_phantom_if_any  # noqa: PLC0415
         _tok = adapter_result.token_usage or {}
         # Fix-forward: an empty own-worktree/dispatch-branch diff is falsely read as phantom when
         # the dispatch targets an existing PR (spec.pr_id) and pushed its commit onto THAT branch
@@ -553,12 +553,25 @@ def _govern(
         _effective_diff = _resolve_fix_forward_diff(spec, phantom_diff, base_ref=base_ref)
         record_phantom_if_any(
             dispatch_id=spec.dispatch_id,
-            role=spec.role,
-            status=_effective_status,
+            context=PhantomDecisionContext(
+                role=spec.role,
+                # OI-1614: EnvelopeSpec already carries task_class (threaded from the
+                # plan/DispatchSpec at PREPARE) — it was simply never forwarded to the
+                # guard, which is why a research/review dispatch on the provider lane
+                # was rejected despite the guard's own task_class exemption being
+                # correct all along.
+                task_class=spec.task_class,
+                # No provider-lane caller currently computes an explicit read_only
+                # signal — EnvelopeSpec carries no such field. Explicit None (not an
+                # omitted keyword) records that this lane looked and found nothing,
+                # not that it forgot to ask (see PhantomDecisionContext docstring).
+                read_only=None,
+                status=_effective_status,
+                worktree_diff=_effective_diff,  # F1: pre-captured before the worktree teardown
+            ),
             token_usage=(int(_tok.get("input", 0) or 0) + int(_tok.get("output", 0) or 0)) or None,
             worktree_path=None,
             base_sha=None,
-            worktree_diff=_effective_diff,  # F1: pre-captured before the worktree teardown
             receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
             state_dir=spec.state_dir,
         )

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -59,9 +59,27 @@ _LOG = logging.getLogger(__name__)
 # task_class="research_structured" (REVIEW_TASK_CLASSES below), but a role-based
 # reviewer belongs in the role SSOT too so a future caller that checks role alone
 # does not have to rediscover that.
+# OI-1614: "research-analyst" is a CANONICAL, T0-dispatched role
+# (.vnx/worker_permissions.yaml) with Edit/MultiEdit DENIED and file_write_scope
+# limited to the unified-reports drop — structurally incapable of producing a
+# worktree diff, the same permission shape as code-reviewer/plan-reviewer above.
+# It was simply missing. Cross-checked the rest of worker_permissions.yaml's
+# registered roles against this set while fixing it: quality-engineer,
+# frontend-developer, system-architect, security-engineer are documented "Build
+# role"s there (Edit/MultiEdit allowed, push-mandatory footer, expected to
+# deliver a real diff) — adding them here would suppress a genuine phantom for
+# those roles, so they stay out. dispatch_router.py's SKILL_TO_TASK_CLASS lists
+# a few more names (data-analyst, t0-orchestrator, architect, performance-
+# profiler) in its "research_structured" bucket, but none of those are in the
+# canonical worker_permissions.yaml registry — that file's own comment says
+# legacy/undispatched names are "NOT carried here: nobody dispatches them" — so
+# there is no live role behind them to add. A dispatch that genuinely carries
+# task_class="research_structured" for one of those names is still exempt via
+# REVIEW_TASK_CLASSES below; this set only adds a second, role-string key for
+# roles verified to exist and to be permission-locked out of writing.
 REVIEW_ROLES = frozenset({
     "plan-reviewer", "code-reviewer", "security-reviewer", "reviewer",
-    "deliberation-panelist", "review-gate",
+    "deliberation-panelist", "review-gate", "research-analyst",
 })
 
 # SSOT for review/analysis task_class values — a second key onto the same exemption for callers
@@ -78,6 +96,44 @@ REVIEW_TASK_CLASSES = frozenset({
 
 # Receipt status values that assert the work completed.
 COMPLETION_STATUSES = frozenset({"done", "success", "complete", "completed"})
+
+
+@dataclass(frozen=True)
+class PhantomDecisionContext:
+    """The decision-relevant fields the exemption logic reads — ``role``,
+    ``task_class``, ``read_only``, ``status``, ``worktree_diff`` — bundled into ONE
+    object so a lane cannot drop one by simply never writing its keyword (OI-1614).
+
+    Before this contract, ``record_phantom_if_any`` accepted these as five
+    independent keyword arguments with defaults. Each of the three call sites
+    (envelope_govern, dispatch_govern, tmux_interactive_dispatch) picked its own
+    subset — NONE of them passed ``task_class`` or ``read_only`` — and Python's
+    defaults silently supplied ``None`` for whatever a caller forgot, which the
+    decision function reads as "not exempt", not as "nobody asked". The pure
+    decision logic in ``_phantom_guard_decision`` was, and is, correct; the bug
+    was entirely upstream, in the signal never arriving.
+
+    All five fields are REQUIRED, with no default. Constructing
+    ``PhantomDecisionContext(role=x, task_class=y)`` and forgetting
+    ``read_only``/``status``/``worktree_diff`` is a ``TypeError`` at the call
+    site, not a silently-wrong verdict three call-stack frames away.
+
+    A lane that genuinely has no source for a field (e.g. no caller currently
+    computes ``read_only`` — see the three real construction sites) must still
+    say so EXPLICITLY (``read_only=None``) rather than omitting the keyword.
+    Explicit-``None`` and an omitted keyword read identically to the decision
+    logic today (both mean "not exempt via this signal"), but only the former is
+    visible to the call-site guard in
+    ``tests/test_phantom_guard_context_contract.py`` — an AST scan can only see
+    what a call site WROTE, not what a caller silently meant. That test fails
+    the moment a call site's inline ``PhantomDecisionContext(...)`` construction
+    drops one of these five keywords, whatever the reason.
+    """
+    role: Optional[str]
+    task_class: Optional[str]
+    read_only: Optional[bool]
+    status: Optional[str]
+    worktree_diff: Optional[str]
 
 
 @dataclass(frozen=True)
@@ -425,22 +481,28 @@ def guard_at_govern(
 def record_phantom_if_any(
     *,
     dispatch_id: str,
-    role: Optional[str] = None,
-    status: Optional[str] = None,
+    context: PhantomDecisionContext,
     token_usage: Optional[int] = None,
     worktree_path: Optional[Path] = None,
     base_sha: Optional[str] = None,
-    worktree_diff: Optional[str] = None,
     receipts_file: Optional[str] = None,
     state_dir: Optional[Path] = None,
-    task_class: Optional[str] = None,
-    read_only: Optional[bool] = None,
     work_ref: Optional[str] = None,
     pr_id: Optional[str] = None,
     parent_dispatch: Optional[str] = None,
     repo: Optional[Path] = None,
 ) -> PhantomVerdict:
     """``guard_at_govern`` + on a phantom verdict, append a corrective ``failed`` completion receipt.
+
+    OI-1614: ``role``/``status``/``task_class``/``read_only``/``worktree_diff`` — the
+    decision-relevant signals — travel as ONE required ``context``
+    (``PhantomDecisionContext``) instead of five independent optional keywords. See
+    that dataclass's docstring for why: a caller that forgets one no longer produces a
+    silently-wrong verdict, it produces a ``TypeError`` at the call site, and the
+    call-site AST guard (``tests/test_phantom_guard_context_contract.py``) additionally
+    fails the moment an inline construction of it drops a field. ``token_usage``
+    is corroborating detail only (never decision-relevant — see the module docstring)
+    and stays a plain keyword.
 
     The corrective receipt uses ``event_type="subprocess_completion"`` (one of the watchers'
     ACTIONABLE_EVENTS — codex F3: a custom ``phantom_rejected`` event_type is invisible to the live
@@ -456,9 +518,10 @@ def record_phantom_if_any(
     receipt. Degrades quietly on an unlinked dispatch; never fatal to the guard itself.
     """
     verdict = guard_at_govern(
-        dispatch_id=dispatch_id, role=role, status=status, token_usage=token_usage,
-        worktree_path=worktree_path, base_sha=base_sha, worktree_diff=worktree_diff,
-        task_class=task_class, read_only=read_only,
+        dispatch_id=dispatch_id, role=context.role, status=context.status,
+        token_usage=token_usage,
+        worktree_path=worktree_path, base_sha=base_sha, worktree_diff=context.worktree_diff,
+        task_class=context.task_class, read_only=context.read_only,
         work_ref=work_ref, pr_id=pr_id, parent_dispatch=parent_dispatch, repo=repo,
     )
     if verdict.is_phantom and state_dir:

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1328,12 +1328,29 @@ class TmuxInteractiveDispatch:
             return receipt
         try:
             import os  # noqa: PLC0415
-            from phantom_guard import record_phantom_if_any  # noqa: PLC0415
+            from phantom_guard import PhantomDecisionContext, record_phantom_if_any  # noqa: PLC0415
             _tok = pane_tokens or {}
             verdict = record_phantom_if_any(
                 dispatch_id=dispatch_id,
-                role=role,
-                status=receipt.get("status"),
+                context=PhantomDecisionContext(
+                    role=role,
+                    # OI-1614: this method's own signature carries no task_class param
+                    # (the tmux lane's dispatch() never learned one) — mirror the
+                    # VNX_TASK_CLASS env fallback already used for work_ref/pr_id/
+                    # parent_dispatch just below (the door's env, inherited by the
+                    # tmux pane), so a research/review dispatch is exempted here too,
+                    # not just in govern()'s later backstop.
+                    task_class=os.environ.get("VNX_TASK_CLASS") or None,
+                    # No caller on this lane currently computes an explicit read_only
+                    # signal. Explicit None (not an omitted keyword) records that this
+                    # lane looked and found nothing, not that it forgot to ask (see
+                    # PhantomDecisionContext docstring).
+                    read_only=None,
+                    status=receipt.get("status"),
+                    # Not pre-captured here — guard_at_govern resolves it below from
+                    # worktree_path/base_sha.
+                    worktree_diff=None,
+                ),
                 token_usage=(
                     int(_tok.get("input", 0) or 0) + int(_tok.get("output", 0) or 0)
                 ) or None,

--- a/tests/test_phantom_guard_context_contract.py
+++ b/tests/test_phantom_guard_context_contract.py
@@ -1,0 +1,374 @@
+"""tests/test_phantom_guard_context_contract.py — OI-1614: a call-site guard for
+phantom_guard.PhantomDecisionContext, mirroring tests/test_sessionstart_hook_beacon_health.py's
+AST-scan pattern (PR #1742, OI-1594) rather than inventing a new one.
+
+Defect this closes: ``phantom_guard.record_phantom_if_any`` accepted ``role``, ``status``,
+``task_class``, ``read_only``, ``worktree_diff`` as five independent keyword arguments with
+defaults. Each of the three lane call sites (scripts/lib/envelope_govern.py,
+scripts/lib/dispatch_govern.py, scripts/lib/tmux_interactive_dispatch.py) picked its own subset
+— NONE of them passed ``task_class`` or ``read_only`` — and Python's defaults silently supplied
+``None`` for whatever a caller forgot. The guard's own exemption rule
+(task_class="research_structured" or read_only=True exempts a no-diff completion) was, and is,
+correct; the bug was entirely upstream — a dispatch with role="research-analyst",
+task_class="research_structured" was rejected as a phantom because task_class never arrived.
+
+The fix (scripts/lib/phantom_guard.py) bundles the five decision-relevant fields into ONE
+required dataclass, ``PhantomDecisionContext``, with no defaults — a caller that forgets a
+field at construction gets a ``TypeError``, not a silently-wrong verdict. That is real
+protection, but it only fires when the code path actually EXECUTES (e.g. only on the rare
+review-role/empty-diff combination). This test is the STATIC backstop: an AST scan over every
+git-tracked call site of ``record_phantom_if_any``, checking that its ``context=`` argument is
+an INLINE ``PhantomDecisionContext(...)`` construction naming all five required fields as
+keywords — so a NEW, fourth lane that drops one is caught in CI before it ever runs, the same
+"catch the lane that doesn't exist yet" property the beacon test's call-site guard has for
+``all_beacons``/``beacon_summary``.
+
+Three fixture-tree test classes prove the mechanism can actually fail, mirroring
+TestCallSiteGuardCanActuallyFail in the beacon test: a dropped field, an entirely omitted
+``context=`` keyword (the literal historic bug — an omitted keyword, not a wrong value), and a
+non-inline (variable) ``context=`` value the scanner cannot verify statically all turn the
+assertion red with a clear message, never a silent pass.
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+LIB = REPO / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import phantom_guard as pg  # noqa: E402
+
+_TARGET_CALL = "record_phantom_if_any"
+_CONTEXT_CTOR = "PhantomDecisionContext"
+_REQUIRED_CONTEXT_FIELDS = frozenset({"role", "task_class", "read_only", "status", "worktree_diff"})
+_EXCLUDE_DIRS = frozenset({"tests"})
+
+
+def _git_tracked_py_files(root: Path) -> list[Path]:
+    """Absolute paths to every git-tracked ``.py`` file under ``root``.
+
+    Same property as the beacon test's identically-named helper (OI-1597): tracked-ness, not a
+    directory namelist, keeps a build artifact / nested worktree / CI rollout copy out of the
+    scan regardless of what it's named or where it lives. Fails CLOSED — raises ``RuntimeError``
+    — when git is unavailable, rather than silently falling back to an incomplete namelist.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--", "*.py"],
+            cwd=str(root), capture_output=True, timeout=10,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"git is not available to determine tracked .py files under {root}"
+        ) from exc
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"`git ls-files` failed under {root} (not a git work tree?): {stderr}")
+    stdout = result.stdout.decode("utf-8")
+    return [root / rel for rel in stdout.split("\0") if rel]
+
+
+def _call_target_name(node: ast.Call) -> Optional[str]:
+    """The bare callee name of an ast.Call — 'foo' for both foo(...) and mod.foo(...)."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _find_record_phantom_call_sites(
+    root: Path, exclude_dirs: frozenset[str] = _EXCLUDE_DIRS,
+) -> dict[str, list[ast.Call]]:
+    """Map of relative-path -> list of ast.Call nodes invoking record_phantom_if_any(...),
+    over the git-tracked .py files rooted at ``root``. A name that only appears in a
+    docstring/comment (e.g. this file's own module docstring above) is not a call site — an
+    AST scan for real ast.Call nodes can tell the two apart, a grep cannot (OI-1594).
+
+    An unparseable or non-UTF-8 file raises a clean AssertionError naming the file, instead of
+    letting the raw SyntaxError/UnicodeDecodeError traceback escape (OI-1597 advisory).
+    """
+    found: dict[str, list[ast.Call]] = {}
+    for full_path in _git_tracked_py_files(root):
+        rel = full_path.relative_to(root)
+        if any(part in exclude_dirs for part in rel.parts[:-1]):
+            continue
+        try:
+            source = full_path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(full_path))
+        except (SyntaxError, UnicodeDecodeError, ValueError) as exc:
+            raise AssertionError(
+                f"cannot parse {rel} while scanning for record_phantom_if_any call sites: {exc}"
+            ) from exc
+        calls = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and _call_target_name(node) == _TARGET_CALL
+        ]
+        if calls:
+            found[str(rel)] = calls
+    return found
+
+
+def _context_field_names(call: ast.Call, *, file_label: str) -> frozenset[str]:
+    """The keyword-argument names passed to the inline ``PhantomDecisionContext(...)``
+    supplied as this record_phantom_if_any(...) call's ``context=`` argument.
+
+    Fails LOUD (raises AssertionError), never returns an empty/partial result silently, in
+    the two cases a real regression would take:
+      1. ``context=`` is missing from the call entirely — the exact historic OI-1614 shape:
+         an argument the signature accepts but a caller never writes, silently defaulting.
+         (record_phantom_if_any's ``context`` parameter has NO default, so this would also be
+         a TypeError at runtime — this is the static, pre-runtime half of that protection.)
+      2. ``context=`` is present but its value is not an inline ``PhantomDecisionContext(...)``
+         call the scanner can read fields from (e.g. a bare variable) — the scanner refuses to
+         guess, rather than silently treating an unverifiable call site as compliant.
+    """
+    for kw in call.keywords:
+        if kw.arg == "context":
+            value = kw.value
+            if isinstance(value, ast.Call) and _call_target_name(value) == _CONTEXT_CTOR:
+                return frozenset(k.arg for k in value.keywords if k.arg is not None)
+            raise AssertionError(
+                f"{file_label}:{call.lineno}: record_phantom_if_any(context=...) is not an "
+                f"inline PhantomDecisionContext(...) construction — this guard cannot "
+                f"statically verify which decision-relevant fields it carries. Construct the "
+                f"context inline at the call site (see the three lane call sites for the "
+                f"pattern), or extend this guard to resolve the indirection."
+            )
+    raise AssertionError(
+        f"{file_label}:{call.lineno}: record_phantom_if_any(...) is missing the required "
+        f"context= keyword argument entirely — this is the exact OI-1614 defect this guard "
+        f"exists to catch (a decision-relevant signal silently never arriving at the guard)."
+    )
+
+
+_KNOWN_LANE_CALL_SITES = frozenset({
+    "scripts/lib/envelope_govern.py",
+    "scripts/lib/dispatch_govern.py",
+    "scripts/lib/tmux_interactive_dispatch.py",
+})
+
+
+class TestEveryCallSiteCarriesAllDecisionRelevantFields:
+    """The wachter: every real, git-tracked call site of record_phantom_if_any must construct
+    its context= inline with all five required keywords. This does not enumerate a fixed
+    baseline of files (unlike the beacon test's TestCallSiteCountDoesNotGrow) — a brand-new,
+    fourth lane that calls record_phantom_if_any is picked up automatically by the
+    git-tracked-.py scan and held to the same bar, without this test needing to be edited."""
+
+    def test_known_lane_call_sites_are_found(self):
+        sites = _find_record_phantom_call_sites(REPO)
+        missing = _KNOWN_LANE_CALL_SITES - set(sites)
+        assert not missing, f"expected call site(s) not found by the scan: {missing}"
+
+    def test_every_call_site_supplies_all_required_context_fields(self):
+        sites = _find_record_phantom_call_sites(REPO)
+        assert sites, "expected at least the three known lane call sites"
+        problems = []
+        for rel, calls in sites.items():
+            for call in calls:
+                fields = _context_field_names(call, file_label=rel)
+                missing = _REQUIRED_CONTEXT_FIELDS - fields
+                if missing:
+                    problems.append(f"{rel}:{call.lineno} missing={sorted(missing)}")
+        assert not problems, (
+            "call site(s) dropped a decision-relevant PhantomDecisionContext field:\n"
+            + "\n".join(problems)
+        )
+
+
+def _git_init(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=str(root), check=True)
+
+
+def _git_add(root: Path, *relative_paths: str) -> None:
+    subprocess.run(["git", "add", "--", *relative_paths], cwd=str(root), check=True)
+
+
+_GOOD_CALL_SITE = (
+    "from phantom_guard import PhantomDecisionContext, record_phantom_if_any\n"
+    "record_phantom_if_any(\n"
+    "    dispatch_id='d',\n"
+    "    context=PhantomDecisionContext(\n"
+    "        role=role, task_class=task_class, read_only=None,\n"
+    "        status=status, worktree_diff=diff,\n"
+    "    ),\n"
+    ")\n"
+)
+
+
+class TestCallSiteGuardCanActuallyFail:
+    """A wachter die niet kan falen, faalt stil. ``_find_record_phantom_call_sites`` and
+    ``_context_field_names`` are exercised directly against isolated fixture trees (never the
+    real repo) so this guard's MECHANISM is proven, not just today's three call sites."""
+
+    def test_a_compliant_call_site_passes(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "good.py").write_text(_GOOD_CALL_SITE, encoding="utf-8")
+        _git_add(tmp_path, "good.py")
+
+        sites = _find_record_phantom_call_sites(tmp_path)
+        for rel, calls in sites.items():
+            for call in calls:
+                fields = _context_field_names(call, file_label=rel)
+                assert not (_REQUIRED_CONTEXT_FIELDS - fields)
+
+    def test_a_dropped_field_turns_the_assertion_red(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "bad.py").write_text(
+            "from phantom_guard import PhantomDecisionContext, record_phantom_if_any\n"
+            "record_phantom_if_any(\n"
+            "    dispatch_id='d',\n"
+            "    context=PhantomDecisionContext(\n"
+            # task_class dropped — the exact shape of the real OI-1614 bug.
+            "        role=role, read_only=None, status=status, worktree_diff=diff,\n"
+            "    ),\n"
+            ")\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "bad.py")
+
+        sites = _find_record_phantom_call_sites(tmp_path)
+        problems = []
+        for rel, calls in sites.items():
+            for call in calls:
+                fields = _context_field_names(call, file_label=rel)
+                missing = _REQUIRED_CONTEXT_FIELDS - fields
+                if missing:
+                    problems.append((rel, missing))
+        assert problems == [("bad.py", frozenset({"task_class"}))]
+
+    def test_an_omitted_context_keyword_turns_the_assertion_red(self, tmp_path):
+        """The literal historic defect: context= never written at all (old-style flat
+        kwargs, or a call that simply forgot it), not a wrong value for it."""
+        _git_init(tmp_path)
+        (tmp_path / "bad.py").write_text(
+            "from phantom_guard import record_phantom_if_any\n"
+            "record_phantom_if_any(dispatch_id='d', role=role, status=status)\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "bad.py")
+
+        sites = _find_record_phantom_call_sites(tmp_path)
+        with pytest.raises(AssertionError, match="missing the required context"):
+            for rel, calls in sites.items():
+                for call in calls:
+                    _context_field_names(call, file_label=rel)
+
+    def test_a_non_inline_context_value_raises_a_clean_error_not_a_silent_pass(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "bad.py").write_text(
+            "from phantom_guard import record_phantom_if_any\n"
+            "ctx = build_context()\n"
+            "record_phantom_if_any(dispatch_id='d', context=ctx)\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "bad.py")
+
+        sites = _find_record_phantom_call_sites(tmp_path)
+        with pytest.raises(AssertionError, match="cannot statically verify"):
+            for rel, calls in sites.items():
+                for call in calls:
+                    _context_field_names(call, file_label=rel)
+
+    def test_a_docstring_mention_does_not_trip_it(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "mentions_only.py").write_text(
+            '"""Eventually calls record_phantom_if_any(context=...)."""\n'
+            "# see record_phantom_if_any for details\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "mentions_only.py")
+
+        sites = _find_record_phantom_call_sites(tmp_path)
+        assert sites == {}
+
+    def test_an_untracked_file_does_not_trip_it(self, tmp_path):
+        """A fourth-lane call site that exists on disk but was never `git add`-ed (a
+        build artifact, a nested worktree, a scratch file) is invisible to the scan —
+        same property the beacon test's guard relies on (OI-1597)."""
+        _git_init(tmp_path)
+        (tmp_path / "existing.py").write_text(_GOOD_CALL_SITE, encoding="utf-8")
+        _git_add(tmp_path, "existing.py")
+        baseline_files = set(_find_record_phantom_call_sites(tmp_path))
+
+        (tmp_path / "untracked_bad.py").write_text(
+            "from phantom_guard import record_phantom_if_any\n"
+            "record_phantom_if_any(dispatch_id='d')\n",
+            encoding="utf-8",
+        )
+        # Deliberately never git add-ed.
+        matched_files = set(_find_record_phantom_call_sites(tmp_path))
+        # AST nodes from two separate parses are never == to each other even for identical
+        # source, so this compares the set of matched FILES, not the ast.Call objects.
+        assert matched_files == baseline_files
+
+    def test_an_unparseable_file_gives_a_clean_assertion_not_a_traceback(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "broken.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+        _git_add(tmp_path, "broken.py")
+
+        with pytest.raises(AssertionError, match="broken.py"):
+            _find_record_phantom_call_sites(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Part 4: behavioral verdict test — the guard's OUTCOME, not the call-site shape.
+# A test that only asserted "task_class is in kwargs" would test this PR's own
+# mechanism and break on the next refactor; this asserts the actual PhantomVerdict.
+# ---------------------------------------------------------------------------
+
+
+class TestResearchDispatchIsNeverPhantom:
+    """The concrete OI-1614 incident, replayed through record_phantom_if_any end to end
+    (not the pure phantom_guard() decision alone, which was already correct and already
+    covered by test_phantom_guard.py — this proves the WIRING is correct too)."""
+
+    def test_research_analyst_role_with_research_structured_task_class_is_not_phantom(
+        self, tmp_path,
+    ):
+        # The measured real dispatch: role='research-analyst', task_class='research_structured',
+        # status='success', worktree_diff='', token_usage=28428. A non-phantom verdict never
+        # touches the corrective-receipt append path, so no mocking of append_receipt is needed.
+        verdict = pg.record_phantom_if_any(
+            dispatch_id="20260903-oi1609-wie-schuift-de-state-op-r2",
+            context=pg.PhantomDecisionContext(
+                role="research-analyst",
+                task_class="research_structured",
+                read_only=None,
+                status="success",
+                worktree_diff="",
+            ),
+            token_usage=28428,
+            receipts_file=str(tmp_path / "r.ndjson"),
+        )
+        assert not verdict.is_phantom, verdict.reason
+
+    def test_research_analyst_role_alone_is_not_phantom_even_without_task_class(self):
+        # Defense in depth: the role-string exemption (REVIEW_ROLES) must hold even if a
+        # future caller somehow fails to thread task_class — the two signals are independent.
+        verdict = pg.phantom_guard(
+            status="success", worktree_diff="", token_usage=28428, role="research-analyst",
+        )
+        assert not verdict.is_phantom, verdict.reason
+
+    def test_an_actual_delivery_failure_with_the_same_shape_is_still_phantom(self):
+        """Guard rail: this fix must not blanket-exempt every empty-diff completion — a
+        genuine backend-developer delivery failure with the same status/diff shape must
+        still be rejected."""
+        verdict = pg.phantom_guard(
+            status="success", worktree_diff="", token_usage=28428, role="backend-developer",
+        )
+        assert verdict.is_phantom, verdict.reason
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_phantom_guard_inline.py
+++ b/tests/test_phantom_guard_inline.py
@@ -12,6 +12,14 @@ import phantom_guard as pg
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 
+def _ctx(role="backend-developer", status="done", task_class=None, read_only=None,
+         worktree_diff=None):
+    return pg.PhantomDecisionContext(
+        role=role, task_class=task_class, read_only=read_only,
+        status=status, worktree_diff=worktree_diff,
+    )
+
+
 def test_guard_at_govern_abstains_on_unresolvable_ref():
     # an unresolvable branch/worktree must ABSTAIN (ok), never false-reject as "empty diff"
     v = pg.guard_at_govern(dispatch_id="no-such-dispatch-xyz", role="backend-developer",
@@ -35,8 +43,13 @@ def test_record_phantom_appends_corrective_failed_receipt(monkeypatch, tmp_path)
     captured = {}
     monkeypatch.setattr(append_receipt, "append_receipt_payload",
                         lambda payload, **kw: captured.update(payload=payload, kw=kw))
-    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
-                                 receipts_file=str(tmp_path / "r.ndjson"))
+    v = pg.record_phantom_if_any(
+        dispatch_id="d1",
+        context=pg.PhantomDecisionContext(
+            role="backend-developer", task_class=None, read_only=None,
+            status="done", worktree_diff=None,
+        ),
+        receipts_file=str(tmp_path / "r.ndjson"))
     assert v.is_phantom
     assert captured["payload"]["status"] == "failed"
     assert captured["payload"]["phantom_rejected"] is True
@@ -87,10 +100,14 @@ def test_record_phantom_threads_task_class_and_read_only(monkeypatch, tmp_path):
         return pg.PhantomVerdict(False, "ok")
 
     monkeypatch.setattr(pg, "guard_at_govern", _fake_guard_at_govern)
-    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
-                                 token_usage=987, worktree_diff="",
-                                 receipts_file=str(tmp_path / "r.ndjson"),
-                                 task_class="review", read_only=None)
+    v = pg.record_phantom_if_any(
+        dispatch_id="d1",
+        context=pg.PhantomDecisionContext(
+            role="backend-developer", task_class="review", read_only=None,
+            status="done", worktree_diff="",
+        ),
+        token_usage=987,
+        receipts_file=str(tmp_path / "r.ndjson"))
     assert not v.is_phantom
     assert captured["task_class"] == "review"
     assert captured["read_only"] is None
@@ -112,7 +129,7 @@ def test_record_phantom_no_append_when_not_phantom(monkeypatch, tmp_path):
     calls = {"n": 0}
     monkeypatch.setattr(append_receipt, "append_receipt_payload",
                         lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
-    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+    v = pg.record_phantom_if_any(dispatch_id="d1", context=_ctx(),
                                  receipts_file=str(tmp_path / "r.ndjson"))
     assert not v.is_phantom
     assert calls["n"] == 0
@@ -128,7 +145,7 @@ def test_record_phantom_append_failure_is_non_fatal(monkeypatch, tmp_path):
         raise RuntimeError("append exploded")
 
     monkeypatch.setattr(append_receipt, "append_receipt_payload", _boom)
-    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+    v = pg.record_phantom_if_any(dispatch_id="d1", context=_ctx(),
                                  receipts_file=str(tmp_path / "r.ndjson"))
     assert v.is_phantom  # verdict still returned, no exception escaped
 
@@ -145,7 +162,7 @@ def test_record_phantom_calls_gate_findings_bridge(monkeypatch, tmp_path):
         gate_findings_bridge, "record_gate_finding",
         lambda state_dir, **kw: captured.update(state_dir=state_dir, kw=kw) or True,
     )
-    pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+    pg.record_phantom_if_any(dispatch_id="d1", context=_ctx(),
                              receipts_file=str(tmp_path / "r.ndjson"), state_dir=tmp_path)
     assert captured["state_dir"] == tmp_path
     assert captured["kw"]["dispatch_id"] == "d1"
@@ -163,7 +180,7 @@ def test_record_phantom_bridge_failure_is_non_fatal(monkeypatch, tmp_path):
         raise RuntimeError("db locked")
 
     monkeypatch.setattr(gate_findings_bridge, "record_gate_finding", _boom)
-    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+    v = pg.record_phantom_if_any(dispatch_id="d1", context=_ctx(),
                                  receipts_file=str(tmp_path / "r.ndjson"), state_dir=tmp_path)
     assert v.is_phantom  # verdict unaffected by a bridge failure
 
@@ -180,7 +197,7 @@ def test_record_phantom_no_bridge_call_without_state_dir(monkeypatch, tmp_path):
         gate_findings_bridge, "record_gate_finding",
         lambda *a, **k: calls.__setitem__("n", calls["n"] + 1),
     )
-    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+    v = pg.record_phantom_if_any(dispatch_id="d1", context=_ctx(),
                                  receipts_file=str(tmp_path / "r.ndjson"))
     assert v.is_phantom
     assert calls["n"] == 0
@@ -199,7 +216,7 @@ def test_record_phantom_no_append_when_not_phantom_never_gets_a_failure_reason(m
     calls = {"n": 0}
     monkeypatch.setattr(append_receipt, "append_receipt_payload",
                         lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
-    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+    v = pg.record_phantom_if_any(dispatch_id="d1", context=_ctx(),
                                  receipts_file=str(tmp_path / "r.ndjson"))
     assert not v.is_phantom
     assert calls["n"] == 0

--- a/tests/test_tmux_fail_loud_empty_extraction.py
+++ b/tests/test_tmux_fail_loud_empty_extraction.py
@@ -103,7 +103,9 @@ class TestFailLoudOnEmptyExtractionUnit(_BaseCase):
         mock_guard.assert_called_once()
         call_kwargs = mock_guard.call_args.kwargs
         self.assertEqual(call_kwargs["dispatch_id"], self.DISPATCH_ID)
-        self.assertEqual(call_kwargs["status"], "done")
+        # OI-1614: role/status/task_class/read_only/worktree_diff travel bundled in
+        # one PhantomDecisionContext now, not as flat kwargs — see phantom_guard.py.
+        self.assertEqual(call_kwargs["context"].status, "done")
         self.assertEqual(call_kwargs["token_usage"], 231)
         self.assertEqual(call_kwargs["receipts_file"], str(self.receipts_file))
         self.assertEqual(call_kwargs["state_dir"], self.state_dir)
@@ -164,7 +166,7 @@ class TestFailLoudOnEmptyExtractionUnit(_BaseCase):
                 worktree_path=None,
                 base_sha=None,
             )
-        self.assertEqual(mock_guard.call_args.kwargs["role"], "plan-reviewer")
+        self.assertEqual(mock_guard.call_args.kwargs["context"].role, "plan-reviewer")
         self.assertEqual(result["status"], "done")
 
     def test_guard_error_is_non_fatal_receipt_passthrough(self):


### PR DESCRIPTION
## Summary
- `phantom_guard`'s exemption rule was correct (`task_class="research_structured"` or `read_only=True` already exempts a no-diff completion) but the signal never arrived: none of the three lane call sites (`envelope_govern.py`, `dispatch_govern.py`, `tmux_interactive_dispatch.py`) forwarded `task_class`/`read_only` to `record_phantom_if_any` — every dispatch reached the guard as if only `role` had been asked about. The measured incident: dispatch `20260903-oi1609-wie-schuift-de-state-op-r2`, `role='research-analyst'`, was rejected `failed` despite being a legitimate 163-line research report.
- Bundled the five decision-relevant fields (`role`, `task_class`, `read_only`, `status`, `worktree_diff`) into one required `PhantomDecisionContext` dataclass with no defaults — a lane that drops a field now gets a `TypeError` at construction, not a silently-wrong verdict.
- Added an AST call-site guard (`tests/test_phantom_guard_context_contract.py`, mirroring `test_sessionstart_hook_beacon_health.py`'s pattern) that scans every git-tracked call site of `record_phantom_if_any` and fails if its inline `PhantomDecisionContext(...)` construction drops a required keyword — catching a future fourth lane automatically, not just today's three.
- Added `"research-analyst"` to `REVIEW_ROLES`: it's a canonical, T0-dispatched role in `.vnx/worker_permissions.yaml` with `Edit`/`MultiEdit` denied and `file_write_scope` limited to the report drop — structurally incapable of producing a diff, same shape as `code-reviewer`/`plan-reviewer` already in the set.

## Cross-checked but NOT changed (documented in code)
- Cross-referenced `dispatch_router.py`'s `SKILL_TO_TASK_CLASS` research_structured/docs_synthesis bucket against the canonical `.vnx/worker_permissions.yaml` registry. `quality-engineer`/`frontend-developer`/`system-architect`/`security-engineer` are documented "Build role"s there (Edit/MultiEdit allowed, push-mandatory) — adding them to `REVIEW_ROLES` would suppress a genuine phantom for those roles, so they stay out. `data-analyst`/`t0-orchestrator`/`architect`/`performance-profiler` aren't in the canonical registry at all (that file's own comment: legacy names "nobody dispatches").
- `worktree_diff` is pre-captured at only one of the three lanes (`envelope_govern`, which resolves fix-forward via its own `_resolve_fix_forward_diff` before calling the guard); the other two pass `worktree_diff=None` and rely on `guard_at_govern`'s `worktree_path`/`base_sha` fallback. Measured deliberate, not a bug — `envelope_govern`'s pre-resolution already produces the final diff.
- `work_ref`/`pr_id`/`parent_dispatch` are passed by 2 of 3 lanes (not `envelope_govern`, for the same reason above — its diff is already fix-forward-resolved by the time it reaches the guard).
- `read_only` has no source anywhere in the fabric yet (no `DispatchSpec` field, no plan/spec threading) — all three lanes now pass `read_only=None` explicitly (not omitted), documented per-site.

## Test plan
- [x] `tests/test_phantom_guard_context_contract.py` (new, 12 tests): AST call-site guard + fixture-tree "can it fail" tests + behavioral verdict tests for the concrete incident — all green.
- [x] Proved the guard can go red: temporarily dropped `task_class=` from the real `envelope_govern.py` call site → `test_every_call_site_supplies_all_required_context_fields` failed with `scripts/lib/envelope_govern.py:554 missing=['task_class']`; restored → green again.
- [x] `tests/test_phantom_guard.py`, `test_phantom_guard_inline.py` (8 call sites updated to the new `context=` signature), `test_phantom_guard_fix_forward.py`, `test_phantom_guard_branch_fallback.py`, `test_phantom_guard_work_ref.py`, `test_phantom_guard_oi869_oi870.py`, `test_guard_stats.py`, `test_tmux_fail_loud_empty_extraction.py` (kwargs assertions updated for the context bundle), `test_dispatch_envelope_characterization.py`, `test_role_applied_provider_lane.py`, `test_subprocess_dispatch_govern.py`, `test_tmux_interactive_dispatch_metadata.py`, `test_tmux_interactive_dispatch.py`, `test_dispatch_govern.py`, `test_provider_dispatch_governance_integration.py`, `test_review_gate_role.py`, `test_deliberation_panelist_role.py` — 568 passed, 0 failed.
- [x] `python3 -m py_compile` on all edited files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)