### PR TITLE
fix(dispatch): finite default for the claude-lane lock-wait timeout

### DIFF
--- a/scripts/lib/dispatch_serialization.py
+++ b/scripts/lib/dispatch_serialization.py
@@ -25,6 +25,18 @@ subscription session cap is an account property, not a per-project one.
 Setting VNX_LOCK_DIR per project to get 5 slots per project (instead of 5
 across the whole account) multiplies past the real limit — don't.
 
+Lock-wait timeout (VNX_CLAUDE_LOCK_TIMEOUT_SECONDS) is FINITE by default
+(dispatch-20260904-lock-timeout-eindig, OI/gap measured 2026-09-04): the
+default used to be "0" and the wait-loop's `if timeout_secs > 0` guard made
+the TimeoutError branch structurally unreachable at that default — a worker
+waiting on a saturated lane (all N slots busy) polled forever with only a
+one-time 60s log warning, no matter how long the wait ran. See
+_DEFAULT_TIMEOUT_SECONDS below for the grounding of the new default. `0`
+remains a legal, explicit opt-out ("wait forever") via
+VNX_CLAUDE_LOCK_TIMEOUT_SECONDS=0 for an operator who deliberately accepts
+that trade-off — it is no longer the silent default a caller falls into by
+doing nothing.
+
 Posix-only: requires fcntl (unavailable on Windows).
 """
 from __future__ import annotations
@@ -68,11 +80,53 @@ def _warn_seconds() -> float:
         return 60.0
 
 
+# Default lock-wait timeout in seconds (VNX_CLAUDE_LOCK_TIMEOUT_SECONDS), finite
+# by design (dispatch-20260904-lock-timeout-eindig).
+#
+# Grounded on the documented ceiling for how long any ONE slot-holder may
+# legitimately occupy a slot: dispatch_spec.DEADLINE_SECONDS_MAX = 14400 (4h)
+# is the enforced upper bound on a dispatch's own deadline_seconds
+# (scripts/lib/dispatch_spec.py, validate() Rule 11 + the door's
+# --deadline-seconds bound), and serialize_lane holds its acquired slot for
+# the holder's entire execution + receipt/GOVERN write (see module docstring
+# above) — a legitimate holder can never occupy a slot past that ceiling.
+# So under worst-case *legitimate* saturation (all N slots freshly occupied
+# by max-deadline dispatches), the longest a well-behaved waiter should ever
+# need to queue for a first free slot is just under that same ceiling. This
+# is a designed bound, not an empirical median: checked on 2026-09-04 across
+# every retained ~/.vnx-data / <repo>/.vnx-data tree on this machine for a
+# genuinely-fired 60s wait-warn log line (the WARNING at line ~205 below) --
+# every hit found was the literal source text of this file re-read into a
+# past agent transcript/DB blob, not an actual runtime emission, so there is
+# no local telemetry an empirical default could be measured against instead.
+# Waiting longer than the dispatch-deadline ceiling is not "busy", it is
+# stuck (a holder whose process died without releasing flock in a way that
+# still leaves the slot file looking held, a runaway process past its own
+# deadline that never tore down, etc.) and should fail loud well before
+# "hangs until the next morning" (8h+), not after.
+_DEFAULT_TIMEOUT_SECONDS = 14400.0  # 4h — see dispatch_spec.DEADLINE_SECONDS_MAX
+
+
 def _timeout_seconds() -> float:
+    """Lock-wait timeout in seconds, from VNX_CLAUDE_LOCK_TIMEOUT_SECONDS.
+
+    Unset -> _DEFAULT_TIMEOUT_SECONDS (finite). Exactly "0" is a legal,
+    explicit opt-out ("wait forever") and is returned as 0.0 verbatim --
+    see the module docstring. A negative or unparseable value is not a sane
+    explicit choice (there is no meaningful negative wait) and falls back to
+    the finite default, same fail-soft-to-default posture as
+    _max_concurrent()'s clamp of bad input below.
+    """
+    raw = os.environ.get("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS")
+    if raw is None:
+        return _DEFAULT_TIMEOUT_SECONDS
     try:
-        return float(os.environ.get("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS", "0"))
+        value = float(raw)
     except (ValueError, TypeError):
-        return 0.0
+        return _DEFAULT_TIMEOUT_SECONDS
+    if value < 0:
+        return _DEFAULT_TIMEOUT_SECONDS
+    return value
 
 
 def _max_concurrent() -> int:
@@ -159,6 +213,29 @@ def _describe_holder(lock_path: Path) -> str:
 _POLL_INTERVAL = 0.2  # seconds between LOCK_NB retries
 
 
+class LockWaitTimeout(TimeoutError):
+    """No lane slot freed up within the configured lock-wait timeout.
+
+    A dedicated subclass (not a bare TimeoutError) so a future caller can
+    catch this specifically and record a `failed_delivery` outcome instead
+    of folding it into a generic runtime-error path — still catchable as a
+    plain TimeoutError by any existing `except TimeoutError` / `except
+    Exception` (subclass semantics).
+
+    KNOWN GAP (dispatch-20260904-lock-timeout-eindig): as of this fix, no
+    caller does that yet. The single call site of serialize_lane()
+    (scripts/lib/dispatch_cli.py, run_dispatch(), the
+    `with serialize_lane(plan.serialization_class, ...)` block) is wrapped
+    only by a generic `except Exception as exc: print(...REJECT
+    [runtime-error]...); return 1` — it never transitions the dispatch's
+    coordination-DB state to `failed_delivery` (that state is only ever
+    written from inside the lane executors, e.g.
+    headless_adapter.py's `_record_failure`, never from dispatch_cli.py's
+    own exception handling). Wiring that classification is out of scope for
+    this module and must land in dispatch_cli.py.
+    """
+
+
 def _try_acquire_any_slot(fds: List[int]) -> Optional[int]:
     """Try each slot fd non-blocking in turn; return the index of the first
     slot successfully locked, or None if all slots are currently held.
@@ -182,9 +259,12 @@ def _acquire_any_slot_with_warn(
     serialization_class: str,
     dispatch_id: Optional[str],
 ) -> int:
-    """Acquire the first free slot among fds, with wait-warn and optional
-    hard timeout. Polls ALL slots each interval (not just slot 0) so whichever
-    holder releases first is grabbed immediately.
+    """Acquire the first free slot among fds, with wait-warn and a hard
+    timeout that is FINITE by default (_DEFAULT_TIMEOUT_SECONDS; opt out of
+    it entirely with VNX_CLAUDE_LOCK_TIMEOUT_SECONDS=0 -- see _timeout_seconds()
+    and the module docstring). Polls ALL slots each interval (not just slot 0)
+    so whichever holder releases first is grabbed immediately. Raises
+    LockWaitTimeout when the timeout elapses with no free slot.
     """
     warn_secs = _warn_seconds()
     timeout_secs = _timeout_seconds()
@@ -212,7 +292,7 @@ def _acquire_any_slot_with_warn(
             warned = True
 
         if timeout_secs > 0 and elapsed >= timeout_secs:
-            raise TimeoutError(
+            raise LockWaitTimeout(
                 f"{serialization_class} serial lock: no free slot within "
                 f"{timeout_secs:.0f}s (elapsed {elapsed:.0f}s, "
                 f"{len(fds)} slot(s) all busy); "
@@ -250,6 +330,11 @@ def serialize_lane(
     Note: advisory flock() over NFS may not serialize across all client/kernel
     combinations. The default lock dir (~/.vnx-data/locks) is local — informational
     only; no action needed unless running lock dir on a network filesystem.
+
+    Raises LockWaitTimeout (a TimeoutError subclass) if no slot frees up
+    within VNX_CLAUDE_LOCK_TIMEOUT_SECONDS (default _DEFAULT_TIMEOUT_SECONDS,
+    finite; VNX_CLAUDE_LOCK_TIMEOUT_SECONDS=0 opts out and waits forever,
+    explicitly). See the module docstring for the default's rationale.
     """
     if not serialization_class:
         yield

--- a/tests/test_dispatch_serialization.py
+++ b/tests/test_dispatch_serialization.py
@@ -545,6 +545,142 @@ def test_force_release_after_clean_release_shows_no_prior_holder(tmp_path, monke
 
 
 # ---------------------------------------------------------------------------
+# test_lock_wait_times_out_by_default (dispatch-20260904-lock-timeout-eindig)
+# ---------------------------------------------------------------------------
+
+def test_lock_wait_times_out_within_bounded_default(tmp_path, monkeypatch):
+    """A waiter on a PERMANENTLY FULL lane must give up under the DEFAULT
+    config (no VNX_CLAUDE_LOCK_TIMEOUT_SECONDS set) -- forced via a
+    monkeypatched "lane always full" acquire plus a fast-forwarded fake
+    clock, executed on a background thread joined with a short real
+    wall-clock bound. Before the fix, VNX_CLAUDE_LOCK_TIMEOUT_SECONDS
+    defaulted to "0" and the wait-loop's `if timeout_secs > 0` guard (line
+    214) made the TimeoutError branch structurally unreachable on default
+    config -- the thread never finishes and this test fails on that
+    behavior (not on a missing symbol)."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+    monkeypatch.delenv("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS", raising=False)
+    # Lane is permanently full: every acquire attempt reports "busy".
+    monkeypatch.setattr(_ds_mod, "_try_acquire_any_slot", lambda fds: None)
+
+    # Fast-forward the fake clock 5000s per time.monotonic() call so even a
+    # multi-hour default timeout trips within a handful of loop iterations,
+    # instead of the test needing to wait out that timeout in real time.
+    fake_clock = {"t": 0.0}
+
+    def fake_monotonic():
+        fake_clock["t"] += 5000.0
+        return fake_clock["t"]
+
+    monkeypatch.setattr(_ds_mod.time, "monotonic", fake_monotonic)
+    # Small real sleep per poll (not a true no-op) so a still-buggy run
+    # burns bounded CPU instead of a tight spin for the full join window.
+    # Captures the real time.sleep BEFORE patching -- referencing the
+    # (patched) module attribute from inside its own replacement would
+    # self-recurse.
+    _real_sleep = _ds_mod.time.sleep
+    monkeypatch.setattr(_ds_mod.time, "sleep", lambda secs: _real_sleep(0.001))
+
+    outcome: dict = {}
+
+    def waiter():
+        try:
+            with serialize_lane("claude-tmux", dispatch_id="perma-full"):
+                pass  # must never be reached -- lane is permanently full
+        except BaseException as exc:  # capture anything, including TimeoutError
+            outcome["exc"] = exc
+        else:
+            outcome["exc"] = None
+        outcome["done"] = True
+
+    t = threading.Thread(target=waiter, daemon=True)
+    t.start()
+    t.join(timeout=2.0)
+
+    assert outcome.get("done"), (
+        "serialize_lane on a permanently-full lane did not return/raise "
+        "within 2s under the DEFAULT config -- the default lock-wait "
+        "timeout is not finite (VNX_CLAUDE_LOCK_TIMEOUT_SECONDS default "
+        "must be > 0, not \"0\")"
+    )
+    assert isinstance(outcome.get("exc"), TimeoutError), (
+        f"expected a TimeoutError from the default lock-wait timeout, "
+        f"got {outcome.get('exc')!r}"
+    )
+
+
+def test_timeout_seconds_default_is_finite(monkeypatch):
+    """No VNX_CLAUDE_LOCK_TIMEOUT_SECONDS set -> a positive, finite default
+    (not the old "0" == wait-forever default)."""
+    monkeypatch.delenv("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS", raising=False)
+    result = _ds_mod._timeout_seconds()
+    assert 0 < result < float("inf"), (
+        f"expected a positive finite default timeout, got {result!r}"
+    )
+
+
+@pytest.mark.parametrize("raw_value", ["x", "", "-5", "-0.001"])
+def test_timeout_seconds_bad_or_negative_values_fall_back_to_finite_default(
+    raw_value, monkeypatch,
+):
+    """Unparseable or negative VNX_CLAUDE_LOCK_TIMEOUT_SECONDS falls back to
+    the finite default -- same fail-soft-to-default posture as
+    _max_concurrent()'s clamp of bad input (test_max_concurrent_clamps_bad_values).
+    A negative wait has no sane meaning and is not the sanctioned opt-out
+    (that is exactly "0", covered by test_lock_timeout_zero_is_explicit_infinite_wait_opt_out)."""
+    monkeypatch.setenv("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS", raw_value)
+    result = _ds_mod._timeout_seconds()
+    assert result == _ds_mod._DEFAULT_TIMEOUT_SECONDS
+
+
+def test_timeout_seconds_zero_is_preserved_as_explicit_value(monkeypatch):
+    """VNX_CLAUDE_LOCK_TIMEOUT_SECONDS=0 must still resolve to exactly 0.0 --
+    the sanctioned explicit opt-out for "wait forever", not silently clamped
+    to the finite default like a negative/garbage value is."""
+    monkeypatch.setenv("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS", "0")
+    assert _ds_mod._timeout_seconds() == 0.0
+
+
+def test_lock_timeout_zero_is_explicit_infinite_wait_opt_out(monkeypatch):
+    """VNX_CLAUDE_LOCK_TIMEOUT_SECONDS=0 remains a legal, explicit opt-out:
+    the waiter keeps retrying no matter how much (simulated) time has
+    passed. Proven with a bounded, deterministic acquire-eventually-
+    succeeds sequence (3rd attempt succeeds) rather than an actual
+    unbounded wait."""
+    monkeypatch.setenv("VNX_CLAUDE_LOCK_TIMEOUT_SECONDS", "0")
+
+    calls = {"n": 0}
+
+    def flaky_then_ok(fds):
+        calls["n"] += 1
+        return None if calls["n"] < 3 else 0
+
+    monkeypatch.setattr(_ds_mod, "_try_acquire_any_slot", flaky_then_ok)
+
+    fake_clock = {"t": 0.0}
+
+    def fake_monotonic():
+        fake_clock["t"] += 10 ** 9  # astronomically past any sane finite default
+        return fake_clock["t"]
+
+    monkeypatch.setattr(_ds_mod.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(_ds_mod.time, "sleep", lambda secs: None)
+
+    idx = _ds_mod._acquire_any_slot_with_warn(
+        fds=[object(), object(), object()],  # never dereferenced by the mocked acquire
+        lock_paths=[
+            Path("/nonexistent-a"), Path("/nonexistent-b"), Path("/nonexistent-c"),
+        ],
+        serialization_class="claude-tmux",
+        dispatch_id="opt-out-test",
+    )
+    assert idx == 0
+    assert calls["n"] == 3, (
+        "explicit 0 must keep retrying past any elapsed time, not give up early"
+    )
+
+
+# ---------------------------------------------------------------------------
 # test_iso_now_is_timezone_aware
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`_timeout_seconds()` (`scripts/lib/dispatch_serialization.py`) defaulted `VNX_CLAUDE_LOCK_TIMEOUT_SECONDS` to `"0"`. The wait-loop's `if timeout_secs > 0 and elapsed >= timeout_secs:` guard (previously line 214) made the `TimeoutError` branch structurally unreachable at that default: a worker waiting on a saturated claude lane (all N=10 slots busy) polled forever with only a one-time 60s log warning — no bounded failure, just an indefinite hang until an operator manually intervened.

## Changes

- `_DEFAULT_TIMEOUT_SECONDS = 14400.0` (4h), grounded on `dispatch_spec.DEADLINE_SECONDS_MAX` — the enforced ceiling on a single dispatch's own `deadline_seconds` (`scripts/lib/dispatch_spec.py`, `validate()` Rule 11 + the door's `--deadline-seconds` bound). `serialize_lane` holds its acquired slot for the holder's entire execution + receipt/GOVERN write, so a legitimate holder can never occupy a slot past that ceiling — under worst-case *legitimate* saturation (all N slots freshly occupied by max-deadline dispatches), the longest a well-behaved waiter should ever need to queue for a first free slot is just under that same ceiling. This is a designed bound, not an empirical median — checked every retained `.vnx-data` tree on this machine for a genuinely-fired wait-warn log line; every hit was this file's own source re-read into a past agent transcript/DB blob, never a real runtime emission, so there's no local telemetry to measure an empirical default against instead.
- `VNX_CLAUDE_LOCK_TIMEOUT_SECONDS=0` remains a legal, explicit opt-out ("wait forever") for an operator who deliberately accepts that trade-off — no longer the silent default a caller falls into by doing nothing. A negative or unparseable value is not a sane explicit choice and now falls back to the finite default (same fail-soft-to-default posture as `_max_concurrent()`'s clamp of bad input).
- The raised exception is now `LockWaitTimeout(TimeoutError)` — a dedicated, addressable subclass so a future caller can classify it as `failed_delivery` instead of a generic runtime-error, while staying catchable by any existing `except TimeoutError`/`except Exception`.

## Known gap (out of scope for this PR)

`scripts/lib/dispatch_cli.py`'s `run_dispatch()` wraps the `with serialize_lane(plan.serialization_class, ...)` call site (~line 2542) only in a generic `except Exception as exc: print(...REJECT [runtime-error]...); return 1` (~line 2601-2602). It never transitions the dispatch's coordination-DB state to `failed_delivery` — that transition is only ever written from inside the lane executors (e.g. `headless_adapter.py`'s `_record_failure`), never from `dispatch_cli.py`'s own exception handling. So a `LockWaitTimeout` today still lands as a generic `REJECT [runtime-error]`, not a `failed_delivery` dispatch state. Wiring that classification needs a follow-up dispatch touching `dispatch_cli.py`, which is outside this PR's assigned scope (`scripts/lib/dispatch_serialization.py` + its tests only — three clusters ran in parallel on adjacent files and cross-touching was explicitly disallowed).

## Verification

Red (before fix): 6 failed, 25 passed (31 total) in `tests/test_dispatch_serialization.py`.
Green (after fix): 31 passed, 0 failed.

New tests (fake-clock + monkeypatched acquire, no real multi-hour waits, bounded by a short real thread-join):
- `test_lock_wait_times_out_within_bounded_default` — the primary red test: forces a permanently-full lane and proves the DEFAULT config raises `TimeoutError` within a bounded wall-clock window, on a background thread joined with a short timeout so a regression to unbounded-wait fails this test instead of hanging the suite.
- `test_timeout_seconds_default_is_finite`
- `test_timeout_seconds_bad_or_negative_values_fall_back_to_finite_default` (parametrized: `"x"`, `""`, `"-5"`, `"-0.001"`)
- `test_timeout_seconds_zero_is_preserved_as_explicit_value`
- `test_lock_timeout_zero_is_explicit_infinite_wait_opt_out`

## Open items

Follow-up dispatch needed for `scripts/lib/dispatch_cli.py` to catch `LockWaitTimeout` specifically around the `serialize_lane()` call site in `run_dispatch()` and transition the dispatch to `failed_delivery` (mirroring how `headless_adapter.py`'s `_record_failure` does it), instead of the current generic `REJECT [runtime-error]` fallthrough.

> Buiten de dispatch-deur om geproduceerd via een Agent-subagent, operator-besluit 2026-09-04. Tijdelijke afwijking: de gegovernde dispatch-paden zijn traag en de deur is zelf onderwerp van reparatie. PR en CI blijven onverkort gelden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR