### PR TITLE
feat(gate): measure T0 stop-conditions in code (E1/E4/exhaustion/E6)

### DIFF
--- a/scripts/lib/stop_conditions.py
+++ b/scripts/lib/stop_conditions.py
@@ -1,0 +1,652 @@
+"""stop_conditions.py — measurable stop-conditions for an autonomous T0 chain.
+
+The T0 orchestrator role (``.claude/terminals/T0/role-orchestrator.md``,
+section "Stop conditions (wake operator)") names six cases where an
+autonomous chain must halt and wake the operator (E1-E6). Until this module,
+that list existed only as prose: nothing in the fabric measured any of them,
+so a chain running unattended had no way to observe its own stop conditions.
+
+This module measures FOUR of the six:
+
+  1. ``check_main_ci_red``              — E1 (main branch CI conclusion != success)
+  2. ``check_gh_auth_dead``              — E4 (gh cannot authenticate, or quota is 0)
+  3. ``check_provider_exhausted``        — a provider refuses structurally (the
+     live example: kimi has returned HTTP 403 access_terminated_error on its
+     weekly quota since 2026-09-03 — failure_class "auth_rejected" on the
+     receipt ledger)
+  4. ``check_repeated_gate_failure_cause`` — E6 (N consecutive PR gate results
+     blocked by the same recurring cause)
+
+E2 (data-loss risk) and E3 (secrets in logs/PRs) are NOT measured here: both
+require judging the CONTENT of a diff or a log line, not a state signal this
+module can read cheaply and deterministically. Building a shallow pattern
+match for either would produce exactly the false confidence this dispatch
+exists to avoid — a check that looks like it covers E2/E3 but doesn't. They
+stay prose-only pending a dedicated design.
+
+Data model — a THIRD branch, not a third value of an existing branch
+----------------------------------------------------------------------
+Every check answers one of three things, never two:
+
+  - ``CheckStatus.TRIGGERED``    — the condition holds; halt.
+  - ``CheckStatus.CLEAR``        — measured, and the condition does not hold.
+  - ``CheckStatus.UNMEASURABLE`` — could not be measured (tool missing, file
+    absent, not enough data, a timeout, unparseable output, ...).
+
+``UNMEASURABLE`` never collapses into ``CLEAR`` ("no evidence of harm" is not
+"evidence of no harm") and never collapses into ``TRIGGERED`` (a halt must be
+backed by a real reading, not a shrug). A caller that only checks
+``status == CheckStatus.TRIGGERED`` before proceeding is correct by
+construction: unmeasurable is silently *not* a green light.
+
+Wiring note (deliberately out of scope here)
+---------------------------------------------
+This module is self-contained and callable/testable on its own. Calling it
+from the dispatch door (``dispatch_cli.py``) is a separate, later PR — see
+the module's own dispatch note. Do not import this module from
+``dispatch_cli.py`` in the same change that adds it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections import deque
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from project_root import resolve_project_root  # noqa: E402
+
+try:
+    from failure_classification import FAILURE_CLASSES as _KNOWN_FAILURE_CLASSES
+except ImportError:  # vnx-silent-except: cross-check is advisory only, module must stay importable standalone
+    _KNOWN_FAILURE_CLASSES = None
+
+
+# ── Data model ──────────────────────────────────────────────────────────────
+
+
+class CheckStatus(str, Enum):
+    TRIGGERED = "triggered"
+    CLEAR = "clear"
+    UNMEASURABLE = "unmeasurable"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class StopConditionResult:
+    check_id: str
+    status: CheckStatus
+    message: str
+    evidence: Dict[str, Any] = field(default_factory=dict)
+    checked_at: str = field(default_factory=_utc_now_iso)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["status"] = self.status.value
+        return d
+
+
+def _triggered(check_id: str, message: str, **evidence: Any) -> StopConditionResult:
+    return StopConditionResult(check_id, CheckStatus.TRIGGERED, message, evidence=evidence)
+
+
+def _clear(check_id: str, message: str, **evidence: Any) -> StopConditionResult:
+    return StopConditionResult(check_id, CheckStatus.CLEAR, message, evidence=evidence)
+
+
+def _unmeasurable(check_id: str, message: str, **evidence: Any) -> StopConditionResult:
+    return StopConditionResult(check_id, CheckStatus.UNMEASURABLE, message, evidence=evidence)
+
+
+def _combine(check_id: str, sub_results: List[StopConditionResult], *, sub_key: str) -> StopConditionResult:
+    """Fold N per-entity sub-results (per-provider, per-gate, ...) into one.
+
+    ANY triggered sub-result -> TRIGGERED overall (fail loud on a single hit).
+    Else, if AT LEAST ONE sub-result was actually measured (CLEAR) -> CLEAR.
+    Else (every sub-result is UNMEASURABLE, or there were none) -> UNMEASURABLE.
+    """
+    by_id = {r.check_id: r.to_dict() for r in sub_results}
+    triggered = [r for r in sub_results if r.status == CheckStatus.TRIGGERED]
+    if triggered:
+        return _triggered(
+            check_id,
+            "; ".join(r.message for r in triggered),
+            **{sub_key: by_id},
+        )
+    if any(r.status == CheckStatus.CLEAR for r in sub_results):
+        return _clear(
+            check_id,
+            f"{len(sub_results)} sub-check(s) gemeten, geen triggered",
+            **{sub_key: by_id},
+        )
+    return _unmeasurable(
+        check_id,
+        "geen van de sub-checks kon gemeten worden" if sub_results else "geen meetbare entiteiten gevonden",
+        **{sub_key: by_id},
+    )
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp; None on anything not cleanly parseable.
+
+    Mirrors merge_preflight_ci_check._parse_created_at: a missing/unparseable
+    timestamp means "order unknown" to the caller, never "sorts first" or
+    "sorts last" (OI-1613 precedent) — so this returns None rather than
+    raising or guessing.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ── Path resolution (mirrors dispatch_register.py's fallback chain) ────────
+
+
+def _resolve_state_dir() -> Path:
+    """Resolve VNX_STATE_DIR via the canonical resolver, with the same
+    fallback chain dispatch_register.py uses when it is unavailable. Never
+    a hardcoded ``.vnx-data/`` literal — see project CLAUDE.md on
+    central-store authority (ADR-026)."""
+    try:
+        from vnx_paths import resolve_paths
+
+        return Path(resolve_paths()["VNX_STATE_DIR"])
+    except Exception:  # vnx-silent-except: fallback chain below mirrors dispatch_register._register_path
+        state_dir_env = os.environ.get("VNX_STATE_DIR")
+        if state_dir_env:
+            return Path(state_dir_env)
+        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+            return Path(os.environ["VNX_DATA_DIR"]) / "state"
+        return resolve_project_root(__file__) / ".vnx-data" / "state"
+
+
+def _default_project_root() -> Optional[Path]:
+    try:
+        return resolve_project_root(__file__)
+    except RuntimeError:
+        return None
+
+
+# ── Subprocess helper (mirrors merge_preflight_ci_check._capture) ──────────
+
+
+def _capture(
+    argv: List[str], *, timeout: int, cwd: Optional[str] = None
+) -> Tuple[Optional[subprocess.CompletedProcess], Optional[str]]:
+    """Run a command, returning (result, error_tag).
+
+    error_tag is "missing" (binary not found), "timeout", or None. A non-zero
+    exit is NOT an error_tag — the caller inspects returncode itself so it can
+    distinguish "ran and said no" from "could not run at all"."""
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+        return result, None
+    except FileNotFoundError:
+        return None, "missing"
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+
+
+# ── Check 1: E1 — main-branch CI conclusion ─────────────────────────────────
+
+DEFAULT_CI_WORKFLOW_NAME = "VNX CI"
+CI_WORKFLOW_NAME_ENV_VAR = "VNX_CI_WORKFLOW_NAME"
+DEFAULT_MAIN_BRANCH = "main"
+GH_RUN_LIST_TIMEOUT = 15
+
+
+def check_main_ci_red(
+    project_root: Optional[Path] = None,
+    *,
+    branch: str = DEFAULT_MAIN_BRANCH,
+    workflow_name: Optional[str] = None,
+    gh_bin: str = "gh",
+) -> StopConditionResult:
+    """E1: main branch broken after merge.
+
+    Measures the VNX CI workflow conclusion of the most recent run on
+    ``branch`` (default: main). A still-running latest run (in_progress /
+    queued) is UNMEASURABLE — "not yet known", never read as clear or
+    triggered.
+    """
+    check_id = "main_ci_red"
+    resolved_workflow = workflow_name or os.environ.get(CI_WORKFLOW_NAME_ENV_VAR) or DEFAULT_CI_WORKFLOW_NAME
+    root = Path(project_root) if project_root is not None else _default_project_root()
+    if root is None:
+        return _unmeasurable(check_id, "kon project-root niet resolven: main-CI-status niet meetbaar")
+
+    if shutil.which(gh_bin) is None:
+        return _unmeasurable(check_id, "gh CLI niet beschikbaar: main-CI-status niet meetbaar", workflow=resolved_workflow)
+
+    result, err = _capture(
+        [
+            gh_bin, "run", "list",
+            "--branch", branch,
+            "--workflow", resolved_workflow,
+            "--limit", "1",
+            "--json", "conclusion,status,headSha,createdAt,databaseId",
+        ],
+        timeout=GH_RUN_LIST_TIMEOUT,
+        cwd=str(root),
+    )
+    if err == "missing":
+        return _unmeasurable(check_id, "gh CLI niet beschikbaar: main-CI-status niet meetbaar", workflow=resolved_workflow)
+    if err == "timeout":
+        return _unmeasurable(check_id, f"gh run list liep vast voor workflow '{resolved_workflow}'", workflow=resolved_workflow, branch=branch)
+    if result is None or result.returncode != 0:
+        stderr = (result.stderr if result else "").strip()
+        return _unmeasurable(
+            check_id,
+            f"gh run list faalde voor workflow '{resolved_workflow}' op branch '{branch}'"
+            + (f" ({stderr[:200]})" if stderr else ""),
+            workflow=resolved_workflow,
+            branch=branch,
+        )
+
+    try:
+        runs = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return _unmeasurable(check_id, f"gh-uitvoer niet te parsen voor workflow '{resolved_workflow}'", workflow=resolved_workflow, branch=branch)
+
+    if not runs:
+        return _unmeasurable(check_id, f"geen VNX CI-run gevonden op branch '{branch}'", workflow=resolved_workflow, branch=branch)
+
+    run = runs[0]
+    status = run.get("status") or ""
+    if status in ("in_progress", "queued"):
+        return _unmeasurable(
+            check_id,
+            f"{resolved_workflow} draait nog op '{branch}' (status={status}): conclusie nog niet bekend",
+            workflow=resolved_workflow, branch=branch, run=run,
+        )
+
+    conclusion = run.get("conclusion") or ""
+    if not conclusion:
+        return _unmeasurable(check_id, f"run afgerond zonder conclusion-veld op '{branch}'", workflow=resolved_workflow, branch=branch, run=run)
+
+    if conclusion == "success":
+        return _clear(check_id, f"{resolved_workflow} geslaagd op '{branch}'", workflow=resolved_workflow, branch=branch, run=run)
+
+    return _triggered(
+        check_id,
+        f"{resolved_workflow} conclusion='{conclusion}' op '{branch}' (E1: main branch broken after merge)",
+        workflow=resolved_workflow, branch=branch, run=run,
+    )
+
+
+# ── Check 2: E4 — gh auth / quota ───────────────────────────────────────────
+
+GH_AUTH_TIMEOUT = 10
+GH_RATE_LIMIT_TIMEOUT = 10
+
+
+def check_gh_auth_dead(*, gh_bin: str = "gh") -> StopConditionResult:
+    """E4: GitHub auth/quota fully dead (cannot proceed).
+
+    Two sub-signals fold into one TRIGGERED: ``gh auth status`` failing
+    outright, or the REST rate limit reading zero remaining. A missing gh
+    binary or a subprocess timeout is UNMEASURABLE, not TRIGGERED — those are
+    "the tool to check is unavailable", a different fact than "checked, and
+    it is dead".
+    """
+    check_id = "gh_auth_dead"
+    if shutil.which(gh_bin) is None:
+        return _unmeasurable(check_id, "gh CLI niet geinstalleerd: auth-status niet meetbaar")
+
+    auth, err = _capture([gh_bin, "auth", "status"], timeout=GH_AUTH_TIMEOUT)
+    if err == "missing":
+        return _unmeasurable(check_id, "gh CLI niet geinstalleerd: auth-status niet meetbaar")
+    if err == "timeout":
+        return _unmeasurable(check_id, "gh auth status liep vast (timeout): niet meetbaar")
+    if auth is None:
+        return _unmeasurable(check_id, "gh auth status gaf geen resultaat: niet meetbaar")
+    if auth.returncode != 0:
+        stderr = (auth.stderr or "").strip()
+        return _triggered(
+            check_id,
+            f"gh is niet geauthenticeerd (E4: GitHub auth/quota fully dead)" + (f": {stderr[:200]}" if stderr else ""),
+            stderr=stderr,
+        )
+
+    rate, err2 = _capture([gh_bin, "api", "rate_limit", "--jq", ".rate.remaining"], timeout=GH_RATE_LIMIT_TIMEOUT)
+    if err2 == "missing":
+        return _unmeasurable(check_id, "gh CLI verdween tussen auth-check en quota-check: niet meetbaar", auth_ok=True)
+    if err2 == "timeout":
+        return _unmeasurable(check_id, "gh api rate_limit liep vast (timeout): auth is OK, quotum onbekend", auth_ok=True)
+    if rate is None or rate.returncode != 0:
+        stderr = (rate.stderr if rate else "").strip()
+        return _unmeasurable(
+            check_id,
+            "gh api rate_limit faalde: auth is OK, quotum onbekend" + (f" ({stderr[:200]})" if stderr else ""),
+            auth_ok=True,
+        )
+
+    raw = (rate.stdout or "").strip()
+    try:
+        remaining = int(raw)
+    except ValueError:
+        return _unmeasurable(check_id, f"quota-uitvoer niet te parsen ('{raw}'): auth is OK, quotum onbekend", auth_ok=True, raw=raw)
+
+    if remaining <= 0:
+        return _triggered(check_id, f"GitHub API-quotum op (remaining={remaining}) (E4: GitHub auth/quota fully dead)", remaining=remaining)
+
+    return _clear(check_id, f"gh geauthenticeerd, quotum remaining={remaining}", remaining=remaining)
+
+
+# ── Shared receipt-ledger reading helpers ───────────────────────────────────
+
+_ATTEMPT_EVENT_TYPES = frozenset({"task_complete", "subprocess_completion", "task_failed"})
+_SUCCESS_STATUSES = frozenset({"success", "done", "complete"})
+_FAILURE_STATUSES = frozenset({"failed", "failure"})
+
+# The two failure_classification.py classes that mean "the provider itself
+# structurally refuses" — auth/quota rejection (401/403) or balance/credit
+# exhaustion — as opposed to a transient model_error, timeout, or an
+# unrelated unknown failure. Grounded on the live ledger 2026-09-04: kimi's
+# weekly-quota 403 ("access_terminated_error") classifies as auth_rejected.
+EXHAUSTION_FAILURE_CLASSES = frozenset({"auth_rejected", "credit_exhausted"})
+
+if _KNOWN_FAILURE_CLASSES is not None:
+    assert EXHAUSTION_FAILURE_CLASSES <= _KNOWN_FAILURE_CLASSES, (
+        "EXHAUSTION_FAILURE_CLASSES drifted from failure_classification.FAILURE_CLASSES"
+    )
+
+
+def _tail_lines(path: Path, max_lines: int) -> List[str]:
+    """Return up to the last ``max_lines`` non-empty lines of ``path``,
+    oldest first. Streams the file line-by-line into a bounded deque —
+    O(max_lines) memory regardless of file size (t0_receipts.ndjson measured
+    170MB+ on 2026-09-04): a plain read_text()/readlines() would load the
+    whole ledger just to look at its tail."""
+    dq: deque = deque(maxlen=max_lines)
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                dq.append(line)
+    return list(dq)
+
+
+# ── Check 3: provider/lane exhaustion ───────────────────────────────────────
+
+DEFAULT_RECEIPT_TAIL_LINES = 5000
+DEFAULT_EXHAUSTION_THRESHOLD = 3
+
+
+def check_provider_exhausted(
+    receipts_path: Optional[Path] = None,
+    *,
+    providers: Optional[List[str]] = None,
+    threshold: int = DEFAULT_EXHAUSTION_THRESHOLD,
+    tail_lines: int = DEFAULT_RECEIPT_TAIL_LINES,
+) -> StopConditionResult:
+    """A provider/lane refuses structurally (example live on the ledger since
+    2026-09-03: kimi's weekly quota, HTTP 403 access_terminated_error).
+
+    Per provider seen in the last ``tail_lines`` receipt-ledger lines, this
+    looks at the most recent ``threshold`` clean attempts (status normalized
+    to success/failure; anything ambiguous — timeout, unknown, no_signal,
+    contract_invalid, ... — is excluded from the timeline rather than guessed
+    either way) and triggers only when ALL of them are exhaustion-class
+    failures. A single success in that window clears the streak.
+    """
+    check_id = "provider_exhausted"
+    resolved_path = Path(receipts_path) if receipts_path is not None else (_resolve_state_dir() / "t0_receipts.ndjson")
+
+    if not resolved_path.is_file():
+        return _unmeasurable(check_id, f"receipts-bestand ontbreekt: {resolved_path}")
+
+    try:
+        lines = _tail_lines(resolved_path, tail_lines)
+    except OSError as exc:
+        return _unmeasurable(check_id, f"receipts-bestand niet leesbaar: {exc}")
+
+    by_provider: Dict[str, List[Dict[str, Any]]] = {}
+    for line in lines:
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if d.get("event_type") not in _ATTEMPT_EVENT_TYPES:
+            continue
+        provider = d.get("provider")
+        if not provider:
+            continue
+        if providers is not None and provider not in providers:
+            continue
+        raw_status = str(d.get("status") or "").strip().lower()
+        if raw_status in _SUCCESS_STATUSES:
+            norm = "success"
+        elif raw_status in _FAILURE_STATUSES:
+            norm = "failure"
+        else:
+            continue
+        by_provider.setdefault(provider, []).append(
+            {
+                "status": norm,
+                "failure_class": d.get("failure_class"),
+                "timestamp": d.get("timestamp"),
+                "dispatch_id": d.get("dispatch_id"),
+            }
+        )
+
+    if not by_provider:
+        return _unmeasurable(check_id, f"geen bruikbare provider-attempts gevonden in laatste {tail_lines} regels")
+
+    sub_results: List[StopConditionResult] = []
+    for provider, records in by_provider.items():
+        sub_id = f"{check_id}:{provider}"
+        if len(records) < threshold:
+            sub_results.append(
+                _unmeasurable(sub_id, f"minder dan {threshold} attempts voor '{provider}' in venster ({len(records)})", provider=provider, attempts=len(records))
+            )
+            continue
+        window = records[-threshold:]
+        if all(r["status"] == "failure" and r["failure_class"] in EXHAUSTION_FAILURE_CLASSES for r in window):
+            sub_results.append(
+                _triggered(
+                    sub_id,
+                    f"laatste {threshold} attempts voor '{provider}' allemaal exhaustion-failures ({window[-1]['failure_class']})",
+                    provider=provider, window=window,
+                )
+            )
+        else:
+            sub_results.append(
+                _clear(sub_id, f"laatste {threshold} attempts voor '{provider}' niet allemaal exhaustion-failures", provider=provider, window=window)
+            )
+
+    return _combine(check_id, sub_results, sub_key="per_provider")
+
+
+# ── Check 4: E6 — repeated gate-failure cause ───────────────────────────────
+
+_INFRA_FAIL_STATUSES = frozenset({"failed", "fail", "unavailable", "not_executable"})
+DEFAULT_REPEAT_THRESHOLD = 3
+
+
+def _gate_result_cause(record: Dict[str, Any]) -> Optional[str]:
+    """Canonical 'cause' for a review_gates/results/*.json record, or None
+    for a clean pass (or an outcome this can't classify either way).
+
+    Two blocked shapes exist in that store:
+      - an infra-level non-run (status in {failed, fail, unavailable,
+        not_executable}) carrying a ``reason`` enum (e.g.
+        "provider_not_installed", "gate_execution_degenerate") — the exact
+        shape the role file's own E6 example (Legacy path gate tripping on a
+        literal string) would produce.
+      - a completed run with non-empty ``blocking_findings``.
+    """
+    status = record.get("status")
+    if status in _INFRA_FAIL_STATUSES:
+        reason = record.get("reason")
+        return f"reason:{reason}" if reason else None
+    if status == "completed":
+        return "blocking_findings" if record.get("blocking_findings") else None
+    return None
+
+
+def check_repeated_gate_failure_cause(
+    results_dir: Optional[Path] = None,
+    *,
+    n: int = DEFAULT_REPEAT_THRESHOLD,
+    gates: Optional[List[str]] = None,
+) -> StopConditionResult:
+    """E6: three consecutive PRs blocked by the same recurring CI/gate issue.
+
+    Reads ``review_gates/results/pr-<n>-<gate>.json`` (one file per PR+gate
+    pair; a rerun overwrites it, so a single retried PR never inflates a
+    streak). Per gate, orders by ``recorded_at`` (a record with a missing or
+    unparseable timestamp is excluded — order-unknown, never guessed, mirrors
+    OI-1613's rule) and checks whether the last ``n`` results for that gate
+    all carry the same non-null cause.
+    """
+    check_id = "repeated_gate_failure_cause"
+    resolved_dir = Path(results_dir) if results_dir is not None else (_resolve_state_dir() / "review_gates" / "results")
+
+    if not resolved_dir.is_dir():
+        return _unmeasurable(check_id, f"resultaten-map ontbreekt: {resolved_dir}")
+
+    try:
+        files = sorted(resolved_dir.glob("pr-*.json"))
+    except OSError as exc:
+        return _unmeasurable(check_id, f"resultaten-map niet leesbaar: {exc}")
+
+    by_gate: Dict[str, List[Tuple[datetime, Any, Optional[str]]]] = {}
+    for fp in files:
+        try:
+            d = json.loads(fp.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        gate = d.get("gate")
+        if not gate:
+            continue
+        if gates is not None and gate not in gates:
+            continue
+        ts = _parse_iso(d.get("recorded_at"))
+        if ts is None:
+            continue
+        cause = _gate_result_cause(d)
+        by_gate.setdefault(gate, []).append((ts, d.get("pr_number"), cause))
+
+    if not by_gate:
+        return _unmeasurable(check_id, "geen bruikbare gate-resultaten met geldige recorded_at gevonden")
+
+    sub_results: List[StopConditionResult] = []
+    for gate, entries in by_gate.items():
+        sub_id = f"{check_id}:{gate}"
+        entries.sort(key=lambda e: e[0])
+        if len(entries) < n:
+            sub_results.append(_unmeasurable(sub_id, f"minder dan {n} geordende resultaten voor gate '{gate}' ({len(entries)})", gate=gate, count=len(entries)))
+            continue
+        window = entries[-n:]
+        causes = [c for (_, _, c) in window]
+        prs = [pr for (_, pr, _) in window]
+        if causes[0] is not None and all(c == causes[0] for c in causes):
+            sub_results.append(
+                _triggered(
+                    sub_id,
+                    f"laatste {n} PR's op gate '{gate}' allemaal geblokkeerd door dezelfde oorzaak ({causes[0]}) (E6)",
+                    gate=gate, cause=causes[0], prs=prs,
+                )
+            )
+        else:
+            sub_results.append(_clear(sub_id, f"laatste {n} PR's op gate '{gate}' niet allemaal dezelfde blokkade-oorzaak", gate=gate, causes=causes, prs=prs))
+
+    return _combine(check_id, sub_results, sub_key="per_gate")
+
+
+# ── Orchestration + halt.json ───────────────────────────────────────────────
+
+HALT_FILENAME = "halt.json"
+
+ALL_CHECK_IDS = (
+    "main_ci_red",
+    "gh_auth_dead",
+    "provider_exhausted",
+    "repeated_gate_failure_cause",
+)
+
+
+def run_all_checks(
+    *,
+    state_dir: Optional[Path] = None,
+    project_root: Optional[Path] = None,
+    write_halt: bool = True,
+) -> List[StopConditionResult]:
+    """Run all four stop-condition checks. When any is TRIGGERED and
+    ``write_halt`` is true, write/overwrite ``halt.json`` in ``state_dir``.
+
+    Never raises: each check function is itself fail-closed-to-unmeasurable,
+    never fail-open-to-clear.
+    """
+    resolved_state_dir = Path(state_dir) if state_dir is not None else _resolve_state_dir()
+    resolved_root = Path(project_root) if project_root is not None else _default_project_root()
+
+    results = [
+        check_main_ci_red(resolved_root),
+        check_gh_auth_dead(),
+        check_provider_exhausted(resolved_state_dir / "t0_receipts.ndjson"),
+        check_repeated_gate_failure_cause(resolved_state_dir / "review_gates" / "results"),
+    ]
+
+    if write_halt and any(r.status == CheckStatus.TRIGGERED for r in results):
+        write_halt_file(resolved_state_dir, results)
+
+    return results
+
+
+def write_halt_file(state_dir: Path, results: List[StopConditionResult]) -> Path:
+    """Write ``halt.json`` atomically (tmp file + os.replace via atomic_io).
+
+    This module only ever WRITES halt.json on a trigger — it never clears an
+    existing one. Recovery (deciding the operator has addressed the halt and
+    the chain may resume) is a deliberate, separate action, not something a
+    measurement pass should do implicitly.
+    """
+    from atomic_io import atomic_write_json
+
+    state_dir = Path(state_dir)
+    halt_path = state_dir / HALT_FILENAME
+    payload = {
+        "halted_at": _utc_now_iso(),
+        "triggered": [r.to_dict() for r in results if r.status == CheckStatus.TRIGGERED],
+        "all_checks": [r.to_dict() for r in results],
+    }
+    atomic_write_json(halt_path, payload)
+    return halt_path
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entrypoint: run all checks, print JSON, exit 1 iff any triggered."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Measure T0 autonomous-chain stop-conditions (E1/E4/provider-exhaustion/E6).")
+    parser.add_argument("--state-dir", default=None, help="override VNX_STATE_DIR resolution")
+    parser.add_argument("--no-write-halt", action="store_true", help="measure only, never write halt.json")
+    args = parser.parse_args(argv)
+
+    state_dir = Path(args.state_dir) if args.state_dir else None
+    results = run_all_checks(state_dir=state_dir, write_halt=not args.no_write_halt)
+    print(json.dumps([r.to_dict() for r in results], indent=2, default=str))
+    return 1 if any(r.status == CheckStatus.TRIGGERED for r in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/stop_conditions.py
+++ b/scripts/lib/stop_conditions.py
@@ -66,6 +66,7 @@ if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
 from project_root import resolve_project_root  # noqa: E402
+from receipt_verdict import HARD_FAILURE_STATUSES, SUCCESS_STATUSES  # noqa: E402
 
 try:
     from failure_classification import FAILURE_CLASSES as _KNOWN_FAILURE_CLASSES
@@ -159,27 +160,63 @@ def _parse_iso(value: Any) -> Optional[datetime]:
 # ── Path resolution (mirrors dispatch_register.py's fallback chain) ────────
 
 
+class StateDirUnresolvable(RuntimeError):
+    """Raised when VNX_STATE_DIR cannot be resolved by any legitimate means.
+
+    There is deliberately NO further fallback beyond the canonical resolver
+    and the direct env-var overrides: a ``resolve_project_root(__file__) /
+    ".vnx-data" / "state"`` last resort is exactly the bug class the
+    central-mode path gate (``scripts/check_no_file_derived_data_paths.py``)
+    exists to block — in a central install that derivation resolves the
+    shared fabric checkout's own ``.vnx-data``, not the project's
+    ``~/.vnx-data/<project_id>``, forking state and producing split-brain.
+    A caller that cannot resolve the canonical state dir must read that as
+    "this measurement is UNMEASURABLE", never synthesize a wrong path.
+    """
+
+
 def _resolve_state_dir() -> Path:
-    """Resolve VNX_STATE_DIR via the canonical resolver, with the same
-    fallback chain dispatch_register.py uses when it is unavailable. Never
-    a hardcoded ``.vnx-data/`` literal — see project CLAUDE.md on
-    central-store authority (ADR-026)."""
+    """Resolve VNX_STATE_DIR via the canonical resolver, or the same direct
+    env-var overrides dispatch_register.py honors when it is unavailable.
+
+    Raises StateDirUnresolvable when neither works. Callers that need a
+    default state dir must catch this and report UNMEASURABLE — see the
+    module docstring's tri-state contract.
+    """
     try:
         from vnx_paths import resolve_paths
 
         return Path(resolve_paths()["VNX_STATE_DIR"])
-    except Exception:  # vnx-silent-except: fallback chain below mirrors dispatch_register._register_path
-        state_dir_env = os.environ.get("VNX_STATE_DIR")
-        if state_dir_env:
-            return Path(state_dir_env)
-        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
-            return Path(os.environ["VNX_DATA_DIR"]) / "state"
-        return resolve_project_root(__file__) / ".vnx-data" / "state"
+    except Exception:  # vnx-silent-except: fall through to the direct env-var overrides below
+        pass
+
+    state_dir_env = os.environ.get("VNX_STATE_DIR")
+    if state_dir_env:
+        return Path(state_dir_env)
+    if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+        return Path(os.environ["VNX_DATA_DIR"]) / "state"
+
+    raise StateDirUnresolvable(
+        "vnx_paths.resolve_paths() faalde en geen VNX_STATE_DIR/VNX_DATA_DIR "
+        "override staat: geen repo-lokale __file__-fallback (central-mode "
+        "path gate verbiedt dat expliciet, zie OI 'un-grandfathered violation')"
+    )
 
 
 def _default_project_root() -> Optional[Path]:
+    """Best-effort project root for check_main_ci_red's ``gh`` invocation.
+
+    Deliberately calls resolve_project_root() WITHOUT a __file__ anchor: with
+    no caller_file, resolution is CWD-first (git rev-parse from the process's
+    working directory), never derived from where this module physically
+    lives on disk. That is exactly what a ``gh run list`` needs — the git
+    checkout the orchestrator is actually running in — and it is immune to
+    the central-mode keystone bug an anchored resolve_project_root(__file__)
+    would reintroduce (in a central install that resolves the shared fabric
+    checkout, not the project).
+    """
     try:
-        return resolve_project_root(__file__)
+        return resolve_project_root()
     except RuntimeError:
         return None
 
@@ -353,8 +390,18 @@ def check_gh_auth_dead(*, gh_bin: str = "gh") -> StopConditionResult:
 # ── Shared receipt-ledger reading helpers ───────────────────────────────────
 
 _ATTEMPT_EVENT_TYPES = frozenset({"task_complete", "subprocess_completion", "task_failed"})
-_SUCCESS_STATUSES = frozenset({"success", "done", "complete"})
-_FAILURE_STATUSES = frozenset({"failed", "failure"})
+
+# Completion-outcome vocabulary: imported from receipt_verdict.py (ADR-035
+# §3.1), the same source deliberation_panel.py and dispatch_outcome_classifier.py
+# already import from — not re-typed here. HARD_FAILURE_STATUSES is WIDER
+# than a hand-picked {"failed", "failure"} would be: it also carries "error",
+# "blocked", "timeout", "contract_invalid". That widening is a deliberate
+# improvement, not just import hygiene — see check_provider_exhausted's
+# docstring for the behavior it changes and why that is more correct, not
+# less. No narrower derived subset is needed: every extra status the
+# canonical set adds is itself a distinguishable, non-ambiguous outcome (a
+# receipt genuinely means it), so nothing here needs to strip entries back
+# out.
 
 # The two failure_classification.py classes that mean "the provider itself
 # structurally refuses" — auth/quota rejection (401/403) or balance/credit
@@ -402,13 +449,33 @@ def check_provider_exhausted(
 
     Per provider seen in the last ``tail_lines`` receipt-ledger lines, this
     looks at the most recent ``threshold`` clean attempts (status normalized
-    to success/failure; anything ambiguous — timeout, unknown, no_signal,
-    contract_invalid, ... — is excluded from the timeline rather than guessed
-    either way) and triggers only when ALL of them are exhaustion-class
-    failures. A single success in that window clears the streak.
+    to success/failure via receipt_verdict.py's canonical
+    SUCCESS_STATUSES/HARD_FAILURE_STATUSES vocabulary — genuinely ambiguous
+    values like "unknown"/"no_signal"/"in_progress"/"" are excluded from the
+    timeline rather than guessed either way) and triggers only when ALL of
+    them are exhaustion-class failures. A single success in that window
+    clears the streak.
+
+    Behavior note: HARD_FAILURE_STATUSES is wider than {"failed", "failure"}
+    — it also carries "error", "blocked", "timeout", "contract_invalid".
+    Those now count as real (non-exhaustion) "failure" attempts instead of
+    being skipped as ambiguous. That is strictly more correct for this
+    check: a "timeout" or "contract_invalid" receipt IS a definite, legible
+    outcome (just not an exhaustion one), so it should occupy a window slot
+    and correctly dilute/break a would-be exhaustion streak — the same way a
+    success does — rather than being invisible to the measurement. The
+    practical effect is fewer false UNMEASURABLE verdicts (more real
+    attempts are now recognized) without weakening the TRIGGERED condition,
+    which still requires the failure_class itself to be exhaustion-specific.
     """
     check_id = "provider_exhausted"
-    resolved_path = Path(receipts_path) if receipts_path is not None else (_resolve_state_dir() / "t0_receipts.ndjson")
+    if receipts_path is not None:
+        resolved_path = Path(receipts_path)
+    else:
+        try:
+            resolved_path = _resolve_state_dir() / "t0_receipts.ndjson"
+        except StateDirUnresolvable as exc:
+            return _unmeasurable(check_id, f"kon state-dir niet resolven: {exc}")
 
     if not resolved_path.is_file():
         return _unmeasurable(check_id, f"receipts-bestand ontbreekt: {resolved_path}")
@@ -432,9 +499,9 @@ def check_provider_exhausted(
         if providers is not None and provider not in providers:
             continue
         raw_status = str(d.get("status") or "").strip().lower()
-        if raw_status in _SUCCESS_STATUSES:
+        if raw_status in SUCCESS_STATUSES:
             norm = "success"
-        elif raw_status in _FAILURE_STATUSES:
+        elif raw_status in HARD_FAILURE_STATUSES:
             norm = "failure"
         else:
             continue
@@ -518,7 +585,13 @@ def check_repeated_gate_failure_cause(
     all carry the same non-null cause.
     """
     check_id = "repeated_gate_failure_cause"
-    resolved_dir = Path(results_dir) if results_dir is not None else (_resolve_state_dir() / "review_gates" / "results")
+    if results_dir is not None:
+        resolved_dir = Path(results_dir)
+    else:
+        try:
+            resolved_dir = _resolve_state_dir() / "review_gates" / "results"
+        except StateDirUnresolvable as exc:
+            return _unmeasurable(check_id, f"kon state-dir niet resolven: {exc}")
 
     if not resolved_dir.is_dir():
         return _unmeasurable(check_id, f"resultaten-map ontbreekt: {resolved_dir}")
@@ -594,19 +667,38 @@ def run_all_checks(
     ``write_halt`` is true, write/overwrite ``halt.json`` in ``state_dir``.
 
     Never raises: each check function is itself fail-closed-to-unmeasurable,
-    never fail-open-to-clear.
+    never fail-open-to-clear. When the state dir cannot be resolved at all
+    (no explicit ``state_dir`` and ``_resolve_state_dir`` raises
+    StateDirUnresolvable), the two ledger-backed checks report UNMEASURABLE
+    and halt.json is not written — there is no canonical location left to
+    write it to, and no repo-local guess is taken instead.
     """
-    resolved_state_dir = Path(state_dir) if state_dir is not None else _resolve_state_dir()
+    resolved_state_dir: Optional[Path]
+    if state_dir is not None:
+        resolved_state_dir = Path(state_dir)
+    else:
+        try:
+            resolved_state_dir = _resolve_state_dir()
+        except StateDirUnresolvable:
+            resolved_state_dir = None
+
     resolved_root = Path(project_root) if project_root is not None else _default_project_root()
+
+    if resolved_state_dir is not None:
+        provider_result = check_provider_exhausted(resolved_state_dir / "t0_receipts.ndjson")
+        gate_result = check_repeated_gate_failure_cause(resolved_state_dir / "review_gates" / "results")
+    else:
+        provider_result = _unmeasurable("provider_exhausted", "state-dir niet resolvbaar: geen locatie voor t0_receipts.ndjson")
+        gate_result = _unmeasurable("repeated_gate_failure_cause", "state-dir niet resolvbaar: geen locatie voor review_gates/results")
 
     results = [
         check_main_ci_red(resolved_root),
         check_gh_auth_dead(),
-        check_provider_exhausted(resolved_state_dir / "t0_receipts.ndjson"),
-        check_repeated_gate_failure_cause(resolved_state_dir / "review_gates" / "results"),
+        provider_result,
+        gate_result,
     ]
 
-    if write_halt and any(r.status == CheckStatus.TRIGGERED for r in results):
+    if write_halt and resolved_state_dir is not None and any(r.status == CheckStatus.TRIGGERED for r in results):
         write_halt_file(resolved_state_dir, results)
 
     return results

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/stop_conditions.py (T0 autonomous-chain halts).
+
+Covers the tri-state contract (TRIGGERED / CLEAR / UNMEASURABLE — UNMEASURABLE
+is a third branch, never a stand-in value of either other state) for all four
+measurable checks:
+
+  - check_main_ci_red               (E1)
+  - check_gh_auth_dead               (E4)
+  - check_provider_exhausted         (kimi-style structural exhaustion)
+  - check_repeated_gate_failure_cause (E6)
+
+plus run_all_checks()/write_halt_file() orchestration. gh is always mocked —
+no network, no dependency on this machine's actual GitHub auth state.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+import stop_conditions as sc  # noqa: E402
+from stop_conditions import (  # noqa: E402
+    CheckStatus,
+    StopConditionResult,
+    check_gh_auth_dead,
+    check_main_ci_red,
+    check_provider_exhausted,
+    check_repeated_gate_failure_cause,
+    run_all_checks,
+    write_halt_file,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _run_list_output(conclusion, status="completed", head_sha="a" * 40, created_at="2026-09-04T08:00:00Z"):
+    runs = [{"conclusion": conclusion, "status": status, "headSha": head_sha, "createdAt": created_at, "databaseId": 1}]
+    return _proc(0, json.dumps(runs), "")
+
+
+def _write_receipt_lines(path: Path, records: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _attempt(provider, status, failure_class=None, dispatch_id="d1", ts="2026-09-04T00:00:00Z", event_type="task_complete"):
+    return {
+        "event_type": event_type,
+        "provider": provider,
+        "status": status,
+        "failure_class": failure_class,
+        "dispatch_id": dispatch_id,
+        "timestamp": ts,
+    }
+
+
+def _kimi_403_failure_reason() -> str:
+    # The exact live shape measured on the ledger 2026-09-03/04 (grounds the
+    # exhaustion check against a case known to exist, not a fabricated one).
+    return (
+        "kimi-cli: [quota_or_auth] provider=kimi reason=quota_or_auth "
+        "msg='Expecting value: line 1 column 1 (char 0)' "
+        "raw='Error code: 403 - {\\'error\\': {\\'message\\': \"You've reached "
+        "your weekly (7-day) usage limit"
+    )
+
+
+def _gate_result(pr_number, gate, *, status, reason=None, blocking_findings=None, recorded_at="2026-09-04T00:00:00Z"):
+    d = {"pr_number": pr_number, "gate": gate, "status": status, "recorded_at": recorded_at}
+    if reason is not None:
+        d["reason"] = reason
+    if blocking_findings is not None:
+        d["blocking_findings"] = blocking_findings
+    return d
+
+
+# ── check_main_ci_red (E1) ──────────────────────────────────────────────
+
+
+class TestMainCiRed:
+    def test_gh_missing_is_unmeasurable(self, tmp_path):
+        with patch("stop_conditions.shutil.which", return_value=None):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_success_conclusion_is_clear(self, tmp_path):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", return_value=_run_list_output("success")):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.CLEAR
+
+    def test_failure_conclusion_is_triggered(self, tmp_path):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", return_value=_run_list_output("failure")):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.TRIGGERED
+        assert "failure" in result.message
+
+    def test_empty_run_list_is_unmeasurable(self, tmp_path):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", return_value=_proc(0, "[]", "")):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_in_progress_run_is_unmeasurable_not_clear(self, tmp_path):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", return_value=_run_list_output(None, status="in_progress")):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_gh_run_list_nonzero_exit_is_unmeasurable(self, tmp_path):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", return_value=_proc(1, "", "boom")):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_malformed_json_is_unmeasurable(self, tmp_path):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", return_value=_proc(0, "not json", "")):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_timeout_is_unmeasurable(self, tmp_path):
+        import subprocess as _sp
+
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", side_effect=_sp.TimeoutExpired(cmd="gh", timeout=15)):
+            result = check_main_ci_red(tmp_path)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+
+# ── check_gh_auth_dead (E4) ──────────────────────────────────────────────
+
+
+class TestGhAuthDead:
+    def test_gh_missing_is_unmeasurable(self):
+        with patch("stop_conditions.shutil.which", return_value=None):
+            result = check_gh_auth_dead()
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_auth_status_nonzero_is_triggered(self):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", return_value=_proc(1, "", "not logged in")):
+            result = check_gh_auth_dead()
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_auth_timeout_is_unmeasurable(self):
+        import subprocess as _sp
+
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", side_effect=_sp.TimeoutExpired(cmd="gh", timeout=10)):
+            result = check_gh_auth_dead()
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_auth_ok_quota_positive_is_clear(self):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", side_effect=[_proc(0, "", ""), _proc(0, "4999", "")]):
+            result = check_gh_auth_dead()
+        assert result.status == CheckStatus.CLEAR
+        assert result.evidence["remaining"] == 4999
+
+    def test_auth_ok_quota_zero_is_triggered(self):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", side_effect=[_proc(0, "", ""), _proc(0, "0", "")]):
+            result = check_gh_auth_dead()
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_auth_ok_quota_check_fails_is_unmeasurable(self):
+        with patch("stop_conditions.shutil.which", return_value="/usr/bin/gh"), \
+             patch("stop_conditions.subprocess.run", side_effect=[_proc(0, "", ""), _proc(1, "", "boom")]):
+            result = check_gh_auth_dead()
+        assert result.status == CheckStatus.UNMEASURABLE
+        assert result.evidence.get("auth_ok") is True
+
+
+# ── check_provider_exhausted ─────────────────────────────────────────────
+
+
+class TestProviderExhausted:
+    def test_missing_receipts_file_is_unmeasurable(self, tmp_path):
+        result = check_provider_exhausted(tmp_path / "nope.ndjson")
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_kimi_403_streak_triggers(self, tmp_path):
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [_attempt("kimi", "success")] + [
+            _attempt("kimi", "failure", failure_class="auth_rejected", dispatch_id=f"d{i}")
+            for i in range(3)
+        ]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.TRIGGERED
+        assert "kimi" in result.message or "kimi" in json.dumps(result.evidence)
+
+    def test_success_breaks_the_streak(self, tmp_path):
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [
+            _attempt("kimi", "failure", failure_class="auth_rejected"),
+            _attempt("kimi", "success"),
+            _attempt("kimi", "failure", failure_class="auth_rejected"),
+        ]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.CLEAR
+
+    def test_non_exhaustion_failures_do_not_trigger(self, tmp_path):
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [_attempt("glm-harness", "failure", failure_class="timeout") for _ in range(3)]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.CLEAR
+
+    def test_insufficient_attempts_is_unmeasurable(self, tmp_path):
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [_attempt("kimi", "failure", failure_class="auth_rejected")]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_ambiguous_status_excluded_from_timeline(self, tmp_path):
+        # "timeout"/"unknown"/"no_signal" statuses must not silently count as
+        # either a success (masking exhaustion) or a matching failure.
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = (
+            [_attempt("kimi", "unknown", failure_class=None)] * 5
+            + [_attempt("kimi", "failure", failure_class="auth_rejected") for _ in range(3)]
+        )
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_report_contract_invalid_event_type_excluded(self, tmp_path):
+        # report_contract_invalid carries a top-level provider field too, but
+        # is a report-format concern, not a provider-call outcome.
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [
+            {"event_type": "report_contract_invalid", "provider": "kimi", "status": "failure", "failure_class": "auth_rejected", "timestamp": "t"}
+            for _ in range(5)
+        ]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_kimi_403_realistic_failure_reason_fixture(self, tmp_path):
+        # Grounds the check against the exact live shape (nul-is-eerst-een-
+        # meetfout discipline): the receipt ledger's real kimi 403 records
+        # carry failure_class="auth_rejected" with this failure_reason text.
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [
+            {
+                "event_type": "task_complete",
+                "provider": "kimi",
+                "status": "failure",
+                "failure_class": "auth_rejected",
+                "failure_reason": _kimi_403_failure_reason(),
+                "dispatch_id": f"d{i}",
+                "timestamp": "2026-09-04T00:00:00Z",
+            }
+            for i in range(3)
+        ]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+
+# ── check_repeated_gate_failure_cause (E6) ──────────────────────────────
+
+
+class TestRepeatedGateFailureCause:
+    def test_missing_results_dir_is_unmeasurable(self, tmp_path):
+        result = check_repeated_gate_failure_cause(tmp_path / "nope")
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_same_reason_three_times_triggers(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        for i, pr in enumerate([101, 102, 103]):
+            d = _gate_result(pr, "codex_gate", status="unavailable", reason="provider_not_installed", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-codex_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_different_reasons_does_not_trigger(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        reasons = ["provider_not_installed", "exit_nonzero", "dispatch_error"]
+        for i, (pr, reason) in enumerate(zip([201, 202, 203], reasons)):
+            d = _gate_result(pr, "codex_gate", status="failed", reason=reason, recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-codex_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.CLEAR
+
+    def test_clean_pass_breaks_the_streak(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        d1 = _gate_result(301, "codex_gate", status="unavailable", reason="provider_not_installed", recorded_at="2026-09-01T00:00:00Z")
+        d2 = _gate_result(302, "codex_gate", status="pass", recorded_at="2026-09-02T00:00:00Z")
+        d3 = _gate_result(303, "codex_gate", status="unavailable", reason="provider_not_installed", recorded_at="2026-09-03T00:00:00Z")
+        for pr, d in [(301, d1), (302, d2), (303, d3)]:
+            (results_dir / f"pr-{pr}-codex_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.CLEAR
+
+    def test_blocking_findings_repeated_triggers(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        for i, pr in enumerate([401, 402, 403]):
+            d = _gate_result(
+                pr, "kimi_gate", status="completed",
+                blocking_findings=[{"severity": "blocking", "message": "x"}],
+                recorded_at=f"2026-09-0{i+1}T00:00:00Z",
+            )
+            (results_dir / f"pr-{pr}-kimi_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_insufficient_dated_records_is_unmeasurable(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        d = _gate_result(501, "codex_gate", status="unavailable", reason="provider_not_installed")
+        (results_dir / "pr-501-codex_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_missing_recorded_at_excluded_from_ordering(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        # Two dated + one undated (same cause) — undated must not count
+        # toward the n=3 window, so this reads as insufficient data, not
+        # a triggered 3-streak.
+        d1 = _gate_result(601, "codex_gate", status="unavailable", reason="provider_not_installed", recorded_at="2026-09-01T00:00:00Z")
+        d2 = _gate_result(602, "codex_gate", status="unavailable", reason="provider_not_installed", recorded_at="2026-09-02T00:00:00Z")
+        d3 = {"pr_number": 603, "gate": "codex_gate", "status": "unavailable", "reason": "provider_not_installed"}  # no recorded_at
+        for pr, d in [(601, d1), (602, d2), (603, d3)]:
+            (results_dir / f"pr-{pr}-codex_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_malformed_json_file_skipped(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        (results_dir / "pr-999-codex_gate.json").write_text("not json{")
+        for i, pr in enumerate([701, 702, 703]):
+            d = _gate_result(pr, "codex_gate", status="unavailable", reason="provider_not_installed", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-codex_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_different_gates_scored_independently(self, tmp_path):
+        # codex_gate stays clean; kimi_gate has the 3x repeat — overall must
+        # still trigger (any-sub-triggered wins), and the untriggered gate
+        # must not mask it.
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        for i, pr in enumerate([801, 802, 803]):
+            d = _gate_result(pr, "codex_gate", status="pass", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-codex_gate.json").write_text(json.dumps(d))
+        for i, pr in enumerate([811, 812, 813]):
+            d = _gate_result(pr, "kimi_gate", status="unavailable", reason="provider_not_installed", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-kimi_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+
+# ── tri-state discipline (cross-cutting) ────────────────────────────────
+
+
+class TestTriState:
+    def test_check_status_has_exactly_three_members(self):
+        assert {m.value for m in CheckStatus} == {"triggered", "clear", "unmeasurable"}
+
+    def test_combine_all_unmeasurable_stays_unmeasurable(self):
+        subs = [
+            StopConditionResult("x:a", CheckStatus.UNMEASURABLE, "no data"),
+            StopConditionResult("x:b", CheckStatus.UNMEASURABLE, "no data"),
+        ]
+        combined = sc._combine("x", subs, sub_key="per_thing")
+        assert combined.status == CheckStatus.UNMEASURABLE
+
+    def test_combine_empty_is_unmeasurable_not_clear(self):
+        combined = sc._combine("x", [], sub_key="per_thing")
+        assert combined.status == CheckStatus.UNMEASURABLE
+
+    def test_combine_one_triggered_wins_over_clear(self):
+        subs = [
+            StopConditionResult("x:a", CheckStatus.CLEAR, "fine"),
+            StopConditionResult("x:b", CheckStatus.TRIGGERED, "bad"),
+        ]
+        combined = sc._combine("x", subs, sub_key="per_thing")
+        assert combined.status == CheckStatus.TRIGGERED
+
+    def test_to_dict_status_is_json_safe_string(self):
+        r = StopConditionResult("id", CheckStatus.CLEAR, "msg")
+        d = r.to_dict()
+        json.dumps(d)  # must not raise
+        assert d["status"] == "clear"
+
+
+# ── orchestration ────────────────────────────────────────────────────────
+
+
+class TestRunAllChecksAndHalt:
+    def test_halt_written_when_any_triggered(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        triggered = StopConditionResult("gh_auth_dead", CheckStatus.TRIGGERED, "dead")
+        clear1 = StopConditionResult("main_ci_red", CheckStatus.CLEAR, "ok")
+        clear2 = StopConditionResult("provider_exhausted", CheckStatus.UNMEASURABLE, "no data")
+        clear3 = StopConditionResult("repeated_gate_failure_cause", CheckStatus.CLEAR, "ok")
+        with patch("stop_conditions.check_main_ci_red", return_value=clear1), \
+             patch("stop_conditions.check_gh_auth_dead", return_value=triggered), \
+             patch("stop_conditions.check_provider_exhausted", return_value=clear2), \
+             patch("stop_conditions.check_repeated_gate_failure_cause", return_value=clear3):
+            results = run_all_checks(state_dir=state_dir, project_root=tmp_path)
+        assert any(r.status == CheckStatus.TRIGGERED for r in results)
+        halt_path = state_dir / "halt.json"
+        assert halt_path.is_file()
+        payload = json.loads(halt_path.read_text())
+        assert len(payload["triggered"]) == 1
+        assert payload["triggered"][0]["check_id"] == "gh_auth_dead"
+        assert len(payload["all_checks"]) == 4
+
+    def test_no_halt_written_when_nothing_triggered(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        clear = StopConditionResult("x", CheckStatus.CLEAR, "ok")
+        with patch("stop_conditions.check_main_ci_red", return_value=clear), \
+             patch("stop_conditions.check_gh_auth_dead", return_value=clear), \
+             patch("stop_conditions.check_provider_exhausted", return_value=clear), \
+             patch("stop_conditions.check_repeated_gate_failure_cause", return_value=clear):
+            run_all_checks(state_dir=state_dir, project_root=tmp_path)
+        assert not (state_dir / "halt.json").is_file()
+
+    def test_write_halt_file_is_atomic_no_partial_on_disk(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        results = [StopConditionResult("x", CheckStatus.TRIGGERED, "bad")]
+        halt_path = write_halt_file(state_dir, results)
+        assert halt_path == state_dir / "halt.json"
+        # no leftover tmp files
+        assert not list(state_dir.glob("*.tmp"))
+        payload = json.loads(halt_path.read_text())
+        assert payload["triggered"][0]["check_id"] == "x"

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 import stop_conditions as sc  # noqa: E402
 from stop_conditions import (  # noqa: E402
     CheckStatus,
+    StateDirUnresolvable,
     StopConditionResult,
     check_gh_auth_dead,
     check_main_ci_red,
@@ -455,3 +456,112 @@ class TestRunAllChecksAndHalt:
         assert not list(state_dir.glob("*.tmp"))
         payload = json.loads(halt_path.read_text())
         assert payload["triggered"][0]["check_id"] == "x"
+
+
+# ── central-mode path gate (OI: un-grandfathered violation, PR #1754 review) ─
+#
+# stop_conditions.py must never fall back to a __file__-anchored repo-local
+# .vnx-data guess: scripts/check_no_file_derived_data_paths.py forbids this
+# exact bug class (a central install would resolve the shared fabric
+# checkout's own .vnx-data instead of the project's ~/.vnx-data/<project_id>,
+# forking state). These tests pin that both directly (the gate's own scanner
+# against this module's source) and behaviorally (the tri-state contract
+# a caller sees when state-dir truly cannot be resolved).
+
+
+class TestCentralModePathGate:
+    def test_module_source_has_no_file_derived_data_path_violations(self):
+        import importlib
+
+        scripts_dir = str(Path(sc.__file__).resolve().parent.parent)
+        if scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+        gate = importlib.import_module("check_no_file_derived_data_paths")
+        source = Path(sc.__file__).read_text(encoding="utf-8")
+        violations = gate.check_source(source)
+        assert violations == [], f"central-mode path gate violation(s) in stop_conditions.py: {violations}"
+
+    def test_resolve_state_dir_raises_never_a_repo_local_fallback(self, monkeypatch):
+        monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        with patch("vnx_paths.resolve_paths", side_effect=RuntimeError("boom")):
+            with pytest.raises(StateDirUnresolvable):
+                sc._resolve_state_dir()
+
+    def test_resolve_state_dir_honors_direct_env_override_not_canonical(self, monkeypatch, tmp_path):
+        # Direct VNX_STATE_DIR override still works (not __file__-anchored) —
+        # only the removed repo-local __file__ fallback is forbidden.
+        monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+        with patch("vnx_paths.resolve_paths", side_effect=RuntimeError("boom")):
+            result = sc._resolve_state_dir()
+        assert result == tmp_path
+
+    def test_provider_exhausted_unmeasurable_when_state_dir_unresolvable(self):
+        with patch("stop_conditions._resolve_state_dir", side_effect=StateDirUnresolvable("boom")):
+            result = check_provider_exhausted()
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_repeated_gate_failure_cause_unmeasurable_when_state_dir_unresolvable(self):
+        with patch("stop_conditions._resolve_state_dir", side_effect=StateDirUnresolvable("boom")):
+            result = check_repeated_gate_failure_cause()
+        assert result.status == CheckStatus.UNMEASURABLE
+
+    def test_run_all_checks_survives_unresolvable_state_dir_no_halt_written(self, tmp_path):
+        clear = StopConditionResult("x", CheckStatus.CLEAR, "ok")
+        with patch("stop_conditions._resolve_state_dir", side_effect=StateDirUnresolvable("boom")), \
+             patch("stop_conditions.check_main_ci_red", return_value=clear), \
+             patch("stop_conditions.check_gh_auth_dead", return_value=clear):
+            results = run_all_checks(state_dir=None, project_root=tmp_path)
+        by_id = {r.check_id: r for r in results}
+        assert by_id["provider_exhausted"].status == CheckStatus.UNMEASURABLE
+        assert by_id["repeated_gate_failure_cause"].status == CheckStatus.UNMEASURABLE
+        # nothing crashed and no halt.json materialized anywhere under tmp_path
+        assert not list(tmp_path.rglob("halt.json"))
+
+    def test_default_project_root_calls_resolver_with_no_file_anchor(self):
+        with patch("stop_conditions.resolve_project_root", return_value=Path("/x")) as mock_resolver:
+            sc._default_project_root()
+        mock_resolver.assert_called_once_with()
+
+
+# ── completion-outcome vocabulary (OI: hand-typed duplicate of receipt_verdict) ─
+
+
+class TestCompletionOutcomeVocabulary:
+    def test_vocab_is_imported_not_redefined(self):
+        import receipt_verdict
+
+        assert sc.SUCCESS_STATUSES is receipt_verdict.SUCCESS_STATUSES
+        assert sc.HARD_FAILURE_STATUSES is receipt_verdict.HARD_FAILURE_STATUSES
+
+    def test_contract_invalid_status_counts_as_a_real_failure_attempt(self, tmp_path):
+        # "contract_invalid" is in the canonical HARD_FAILURE_STATUSES but was
+        # NOT in the old hand-typed {"failed", "failure"} pair — with only the
+        # hand-typed pair, only 1 of these 3 records would register as an
+        # "attempt" (insufficient data -> UNMEASURABLE). With the canonical
+        # vocabulary all 3 register; none are exhaustion-class, so the verdict
+        # is a measured CLEAR, not a data-starved UNMEASURABLE.
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [
+            _attempt("glm-harness", "contract_invalid", failure_class=None),
+            _attempt("glm-harness", "contract_invalid", failure_class=None),
+            _attempt("glm-harness", "failure", failure_class="auth_rejected"),
+        ]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.CLEAR
+
+    def test_completed_status_recognized_as_success_breaks_streak(self, tmp_path):
+        # "completed" (distinct from "complete") is in the canonical
+        # SUCCESS_STATUSES but was NOT in the old hand-typed
+        # {"success", "done", "complete"} triple.
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [
+            _attempt("kimi", "failure", failure_class="auth_rejected"),
+            _attempt("kimi", "completed"),
+            _attempt("kimi", "failure", failure_class="auth_rejected"),
+        ]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.CLEAR


### PR DESCRIPTION
## Summary

The T0 orchestrator role (`.claude/terminals/T0/role-orchestrator.md`, "Stop
conditions (wake operator)") names six stop conditions (E1-E6) where an
autonomous chain must halt and wake the operator. All six existed only as
prose — nothing measured any of them, so an autonomous chain had no way to
observe its own stop conditions.

Adds `scripts/lib/stop_conditions.py`: four measurable checks, each answering
a tri-state (`TRIGGERED` / `CLEAR` / `UNMEASURABLE`). Unmeasurable is a third
branch, never collapsed into either of the other two — a check that could not
measure never silently reads as "in orde" and never silently reads as "kapot".

- `check_main_ci_red` (E1) — VNX CI workflow conclusion on `main` via
  `gh run list`. A still-running latest run is UNMEASURABLE, not a guess.
- `check_gh_auth_dead` (E4) — `gh auth status` + REST rate-limit remaining.
- `check_provider_exhausted` — a provider/lane refuses structurally N times
  in a row. Live example on the ledger since 2026-09-03: kimi's weekly quota,
  HTTP 403 `access_terminated_error`, classified `auth_rejected` by
  `failure_classification.py`.
- `check_repeated_gate_failure_cause` (E6) — N consecutive PR gate results in
  `review_gates/results/pr-<n>-<gate>.json` blocked by the same recurring
  cause (an infra-level `reason` enum, or repeated `blocking_findings`).

`run_all_checks()` / `write_halt_file()` write an atomic `halt.json` (via
`atomic_io.atomic_write_json`) into the resolved `VNX_STATE_DIR` when any
check triggers. State-dir resolution mirrors `dispatch_register.py`'s
canonical `vnx_paths.resolve_paths()` + fallback chain — never a hardcoded
`.vnx-data/` literal.

**Scope note (E2/E3 not covered):** data-loss risk and secrets-in-logs both
require judging diff/log CONTENT, not a state signal this module can read
cheaply and deterministically. A shallow pattern match would produce false
confidence rather than a real measurement, so they stay prose-only pending a
dedicated design — this PR ships 4 of 6, not a padded 6.

**Wiring is explicitly out of scope.** Calling this module from the dispatch
door (`dispatch_cli.py`) is cluster A's job, running in parallel on the same
file. This module is self-contained and independently callable/testable —
`python3 scripts/lib/stop_conditions.py [--state-dir DIR] [--no-write-halt]`.

## Changes

- `scripts/lib/stop_conditions.py` (new) — the four checks + orchestration.
- `tests/test_stop_conditions.py` (new) — 39 tests, gh always mocked (no
  network dependency).

## Verification

**Red run (before implementation, deliberate bugs on the four decision
branches — inverted/wrong comparisons, not stubs):** 9 failed / 30 passed.
All 9 failures were real assertion mismatches on `CheckStatus` (e.g.
`assert TRIGGERED == CLEAR`), never an `ImportError` or collection error —
confirms the suite exercises behavior, not just importability.

**Green run (after fix):** `39 passed` (`pytest tests/test_stop_conditions.py`).

**Neighbor tests** (`test_failure_classification.py`, `test_atomic_io.py`,
`test_project_root_resolution.py`) — 129 passed combined, no regressions.

**Lint gate** (`scripts/ci_lint_patterns.py --files-from-stdin`) — clean, exit 0.

**Live smoke test** against the real central store
(`~/.vnx-data/vnx-dev/state`, `--no-write-halt`): all four checks measured
real production data end-to-end and correctly found two genuine live
triggers — `provider_exhausted` on kimi (3/3 recent attempts
`auth_rejected`) and `repeated_gate_failure_cause` on `kimi_gate`/`codex_gate`/
`gemini_review` (each blocked 3x running by the same `reason` code). This
was not staged: it's exactly the kimi 403 condition named in the dispatch,
observed live by the new check.

## Open Items

None.

---

Buiten de dispatch-deur om geproduceerd via een Agent-subagent,
operator-besluit 2026-09-04. Tijdelijke afwijking: de gegovernde
dispatch-paden zijn traag en de deur is zelf onderwerp van reparatie. PR en
CI blijven onverkort gelden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR