### PR TITLE
fix(gate): audit chain, pytest-noise, and converter-rejection stop lying in the receipt trail

### DIFF
--- a/scripts/audit_chain.py
+++ b/scripts/audit_chain.py
@@ -24,8 +24,16 @@ def main():
     if args.cmd == "verify":
         ok, violations, status = verify_chain(args.path)
         if status == "unchained":
+            # D1: "unchained" means verify_chain() could not check anything —
+            # no entry carries prev_hash, so integrity is UNMEASURED, not
+            # confirmed. Reporting verified:true/exit 0 here reads to any
+            # caller checking only the exit code or the "verified" field as
+            # "the chain is fine", when no chain was ever there to check.
+            # This does NOT build the hash-chain — that stays an explicit,
+            # separate decision (VNX_CHAIN_RECEIPTS=1). It only stops the
+            # tool from asserting a positive it never measured.
             print(json.dumps({
-                "verified": True,
+                "verified": False,
                 "status": "unchained",
                 "path": str(args.path),
                 "warning": (
@@ -33,7 +41,7 @@ def main():
                     "Enable chaining by setting VNX_CHAIN_RECEIPTS=1."
                 ),
             }, indent=2))
-            sys.exit(0)
+            sys.exit(2)
         elif status == "verified":
             print(json.dumps({
                 "verified": True,

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1668,6 +1668,32 @@ def _build_active_work(
 # Recent receipts (last N lines from t0_receipts.ndjson)
 # ---------------------------------------------------------------------------
 
+# D2 (OI, measured 2026-09-04): t0_receipts.ndjson carries pytest-fixture
+# noise (source == "pytest") — test runs that append onto the live ledger
+# instead of an isolated tmp_path. Measured on
+# ~/.vnx-data/vnx-dev/state/t0_receipts.ndjson: 28,944 lines total, 7,738
+# (27%) carrying source == "pytest". These are synthetic test entries
+# (dispatch_id like "DISP-007"/"TASK-021"), not real dispatch work, and any
+# state-reader that folds them into a success/completion count is reading a
+# polluted number. PYTEST_NOISE_FILTER_EPOCH is the explicit marker for when
+# this filter was introduced (mirrors ADR-029's chain_epoch_start
+# convention): a reader comparing an old cached count to a new one has an
+# auditable reason for the delta. The ledger itself is untouched — it is
+# append-only (ADR-005) — only the reader's interpretation changes from this
+# point forward.
+PYTEST_NOISE_FILTER_EPOCH = "2026-09-04T00:00:00+00:00"
+
+
+def _is_pytest_noise_receipt(entry: Dict[str, Any]) -> bool:
+    """True when a receipt entry is pytest-fixture noise, not real work.
+
+    D2: any receipt with ``source == "pytest"`` was written by a test run,
+    never by a real dispatch. State-readers must exclude these from recent-
+    activity views and from any derived success/completion metric.
+    """
+    return str(entry.get("source") or "").strip().lower() == "pytest"
+
+
 _STATUS_PRIORITY: Dict[str, int] = {
     "done": 0, "success": 0, "completed": 0, "pass": 0,
     "failed": 1, "failure": 1, "timeout": 1, "blocked": 1,
@@ -1720,6 +1746,9 @@ def _build_recent_receipts(
         try:
             r = json.loads(line)
         except Exception:
+            continue
+        # D2: pytest-fixture noise never represents real dispatch work.
+        if _is_pytest_noise_receipt(r):
             continue
         # Skip internal bookkeeping events — T0 wants worker completion signals
         if r.get("event_type") == "state_mutation":

--- a/scripts/lib/queue_reconciler.py
+++ b/scripts/lib/queue_reconciler.py
@@ -248,6 +248,14 @@ def load_receipt_dispatch_ids(receipts_file: Path) -> Set[str]:
                 record = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            # D2: pytest-fixture receipts (source == "pytest") are test noise
+            # from runs that appended onto the live ledger instead of an
+            # isolated tmp_path — never real dispatch work. Measured
+            # 2026-09-04: 7,738 of 28,944 lines on the real t0_receipts.ndjson.
+            # A dispatch must not be marked "confirmed complete" by one of
+            # these, or the completion_pct this feeds is polluted.
+            if str(record.get("source") or "").strip().lower() == "pytest":
+                continue
             event_type = record.get("event_type", "")
             status = record.get("status", "")
             # Terminal event OR explicit success status on a completion-type event

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -358,11 +358,34 @@ _ppr_process_rate_limited() {
     [ "$MAX_PROCESSED_MTIME" -gt 0 ] && echo "$MAX_PROCESSED_MTIME" > "$WATERMARK_FILE"
     log "INFO" "Processed $processed_count reports successfully"
     # Run Python converter after the Bash scan so YAML-frontmatter reports
-    # not handled by report_parser.py also get receipts.  Non-fatal.
-    python3 "$SCRIPTS_DIR/lib/report_to_receipt_converter.py" \
+    # not handled by report_parser.py also get receipts.  Non-fatal: a
+    # crash here must never abort the processor loop (kept, unchanged).
+    #
+    # D3: the converter fail-closed-refuses a report with no valid Model
+    # field (scripts/lib/append_receipt_internals/validation.py::
+    # _validate_model_present) and logs that refusal as a WARNING on its
+    # own logger — which writes to stderr. main() always returns 0 even
+    # when it rejected reports this scan (a rejection is not a crash), so
+    # the old `|| log ERROR ... (exit $?)` fallback below never fired for
+    # a REJECTED — and the plain `2>/dev/null` threw the WARNING away
+    # regardless of exit code. Net effect: a refused report vanished from
+    # the audit trail with zero trace in this log. Capture stderr
+    # explicitly (independent of exit code, since exit code is not a
+    # reliable signal here) and route every line through log() so a
+    # REJECTED is visible; the non-fatal design itself is unchanged.
+    local _converter_stderr _converter_rc
+    _converter_stderr="$(python3 "$SCRIPTS_DIR/lib/report_to_receipt_converter.py" \
         --state-dir "$STATE_DIR" \
-        "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" 2>/dev/null \
-        || log "ERROR" "report_to_receipt_converter catchup scan FAILED non-fatal, processor continues (exit $?)"
+        "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" 2>&1 >/dev/null)"
+    _converter_rc=$?
+    if [ -n "$_converter_stderr" ]; then
+        while IFS= read -r _converter_line; do
+            [ -n "$_converter_line" ] && log "WARNING" "report_to_receipt_converter: $_converter_line"
+        done <<< "$_converter_stderr"
+    fi
+    if [ "$_converter_rc" -ne 0 ]; then
+        log "ERROR" "report_to_receipt_converter catchup scan FAILED non-fatal, processor continues (exit $_converter_rc)"
+    fi
 }
 
 # Process all pending reports with flood protection and rate limiting.

--- a/tests/test_audit_chain_cli.py
+++ b/tests/test_audit_chain_cli.py
@@ -1,0 +1,115 @@
+"""Tests for scripts/audit_chain.py's ``verify`` CLI subcommand (OI D1).
+
+Bug: ``verify_chain()`` reports ``status="unchained"`` for a ledger where no
+entry carries ``prev_hash`` — correct in isolation (chaining is default-off
+fleet-wide, VNX_CHAIN_RECEIPTS). But the CLI wrapper in audit_chain.py turned
+that into ``{"verified": true, "status": "unchained"}`` with exit code 0. A
+caller that reads only the exit code or only the ``verified`` field sees a
+green "chain is fine" result for a ledger that was never chained at all —
+absence of evidence read as evidence of presence.
+
+This does NOT touch verify_chain() or the hash-chain mechanism itself — only
+the CLI's translation of "unchained" into an exit code / verified field. The
+CLI must stop asserting a positive that it never measured.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_AUDIT_CHAIN = _REPO_ROOT / "scripts" / "audit_chain.py"
+
+GENESIS_HASH = "0" * 64
+
+
+def _run_verify(path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_AUDIT_CHAIN), "verify", str(path)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_unchained_ledger_is_not_reported_verified_true(tmp_path: Path) -> None:
+    """An unchained ledger (no entry carries prev_hash) must NOT come back
+    verified:true / exit 0 — that reads as 'the chain is fine' when there is
+    no chain to check."""
+    ledger = tmp_path / "t0_receipts.ndjson"
+    ledger.write_text(
+        json.dumps({"dispatch_id": "d-1", "status": "success"}) + "\n"
+        + json.dumps({"dispatch_id": "d-2", "status": "success"}) + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_verify(ledger)
+
+    assert result.returncode != 0, (
+        f"unchained ledger must exit non-zero, got 0. stdout={result.stdout!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload.get("status") == "unchained"
+    assert payload.get("verified") is not True, (
+        f"unchained ledger must not report verified:true, got {payload!r}"
+    )
+
+
+def test_missing_ledger_is_not_reported_verified_true(tmp_path: Path) -> None:
+    """A ledger file that does not exist at all is the same 'unchained'
+    branch in verify_chain() — must not silently read as a verified chain."""
+    ledger = tmp_path / "does_not_exist.ndjson"
+
+    result = _run_verify(ledger)
+
+    assert result.returncode != 0
+    payload = json.loads(result.stdout)
+    assert payload.get("status") == "unchained"
+    assert payload.get("verified") is not True
+
+
+def test_genuinely_verified_chain_still_exits_zero(tmp_path: Path) -> None:
+    """Sanity: a real, intact chain must still report verified:true / exit 0
+    — the fix must not turn the good case red."""
+    ledger = tmp_path / "t0_receipts.ndjson"
+    first = {"dispatch_id": "d-1", "status": "success", "prev_hash": GENESIS_HASH}
+
+    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+    from ndjson_hash_chain import compute_entry_hash  # noqa: E402
+
+    second = {
+        "dispatch_id": "d-2",
+        "status": "success",
+        "prev_hash": compute_entry_hash(first),
+    }
+    ledger.write_text(
+        json.dumps(first) + "\n" + json.dumps(second) + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_verify(ledger)
+
+    assert result.returncode == 0, f"verified chain must exit 0: {result.stdout!r} {result.stderr!r}"
+    payload = json.loads(result.stdout)
+    assert payload.get("verified") is True
+    assert payload.get("status") == "verified"
+
+
+def test_broken_chain_still_exits_nonzero(tmp_path: Path) -> None:
+    """Sanity: a genuinely broken chain must still exit 1 / verified:false —
+    unrelated to this fix, but must not regress."""
+    ledger = tmp_path / "t0_receipts.ndjson"
+    ledger.write_text(
+        json.dumps({"dispatch_id": "d-1", "status": "success", "prev_hash": GENESIS_HASH}) + "\n"
+        + json.dumps({"dispatch_id": "d-2", "status": "success", "prev_hash": "deadbeef" * 8}) + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_verify(ledger)
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload.get("verified") is False
+    assert payload.get("status") == "broken"

--- a/tests/test_build_t0_state_pytest_noise_filter.py
+++ b/tests/test_build_t0_state_pytest_noise_filter.py
@@ -1,0 +1,139 @@
+"""Tests for OI D2: pytest-fixture receipts must not count as real work.
+
+Measured 2026-09-04 on ~/.vnx-data/vnx-dev/state/t0_receipts.ndjson: 28,944
+lines total, 7,738 (27%) carrying ``source == "pytest"`` — synthetic test
+entries (dispatch_id like "DISP-007"), never real dispatch work. Any
+state-reader that folds them into recent-activity or a derived success rate
+is reading a polluted number.
+
+Covers:
+- ``_is_pytest_noise_receipt`` — the shared predicate.
+- ``_build_recent_receipts`` excludes pytest-source receipts.
+- A before/after count on a constructed ledger: the delta must equal exactly
+  the number of pytest-source receipts injected (OI D2's own "test your
+  filter" requirement — a filter that removes too much is as wrong as one
+  that removes nothing).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Make scripts/ importable
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+def _make_ndjson(state_dir: Path, entries: list[dict]) -> Path:
+    p = state_dir / "t0_receipts.ndjson"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lines = "\n".join(json.dumps(e) for e in entries)
+    p.write_text(lines + "\n", encoding="utf-8")
+    return p
+
+
+def _real_receipt(dispatch_id: str, timestamp: str) -> dict:
+    return {
+        "event_type": "subprocess_completion",
+        "dispatch_id": dispatch_id,
+        "status": "done",
+        "project_id": "vnx-dev",
+        "terminal": "T1",
+        "timestamp": timestamp,
+    }
+
+
+def _pytest_receipt(dispatch_id: str, timestamp: str) -> dict:
+    return {
+        "event_type": "task_complete",
+        "dispatch_id": dispatch_id,
+        "status": "success",
+        "project_id": "vnx-dev",
+        "terminal": "T1",
+        "timestamp": timestamp,
+        "source": "pytest",
+    }
+
+
+class TestIsPytestNoiseReceipt:
+    def test_source_pytest_is_noise(self) -> None:
+        from build_t0_state import _is_pytest_noise_receipt
+        assert _is_pytest_noise_receipt({"source": "pytest"}) is True
+
+    def test_source_pytest_case_insensitive(self) -> None:
+        from build_t0_state import _is_pytest_noise_receipt
+        assert _is_pytest_noise_receipt({"source": "PyTest"}) is True
+
+    def test_real_source_is_not_noise(self) -> None:
+        from build_t0_state import _is_pytest_noise_receipt
+        assert _is_pytest_noise_receipt({"source": "subprocess"}) is False
+
+    def test_missing_source_is_not_noise(self) -> None:
+        from build_t0_state import _is_pytest_noise_receipt
+        assert _is_pytest_noise_receipt({}) is False
+
+
+class TestBuildRecentReceiptsExcludesPytestNoise:
+    def _fn(self, state_dir: Path, project_id: str = "vnx-dev", limit: int = 20) -> list:
+        from build_t0_state import _build_recent_receipts
+        os.environ.pop("VNX_USE_CENTRAL_DB", None)
+        return _build_recent_receipts(state_dir, project_id=project_id, limit=limit)
+
+    def test_pytest_source_receipt_excluded(self, tmp_path: Path) -> None:
+        entries = [
+            _real_receipt("real-1", "2026-06-03T10:00:00Z"),
+            _pytest_receipt("DISP-007", "2026-06-03T10:05:00Z"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(state_dir, entries)
+        result = self._fn(state_dir)
+        ids = [r["dispatch_id"] for r in result]
+        assert "real-1" in ids
+        assert "DISP-007" not in ids
+
+    def test_before_after_count_delta_equals_injected_pytest_count(self, tmp_path: Path) -> None:
+        """OI D2's own instruction: prove the filter removes exactly the
+        pytest receipts, not more and not less."""
+        real_entries = [
+            _real_receipt(f"real-{i:03d}", f"2026-06-03T{i:02d}:00:00Z")
+            for i in range(12)
+        ]
+        pytest_entries = [
+            _pytest_receipt(f"DISP-{i:03d}", f"2026-06-04T{i:02d}:00:00Z")
+            for i in range(7)
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(state_dir, real_entries + pytest_entries)
+
+        # "Before": count what a naive scan of the raw file would see.
+        raw_lines = (state_dir / "t0_receipts.ndjson").read_text(encoding="utf-8").splitlines()
+        before_count = sum(1 for ln in raw_lines if ln.strip())
+        assert before_count == 19
+
+        after = self._fn(state_dir, limit=100)
+        after_count = len(after)
+
+        assert before_count - after_count == 7, (
+            f"expected the delta to equal exactly the 7 injected pytest "
+            f"receipts, got before={before_count} after={after_count}"
+        )
+        assert after_count == 12
+        for r in after:
+            assert not r["dispatch_id"].startswith("DISP-")
+
+    def test_pytest_receipt_with_real_looking_dispatch_id_still_excluded(self, tmp_path: Path) -> None:
+        """A pytest receipt whose dispatch_id happens to collide with a real
+        naming scheme must still be excluded — the filter keys off
+        ``source``, not the shape of dispatch_id."""
+        entries = [
+            _pytest_receipt("20260904-120000-realistic-id", "2026-06-03T10:00:00Z"),
+        ]
+        state_dir = tmp_path / "state"
+        _make_ndjson(state_dir, entries)
+        result = self._fn(state_dir)
+        assert result == []

--- a/tests/test_queue_reconciler.py
+++ b/tests/test_queue_reconciler.py
@@ -382,6 +382,38 @@ class TestLoadReceiptDispatchIds:
         confirmed = load_receipt_dispatch_ids(receipts)
         assert confirmed == {"dispatch-0", "dispatch-1", "dispatch-2"}
 
+    def test_pytest_source_receipt_not_confirmed(self, tmp_path):
+        """D2: a pytest-fixture receipt (source == 'pytest') must never
+        confirm a dispatch as complete — it is test noise, not real work.
+        Measured 2026-09-04: 7,738 of 28,944 lines on the real
+        t0_receipts.ndjson carry source == 'pytest'."""
+        receipts = tmp_path / "receipts.ndjson"
+        record = {
+            "dispatch_id": "PR-42",
+            "event_type": "task_complete",
+            "status": "success",
+            "source": "pytest",
+        }
+        receipts.write_text(json.dumps(record) + "\n")
+        confirmed = load_receipt_dispatch_ids(receipts)
+        assert "PR-42" not in confirmed
+
+    def test_pytest_source_does_not_shadow_real_confirmation(self, tmp_path):
+        """A real receipt for the same dispatch_id must still confirm it,
+        even when a pytest-noise receipt for the same id is also present."""
+        receipts = tmp_path / "receipts.ndjson"
+        with receipts.open("a") as f:
+            f.write(json.dumps({
+                "dispatch_id": "PR-99", "event_type": "task_complete",
+                "status": "success", "source": "pytest",
+            }) + "\n")
+            f.write(json.dumps({
+                "dispatch_id": "PR-99", "event_type": "task_complete",
+                "status": "success", "source": "subprocess",
+            }) + "\n")
+        confirmed = load_receipt_dispatch_ids(receipts)
+        assert "PR-99" in confirmed
+
 
 # ---------------------------------------------------------------------------
 # State derivation tests

--- a/tests/test_receipt_processor_converter_rejection_visible.py
+++ b/tests/test_receipt_processor_converter_rejection_visible.py
@@ -1,0 +1,166 @@
+"""Tests for OI D3: a report_to_receipt_converter REJECTED must be visible
+in the receipt_processor.sh log.
+
+Bug: _ppr_process_rate_limited() ran the converter with ``2>/dev/null``,
+throwing away its stderr — and that is exactly where the converter's
+fail-closed REJECTED warning is logged (Python's ``logging`` default handler
+writes to stderr). The converter's own ``main()`` always returns 0 even when
+it rejected reports this scan (a rejection is not a crash), so the
+``|| log ERROR ... (exit $?)`` fallback never fired for this case either —
+the two defects compounded into total silence: a refused report vanished
+from the audit trail with zero trace anywhere in the log.
+
+Exercises the REAL receipt_processor.sh function (_ppr_process_rate_limited)
+by sourcing the production script in _RP_LIB_MODE=1, with SCRIPTS_DIR
+redirected to a stub converter that reproduces the real converter's
+behavior: prints a WARNING to stderr, exits 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+RP_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "receipt_processor.sh"
+
+ENV_PREAMBLE = """
+set -u
+export _RP_LIB_MODE=1
+export VNX_DATA_DIR="{data_dir}"
+export VNX_STATE_DIR="{state}"
+export VNX_PIDS_DIR="{pids}"
+export VNX_LOCKS_DIR="{locks}"
+export VNX_REPORTS_DIR="{unified}"
+export VNX_HEADLESS_REPORTS_DIR="{headless}"
+source "{rp_script}" || {{ echo "FATAL: source failed" >&2; exit 1; }}
+"""
+
+_REJECTED_LINE = (
+    "WARNING report_to_receipt_converter: report_to_receipt_converter: "
+    "REJECTED (fail-closed) dispatch=DISP-STUB file=stub.md reason=missing model"
+)
+_SUMMARY_LINE = (
+    "WARNING report_to_receipt_converter: report_to_receipt_converter: "
+    "1 rejected, 0 malformed, 0 error(s) this scan"
+)
+
+
+def _make_dirs(tmp: Path) -> dict:
+    data_dir = tmp / "data"
+    dirs = {
+        "unified": tmp / "unified",
+        "headless": tmp / "headless",
+        "state": data_dir / "state",
+        "pids": tmp / "pids",
+        "locks": tmp / "locks",
+        "data_dir": data_dir,
+    }
+    for d in dirs.values():
+        d.mkdir(parents=True, exist_ok=True)
+    return dirs
+
+
+def _make_stub_converter(tmp: Path, *, exit_code: int = 0) -> Path:
+    """A stub lib/report_to_receipt_converter.py reproducing the real
+    converter's fail-closed REJECTED warning-to-stderr, exit-0 behavior."""
+    stub_scripts = tmp / "stub_scripts"
+    stub_lib = stub_scripts / "lib"
+    stub_lib.mkdir(parents=True, exist_ok=True)
+    converter = stub_lib / "report_to_receipt_converter.py"
+    converter.write_text(
+        textwrap.dedent(f"""\
+            #!/usr/bin/env python3
+            import sys
+            print({_REJECTED_LINE!r}, file=sys.stderr)
+            print({_SUMMARY_LINE!r}, file=sys.stderr)
+            sys.exit({exit_code})
+            """),
+        encoding="utf-8",
+    )
+    converter.chmod(0o755)
+    return stub_scripts
+
+
+def _run_bash(dirs: dict, body: str) -> subprocess.CompletedProcess:
+    cmd = ENV_PREAMBLE.format(rp_script=RP_SCRIPT, **dirs) + body
+    return subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
+
+
+def test_rejected_warning_is_not_silently_lost_first_confirm_it_would_show(tmp_path: Path) -> None:
+    """Nul-is-eerst-een-meetfout sanity check: before trusting an assertion
+    that REJECTED is absent from the log, prove the search mechanism itself
+    would find a known-present string. Run the stub converter directly
+    (no receipt_processor.sh redirection at all) and confirm its stderr
+    really does carry the REJECTED text."""
+    stub_scripts = _make_stub_converter(tmp_path)
+    converter = stub_scripts / "lib" / "report_to_receipt_converter.py"
+    result = subprocess.run(
+        ["python3", str(converter), "--state-dir", str(tmp_path), str(tmp_path), str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert "REJECTED (fail-closed)" in result.stderr, (
+        f"sanity check failed: stub converter did not write REJECTED to stderr: {result.stderr!r}"
+    )
+    assert result.returncode == 0
+
+
+def test_rejected_warning_reaches_the_processing_log(tmp_path: Path) -> None:
+    """The real defect: with the current receipt_processor.sh, does the
+    converter's REJECTED warning land in $PROCESSING_LOG (receipt_processing.log)?"""
+    dirs = _make_dirs(tmp_path)
+    stub_scripts = _make_stub_converter(tmp_path)
+
+    body = f"""
+SCRIPTS_DIR="{stub_scripts}"
+_ppr_process_rate_limited
+"""
+    result = _run_bash(dirs, body)
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+
+    processing_log = dirs["state"] / "receipt_processing.log"
+    assert processing_log.is_file(), "receipt_processing.log was never created"
+    log_contents = processing_log.read_text(encoding="utf-8")
+
+    assert "REJECTED (fail-closed)" in log_contents, (
+        "converter's REJECTED warning never reached the processing log "
+        f"(stderr was thrown away). log contents:\n{log_contents}"
+    )
+    assert "1 rejected, 0 malformed, 0 error(s) this scan" in log_contents
+
+
+def test_rejected_warning_also_reaches_stderr_stream(tmp_path: Path) -> None:
+    """log() tees to both the log file AND stderr — confirm the live
+    stream (what an operator watching the daemon sees) carries it too."""
+    dirs = _make_dirs(tmp_path)
+    stub_scripts = _make_stub_converter(tmp_path)
+
+    body = f"""
+SCRIPTS_DIR="{stub_scripts}"
+_ppr_process_rate_limited
+"""
+    result = _run_bash(dirs, body)
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+    assert "REJECTED (fail-closed)" in result.stderr
+
+
+def test_non_fatal_design_preserved_on_a_real_crash(tmp_path: Path) -> None:
+    """Sanity: a genuine converter crash (nonzero exit) must still be
+    logged as a non-fatal ERROR and must NOT abort the processor — the
+    non-fatal contract is explicit-by-design and this fix must not change it."""
+    dirs = _make_dirs(tmp_path)
+    stub_scripts = _make_stub_converter(tmp_path, exit_code=1)
+
+    body = f"""
+SCRIPTS_DIR="{stub_scripts}"
+_ppr_process_rate_limited
+echo "REACHED_END=yes"
+"""
+    result = _run_bash(dirs, body)
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+    assert "REACHED_END=yes" in result.stdout, "processor must continue past a converter crash"
+
+    processing_log = (dirs["state"] / "receipt_processing.log").read_text(encoding="utf-8")
+    assert "FAILED non-fatal" in processing_log
+    assert "exit 1" in processing_log


### PR DESCRIPTION
## Summary

Three places where the evidence chain asserted something it never measured, all verified on main `065939fa` (Cluster D of a three-cluster parallel dispatch: B touches `dispatch_serialization.py`, C builds `stop_conditions.py`, both untouched here).

**D1 — `scripts/audit_chain.py`**: `verify` on an unchained ledger (no entry carries `prev_hash`) reported `verified: true` / exit 0. A caller reading only the exit code sees "chain is fine" when no chain was ever checked. Now: `verified: false` / exit 2 for status `unchained`. Does **not** build the hash-chain — `VNX_CHAIN_RECEIPTS` stays the separate, explicit opt-in. Caller sweep: zero in-repo subprocess callers of `audit_chain.py` (grep-confirmed across `.py`/`.sh`/`.yml` and `.github/`) — it's operator-invoked per `docs/operations/RECEIPT_PIPELINE.md`. Every other `verify_chain()` consumer (`fabric_audit.py`, `chain_epoch_seal.py`, `ledger_health.py`, `attest_override.py`, `chain_origin_anchor.py`, `evidence_bound_gate.py`, `governance_effectiveness_probe.py`) calls the library function directly, not the CLI — unaffected.

**D2 — `scripts/build_t0_state.py` + `scripts/lib/queue_reconciler.py`**: `t0_receipts.ndjson` carries pytest-fixture noise (`source == "pytest"`) — measured 28,947 lines / 7,738 (26.7%) on the real ledger (dispatch cited 28,944/7,738/27% — matches, small drift from the live append-only ledger growing between measurements). These are test runs that appended fixtures onto the live ledger instead of an isolated `tmp_path`, not real dispatch work. `_build_recent_receipts` now excludes them via a shared `_is_pytest_noise_receipt` predicate; `PYTEST_NOISE_FILTER_EPOCH` marks the point this filter was introduced (mirrors ADR-029's `chain_epoch_start` convention) so a before/after count has an auditable reason. Second-place sweep found the identical pollution in `queue_reconciler.load_receipt_dispatch_ids` — which feeds `completion_pct` via `build_t0_state._build_pr_progress` — and fixed it there too. That function is also used by `reconcile_queue_state.py`, `closure_verifier.py`, `kickoff_preflight.py`, and `projection_reconciler.py`, which inherit the fix without being touched directly. Ledger itself untouched (append-only, ADR-005).

**D3 — `scripts/receipt_processor.sh`**: the catchup-scan converter call redirected stderr to `/dev/null` — exactly where the converter's fail-closed REJECTED warning lands (missing-Model refusal, `_validate_model_present`). Its `main()` always returns 0 even when it rejected reports this scan (a rejection isn't a crash), so the old `|| log ERROR ... (exit $?)` fallback never fired for that case either — the two defects compounded into a refused report vanishing from the audit trail with zero trace anywhere in the log. Stderr is now captured unconditionally (independent of exit code) and routed through `log()` so a REJECTED is visible; the non-fatal design (a crash must not abort the processor loop) is explicitly preserved and tested.

## Changes
- `scripts/audit_chain.py` — `unchained` -> `verified: false`, exit 2
- `scripts/build_t0_state.py` — `_is_pytest_noise_receipt` + `PYTEST_NOISE_FILTER_EPOCH`, wired into `_build_recent_receipts`
- `scripts/lib/queue_reconciler.py` — same pytest-source filter in `load_receipt_dispatch_ids`
- `scripts/receipt_processor.sh` — capture converter stderr unconditionally, log every line, keep non-fatal design
- Tests: `tests/test_audit_chain_cli.py` (new), `tests/test_build_t0_state_pytest_noise_filter.py` (new), `tests/test_receipt_processor_converter_rejection_visible.py` (new), `tests/test_queue_reconciler.py` (extended)

## Verification

Red-then-green per defect, each confirmed failing on current code before the fix and passing after (via `git stash` on the fix file, not the test):

- **D1**: 2/4 failed before (`test_unchained_ledger_is_not_reported_verified_true`, `test_missing_ledger_is_not_reported_verified_true`) -> 4/4 pass after.
- **D2** (`build_t0_state`): 7/7 failed before -> 7/7 pass after. Before/after count on a constructed 19-line ledger (12 real + 7 pytest) confirms the delta is exactly 7.
- **D2** (`queue_reconciler`): 1/2 new tests failed before -> 54/54 pass after (full file, no regressions).
- **D3**: 2/4 failed before (log-file + stderr-stream assertions) -> 4/4 pass after, including a sanity check that the search string really would be found when not redirected, and a regression check that a genuine converter crash is still logged non-fatally and doesn't abort the loop.

No regressions in neighboring suites: `test_ndjson_hash_chain.py`, `test_receipt_hashchain.py`, `test_chain_epoch_seal.py`, `test_chain_origin_anchor.py`, `test_chain_branch_protection_check.py` (100/100), `test_ledger_health.py` + `test_ledger_health_launchd.py` (44/44), `test_report_to_receipt_converter.py` (169/169), all `test_build_t0_state_*.py` + related (164/165, one pre-existing DB-migration failure confirmed present on unmodified main too), all `test_receipt_processor_*.py` + neighbors (111/112, one pre-existing unrelated `report_parser`/`auto_report_contract` failure confirmed present on unmodified main too).

Live measurement against `~/.vnx-data/vnx-dev/state/t0_receipts.ndjson` confirms the dispatch's premise: 28,947 total lines, 7,738 `source=="pytest"` (26.7%).

## Open items
None.

Dispatch-ID: 20260904-bewijsketen-liegt-niet-meer
Model: opus
Provider: claude

> Buiten de dispatch-deur om geproduceerd via een Agent-subagent, operator-besluit 2026-09-04. Tijdelijke afwijking: de gegovernde dispatch-paden zijn traag en de deur is zelf onderwerp van reparatie. PR en CI blijven onverkort gelden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR