### PR TITLE
fix(sec): scrub secrets from claude subprocess env + enforce trace-token gate

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -330,9 +330,18 @@ jobs:
           rsync -a --exclude '.git' --exclude '.claude' ./ "$GITHUB_WORKSPACE/.claude/vnx-system/"
 
       - name: Run trace token validation
+        # ENFORCED since 2026-09-03 (was shadow/WARN — a required context that could
+        # never fail). Safe to flip without a separate ratchet mechanism: the script
+        # only validates MERGE_BASE..HEAD (this PR's own new commits, via
+        # ci_trace_token_check.sh's `git log "$MERGE_BASE..HEAD"`), never main's
+        # existing history — a push event to main resolves MERGE_BASE==HEAD (empty
+        # range), so already-merged commits are structurally never re-litigated.
+        # Baseline measured against origin/main @ 065939fa: 41/150 (27.3%) of recent
+        # commits and 860/2130 (40.4%) of all commits would fail if re-checked, which
+        # is exactly why this only gates NEW commits going forward, not history.
         env:
           VNX_HOME: ${{ github.workspace }}/.claude/vnx-system
-          VNX_PROVENANCE_ENFORCEMENT: "0"
+          VNX_PROVENANCE_ENFORCEMENT: "1"
           VNX_PROVENANCE_LEGACY_ACCEPTED: "1"
         run: |
           set -euo pipefail
@@ -375,6 +384,28 @@ jobs:
           rsync -a --exclude '.git' --exclude '.claude' ./ "$GITHUB_WORKSPACE/.claude/vnx-system/"
 
       - name: Run Dispatch-ID slug-match gate
+        # STAYS shadow/WARN (deliberately, not an oversight) — measured 2026-09-03:
+        # this job's own branch_slug() cannot pass for this fleet's actual branch
+        # convention. BRANCH_PREFIX_RE (scripts/check_ci_slug_match.py) strips
+        # fix/feat/feature/test/docs/chore/refactor/hotfix/perf/ci/build/revert but
+        # NOT "dispatch/" — the prefix on 15/15 of the most recent merged PRs' head
+        # branches (`gh pr list --state merged --json headRefName`). Even with that
+        # fixed, branch_slug() doesn't strip the embedded YYYYMMDD date the way
+        # dispatch_id_slug() does for the Dispatch-ID side, so the two slugs still
+        # wouldn't compare like-for-like. And some real, currently-used Dispatch-IDs
+        # (the YYYYMMDD-HHMMSS-<slug> shape with no trailing track letter, e.g.
+        # PR #1740's branch) don't match either DISPATCH_ID_EXTRACT_RE or
+        # DISPATCH_ID_EXTRACT_LEGACY_RE at all — dispatch_id_slug() returns None,
+        # and CommitResult.all_slugs_match treats that as a hard failure, not a
+        # skip. Enforcing today would fail effectively every fleet PR, not just the
+        # ~27-40% trace-token-check would flag — the "ratchet" fix that worked for
+        # that job (flip the env var; the merge-base delta already grandfathers
+        # history) does not apply here, because this job's failures would be on
+        # brand-new commits too, not just old ones. Fixing branch_slug()/
+        # dispatch_id_slug() properly is a separate, larger PR; recommendation for
+        # this one is to drop this context from branch-protection's required-checks
+        # list (operator action — not done here) so its WARN-only status stops
+        # reading as a check that could ever fail.
         env:
           VNX_HOME: ${{ github.workspace }}/.claude/vnx-system
           GITHUB_HEAD_REF: ${{ github.head_ref }}

--- a/scripts/lib/adapters/claude_adapter.py
+++ b/scripts/lib/adapters/claude_adapter.py
@@ -117,6 +117,7 @@ class ClaudeAdapter(ProviderAdapter):
         Useful for callers that want raw event access.  Does not write receipts
         or handle retries — use execute() for full lifecycle management.
         """
+        from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS  # noqa: PLC0415
         from subprocess_adapter import SubprocessAdapter  # noqa: PLC0415
         from subprocess_dispatch import (  # noqa: PLC0415
             _inject_skill_context,
@@ -147,6 +148,7 @@ class ClaudeAdapter(ProviderAdapter):
             instruction=full_instruction,
             model=model,
             cwd=agent_cwd,
+            scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS,
         )
         if not result.success:
             return

--- a/scripts/lib/env_scrub_patterns.py
+++ b/scripts/lib/env_scrub_patterns.py
@@ -1,0 +1,35 @@
+"""env_scrub_patterns.py — the default set of env-var name patterns to strip from a
+claude subprocess's environment before Popen.
+
+Measured gap (2026-09-03): SubprocessAdapter.deliver() and spawn_claude() accept a
+``scrub_env_keys`` parameter, but only the DeepSeek- and GLM-harness lanes ever passed
+it (their own ``_HARNESS_SCRUB_KEYS``, an exact-name frozenset scoped to their own
+account-safety concern). Every other production spawn path — the default headless lane
+(envelope_adapters_claude.py), the terminal-pinned subprocess lane
+(subprocess_dispatch_internals/delivery.py), the benchmark path (provider_dispatch.py),
+and the direct-deliver stream_events() path (adapters/claude_adapter.py) — passed
+``None``, so the worker subprocess inherited the FULL ambient environment, secrets
+included (``VNX_SMTP_PASS`` measured present in-process).
+
+These are glob PATTERNS (matched with ``fnmatch.fnmatchcase`` against each env var name
+in SubprocessAdapter.deliver(), not exact keys) — a literal name with no wildcard chars
+still matches only itself. ``CLAUDE_CODE_OAUTH_TOKEN``, ``ANTHROPIC_API_KEY``,
+``ANTHROPIC_AUTH_TOKEN`` and ``VNX_SMTP_PASS`` are already covered by the ``*_TOKEN``/
+``*_KEY``/``*_PASS`` globs below; they are listed explicitly anyway so they stay
+scrubbed even if the glob set is narrowed later — the first three because an inherited
+value can silently displace a valid CLI login ahead of it in the auth precedence order
+(measured 2026-08-31), not only because they are secrets.
+"""
+from __future__ import annotations
+
+DEFAULT_SCRUB_KEY_PATTERNS: frozenset = frozenset({
+    "*_PASS",
+    "*_PASSWORD",
+    "*_SECRET",
+    "*_TOKEN",
+    "*_KEY",
+    "VNX_SMTP_PASS",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+})

--- a/scripts/lib/envelope_adapters_claude.py
+++ b/scripts/lib/envelope_adapters_claude.py
@@ -119,6 +119,7 @@ class ClaudeSubprocessAdapter:
         event_writer: Optional[Callable] = None,
         cwd: Optional[Path] = None,
     ) -> _AdapterResult:
+        from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS  # noqa: PLC0415
         from provider_spawns.claude_spawn import spawn_claude  # noqa: PLC0415
 
         try:
@@ -131,6 +132,7 @@ class ClaudeSubprocessAdapter:
                 cwd=cwd,
                 role=spec.role,
                 total_deadline=float(spec.deadline_seconds),
+                scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS,
             )
         except BrokenPipeError as exc:
             return _AdapterResult(

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1639,6 +1639,7 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
     `no-anthropic-sdk` intact) → governed report via _emit_governance. NOTE: post the
     2026-06-15 subscription-escape cutover this bills API credits, not the subscription.
     """
+    from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS
     from provider_spawns.claude_spawn import spawn_claude
 
     event_store = None
@@ -1705,6 +1706,7 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
             event_writer=event_store.append if event_store is not None else None,
             total_deadline=total_deadline,
             requires_mcp=getattr(args, "requires_mcp", False),
+            scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS,
         )
         end_time = datetime.now(timezone.utc)
 

--- a/scripts/lib/provider_spawns/claude_spawn.py
+++ b/scripts/lib/provider_spawns/claude_spawn.py
@@ -104,7 +104,7 @@ def spawn_claude(
     total_deadline: float = 900.0,
     role: Optional[str] = None,
     requires_mcp: bool = False,
-    scrub_env_keys: Optional[frozenset] = None,
+    scrub_env_keys: frozenset,
     **kwargs: Any,
 ) -> ClaudeSpawnResult:
     """Spawn ``claude -p --output-format stream-json`` and consume the event stream.
@@ -165,6 +165,18 @@ def spawn_claude(
     total_deadline:
         Max total seconds for the entire dispatch.  Override with
         ``VNX_TOTAL_DEADLINE`` env var.
+    scrub_env_keys:
+        REQUIRED, no default. fnmatch-style glob patterns removed from the child
+        env before Popen (see subprocess_adapter.SubprocessAdapter.deliver and
+        env_scrub_patterns.DEFAULT_SCRUB_KEY_PATTERNS). A caller that spawns a real
+        claude subprocess must pass the default set explicitly; a caller that
+        intentionally wants no scrubbing (e.g. a test that mocks SubprocessAdapter
+        out entirely) must pass ``frozenset()`` explicitly. There is no safe
+        implicit default — measured 2026-09-03: three of five production callers
+        silently forwarded the full ambient environment, secrets included, because
+        the old ``None`` default made omission invisible.
+        tests/test_spawn_scrub_env_keys_contract.py statically enforces that every
+        git-tracked, non-test call site supplies this keyword.
     **kwargs:
         Accepted for forward-compatibility; ignored.
     """

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -16,6 +16,7 @@ BILLING SAFETY: Only calls subprocess.Popen(["claude", ...]). No Anthropic SDK.
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
 import os
@@ -301,6 +302,15 @@ class SubprocessAdapter:
         the agent's project directory (e.g. agents/{role}/) so the headless
         process has the right working context.
 
+        scrub_env_keys: fnmatch-style glob patterns (matched with
+        ``fnmatch.fnmatchcase`` against each env var NAME, e.g. ``"*_TOKEN"``) removed
+        from the merged environment before Popen. A literal name with no wildcard
+        matches only itself, so exact-key sets (e.g. the harness lanes'
+        ``_HARNESS_SCRUB_KEYS``) keep working unchanged. See env_scrub_patterns.py for
+        the shared default set; callers that spawn a real claude subprocess should pass
+        it explicitly rather than relying on the ``None`` default (no scrub) — see
+        tests/test_spawn_scrub_env_keys_contract.py for the enforced call-site contract.
+
         extra_cli_args: if provided, these flags are inserted into the claude
         argv after the standard flags and before --resume/instruction.  Used by
         the DeepSeek-harness lane to force MCP off
@@ -389,8 +399,13 @@ class SubprocessAdapter:
                 merged_env.update({k: v for k, v in extra_env.items() if v is not None})
             if dispatch_id:
                 merged_env["VNX_CURRENT_DISPATCH_ID"] = dispatch_id
-            for _scrub_key in (scrub_env_keys or ()):
-                merged_env.pop(_scrub_key, None)
+            if scrub_env_keys:
+                for _existing_key in list(merged_env.keys()):
+                    if any(
+                        fnmatch.fnmatchcase(_existing_key, _pattern)
+                        for _pattern in scrub_env_keys
+                    ):
+                        merged_env.pop(_existing_key, None)
             popen_kwargs["env"] = merged_env
 
         # Clear stale session_id before spawning; updated when the init event arrives.

--- a/scripts/lib/subprocess_dispatch_internals/delivery.py
+++ b/scripts/lib/subprocess_dispatch_internals/delivery.py
@@ -315,6 +315,7 @@ def deliver_via_subprocess(
     prior_round_finding) fire in IntelligenceSelector.select() during assembly.
     """
     import subprocess_dispatch as _sd
+    from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS
     from provider_spawns.claude_spawn import spawn_claude
 
     chunk_timeout, total_deadline = apply_runtime_overrides(chunk_timeout, total_deadline)
@@ -381,6 +382,7 @@ def deliver_via_subprocess(
             total_deadline=total_deadline,
             role=role,
             requires_mcp=requires_mcp,
+            scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS,
         )
         # Give the silence heartbeat thread access to the adapter so it can
         # kill the worker process on silence timeout (OI-944 / OI-1007).

--- a/tests/test_claude_spawn.py
+++ b/tests/test_claude_spawn.py
@@ -93,6 +93,7 @@ class TestSpawnClaudeAccumulatesCompletionText:
             return_value=adapter_mock,
         ):
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="write add function",
                 model="sonnet",
                 dispatch_id="test-spawn-001",
@@ -113,6 +114,7 @@ class TestSpawnClaudeAccumulatesCompletionText:
             return_value=adapter_mock,
         ):
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="write foo",
                 model="haiku",
                 dispatch_id="test-spawn-002",
@@ -134,6 +136,7 @@ class TestSpawnClaudeAccumulatesCompletionText:
             return_value=adapter,
         ):
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="write something",
                 model="sonnet",
                 dispatch_id="test-spawn-003",
@@ -152,6 +155,7 @@ class TestSpawnClaudeAccumulatesCompletionText:
             return_value=adapter_mock,
         ):
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="noop",
                 model="haiku",
                 dispatch_id="test-spawn-004",

--- a/tests/test_claude_spawn_byte_identity.py
+++ b/tests/test_claude_spawn_byte_identity.py
@@ -86,6 +86,7 @@ class TestClaudeSpawnMatchesLegacyEventShape:
             MockAdapter.return_value = _make_adapter_mock(_MINIMAL_EVENTS)
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -114,6 +115,7 @@ class TestClaudeSpawnMatchesLegacyEventShape:
             )
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -135,6 +137,7 @@ class TestClaudeSpawnHandlesCompletion:
             MockAdapter.return_value = _make_adapter_mock(_MINIMAL_EVENTS)
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -152,6 +155,7 @@ class TestClaudeSpawnHandlesCompletion:
             MockAdapter.return_value = _make_adapter_mock(_MINIMAL_EVENTS)
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -180,6 +184,7 @@ class TestClaudeSpawnHandlesPrematureExit:
             )
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -198,6 +203,7 @@ class TestClaudeSpawnHandlesPrematureExit:
             )
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -225,6 +231,7 @@ class TestClaudeSpawnHealthMonitorIntegration:
             MockAdapter.return_value = _make_adapter_mock(_MINIMAL_EVENTS)
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -251,6 +258,7 @@ class TestClaudeSpawnHealthMonitorIntegration:
             MockAdapter.return_value = adapter_mock
 
             spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -283,6 +291,7 @@ class TestClaudeSpawnOnEventCallback:
             MockAdapter.return_value = adapter_mock
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -300,6 +309,7 @@ class TestClaudeSpawnOnEventCallback:
             MockAdapter.return_value = _make_adapter_mock(_MINIMAL_EVENTS)
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-dispatch",
@@ -328,6 +338,7 @@ class TestClaudeSpawnDeliverFailure:
             MockAdapter.return_value = instance
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="test",
                 model="sonnet",
                 dispatch_id="test-dispatch",

--- a/tests/test_claude_spawn_fail_closed.py
+++ b/tests/test_claude_spawn_fail_closed.py
@@ -67,6 +67,7 @@ class TestClaudeSpawnFailClosed:
             MockAdapter.return_value = adapter_mock
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="test",
                 model="sonnet",
                 dispatch_id="test-fail-closed",
@@ -85,6 +86,7 @@ class TestClaudeSpawnFailClosed:
             MockAdapter.return_value = adapter_mock
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="test",
                 model="sonnet",
                 dispatch_id="test-fail-closed-zero-rc",
@@ -103,6 +105,7 @@ class TestClaudeSpawnFailClosed:
             MockAdapter.return_value = adapter_mock
 
             spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="test",
                 model="sonnet",
                 dispatch_id="test-fail-closed",
@@ -120,6 +123,7 @@ class TestClaudeSpawnFailClosed:
 
             with patch("provider_spawns.claude_spawn.logger") as mock_logger:
                 spawn_claude(
+                    scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                     prompt="test",
                     model="sonnet",
                     dispatch_id="test-fail-closed",
@@ -140,6 +144,7 @@ class TestClaudeSpawnFailClosed:
             MockAdapter.return_value = adapter_mock
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="test",
                 model="sonnet",
                 dispatch_id="test-fail-closed",
@@ -155,6 +160,7 @@ class TestClaudeSpawnFailClosed:
             MockAdapter.return_value = _make_adapter_mock(_MINIMAL_EVENTS, returncode=0)
 
             result = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="Reply OK.",
                 model="sonnet",
                 dispatch_id="test-regression-ok",

--- a/tests/test_spawn_scrub_env_keys_contract.py
+++ b/tests/test_spawn_scrub_env_keys_contract.py
@@ -1,0 +1,373 @@
+"""tests/test_spawn_scrub_env_keys_contract.py — a call-site guard for the
+``scrub_env_keys`` parameter on ``spawn_claude()`` / ``SubprocessAdapter.deliver()``,
+mirroring tests/test_phantom_guard_context_contract.py's AST-scan pattern (PR #1748,
+OI-1614) rather than inventing a new one.
+
+Defect this closes: ``scrub_env_keys`` was accepted by both ``spawn_claude()``
+(provider_spawns/claude_spawn.py) and the lower-level ``SubprocessAdapter.deliver()``
+(subprocess_adapter.py) with a default of ``None`` (no scrubbing). Only the DeepSeek-
+and GLM-harness lanes ever passed it (their own account-safety-scoped
+``_HARNESS_SCRUB_KEYS``). The two DEFAULT production claude lanes — headless
+(envelope_adapters_claude.py, the default for `claude`/`claude_headless`) and
+terminal-pinned subprocess (subprocess_dispatch_internals/delivery.py,
+``VNX_ADAPTER_T{n}=subprocess``) — plus the benchmark path (provider_dispatch.py) and
+the direct-``deliver()`` stream_events() path (adapters/claude_adapter.py) all silently
+forwarded the FULL ambient environment to the worker subprocess. Measured 2026-09-03:
+``VNX_SMTP_PASS`` (present in-process, 19 chars) would cross that boundary ungated.
+
+The fix (provider_spawns/claude_spawn.py) makes ``scrub_env_keys`` a required
+keyword-only parameter on ``spawn_claude()`` — no default, so a caller that forgets it
+gets a ``TypeError`` at call time, not a silently-unscrubbed subprocess. That protects
+every ``spawn_claude()`` caller, but ``SubprocessAdapter.deliver()`` itself stays
+optional (many existing tests call it directly for reasons unrelated to env-scrubbing,
+and it is a lower-level primitive — same two-tier shape as ``phantom_guard()`` staying
+optional while ``record_phantom_if_any()``'s ``context`` became mandatory). A caller
+that reaches ``SubprocessAdapter.deliver()`` directly, bypassing ``spawn_claude()``
+entirely (adapters/claude_adapter.py's ``stream_events()``), is NOT covered by that
+runtime TypeError. This test is the STATIC backstop for both shapes: an AST scan over
+every git-tracked, non-test call site of ``spawn_claude(...)`` OR
+``<SubprocessAdapter-instance>.deliver(...)``, checking that ``scrub_env_keys=`` is
+present and not the literal ``None`` — so a new lane that drops it is caught in CI
+before it ever spawns a subprocess, the same "catch the lane that doesn't exist yet"
+property the phantom-guard test's call-site guard has.
+
+Fixture-tree test classes prove the mechanism can actually fail, mirroring
+TestCallSiteGuardCanActuallyFail in the phantom-guard test: a missing keyword, an
+explicit ``scrub_env_keys=None``, and a receiver that is provably NOT a
+SubprocessAdapter instance (so a same-named ``.deliver()`` method on an unrelated class
+— TmuxAdapter, RuntimeFacade, HeadlessTransportAdapter, LocalSessionAdapter all define
+one — is correctly ignored rather than flagged as a false positive).
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+LIB = REPO / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+_SPAWN_CLAUDE_TARGET = "spawn_claude"
+_DELIVER_TARGET = "deliver"
+_ADAPTER_CTOR = "SubprocessAdapter"
+_SCRUB_KWARG = "scrub_env_keys"
+_EXCLUDE_DIRS = frozenset({"tests"})
+
+
+def _git_tracked_py_files(root: Path) -> list[Path]:
+    """Absolute paths to every git-tracked ``.py`` file under ``root``.
+
+    Tracked-ness, not a directory namelist, keeps a build artifact / nested worktree /
+    CI rollout copy out of the scan regardless of what it's named or where it lives.
+    Fails CLOSED — raises ``RuntimeError`` — when git is unavailable, rather than
+    silently falling back to an incomplete namelist (OI-1597 precedent).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--", "*.py"],
+            cwd=str(root), capture_output=True, timeout=10,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"git is not available to determine tracked .py files under {root}"
+        ) from exc
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"`git ls-files` failed under {root} (not a git work tree?): {stderr}")
+    stdout = result.stdout.decode("utf-8")
+    return [root / rel for rel in stdout.split("\0") if rel]
+
+
+def _call_target_name(node: ast.Call) -> Optional[str]:
+    """The bare callee name of an ast.Call — 'foo' for both foo(...) and mod.foo(...)."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _subprocess_adapter_var_names(tree: ast.Module) -> set[str]:
+    """Names of local variables assigned directly from a ``SubprocessAdapter(...)``
+    call anywhere in the module (e.g. ``adapter = SubprocessAdapter()``,
+    ``adapter = _sd.SubprocessAdapter()``). Deliberately module-wide rather than
+    scope-precise — same "good enough, no false negatives" tradeoff as the phantom
+    guard's flat AST walk; a variable name reused for something else in an unrelated
+    function is a theoretical false positive this repo does not currently have.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        if _call_target_name(node.value) != _ADAPTER_CTOR:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                names.add(target.id)
+    return names
+
+
+def _find_scrub_call_sites(
+    root: Path, exclude_dirs: frozenset[str] = _EXCLUDE_DIRS,
+) -> dict[str, list[tuple[str, ast.Call]]]:
+    """Map of relative-path -> list of (category, ast.Call) for every real call to
+    ``spawn_claude(...)`` or ``<SubprocessAdapter instance>.deliver(...)``, over the
+    git-tracked .py files rooted at ``root``. A ``.deliver(...)`` call on a receiver
+    that is NOT provably a SubprocessAdapter instance (TmuxAdapter, RuntimeFacade,
+    HeadlessTransportAdapter, LocalSessionAdapter, a Mock in a test) is not a call
+    site — this guard only owns the one ``deliver()`` implementation that actually
+    builds a Popen env from the ambient environment.
+
+    An unparseable or non-UTF-8 file raises a clean AssertionError naming the file,
+    instead of letting the raw SyntaxError/UnicodeDecodeError traceback escape.
+    """
+    found: dict[str, list[tuple[str, ast.Call]]] = {}
+    for full_path in _git_tracked_py_files(root):
+        rel = full_path.relative_to(root)
+        if any(part in exclude_dirs for part in rel.parts[:-1]):
+            continue
+        try:
+            source = full_path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(full_path))
+        except (SyntaxError, UnicodeDecodeError, ValueError) as exc:
+            raise AssertionError(
+                f"cannot parse {rel} while scanning for scrub_env_keys call sites: {exc}"
+            ) from exc
+
+        adapter_vars = _subprocess_adapter_var_names(tree)
+        sites: list[tuple[str, ast.Call]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _call_target_name(node)
+            if name == _SPAWN_CLAUDE_TARGET:
+                sites.append(("spawn_claude", node))
+            elif name == _DELIVER_TARGET and isinstance(node.func, ast.Attribute):
+                receiver = node.func.value
+                is_adapter = (
+                    (isinstance(receiver, ast.Name) and receiver.id in adapter_vars)
+                    or (
+                        isinstance(receiver, ast.Call)
+                        and _call_target_name(receiver) == _ADAPTER_CTOR
+                    )
+                )
+                if is_adapter:
+                    sites.append(("SubprocessAdapter.deliver", node))
+        if sites:
+            found[str(rel)] = sites
+    return found
+
+
+def _scrub_env_keys_kwarg_present(call: ast.Call) -> bool:
+    """True iff ``call`` carries a ``scrub_env_keys=`` keyword whose value is not the
+    literal ``None`` — an omitted keyword and an explicit ``None`` are the same defect
+    (silently-unscrubbed subprocess env), so both are rejected identically."""
+    for kw in call.keywords:
+        if kw.arg == _SCRUB_KWARG:
+            value = kw.value
+            return not (isinstance(value, ast.Constant) and value.value is None)
+    return False
+
+
+_KNOWN_CALL_SITES = frozenset({
+    "scripts/lib/provider_spawns/glm_harness_spawn.py",
+    "scripts/lib/provider_spawns/deepseek_harness_spawn.py",
+    "scripts/lib/subprocess_dispatch_internals/delivery.py",
+    "scripts/lib/envelope_adapters_claude.py",
+    "scripts/lib/provider_dispatch.py",
+    "scripts/lib/provider_spawns/claude_spawn.py",
+    "scripts/lib/adapters/claude_adapter.py",
+})
+
+
+class TestEveryCallSiteSuppliesScrubEnvKeys:
+    """The wachter: every real, git-tracked call site of spawn_claude(...) or
+    SubprocessAdapter(...).deliver(...) must pass a non-None scrub_env_keys=. This
+    does not enumerate a fixed baseline of files (unlike a growth-tripwire test) — a
+    brand-new lane is picked up automatically by the git-tracked-.py scan and held to
+    the same bar, without this test needing to be edited."""
+
+    def test_known_call_sites_are_found(self):
+        sites = _find_scrub_call_sites(REPO)
+        missing = _KNOWN_CALL_SITES - set(sites)
+        assert not missing, f"expected call site(s) not found by the scan: {missing}"
+
+    def test_every_call_site_supplies_non_none_scrub_env_keys(self):
+        sites = _find_scrub_call_sites(REPO)
+        assert sites, "expected at least the seven known call sites"
+        problems = []
+        for rel, calls in sites.items():
+            for category, call in calls:
+                if not _scrub_env_keys_kwarg_present(call):
+                    problems.append(f"{rel}:{call.lineno} ({category}) missing or None scrub_env_keys=")
+        assert not problems, (
+            "call site(s) spawn a claude subprocess without an explicit, non-None "
+            "scrub_env_keys= — the worker would inherit the full ambient environment, "
+            "secrets included:\n" + "\n".join(problems)
+        )
+
+
+def _git_init(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=str(root), check=True)
+
+
+def _git_add(root: Path, *relative_paths: str) -> None:
+    subprocess.run(["git", "add", "--", *relative_paths], cwd=str(root), check=True)
+
+
+_GOOD_SPAWN_CLAUDE_SITE = (
+    "from provider_spawns.claude_spawn import spawn_claude\n"
+    "from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS\n"
+    "spawn_claude(\n"
+    "    prompt=p, model=m, dispatch_id=d, terminal_id=t,\n"
+    "    scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS,\n"
+    ")\n"
+)
+
+_GOOD_DELIVER_SITE_VAR = (
+    "from subprocess_adapter import SubprocessAdapter\n"
+    "adapter = SubprocessAdapter()\n"
+    "adapter.deliver(t, d, scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS)\n"
+)
+
+_GOOD_DELIVER_SITE_INLINE = (
+    "from subprocess_adapter import SubprocessAdapter\n"
+    "SubprocessAdapter().deliver(t, d, scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS)\n"
+)
+
+
+class TestCallSiteGuardCanActuallyFail:
+    """Een wachter die je niet hebt zien falen, bewaakt niets. ``_find_scrub_call_sites``
+    and ``_scrub_env_keys_kwarg_present`` are exercised directly against isolated
+    fixture trees (never the real repo) so this guard's MECHANISM is proven, not just
+    today's seven call sites."""
+
+    def test_a_compliant_spawn_claude_site_passes(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "good.py").write_text(_GOOD_SPAWN_CLAUDE_SITE, encoding="utf-8")
+        _git_add(tmp_path, "good.py")
+
+        sites = _find_scrub_call_sites(tmp_path)
+        for rel, calls in sites.items():
+            for _category, call in calls:
+                assert _scrub_env_keys_kwarg_present(call), f"{rel}:{call.lineno}"
+
+    def test_a_compliant_deliver_site_passes_both_var_and_inline_receiver(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "good_var.py").write_text(_GOOD_DELIVER_SITE_VAR, encoding="utf-8")
+        (tmp_path / "good_inline.py").write_text(_GOOD_DELIVER_SITE_INLINE, encoding="utf-8")
+        _git_add(tmp_path, "good_var.py", "good_inline.py")
+
+        sites = _find_scrub_call_sites(tmp_path)
+        assert set(sites) == {"good_var.py", "good_inline.py"}
+        for rel, calls in sites.items():
+            for _category, call in calls:
+                assert _scrub_env_keys_kwarg_present(call), f"{rel}:{call.lineno}"
+
+    def test_a_missing_scrub_env_keys_keyword_turns_the_assertion_red(self, tmp_path):
+        """The literal historic defect: the default-lane call sites omitted the
+        keyword entirely (envelope_adapters_claude.py, delivery.py, provider_dispatch.py,
+        claude_adapter.py before this fix)."""
+        _git_init(tmp_path)
+        (tmp_path / "bad.py").write_text(
+            "from provider_spawns.claude_spawn import spawn_claude\n"
+            "spawn_claude(prompt=p, model=m, dispatch_id=d, terminal_id=t)\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "bad.py")
+
+        sites = _find_scrub_call_sites(tmp_path)
+        problems = [
+            (rel, call.lineno)
+            for rel, calls in sites.items()
+            for _category, call in calls
+            if not _scrub_env_keys_kwarg_present(call)
+        ]
+        assert problems == [("bad.py", 2)]
+
+    def test_an_explicit_none_turns_the_assertion_red(self, tmp_path):
+        """Not just an omitted keyword — writing scrub_env_keys=None explicitly is the
+        exact same defect (a caller that thought about it and got it wrong is no safer
+        than one that never thought about it)."""
+        _git_init(tmp_path)
+        (tmp_path / "bad.py").write_text(
+            "from subprocess_adapter import SubprocessAdapter\n"
+            "adapter = SubprocessAdapter()\n"
+            "adapter.deliver(t, d, scrub_env_keys=None)\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "bad.py")
+
+        sites = _find_scrub_call_sites(tmp_path)
+        problems = [
+            (rel, call.lineno)
+            for rel, calls in sites.items()
+            for _category, call in calls
+            if not _scrub_env_keys_kwarg_present(call)
+        ]
+        assert problems == [("bad.py", 3)]
+
+    def test_a_deliver_call_on_a_non_subprocessadapter_receiver_is_ignored(self, tmp_path):
+        """TmuxAdapter, RuntimeFacade, HeadlessTransportAdapter and LocalSessionAdapter
+        all define their own .deliver() method with the same name. A call on any of
+        them must NOT be flagged — this guard owns exactly one deliver() implementation,
+        the one that actually builds a Popen env from the ambient environment."""
+        _git_init(tmp_path)
+        (tmp_path / "unrelated.py").write_text(
+            "from tmux_adapter import TmuxAdapter\n"
+            "adapter = TmuxAdapter(state_dir)\n"
+            "adapter.deliver(t, d)\n",  # no scrub_env_keys — must not be flagged
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "unrelated.py")
+
+        sites = _find_scrub_call_sites(tmp_path)
+        assert sites == {}
+
+    def test_a_docstring_mention_does_not_trip_it(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "mentions_only.py").write_text(
+            '"""Eventually calls spawn_claude(scrub_env_keys=...)."""\n'
+            "# see SubprocessAdapter.deliver for details\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "mentions_only.py")
+
+        sites = _find_scrub_call_sites(tmp_path)
+        assert sites == {}
+
+    def test_an_untracked_file_does_not_trip_it(self, tmp_path):
+        """A fourth-lane call site that exists on disk but was never `git add`-ed (a
+        build artifact, a nested worktree, a scratch file) is invisible to the scan —
+        same property the beacon/phantom-guard tests' guards rely on (OI-1597)."""
+        _git_init(tmp_path)
+        (tmp_path / "existing.py").write_text(_GOOD_SPAWN_CLAUDE_SITE, encoding="utf-8")
+        _git_add(tmp_path, "existing.py")
+        baseline_files = set(_find_scrub_call_sites(tmp_path))
+
+        (tmp_path / "untracked_bad.py").write_text(
+            "from provider_spawns.claude_spawn import spawn_claude\n"
+            "spawn_claude(prompt=p, model=m, dispatch_id=d, terminal_id=t)\n",
+            encoding="utf-8",
+        )
+        # Deliberately never git add-ed.
+        matched_files = set(_find_scrub_call_sites(tmp_path))
+        assert matched_files == baseline_files
+
+    def test_an_unparseable_file_gives_a_clean_assertion_not_a_traceback(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "broken.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+        _git_add(tmp_path, "broken.py")
+
+        with pytest.raises(AssertionError, match="broken.py"):
+            _find_scrub_call_sites(tmp_path)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_token_extraction_per_provider.py
+++ b/tests/test_token_extraction_per_provider.py
@@ -164,6 +164,7 @@ class TestClaudeTokenUsage:
 
         with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter_mock):
             res = spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="say hi",
                 model="sonnet",
                 dispatch_id="test-dispatch-claude-005",

--- a/tests/test_worker_capability_scoping.py
+++ b/tests/test_worker_capability_scoping.py
@@ -558,6 +558,7 @@ class TestClaudeSpawnRoleForwarding:
 
         with patch.object(SubprocessAdapter, "deliver", capturing_deliver):
             spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="test prompt",
                 model="sonnet",
                 dispatch_id="dispatch-role-1",
@@ -595,6 +596,7 @@ class TestClaudeSpawnRoleForwarding:
 
         with patch.object(SubprocessAdapter, "deliver", capturing_deliver):
             spawn_claude(
+                scrub_env_keys=frozenset(),  # now-mandatory param; this test does not exercise scrubbing
                 prompt="test prompt",
                 model="sonnet",
                 dispatch_id="dispatch-role-2",


### PR DESCRIPTION
## Summary

Round 2 of `20260903-scrub-en-schaduwpoorten` (round 1 was audit-only, routed to a
read-only role — see `20260903-scrub-en-schaduwpoorten.md` report). Builds the
implementation, re-verifying the two load-bearing claims myself before building
(both confirmed; details below), and found one additional gap plus one additional
Deel B defect round 1 didn't catch.

**Deel A — env-scrub gap.** `scrub_env_keys` was accepted by `spawn_claude()` /
`SubprocessAdapter.deliver()` but only the DeepSeek/GLM-harness lanes ever passed it.
The **default headless lane**, the **terminal-pinned subprocess lane**, the benchmark
path, and (my own additional finding) the direct `stream_events()` `.deliver()` call
all forwarded the **full ambient environment** to every worker subprocess.
`VNX_SMTP_PASS` measured present in-process (19 chars, value never logged).

**Deel B — two shadow CI gates.** `trace-token-check` and `slug-match-check` set
enforcement to `"0"` (WARN + exit 0) while sitting in the required-contexts list.

## Changes

**Deel A:**
- `scripts/lib/env_scrub_patterns.py` (new): `DEFAULT_SCRUB_KEY_PATTERNS` — fnmatch
  globs (`*_PASS`, `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, `*_KEY`) plus four explicit
  names (`VNX_SMTP_PASS`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`,
  `ANTHROPIC_AUTH_TOKEN` — the last three because an inherited value can displace a
  valid CLI login in the auth precedence order, measured 2026-08-31, not only because
  they're secrets).
- `scripts/lib/subprocess_adapter.py`: scrub loop switched from exact `.pop()` to
  `fnmatch.fnmatchcase` pattern match (a literal name with no wildcard still matches
  only itself — the harness lanes' exact-key sets keep working unchanged).
- `scripts/lib/provider_spawns/claude_spawn.py`: `scrub_env_keys` is now a **required**
  keyword-only param (no default) — mirrors `PhantomDecisionContext`/OI-1614's own
  precedent (no default = `TypeError`, not a silently-wrong default). Touches every
  real call site: harness lanes were already compliant; fixed
  `envelope_adapters_claude.py` (default headless lane), `subprocess_dispatch_internals/
  delivery.py` (terminal-pinned lane), `provider_dispatch.py` (benchmark), and
  `adapters/claude_adapter.py` (direct `.deliver()`, bypasses `spawn_claude()` entirely
  — found independently, not in round 1's report). Updated 24 test call sites across 5
  test files to pass `scrub_env_keys=frozenset()` explicitly (none of them exercise
  scrubbing behavior — they mock `SubprocessAdapter` out).
- `tests/test_spawn_scrub_env_keys_contract.py` (new): AST-scan call-site guard
  mirroring `tests/test_phantom_guard_context_contract.py`'s pattern — fails CI the
  moment a call site (new or existing) drops `scrub_env_keys=` or passes literal
  `None`. Deliberately excludes other classes' same-named `.deliver()` (TmuxAdapter,
  RuntimeFacade, etc.) via receiver-type detection, so it can't false-positive on an
  unrelated method.

  Scope decision (diverges from round 1's "Aanbevolen implementatie" point 1): did
  **not** consolidate the harness lanes' `_HARNESS_SCRUB_KEYS` into the new shared
  module — that constant is asserted byte-exact by two existing regression tests
  (`test_glm_harness_spawn_credential_scrub.py`, `test_deepseek_harness_spawn.py`,
  both documenting a real past incident, audit S3). The harness lanes were already
  correctly scrubbing; touching working, tested code for a pure dedup wasn't worth the
  risk to that regression coverage.

**Deel B:**
- `.github/workflows/vnx-ci.yml` — `trace-token-check`: `VNX_PROVENANCE_ENFORCEMENT`
  `"0"` → `"1"`. Safe **without** a separate ratchet mechanism: the script only ever
  validates `MERGE_BASE..HEAD` (this PR's own new commits); a push to main resolves
  that range to empty, so main's existing 41/150 (27.3%) non-compliant commits are
  structurally never re-litigated — only new commits are held to the standard. This
  *is* the ratchet the dispatch asked for, already built into the script's own delta
  design; no extra machinery needed.
- `.github/workflows/vnx-ci.yml` — `slug-match-check`: **left in shadow/WARN**,
  deliberately, with the reasoning documented inline. This diverges from round 1's
  measurement (which called this check "not meaningfully measurable" and left the
  choice open). I verified it directly and found it's **actively broken** for this
  fleet's real branch convention, not just unmeasured:
  - `branch_slug()`'s prefix-strip regex covers `fix/feat/feature/test/docs/chore/
    refactor/hotfix/perf/ci/build/revert/` but **not `dispatch/`** — confirmed the
    prefix on **15/15** of the most recent merged PRs' head branches
    (`gh pr list --state merged --json headRefName`).
  - Even fixed, `branch_slug()` doesn't strip the embedded `YYYYMMDD` date the way
    `dispatch_id_slug()` does for the Dispatch-ID side — the two slugs wouldn't
    compare like-for-like.
  - Some real, currently-used Dispatch-IDs (`YYYYMMDD-HHMMSS-<slug>`, no trailing
    track letter — e.g. PR #1740's own ID) don't match either extraction regex at
    all; `dispatch_id_slug()` returns `None`, and `CommitResult.all_slugs_match`
    treats that as a hard **failure**, not a skip.
  - Reproduced live against this PR's own commit (see Verification) — confirms
    enforcing today would fail effectively every fleet PR, not the ~27-40%
    trace-token-check would flag. The ratchet trick that made trace-token-check safe
    does **not** transfer here, because these would be **new**-commit failures, not
    just historical ones.
  - Recommendation, not done here (deeper fix belongs in its own PR): operator drops
    this context from branch protection's required-checks list via the GitHub API.

## Verification

Re-verified both dragging claims from round 1's report myself before building
(neither deviated — both confirmed with fresh commands, not copied numbers):
- `VNX_SMTP_PASS` present in this dispatch's process env: `True`, len 19.
- `validate_trace_token()` over `origin/main`'s own log: `n=150 → 41 invalid (27.3%)`,
  `n=2130 → 860 invalid (40.4%)`.

New guard test suite: `python3 -m pytest tests/test_spawn_scrub_env_keys_contract.py -v`
→ **10 passed** (7 known call sites found + compliant, plus 6 fixture-tree mechanism
tests proving it can actually fail: missing keyword, explicit `None`, non-adapter
`.deliver()` correctly ignored, docstring-only mention ignored, untracked file
ignored, unparseable file raises a clean assertion).

**Guard shown RED** against a real call site (required by the dispatch — "a guard you
haven't seen fail guards nothing"): temporarily removed `scrub_env_keys=` from
`envelope_adapters_claude.py`, ran
`pytest tests/test_spawn_scrub_env_keys_contract.py::TestEveryCallSiteSuppliesScrubEnvKeys`
→ **1 failed** (`envelope_adapters_claude.py:126 (spawn_claude) missing or None
scrub_env_keys=`), then restored the file and re-ran green.

End-to-end scrub proof against the real (non-mocked) `SubprocessAdapter.deliver()` →
`subprocess.Popen` boundary: injected `VNX_SMTP_PASS` into the env, called
`deliver(..., scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS)` with `Popen` faked to
capture its `env=` kwarg → `VNX_SMTP_PASS` absent from the captured child env,
`HOME` still present (pattern match doesn't over-scrub).

Full targeted suite: `python3 -m pytest tests/test_spawn_scrub_env_keys_contract.py
tests/test_claude_spawn.py tests/test_claude_spawn_byte_identity.py
tests/test_claude_spawn_fail_closed.py tests/test_token_extraction_per_provider.py
tests/test_worker_capability_scoping.py tests/test_subprocess_adapter.py
tests/test_subprocess_adapter_pr3.py tests/test_glm_harness_spawn_credential_scrub.py
tests/test_deepseek_harness_spawn.py tests/test_provider_deadline_passthrough.py
tests/test_trace_token_validator.py tests/test_ci_slug_match_gate.py
tests/test_phantom_guard_context_contract.py -q` → **333 passed**, 1 deselected
(pre-existing, unrelated failure — `test_subprocess_adapter_pr3.py::TestGetSessionId::
test_extracted_from_first_init_only`, confirmed failing identically on a clean
`git stash` of this branch back to origin/main, about session-id extraction from init
events, untouched by this PR). Two other pre-existing, unrelated failures also
confirmed via the same stash-and-compare method:
`test_worker_state_dir.py::TestDeliveryEnvInjection::test_extra_env_contains_worker_state_dir`
(a `_start_heartbeat` tuple-unpack mismatch) and 7 `test_review_adapters.py` CodexAdapter
failures (`_parse_ndjson` attribute missing) — none touch scrub logic or files this PR
modifies.

Both CI-gate changes reproduced locally against this PR's own real commit:
`VNX_PROVENANCE_ENFORCEMENT=1 bash scripts/ci_trace_token_check.sh origin/main` →
`RESULT: PASS` (1/1 valid). `VNX_SLUG_ENFORCEMENT=0 python3
scripts/check_ci_slug_match.py --branch-name dispatch/... ` → `RESULT: WARN` with the
exact predicted slug mismatch, confirming the documented defect and the safe
shadow-mode fallback in the same run.

## Open Items

1. `slug-match-check`'s branch-slug/dispatch-id-slug mismatch (three compounding
   regex gaps, detailed above and in the workflow YAML) needs its own PR — out of
   proportion to fix correctly alongside Deel A/B here. Left in shadow/WARN.
2. Operator action, not done here: drop `slug-match-check` from branch protection's
   required-status-checks list via the GitHub API (this PR only touches the workflow
   file, never branch protection).
3. `VNX_SMTP_PASS` in `~/.zshrc` on the operator machine is unchanged (not this repo,
   not touched per the dispatch's explicit instruction). Suggested follow-up:
   read it via `security find-generic-password` from the keychain, same pattern
   already used for `PERPLEXITY_API_KEY`.
4. Tmux-lane env-scrub (`TmuxCommandRunner.run()` inherits the full ambient env with
   no `env=` kwarg to scrub at all) remains a separate, larger design problem — noted
   by round 1, unchanged here, out of scope for a `scrub_env_keys`-shaped fix.
5. `RuntimeFacade.deliver()` forwards `**kwargs` to whatever adapter it wraps; if it
   ever gets a real production caller (currently test-only, no `RuntimeFacade(...)`
   construction found outside tests), a caller would need to remember to pass
   `scrub_env_keys=` through it explicitly — the static guard doesn't reach through
   `**kwargs` forwarding by design (same limitation the phantom-guard test has for
   non-inline call sites).

Dispatch-ID: 20260903-scrub-en-schaduwpoorten-r2