### PR TITLE
fix(digest): fall back to macOS keychain for SMTP password

### DIFF
--- a/scripts/conversation_analyzer_nightly.sh
+++ b/scripts/conversation_analyzer_nightly.sh
@@ -150,8 +150,11 @@ else
     log_msg "Phase 3 WARNING: suggested edits generation failed (non-fatal)"
 fi
 
-# Phase 4: Send digest email (requires VNX_DIGEST_EMAIL + VNX_SMTP_PASS)
-if [ -n "${VNX_DIGEST_EMAIL:-}" ] && [ -n "${VNX_SMTP_PASS:-}" ]; then
+# Phase 4: Send digest email (requires VNX_DIGEST_EMAIL; the SMTP password
+# comes from VNX_SMTP_PASS or, when unset, the macOS keychain — the shell
+# doesn't know which source will resolve, so send_digest_email.py judges
+# availability itself and reports failure via its own exit code + log line).
+if [ -n "${VNX_DIGEST_EMAIL:-}" ]; then
     log_msg "Phase 4: Sending digest email to $VNX_DIGEST_EMAIL..."
     if "$VNX_PYTHON" "$SCRIPT_DIR/send_digest_email.py" 2>&1 | tee -a "$LOG_FILE"; then
         log_msg "Phase 4 complete: digest email sent"
@@ -159,7 +162,7 @@ if [ -n "${VNX_DIGEST_EMAIL:-}" ] && [ -n "${VNX_SMTP_PASS:-}" ]; then
         log_msg "Phase 4 WARNING: digest email failed (non-fatal)"
     fi
 else
-    log_msg "Phase 4: Skipped — VNX_DIGEST_EMAIL or VNX_SMTP_PASS not set"
+    log_msg "Phase 4: Skipped — VNX_DIGEST_EMAIL not set"
 fi
 
 log_msg "=== Nightly analysis pipeline complete (analyzer_exit=$ANALYZER_EXIT) ==="

--- a/scripts/send_digest_email.py
+++ b/scripts/send_digest_email.py
@@ -7,7 +7,8 @@ and sends via SMTP (default: Gmail).
 
 Configuration via environment variables:
   VNX_DIGEST_EMAIL  — recipient email address (required)
-  VNX_SMTP_PASS     — SMTP password / Gmail App Password (required)
+  VNX_SMTP_PASS     — SMTP password / Gmail App Password (falls back to the
+                      macOS keychain item "vnx-smtp-pass" when unset)
   VNX_SMTP_USER     — SMTP username (defaults to VNX_DIGEST_EMAIL)
   VNX_SMTP_HOST     — SMTP server (default: smtp.gmail.com)
   VNX_SMTP_PORT     — SMTP port (default: 587)
@@ -20,6 +21,7 @@ Usage:
 import json
 import os
 import smtplib
+import subprocess
 import sys
 from datetime import datetime, timezone
 from email.mime.multipart import MIMEMultipart
@@ -233,6 +235,34 @@ def build_digest() -> tuple[str, str]:
     return subject, body
 
 
+def _read_smtp_pass_from_keychain() -> str:
+    """Read the SMTP password from the macOS keychain item "vnx-smtp-pass".
+
+    Never raises: returns "" when `security` is unavailable, the item is
+    missing, or the host isn't macOS.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                "vnx-smtp-pass",
+                "-a",
+                os.environ.get("USER", ""),
+                "-w",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
 def send_email(subject: str, body: str, dry_run: bool = False) -> bool:
     """Send the digest email via SMTP.
 
@@ -240,7 +270,7 @@ def send_email(subject: str, body: str, dry_run: bool = False) -> bool:
         True if sent successfully, False otherwise.
     """
     recipient = os.environ.get("VNX_DIGEST_EMAIL", "")
-    smtp_pass = os.environ.get("VNX_SMTP_PASS", "")
+    smtp_pass = os.environ.get("VNX_SMTP_PASS", "") or _read_smtp_pass_from_keychain()
     smtp_user = os.environ.get("VNX_SMTP_USER", "") or recipient
     smtp_host = os.environ.get("VNX_SMTP_HOST", "smtp.gmail.com")
     smtp_port = int(os.environ.get("VNX_SMTP_PORT", "587"))

--- a/tests/test_send_digest_email_smtp_pass.py
+++ b/tests/test_send_digest_email_smtp_pass.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for the SMTP password resolution in send_digest_email.py.
+
+Covers the 2026-09-03 fix: VNX_SMTP_PASS was removed from the operator's
+~/.zshrc export (it leaked to every worker process) and moved into the
+macOS keychain. send_email() must fall back to the keychain when the env
+var is empty, without ever shelling out to `security` in tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import send_digest_email  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_smtp_env(monkeypatch):
+    """Start every test from a known-empty SMTP env so leakage from the
+    real environment (or a prior test) can't mask a broken fallback."""
+    for var in ("VNX_DIGEST_EMAIL", "VNX_SMTP_PASS", "VNX_SMTP_USER"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("VNX_DIGEST_EMAIL", "ops@example.com")
+
+
+def test_env_var_wins_keychain_not_consulted(monkeypatch):
+    monkeypatch.setenv("VNX_SMTP_PASS", "env-secret")
+    keychain = mock.Mock(side_effect=AssertionError("keychain should not be called"))
+    monkeypatch.setattr(send_digest_email, "_read_smtp_pass_from_keychain", keychain)
+
+    assert send_digest_email.send_email("subject", "body", dry_run=True) is True
+    keychain.assert_not_called()
+
+
+def test_empty_env_falls_back_to_keychain(monkeypatch):
+    monkeypatch.setattr(
+        send_digest_email, "_read_smtp_pass_from_keychain", lambda: "keychain-secret"
+    )
+    captured = {}
+
+    class _FakeServer:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def ehlo(self):
+            pass
+
+        def starttls(self):
+            pass
+
+        def login(self, user, password):
+            captured["password"] = password
+
+        def send_message(self, msg):
+            pass
+
+    monkeypatch.setattr(
+        send_digest_email.smtplib, "SMTP", lambda *a, **k: _FakeServer()
+    )
+
+    assert send_digest_email.send_email("subject", "body", dry_run=False) is True
+    assert captured["password"] == "keychain-secret"
+
+
+def test_keychain_missing_item_returns_empty_string_no_raise(monkeypatch):
+    import subprocess
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=44, stdout="", stderr="not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert send_digest_email._read_smtp_pass_from_keychain() == ""
+
+
+def test_keychain_security_binary_absent_returns_empty_string_no_raise(monkeypatch):
+    import subprocess
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("security: command not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert send_digest_email._read_smtp_pass_from_keychain() == ""
+
+
+def test_env_and_keychain_both_empty_fails_with_existing_error(monkeypatch, capsys):
+    monkeypatch.setattr(send_digest_email, "_read_smtp_pass_from_keychain", lambda: "")
+
+    result = send_digest_email.send_email("subject", "body", dry_run=False)
+
+    assert result is False
+    err = capsys.readouterr().err
+    assert "VNX_SMTP_PASS not set" in err


### PR DESCRIPTION
## Summary
- `VNX_SMTP_PASS` was removed from `~/.zshrc` on 2026-09-03 (it leaked to every worker process) and the password moved into the macOS keychain (`vnx-smtp-pass` item).
- `scripts/send_digest_email.py` now resolves the password env-first, keychain-second — the keychain lookup never raises (missing item, missing `security` binary, non-macOS host all resolve to `""` and fall through to the existing error path).
- `scripts/conversation_analyzer_nightly.sh` phase 4 no longer gates on `VNX_SMTP_PASS` (always empty in its environment now); it gates on `VNX_DIGEST_EMAIL` only and lets the Python script judge password availability, since the shell no longer knows which source will resolve.

## Test plan
- [x] `pytest tests/test_send_digest_email_smtp_pass.py -v` — 5/5 passed (env-wins, keychain-fallback, missing-item, missing-binary, both-empty-fails-cleanly); keychain calls are monkeypatched, `security` is never actually invoked
- [x] `pytest tests/test_send_digest_email_smtp_pass.py tests/test_digest_quality.py -v` — 15/15 passed, no collateral breakage
- [x] `bash -n scripts/conversation_analyzer_nightly.sh` — syntax OK
- [x] `python3 -m py_compile scripts/send_digest_email.py` — OK
- [x] Manual smoke test: `VNX_SMTP_PASS="" python3 scripts/send_digest_email.py --dry-run` — digest renders correctly

Dispatch-ID: 20260904-smtp-uit-de-keychain

🤖 Generated with [Claude Code](https://claude.com/claude-code)