### PR TITLE
feat(state): launchd-job liveness is a first-class field (Golf 1B)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -68,6 +68,7 @@ import argparse
 import json
 import logging
 import os
+import plistlib
 import re
 import sqlite3
 import subprocess
@@ -1825,6 +1826,241 @@ def _build_git_context() -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Launchd-job liveness (Golf 1B, absence-is-loud / ledger-is-falsifiable)
+#
+# daemon_liveness (D2, above) already gives t0_state.json first-class, tri-
+# state (running/absent/unknown) visibility into the always-on daemons
+# vnx_supervisor_simple.sh's start_all() starts. It parses ONLY that shell
+# function. The seven com.vnx.* launchd-scheduled BATCH jobs declared in
+# scripts/launchd/*.plist (producer-freshness-monitor, gate-obligation-
+# runner, nightly-intelligence-pipeline, receipt-classifier-batch, ledger-
+# health, conversation-analyzer, headless-trigger) had ZERO visibility here
+# before this: measured live while building this module, `launchctl list`
+# showed conversation-analyzer/gate-obligation-runner/ledger-health/producer-
+# freshness-monitor loaded (TWO of those four with a nonzero last-exit-status
+# -- gate-obligation-runner=11, ledger-health=1, i.e. loaded but failing)
+# while headless-trigger/nightly-intelligence-pipeline/receipt-classifier-
+# batch were not loaded at all. A "the process exists" proxy (daemon_liveness)
+# cannot see any of this: these jobs are not supposed to be a running PID
+# most of the time, only loaded-and-scheduled.
+#
+# Same tri-state discipline as daemon_register.py, never collapsed to two
+# values: "loaded" (measured, now) / "not_loaded" (measured absence, a real
+# finding) / "unknown" (launchctl itself could not be queried). "since when"
+# is a SEPARATE fact -- launchctl list carries no timestamp, so it comes from
+# the most recent matching record in job_exits.ndjson's existing launchd-
+# harvest stream (scripts/lib/job_exit_capture.py) when one exists, and is
+# explicitly None (with since_measured=False) -- never a fabricated value --
+# when no harvest history exists yet.
+# ---------------------------------------------------------------------------
+
+_JOB_EXITS_TAIL_LINES = 2000
+
+
+def _scan_launchd_dir(launchd_dir: Optional[Path] = None) -> "tuple[List[str], List[str]]":
+    """Expected launchd job labels, read explicitly from each plist's own
+    Label key -- never guessed off the filename. Returns ``(labels,
+    unparseable_filenames)``: a plist that fails to parse is excluded from
+    ``labels`` (one broken file must not blank out the rest of the register)
+    but its filename is NOT silently dropped -- it is returned so the caller
+    can surface it as a loud finding instead of a debug-log line nobody
+    reads. This is exactly the failure mode this dispatch exists to prevent:
+    measured live while building this module,
+    ``scripts/launchd/com.vnx.gate-obligation-runner.plist`` contains a
+    literal ``--`` inside an XML comment ("...the --project-id value...")
+    which is invalid XML (comments may never contain ``--``) -- a real,
+    currently-broken plist in this repo, not a hypothetical one.
+    """
+    directory = launchd_dir if launchd_dir is not None else (_PROJECT_ROOT / "scripts" / "launchd")
+    labels: List[str] = []
+    unparseable: List[str] = []
+    try:
+        plist_paths = sorted(directory.glob("*.plist"))
+    except OSError as exc:
+        log.debug("_scan_launchd_dir: cannot list %s: %s", directory, exc)
+        return labels, unparseable
+    for path in plist_paths:
+        try:
+            with open(path, "rb") as fh:
+                data = plistlib.load(fh)
+        except Exception as exc:  # vnx-silent-except: one unparseable plist must not blank out the rest of the register; the filename itself is returned to the caller, not swallowed
+            log.debug("_scan_launchd_dir: could not parse %s: %s", path, exc)
+            unparseable.append(path.name)
+            continue
+        label = data.get("Label") if isinstance(data, dict) else None
+        if isinstance(label, str) and label:
+            labels.append(label)
+        else:
+            unparseable.append(path.name)
+    return sorted(set(labels)), sorted(unparseable)
+
+
+def _discover_launchd_jobs(launchd_dir: Optional[Path] = None) -> List[str]:
+    """Expected launchd job labels only. See ``_scan_launchd_dir`` for the
+    variant that also surfaces filenames that failed to parse -- used by
+    ``_measure_launchd_liveness`` so a broken plist is a loud finding, not a
+    silently-dropped debug line.
+
+    A missing/unreadable directory or zero parseable labels is simply an
+    empty list, never raised: the caller (``_measure_launchd_liveness``)
+    treats a resulting empty list as its own signal ("could not establish a
+    register"), not as "zero jobs expected".
+    """
+    labels, _unparseable = _scan_launchd_dir(launchd_dir)
+    return labels
+
+
+def _measure_launchd_now(
+    labels: Sequence[str],
+    *,
+    runner: Any = None,
+    timeout: int = 10,
+) -> Dict[str, Any]:
+    """Query ``launchctl list`` once, live, for the current loaded/exit-status
+    state of every label. Reuses job_exit_capture's own output parser rather
+    than a second hand-rolled regex.
+
+    Returns ``{"measured": True, "jobs": {label: {"pid", "last_exit_status"}}}``
+    on success (only labels launchctl actually reports are present -- a
+    requested label simply absent from the dict means "not loaded", it is
+    the caller's job to turn that into the "not_loaded" state), or
+    ``{"measured": False, "reason": "..."}`` when launchctl itself could not
+    be queried (missing binary, non-zero exit, timeout) -- this is the
+    'unmeasurable' half of the tri-state contract; it must never collapse
+    into an empty (and therefore "everything absent") jobs dict.
+    """
+    run = runner or subprocess.run
+    try:
+        proc = run(["launchctl", "list"], capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"measured": False, "reason": f"launchctl unavailable: {exc}"}
+    if proc.returncode != 0:
+        return {"measured": False, "reason": f"launchctl list exited {proc.returncode}"}
+
+    try:
+        from job_exit_capture import _parse_launchctl_list
+    except ImportError as exc:
+        return {"measured": False, "reason": f"job_exit_capture unavailable: {exc}"}
+
+    jobs = {job["label"]: job for job in _parse_launchctl_list(proc.stdout)}
+    return {"measured": True, "jobs": jobs}
+
+
+def _last_job_exit_by_label(state_dir: Path, labels: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Best-effort: the most recent ``job_exit`` record per label from
+    ``job_exits.ndjson`` (mirrors the tail-read convention this file already
+    uses for t0_receipts.ndjson -- ``.splitlines()[-N:]``). A missing file,
+    or a label with no matching record, is simply absent from the result --
+    the caller reports that as an explicit "since not measured", never as
+    "never ran" (those are different claims; a job can be loaded and healthy
+    with no harvest history yet because the harvest itself has not run)."""
+    path = state_dir / "job_exits.ndjson"
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return {}
+
+    label_set = set(labels)
+    result: Dict[str, Dict[str, Any]] = {}
+    for line in text.splitlines()[-_JOB_EXITS_TAIL_LINES:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict) or record.get("event_type") != "job_exit":
+            continue
+        job = record.get("job")
+        if job not in label_set:
+            continue
+        prev = result.get(job)
+        ts = str(record.get("timestamp") or "")
+        if prev is None or ts >= str(prev.get("timestamp") or ""):
+            result[job] = record
+    return result
+
+
+def _combine_liveness_overall(*values: Optional[str]) -> str:
+    """Fold sub-signal ``overall`` values (the ``"ok"``/``"fail"``/``"unknown"``
+    vocabulary daemon_liveness already established) into one, mirroring the
+    stop_conditions.py ``CheckStatus``/``_combine`` combination rule (PR
+    #1754, not on this branch's main yet -- rebuilt here in this file's own
+    idiom rather than imported, since 'unmeasurable' must stay a distinct
+    branch, never collapsed into either of the other two): ANY ``"fail"`` ->
+    ``"fail"``; else ANY ``"ok"`` -> ``"ok"``; else ``"unknown"`` (every
+    sub-signal was itself unmeasured, or there were none at all)."""
+    present = [v for v in values if v is not None]
+    if any(v == "fail" for v in present):
+        return "fail"
+    if any(v == "ok" for v in present):
+        return "ok"
+    return "unknown"
+
+
+def _measure_launchd_liveness(
+    state_dir: Path,
+    *,
+    launchd_dir: Optional[Path] = None,
+    runner: Any = None,
+) -> Dict[str, Any]:
+    """Measure whether every expected launchd job is currently loaded, and
+    since when its last recorded exit is known.
+
+    Returns ``{"overall": "ok"|"fail"|"unknown", "jobs": {label: {...}}}``,
+    plus ``"unparseable_plists"`` (filenames, non-empty only when at least
+    one exists) -- a plist that fails to parse names a producer this module
+    cannot even identify, which is itself a "fail", not a reason to fall
+    silently back to "everything else looked fine". Zero discovered plist
+    labels (register + zero valid AND zero unparseable) is its OWN "unknown"
+    case (a register that could not be established at all, exactly the
+    discipline ``daemon_register.read_daemon_register`` already applies to a
+    structurally-empty parse) -- it must never silently read as "ok, nothing
+    to report".
+    """
+    labels, unparseable = _scan_launchd_dir(launchd_dir)
+    if not labels and not unparseable:
+        return {"overall": "unknown", "jobs": {}, "reason": "no launchd plist files discovered"}
+
+    now_result = _measure_launchd_now(labels, runner=runner) if labels else {"measured": True, "jobs": {}}
+    exit_history = _last_job_exit_by_label(state_dir, labels)
+
+    jobs: Dict[str, Any] = {}
+    any_not_loaded = False
+    for label in labels:
+        history = exit_history.get(label)
+        since = history.get("timestamp") if history else None
+        jobs[label] = {
+            "expected": True,
+            "state": (
+                "unknown" if not now_result["measured"]
+                else "loaded" if label in now_result["jobs"]
+                else "not_loaded"
+            ),
+            "since": since,
+            "since_measured": since is not None,
+            "last_exit_code": history.get("exit_code") if history else None,
+        }
+        if now_result["measured"] and label not in now_result["jobs"]:
+            any_not_loaded = True
+
+    if unparseable or (now_result["measured"] and any_not_loaded):
+        overall = "fail"
+    elif not now_result["measured"]:
+        overall = "unknown"
+    else:
+        overall = "ok"
+
+    result: Dict[str, Any] = {"overall": overall, "jobs": jobs}
+    if unparseable:
+        result["unparseable_plists"] = unparseable
+    if not now_result["measured"]:
+        result["reason"] = now_result["reason"]
+    return result
+
+
+# ---------------------------------------------------------------------------
 # System health
 # ---------------------------------------------------------------------------
 
@@ -1836,6 +2072,7 @@ def _build_system_health(
     db_health: str = "healthy",
     daemon_liveness: Optional[Dict[str, Any]] = None,
     expected_beacon_components: Optional[Sequence[str]] = None,
+    launchd_liveness: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     uptime_seconds = 0
     panes_path = state_dir / "panes.json"
@@ -1898,6 +2135,21 @@ def _build_system_health(
         except Exception as exc:  # vnx-silent-except: daemon-liveness read is best-effort, mirrors beacon_health above; a failure here must not break the session-start hot path
             log.debug("measure_daemon_liveness failed (non-critical): %s", exc)
 
+    # Golf 1B: launchd-scheduled batch jobs are a second producer class
+    # daemon_liveness above does not cover at all (it parses ONLY
+    # vnx_supervisor_simple.sh's start_all()). Read the same best-effort way
+    # as beacon_health/daemon_liveness -- but, unlike those two, NEVER
+    # silently omitted from `result` when the measurement raises: an absent
+    # key looks like "nobody wired this in", an explicit "unknown" says "we
+    # tried and could not tell" -- niet-gemeten is een derde tak, geen derde
+    # waarde, en zeker geen weggelaten veld.
+    if launchd_liveness is None:
+        try:
+            launchd_liveness = _measure_launchd_liveness(state_dir)
+        except Exception as exc:  # vnx-silent-except: launchd-liveness read is best-effort, mirrors beacon_health/daemon_liveness above; a failure here must not break the session-start hot path
+            log.debug("measure_launchd_liveness failed (non-critical): %s", exc)
+            launchd_liveness = {"overall": "unknown", "jobs": {}, "reason": f"measurement raised: {exc}"}
+
     # R6.4 (D2): a summary can never report healthier than the worst thing it
     # summarizes. Before this, `status` was computed once above (from
     # db_health/build_degraded/artifact-presence) and never revisited, so
@@ -1905,11 +2157,12 @@ def _build_system_health(
     # `status: "healthy"` in the same object -- a structurally possible
     # outcome of the code, not a fluke (measured 2026-08-30 in production
     # t0_state.json). Every nested health field added here must feed this
-    # aggregation, including daemon_liveness.
+    # aggregation, including daemon_liveness and launchd_liveness.
     status = worst_status(
         status,
         beacon_health.get("overall") if beacon_health else None,
         daemon_liveness.get("overall") if daemon_liveness else None,
+        launchd_liveness.get("overall") if launchd_liveness else None,
     )
 
     result: Dict[str, Any] = {
@@ -1921,6 +2174,30 @@ def _build_system_health(
         result["beacon_health"] = beacon_health
     if daemon_liveness is not None:
         result["daemon_liveness"] = daemon_liveness
+    # launchd_liveness is unconditional -- see the "never silently omitted"
+    # note above; it is always a dict by this point, never None.
+    result["launchd_liveness"] = launchd_liveness
+    # producer_liveness: the single first-class liveness field a caller can
+    # check without knowing daemon_liveness and launchd_liveness are two
+    # separate producer classes that need combining by hand. Folds both via
+    # _combine_liveness_overall -- also unconditional, always a dict.
+    #
+    # Deliberately a SUMMARY, not a re-embedding of the full daemon_liveness/
+    # launchd_liveness dicts: those already sit as sibling keys in this same
+    # result, and t0_index.json copies system_health wholesale into its
+    # cheap, always-loaded ``health`` field under a hard <=5KB budget
+    # (measured live building this module: duplicating both full dicts here
+    # pushed a real t0_index.json from 3559 to 8024 bytes). Per-daemon and
+    # per-job detail is one field away (daemon_liveness/launchd_liveness
+    # above) for a caller that wants it.
+    result["producer_liveness"] = {
+        "overall": _combine_liveness_overall(
+            daemon_liveness.get("overall") if daemon_liveness else None,
+            launchd_liveness.get("overall") if launchd_liveness else None,
+        ),
+        "daemon_overall": daemon_liveness.get("overall") if daemon_liveness else None,
+        "launchd_overall": launchd_liveness.get("overall") if launchd_liveness else None,
+    }
     return result
 
 
@@ -2586,6 +2863,8 @@ def _state_to_brief(state: Dict[str, Any]) -> Dict[str, Any]:
             "db_initialized": sh.get("db_initialized", False),
             "beacon_health": sh.get("beacon_health"),
             "daemon_liveness": sh.get("daemon_liveness"),
+            "launchd_liveness": sh.get("launchd_liveness"),
+            "producer_liveness": sh.get("producer_liveness"),
         },
     }
 
@@ -2609,6 +2888,39 @@ _DETAIL_SECTION_MAP: Dict[str, str] = {
     # brief output but still mirrored to t0_detail/strategic_state.json.
     "_strategic_state_heavy": "strategic_state",
 }
+
+
+def _slim_health_for_index(system_health: Dict[str, Any]) -> Dict[str, Any]:
+    """Compact projection of system_health for the cheap, always-loaded
+    t0_index.json (<=5KB budget, enforced by TestIntegrationWithBuildT0State
+    in tests/test_t0_index_split.py).
+
+    Per-daemon (daemon_liveness.daemons), per-job (launchd_liveness.jobs),
+    and per-beacon (beacon_health.beacons) detail stays ONLY in the full
+    system_health (t0_state.json / t0_detail); the index keeps just each
+    nested signal's ``overall`` value -- still enough to answer "is
+    everything healthy" without loading anything else, matching the
+    module's own index/detail split ("t0_index.json: cheap always-loaded
+    index... t0_detail/<section>.json: full per-section files loaded on-
+    demand"). Measured live while adding launchd_liveness/producer_liveness
+    to this file: re-embedding their full per-item breakdowns in the index
+    pushed a real t0_index.json from 3559 to 8024 bytes, over budget --
+    slimming here (not shrinking the fields themselves) is the fix.
+    """
+    slim: Dict[str, Any] = {
+        "status": system_health.get("status"),
+        "db_initialized": system_health.get("db_initialized"),
+        "uptime_seconds": system_health.get("uptime_seconds"),
+    }
+    for key in ("beacon_health", "daemon_liveness", "launchd_liveness"):
+        nested = system_health.get(key)
+        if nested is not None:
+            slim[key] = {"overall": nested.get("overall")}
+    if "producer_liveness" in system_health:
+        # Already a lightweight summary (overall + two sub-overalls) -- no
+        # per-item breakdown to strip.
+        slim["producer_liveness"] = system_health.get("producer_liveness")
+    return slim
 
 
 def _build_t0_index(state: Dict[str, Any]) -> Dict[str, Any]:
@@ -2645,7 +2957,7 @@ def _build_t0_index(state: Dict[str, Any]) -> Dict[str, Any]:
         },
         "active_dispatches": [d.get("dispatch_id", "") for d in active_work],
         "recent_receipts": (state.get("recent_receipts") or [])[-3:],
-        "health": state.get("system_health") or {},
+        "health": _slim_health_for_index(state.get("system_health") or {}),
         "track_freshness": _track_freshness_summary(state.get("track_freshness")),
         "last_rebuild_seconds": state.get("_build_seconds"),
     }

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -70,6 +70,7 @@ import logging
 import os
 import plistlib
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -1914,36 +1915,54 @@ def _measure_launchd_now(
     labels: Sequence[str],
     *,
     runner: Any = None,
+    which_fn: Any = None,
     timeout: int = 10,
 ) -> Dict[str, Any]:
     """Query ``launchctl list`` once, live, for the current loaded/exit-status
     state of every label. Reuses job_exit_capture's own output parser rather
     than a second hand-rolled regex.
 
-    Returns ``{"measured": True, "jobs": {label: {"pid", "last_exit_status"}}}``
+    Returns ``{"measured": True, "applicable": True, "jobs": {label: {...}}}``
     on success (only labels launchctl actually reports are present -- a
     requested label simply absent from the dict means "not loaded", it is
     the caller's job to turn that into the "not_loaded" state), or
-    ``{"measured": False, "reason": "..."}`` when launchctl itself could not
-    be queried (missing binary, non-zero exit, timeout) -- this is the
-    'unmeasurable' half of the tri-state contract; it must never collapse
-    into an empty (and therefore "everything absent") jobs dict.
+    ``{"measured": False, "applicable": bool, "reason": "..."}`` when
+    launchctl itself could not be queried -- this is the 'unmeasurable' half
+    of the tri-state contract; it must never collapse into an empty (and
+    therefore "everything absent") jobs dict.
+
+    ``applicable`` distinguishes two different kinds of "could not measure"
+    (PR #1755 CI failure, both on a Linux CI runner AND reproduced
+    independently on a real macOS dev machine): ``applicable=False`` means
+    ``launchctl`` does not exist on this platform AT ALL (checked via
+    ``which_fn``, default ``shutil.which``, BEFORE spawning any subprocess)
+    -- a structural, permanent fact (every non-macOS machine, forever), not
+    a transient failure worth investigating. ``applicable=True`` (the prior,
+    only behavior) means launchctl exists but this particular invocation
+    failed (a race where the binary vanished after the which() check,
+    non-zero exit, timeout) -- "tried on a platform where it should work,
+    and this one attempt failed", a genuinely different, more actionable
+    claim than "not applicable here".
     """
+    which = which_fn or shutil.which
+    if which("launchctl") is None:
+        return {"measured": False, "applicable": False, "reason": "launchctl not present on this platform"}
+
     run = runner or subprocess.run
     try:
         proc = run(["launchctl", "list"], capture_output=True, text=True, timeout=timeout)
     except (OSError, subprocess.TimeoutExpired) as exc:
-        return {"measured": False, "reason": f"launchctl unavailable: {exc}"}
+        return {"measured": False, "applicable": True, "reason": f"launchctl unavailable: {exc}"}
     if proc.returncode != 0:
-        return {"measured": False, "reason": f"launchctl list exited {proc.returncode}"}
+        return {"measured": False, "applicable": True, "reason": f"launchctl list exited {proc.returncode}"}
 
     try:
         from job_exit_capture import _parse_launchctl_list
     except ImportError as exc:
-        return {"measured": False, "reason": f"job_exit_capture unavailable: {exc}"}
+        return {"measured": False, "applicable": True, "reason": f"job_exit_capture unavailable: {exc}"}
 
     jobs = {job["label"]: job for job in _parse_launchctl_list(proc.stdout)}
-    return {"measured": True, "jobs": jobs}
+    return {"measured": True, "applicable": True, "jobs": jobs}
 
 
 def _last_job_exit_by_label(state_dir: Path, labels: Sequence[str]) -> Dict[str, Dict[str, Any]]:
@@ -2004,26 +2023,49 @@ def _measure_launchd_liveness(
     *,
     launchd_dir: Optional[Path] = None,
     runner: Any = None,
+    which_fn: Any = None,
 ) -> Dict[str, Any]:
     """Measure whether every expected launchd job is currently loaded, and
     since when its last recorded exit is known.
 
     Returns ``{"overall": "ok"|"fail"|"unknown", "jobs": {label: {...}}}``,
     plus ``"unparseable_plists"`` (filenames, non-empty only when at least
-    one exists) -- a plist that fails to parse names a producer this module
-    cannot even identify, which is itself a "fail", not a reason to fall
-    silently back to "everything else looked fine". Zero discovered plist
-    labels (register + zero valid AND zero unparseable) is its OWN "unknown"
-    case (a register that could not be established at all, exactly the
-    discipline ``daemon_register.read_daemon_register`` already applies to a
-    structurally-empty parse) -- it must never silently read as "ok, nothing
-    to report".
+    one exists).
+
+    ``overall`` is ``"fail"`` ONLY when a label was actually measured
+    (launchctl ran, on a platform where it applies) and found not loaded --
+    a real, actionable finding. Everything else this module could not
+    establish -- launchctl not applicable on this platform, launchctl
+    applicable but this invocation failed, OR a plist that failed to parse
+    and so names a producer this module cannot even identify -- folds into
+    ``"unknown"``. This is a deliberate correction (PR #1755 CI failure):
+    an unparseable plist used to force ``"fail"`` unconditionally, which
+    made ONE broken, cross-platform, this-module-cannot-fix-it plist a
+    permanent, unfalsifiable "everything is unhealthy" signal on every
+    single measurement forever -- niet-gemeten is een derde tak, geen derde
+    waarde: "we could not identify this producer" is a "we don't know", not
+    a "we know and it's broken", and treating it as the latter is exactly
+    the kind of noise that makes a REAL "fail" easy to tune out. The
+    ``unparseable_plists`` finding stays fully visible either way -- it is
+    never dropped, only kept out of the pass/fail verdict. A genuinely
+    measured not-loaded label still wins over an unrelated unparseable
+    plist (a real finding is never laundered away by an unrelated unknown).
+
+    Zero discovered plist labels (register + zero valid AND zero
+    unparseable) is its own "unknown" case (a register that could not be
+    established at all, exactly the discipline
+    ``daemon_register.read_daemon_register`` already applies to a
+    structurally-empty parse) -- it must never silently read as "ok,
+    nothing to report".
     """
     labels, unparseable = _scan_launchd_dir(launchd_dir)
     if not labels and not unparseable:
         return {"overall": "unknown", "jobs": {}, "reason": "no launchd plist files discovered"}
 
-    now_result = _measure_launchd_now(labels, runner=runner) if labels else {"measured": True, "jobs": {}}
+    now_result = (
+        _measure_launchd_now(labels, runner=runner, which_fn=which_fn) if labels
+        else {"measured": True, "applicable": True, "jobs": {}}
+    )
     exit_history = _last_job_exit_by_label(state_dir, labels)
 
     jobs: Dict[str, Any] = {}
@@ -2031,13 +2073,15 @@ def _measure_launchd_liveness(
     for label in labels:
         history = exit_history.get(label)
         since = history.get("timestamp") if history else None
+        if now_result["measured"]:
+            state = "loaded" if label in now_result["jobs"] else "not_loaded"
+        elif not now_result.get("applicable", True):
+            state = "not_applicable"
+        else:
+            state = "unknown"
         jobs[label] = {
             "expected": True,
-            "state": (
-                "unknown" if not now_result["measured"]
-                else "loaded" if label in now_result["jobs"]
-                else "not_loaded"
-            ),
+            "state": state,
             "since": since,
             "since_measured": since is not None,
             "last_exit_code": history.get("exit_code") if history else None,
@@ -2045,9 +2089,9 @@ def _measure_launchd_liveness(
         if now_result["measured"] and label not in now_result["jobs"]:
             any_not_loaded = True
 
-    if unparseable or (now_result["measured"] and any_not_loaded):
+    if now_result["measured"] and any_not_loaded:
         overall = "fail"
-    elif not now_result["measured"]:
+    elif not now_result["measured"] or unparseable:
         overall = "unknown"
     else:
         overall = "ok"

--- a/tests/test_build_t0_state_launchd_liveness.py
+++ b/tests/test_build_t0_state_launchd_liveness.py
@@ -1,0 +1,427 @@
+"""tests/test_build_t0_state_launchd_liveness.py — Golf 1B.
+
+`daemon_liveness` (D2, PR #1732) already gives t0_state.json first-class,
+tri-state (running/absent/unknown) visibility into the always-on daemons
+`vnx_supervisor_simple.sh`'s ``start_all()`` starts -- but that register
+parses ONLY that shell function. The seven ``com.vnx.*`` launchd-scheduled
+batch jobs declared in ``scripts/launchd/*.plist`` (producer-freshness-
+monitor, gate-obligation-runner, nightly-intelligence-pipeline, receipt-
+classifier-batch, ledger-health, conversation-analyzer, headless-trigger)
+have ZERO visibility in t0_state.json before this change -- measured live
+on this machine while building this module: ``launchctl list | grep vnx``
+shows conversation-analyzer/gate-obligation-runner/ledger-health/producer-
+freshness-monitor loaded (two of those four with a NONZERO last exit status:
+gate-obligation-runner=11, ledger-health=1) while headless-trigger/nightly-
+intelligence-pipeline/receipt-classifier-batch are not loaded at all -- a
+real, current gap this module closes, not a hypothetical one.
+
+Same tri-state discipline as daemon_register.py, deliberately NOT collapsed
+into a two-value model:
+  - "loaded"     — launchctl currently knows about the job (measured, now)
+  - "not_loaded" — launchctl was queried and the label is absent (measured
+                   absence, a real finding — not the same claim as "unknown")
+  - "unknown"    — launchctl itself could not be queried (missing binary,
+                   non-zero exit, timeout) — MUST NOT collapse into either
+                   of the other two.
+
+"since when" is a SEPARATE fact from "is it loaded right now": launchctl
+list carries no timestamp, so `since` comes from the most recent matching
+record in job_exits.ndjson (scripts/lib/job_exit_capture.py's existing
+launchd-harvest stream) when one exists, and is explicitly None — never a
+fabricated "now" or "never" — when no harvest history exists yet.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, List
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import build_t0_state as bts  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — fake plist directory + fake job_exits.ndjson
+# ---------------------------------------------------------------------------
+
+_PLIST_TEMPLATE = textwrap.dedent(
+    """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key><string>{label}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>echo hi</string>
+      </array>
+    </dict>
+    </plist>
+    """
+)
+
+
+def _write_plist(directory: Path, label: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{label}.plist"
+    path.write_text(_PLIST_TEMPLATE.format(label=label), encoding="utf-8")
+    return path
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def _fake_runner(labels_loaded: Dict[str, Dict[str, Any]], *, returncode: int = 0):
+    """Build a launchctl-list-shaped fake runner (mirrors job_exit_capture's
+    'PID<TAB>Status<TAB>Label' format)."""
+    lines = ["PID\tStatus\tLabel"]
+    for label, info in labels_loaded.items():
+        pid = info.get("pid", "-")
+        status = info.get("last_exit_status", 0)
+        lines.append(f"{pid if pid is not None else '-'}\t{status}\t{label}")
+
+    def _runner(*args, **kwargs):
+        return _FakeCompletedProcess(stdout="\n".join(lines), returncode=returncode)
+
+    return _runner
+
+
+def _raising_runner(exc: Exception):
+    def _runner(*args, **kwargs):
+        raise exc
+
+    return _runner
+
+
+# ---------------------------------------------------------------------------
+# _discover_launchd_jobs
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverLaunchdJobs:
+    def test_reads_labels_explicitly_from_plist_files(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.alpha-job")
+        _write_plist(launchd_dir, "com.vnx.beta-job")
+
+        labels = bts._discover_launchd_jobs(launchd_dir)
+
+        assert labels == ["com.vnx.alpha-job", "com.vnx.beta-job"]
+
+    def test_empty_directory_returns_empty_list_not_a_default(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        launchd_dir.mkdir()
+
+        assert bts._discover_launchd_jobs(launchd_dir) == []
+
+    def test_missing_directory_returns_empty_list(self, tmp_path: Path) -> None:
+        assert bts._discover_launchd_jobs(tmp_path / "does-not-exist") == []
+
+    def test_malformed_plist_is_skipped_not_fatal(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / "broken.plist").write_text("not a plist at all", encoding="utf-8")
+        _write_plist(launchd_dir, "com.vnx.good-job")
+
+        labels = bts._discover_launchd_jobs(launchd_dir)
+
+        assert labels == ["com.vnx.good-job"]
+
+    def test_real_repo_register_finds_the_known_jobs(self) -> None:
+        """Nul-is-eerst-een-meetfout: prove the real scripts/launchd/ directory
+        is actually found and parsed, not just that an empty/fake dir works.
+
+        Only 6 of the 7 real plist files parse as valid XML today --
+        com.vnx.gate-obligation-runner.plist contains a literal "--" inside
+        an XML comment (invalid XML; see TestScanLaunchdDir below), so it
+        is legitimately excluded from _discover_launchd_jobs's labels list
+        and picked up instead via _scan_launchd_dir's unparseable half."""
+        labels = bts._discover_launchd_jobs()
+        assert "com.vnx.producer-freshness-monitor" in labels
+        assert "com.vnx.ledger-health" in labels
+        assert len(labels) >= 6
+
+
+class TestScanLaunchdDir:
+    """_scan_launchd_dir is the variant _discover_launchd_jobs delegates to
+    -- it additionally surfaces filenames that failed to parse, so a broken
+    plist becomes a loud finding in _measure_launchd_liveness's result
+    instead of a debug-log line nobody reads."""
+
+    def test_malformed_plist_is_reported_by_name(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / "broken.plist").write_text("not a plist at all", encoding="utf-8")
+        _write_plist(launchd_dir, "com.vnx.good-job")
+
+        labels, unparseable = bts._scan_launchd_dir(launchd_dir)
+
+        assert labels == ["com.vnx.good-job"]
+        assert unparseable == ["broken.plist"]
+
+    def test_no_failures_yields_empty_unparseable_list(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.good-job")
+
+        labels, unparseable = bts._scan_launchd_dir(launchd_dir)
+
+        assert labels == ["com.vnx.good-job"]
+        assert unparseable == []
+
+    def test_real_repo_gate_obligation_runner_plist_is_currently_unparseable(self) -> None:
+        """Documents a real, currently-live defect this dispatch surfaced
+        while measuring the register: scripts/launchd/com.vnx.gate-
+        obligation-runner.plist has a literal '--' inside an XML comment
+        ('...the --project-id value...'), which XML forbids inside comments.
+        Once that file is fixed this test's second assertion flips -- update
+        it then, don't silently loosen it now."""
+        labels, unparseable = bts._scan_launchd_dir()
+        assert "com.vnx.gate-obligation-runner.plist" in unparseable
+        assert "com.vnx.gate-obligation-runner" not in labels
+
+
+# ---------------------------------------------------------------------------
+# _measure_launchd_now
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureLaunchdNow:
+    def test_loaded_job_is_measured_loaded(self) -> None:
+        runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        assert result["measured"] is True
+        assert "com.vnx.alpha-job" in result["jobs"]
+        assert result["jobs"]["com.vnx.alpha-job"]["last_exit_status"] == 0
+
+    def test_not_loaded_job_is_absent_from_jobs(self) -> None:
+        runner = _fake_runner({"com.vnx.other-job": {"pid": None, "last_exit_status": 0}})
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        assert result["measured"] is True
+        assert "com.vnx.alpha-job" not in result["jobs"]
+
+    def test_nonzero_last_exit_status_is_captured(self) -> None:
+        runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 11}})
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        assert result["jobs"]["com.vnx.alpha-job"]["last_exit_status"] == 11
+
+    def test_launchctl_missing_binary_is_unmeasurable(self) -> None:
+        runner = _raising_runner(FileNotFoundError("launchctl: not found"))
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        assert result["measured"] is False
+        assert "reason" in result
+
+    def test_launchctl_nonzero_exit_is_unmeasurable(self) -> None:
+        runner = _fake_runner({}, returncode=1)
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        assert result["measured"] is False
+
+
+# ---------------------------------------------------------------------------
+# _last_job_exit_by_label
+# ---------------------------------------------------------------------------
+
+
+class TestLastJobExitByLabel:
+    def _write_job_exits(self, state_dir: Path, records: List[Dict[str, Any]]) -> None:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        path = state_dir / "job_exits.ndjson"
+        with open(path, "w", encoding="utf-8") as fh:
+            for record in records:
+                fh.write(json.dumps(record) + "\n")
+
+    def test_missing_file_returns_empty_dict(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        assert bts._last_job_exit_by_label(state_dir, ["com.vnx.alpha-job"]) == {}
+
+    def test_finds_most_recent_record_for_label(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        self._write_job_exits(
+            state_dir,
+            [
+                {
+                    "event_type": "job_exit",
+                    "job": "com.vnx.alpha-job",
+                    "timestamp": "2026-08-01T00:00:00Z",
+                    "exit_code": 0,
+                },
+                {
+                    "event_type": "job_exit",
+                    "job": "com.vnx.alpha-job",
+                    "timestamp": "2026-09-01T00:00:00Z",
+                    "exit_code": 1,
+                },
+                {
+                    "event_type": "job_exit",
+                    "job": "com.vnx.other-job",
+                    "timestamp": "2026-09-02T00:00:00Z",
+                    "exit_code": 0,
+                },
+            ],
+        )
+        result = bts._last_job_exit_by_label(state_dir, ["com.vnx.alpha-job"])
+        assert result["com.vnx.alpha-job"]["timestamp"] == "2026-09-01T00:00:00Z"
+        assert result["com.vnx.alpha-job"]["exit_code"] == 1
+        assert "com.vnx.other-job" not in result
+
+    def test_non_job_exit_records_are_ignored(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        self._write_job_exits(
+            state_dir,
+            [{"event_type": "something_else", "job": "com.vnx.alpha-job", "timestamp": "2026-09-01T00:00:00Z"}],
+        )
+        assert bts._last_job_exit_by_label(state_dir, ["com.vnx.alpha-job"]) == {}
+
+    def test_malformed_lines_do_not_crash(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        path = state_dir / "job_exits.ndjson"
+        path.write_text("not json\n{\"event_type\": \"job_exit\", \"job\": \"com.vnx.alpha-job\", \"timestamp\": \"2026-09-01T00:00:00Z\"}\n", encoding="utf-8")
+        result = bts._last_job_exit_by_label(state_dir, ["com.vnx.alpha-job"])
+        assert result["com.vnx.alpha-job"]["timestamp"] == "2026-09-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# _combine_liveness_overall
+# ---------------------------------------------------------------------------
+
+
+class TestCombineLivenessOverall:
+    def test_any_fail_wins(self) -> None:
+        assert bts._combine_liveness_overall("ok", "fail", "unknown") == "fail"
+
+    def test_ok_when_no_fail_and_at_least_one_ok(self) -> None:
+        assert bts._combine_liveness_overall("unknown", "ok") == "ok"
+
+    def test_unknown_when_everything_is_unknown_or_absent(self) -> None:
+        assert bts._combine_liveness_overall("unknown", None) == "unknown"
+        assert bts._combine_liveness_overall() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _measure_launchd_liveness — end-to-end (still with injected state_dir/runner)
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureLaunchdLiveness:
+    def test_not_loaded_job_forces_overall_fail(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.alpha-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        runner = _fake_runner({})  # nothing loaded
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+
+        assert result["overall"] == "fail"
+        assert result["jobs"]["com.vnx.alpha-job"]["state"] == "not_loaded"
+
+    def test_loaded_job_is_ok(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.alpha-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+
+        assert result["overall"] == "ok"
+        assert result["jobs"]["com.vnx.alpha-job"]["state"] == "loaded"
+
+    def test_unmeasurable_launchctl_is_unknown_not_ok_or_fail(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.alpha-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        runner = _raising_runner(FileNotFoundError("no launchctl"))
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+
+        assert result["overall"] == "unknown"
+        assert result["jobs"]["com.vnx.alpha-job"]["state"] == "unknown"
+
+    def test_unparseable_plist_forces_overall_fail_even_if_all_valid_jobs_are_loaded(self, tmp_path: Path) -> None:
+        """A plist that fails to parse names a producer this module cannot
+        even identify -- that alone must not be masked by every OTHER,
+        successfully-parsed job happening to be loaded."""
+        launchd_dir = tmp_path / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / "broken.plist").write_text("not a plist at all", encoding="utf-8")
+        _write_plist(launchd_dir, "com.vnx.good-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        runner = _fake_runner({"com.vnx.good-job": {"pid": None, "last_exit_status": 0}})
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+
+        assert result["overall"] == "fail"
+        assert result["unparseable_plists"] == ["broken.plist"]
+        assert result["jobs"]["com.vnx.good-job"]["state"] == "loaded"
+
+    def test_zero_discovered_jobs_is_unknown_not_ok(self, tmp_path: Path) -> None:
+        """An empty register must never silently read as 'nothing to report,
+        all fine' -- it is exactly as suspect as a parse failure elsewhere in
+        this codebase (see daemon_register.read_daemon_register's own
+        'zero start_process entries' -> ValueError precedent)."""
+        launchd_dir = tmp_path / "launchd"
+        launchd_dir.mkdir()
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=_fake_runner({}))
+
+        assert result["overall"] == "unknown"
+        assert result["jobs"] == {}
+
+    def test_since_populated_from_job_exits_history(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.alpha-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        with open(state_dir / "job_exits.ndjson", "w", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "event_type": "job_exit",
+                        "job": "com.vnx.alpha-job",
+                        "timestamp": "2026-08-15T06:00:00Z",
+                        "exit_code": 0,
+                    }
+                )
+                + "\n"
+            )
+        runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+
+        assert result["jobs"]["com.vnx.alpha-job"]["since"] == "2026-08-15T06:00:00Z"
+        assert result["jobs"]["com.vnx.alpha-job"]["since_measured"] is True
+
+    def test_since_explicitly_not_measured_when_no_history(self, tmp_path: Path) -> None:
+        """Third branch, not a third value: no job_exits history means 'we
+        cannot establish since when', never a fabricated timestamp and never
+        silently equal to the 'not running' case."""
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.alpha-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+
+        assert result["jobs"]["com.vnx.alpha-job"]["since"] is None
+        assert result["jobs"]["com.vnx.alpha-job"]["since_measured"] is False

--- a/tests/test_build_t0_state_launchd_liveness.py
+++ b/tests/test_build_t0_state_launchd_liveness.py
@@ -107,6 +107,28 @@ def _raising_runner(exc: Exception):
     return _runner
 
 
+# A test must not measure whichever platform it happens to run on (macOS,
+# where launchctl exists, locally; a Linux CI runner, where it categorically
+# does not -- PR #1755's second CI round: every test below that used
+# `runner=` without also injecting `which_fn` silently fell through to the
+# REAL `shutil.which`, so on this dev machine the tests exercised the
+# "present" branch and on CI they all exercised "absent" instead, no matter
+# what the injected `runner` was built to simulate. Every test that cares
+# about a SPECIFIC launchctl-present behavior now pins `which_fn=_present_which`
+# explicitly; the platform-not-applicable tests pin `which_fn=_absent_which`.
+# Both are asserted, hard, in both directions -- never loosened to accept
+# either outcome (that would test nothing).
+def _present_which(name: str) -> Any:
+    """Pins 'launchctl is on PATH' regardless of the real host OS."""
+    return f"/usr/bin/{name}" if name == "launchctl" else None
+
+
+def _absent_which(name: str) -> None:
+    """Pins 'launchctl does not exist on this platform' regardless of the
+    real host OS -- e.g. every Linux CI runner."""
+    return None
+
+
 # ---------------------------------------------------------------------------
 # _discover_launchd_jobs
 # ---------------------------------------------------------------------------
@@ -200,40 +222,44 @@ class TestScanLaunchdDir:
 
 
 class TestMeasureLaunchdNow:
+    """which_fn=_present_which is pinned on every test here: these all
+    exercise the 'launchctl exists' branch on purpose, and must not depend
+    on whether the machine actually running the suite has launchctl."""
+
     def test_loaded_job_is_measured_loaded(self) -> None:
         runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
-        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner, which_fn=_present_which)
         assert result["measured"] is True
         assert "com.vnx.alpha-job" in result["jobs"]
         assert result["jobs"]["com.vnx.alpha-job"]["last_exit_status"] == 0
 
     def test_not_loaded_job_is_absent_from_jobs(self) -> None:
         runner = _fake_runner({"com.vnx.other-job": {"pid": None, "last_exit_status": 0}})
-        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner, which_fn=_present_which)
         assert result["measured"] is True
         assert "com.vnx.alpha-job" not in result["jobs"]
 
     def test_nonzero_last_exit_status_is_captured(self) -> None:
         runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 11}})
-        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner, which_fn=_present_which)
         assert result["jobs"]["com.vnx.alpha-job"]["last_exit_status"] == 11
 
     def test_launchctl_missing_binary_is_unmeasurable(self) -> None:
-        """A race between which() succeeding and the actual invocation
-        failing (or a test that does not touch which_fn at all, as here --
-        which_fn defaults to the real shutil.which, which finds a real
-        launchctl on this dev machine) is a TRANSIENT failure: applicable
-        stays True (tried on a platform where it should work, failed this
-        time), never conflated with 'does not exist on this platform'."""
+        """which_fn pinned to 'present' -- this test is specifically about
+        a RACE (which() said yes, the actual invocation then failed), a
+        TRANSIENT failure: applicable stays True (tried on a platform where
+        it should work, failed this time), never conflated with 'does not
+        exist on this platform' (that is TestLaunchctlNotApplicableOnThisPlatform,
+        below, which pins which_fn=_absent_which instead)."""
         runner = _raising_runner(FileNotFoundError("launchctl: not found"))
-        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner, which_fn=_present_which)
         assert result["measured"] is False
         assert result["applicable"] is True
         assert "reason" in result
 
     def test_launchctl_nonzero_exit_is_unmeasurable(self) -> None:
         runner = _fake_runner({}, returncode=1)
-        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner, which_fn=_present_which)
         assert result["measured"] is False
         assert result["applicable"] is True
 
@@ -248,7 +274,7 @@ class TestLaunchctlNotApplicableOnThisPlatform:
     non-macOS machine."""
 
     def test_which_fn_absent_is_not_applicable_not_a_transient_failure(self) -> None:
-        result = bts._measure_launchd_now(["com.vnx.alpha-job"], which_fn=lambda _name: None)
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], which_fn=_absent_which)
         assert result["measured"] is False
         assert result["applicable"] is False
         assert "reason" in result
@@ -263,15 +289,15 @@ class TestLaunchctlNotApplicableOnThisPlatform:
             calls.append(args)
             return _FakeCompletedProcess()
 
-        bts._measure_launchd_now(["com.vnx.alpha-job"], runner=_runner, which_fn=lambda _name: None)
+        bts._measure_launchd_now(["com.vnx.alpha-job"], runner=_runner, which_fn=_absent_which)
         assert calls == []
 
     def test_which_fn_present_measures_normally(self) -> None:
         """Sanity: injecting a which_fn that DOES find launchctl behaves
-        exactly like the default (real shutil.which on this dev machine)."""
+        exactly like the 'present' branch regardless of the real host OS."""
         runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
         result = bts._measure_launchd_now(
-            ["com.vnx.alpha-job"], runner=runner, which_fn=lambda name: f"/usr/bin/{name}",
+            ["com.vnx.alpha-job"], runner=runner, which_fn=_present_which,
         )
         assert result["measured"] is True
         assert result["applicable"] is True
@@ -365,6 +391,11 @@ class TestCombineLivenessOverall:
 
 
 class TestMeasureLaunchdLiveness:
+    """which_fn=_present_which is pinned wherever the test simulates a
+    specific launchctl-list outcome via `runner=` -- otherwise the test
+    would measure whichever platform happens to run it (PR #1755's second
+    CI round) instead of the branch it names."""
+
     def test_not_loaded_job_forces_overall_fail(self, tmp_path: Path) -> None:
         launchd_dir = tmp_path / "launchd"
         _write_plist(launchd_dir, "com.vnx.alpha-job")
@@ -372,7 +403,7 @@ class TestMeasureLaunchdLiveness:
         state_dir.mkdir()
         runner = _fake_runner({})  # nothing loaded
 
-        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner, which_fn=_present_which)
 
         assert result["overall"] == "fail"
         assert result["jobs"]["com.vnx.alpha-job"]["state"] == "not_loaded"
@@ -384,19 +415,23 @@ class TestMeasureLaunchdLiveness:
         state_dir.mkdir()
         runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
 
-        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner, which_fn=_present_which)
 
         assert result["overall"] == "ok"
         assert result["jobs"]["com.vnx.alpha-job"]["state"] == "loaded"
 
     def test_unmeasurable_launchctl_is_unknown_not_ok_or_fail(self, tmp_path: Path) -> None:
+        """which_fn pinned 'present' -- this is the TRANSIENT-failure branch
+        (launchctl exists, this one invocation raised), not the
+        not-applicable-platform branch (TestMeasureLaunchdLivenessNotApplicable,
+        below)."""
         launchd_dir = tmp_path / "launchd"
         _write_plist(launchd_dir, "com.vnx.alpha-job")
         state_dir = tmp_path / "state"
         state_dir.mkdir()
         runner = _raising_runner(FileNotFoundError("no launchctl"))
 
-        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner, which_fn=_present_which)
 
         assert result["overall"] == "unknown"
         assert result["jobs"]["com.vnx.alpha-job"]["state"] == "unknown"
@@ -421,7 +456,7 @@ class TestMeasureLaunchdLiveness:
         state_dir.mkdir()
         runner = _fake_runner({"com.vnx.good-job": {"pid": None, "last_exit_status": 0}})
 
-        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner, which_fn=_present_which)
 
         assert result["overall"] == "unknown"
         assert result["unparseable_plists"] == ["broken.plist"]
@@ -439,7 +474,7 @@ class TestMeasureLaunchdLiveness:
         state_dir.mkdir()
         runner = _fake_runner({})  # com.vnx.good-job NOT loaded
 
-        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner, which_fn=_present_which)
 
         assert result["overall"] == "fail"
         assert result["unparseable_plists"] == ["broken.plist"]
@@ -479,10 +514,11 @@ class TestMeasureLaunchdLiveness:
             )
         runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
 
-        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner, which_fn=_present_which)
 
         assert result["jobs"]["com.vnx.alpha-job"]["since"] == "2026-08-15T06:00:00Z"
         assert result["jobs"]["com.vnx.alpha-job"]["since_measured"] is True
+        assert result["jobs"]["com.vnx.alpha-job"]["state"] == "loaded"
 
     def test_since_explicitly_not_measured_when_no_history(self, tmp_path: Path) -> None:
         """Third branch, not a third value: no job_exits history means 'we
@@ -494,10 +530,11 @@ class TestMeasureLaunchdLiveness:
         state_dir.mkdir()
         runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
 
-        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner, which_fn=_present_which)
 
         assert result["jobs"]["com.vnx.alpha-job"]["since"] is None
         assert result["jobs"]["com.vnx.alpha-job"]["since_measured"] is False
+        assert result["jobs"]["com.vnx.alpha-job"]["state"] == "loaded"
 
 
 class TestMeasureLaunchdLivenessNotApplicable:
@@ -514,7 +551,7 @@ class TestMeasureLaunchdLivenessNotApplicable:
         state_dir.mkdir()
 
         result = bts._measure_launchd_liveness(
-            state_dir, launchd_dir=launchd_dir, which_fn=lambda _name: None,
+            state_dir, launchd_dir=launchd_dir, which_fn=_absent_which,
         )
 
         assert result["overall"] == "unknown"
@@ -533,7 +570,7 @@ class TestMeasureLaunchdLivenessNotApplicable:
         state_dir = tmp_path / "state"
         state_dir.mkdir()
 
-        result = bts._measure_launchd_liveness(state_dir, which_fn=lambda _name: None)
+        result = bts._measure_launchd_liveness(state_dir, which_fn=_absent_which)
 
         assert result["overall"] == "unknown"
         assert "com.vnx.gate-obligation-runner.plist" in result.get("unparseable_plists", [])

--- a/tests/test_build_t0_state_launchd_liveness.py
+++ b/tests/test_build_t0_state_launchd_liveness.py
@@ -219,15 +219,62 @@ class TestMeasureLaunchdNow:
         assert result["jobs"]["com.vnx.alpha-job"]["last_exit_status"] == 11
 
     def test_launchctl_missing_binary_is_unmeasurable(self) -> None:
+        """A race between which() succeeding and the actual invocation
+        failing (or a test that does not touch which_fn at all, as here --
+        which_fn defaults to the real shutil.which, which finds a real
+        launchctl on this dev machine) is a TRANSIENT failure: applicable
+        stays True (tried on a platform where it should work, failed this
+        time), never conflated with 'does not exist on this platform'."""
         runner = _raising_runner(FileNotFoundError("launchctl: not found"))
         result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
         assert result["measured"] is False
+        assert result["applicable"] is True
         assert "reason" in result
 
     def test_launchctl_nonzero_exit_is_unmeasurable(self) -> None:
         runner = _fake_runner({}, returncode=1)
         result = bts._measure_launchd_now(["com.vnx.alpha-job"], runner=runner)
         assert result["measured"] is False
+        assert result["applicable"] is True
+
+
+class TestLaunchctlNotApplicableOnThisPlatform:
+    """Golf 1B follow-up (PR #1755 CI failure, both on the Linux CI runner
+    AND reproduced locally on macOS via a different path -- see the
+    TestMeasureLaunchdLiveness unparseable-plist tests above): 'launchctl
+    does not exist on this platform at all' is a DIFFERENT claim than 'we
+    tried launchctl and it failed this time'. which_fn is the injection
+    seam (mirrors runner) so this is testable without needing an actual
+    non-macOS machine."""
+
+    def test_which_fn_absent_is_not_applicable_not_a_transient_failure(self) -> None:
+        result = bts._measure_launchd_now(["com.vnx.alpha-job"], which_fn=lambda _name: None)
+        assert result["measured"] is False
+        assert result["applicable"] is False
+        assert "reason" in result
+
+    def test_which_fn_absent_short_circuits_before_invoking_runner(self) -> None:
+        """No point spawning a subprocess for a binary we already know is
+        not on PATH -- and this proves the short-circuit, not just the
+        outcome."""
+        calls: List[Any] = []
+
+        def _runner(*args: Any, **kwargs: Any) -> _FakeCompletedProcess:
+            calls.append(args)
+            return _FakeCompletedProcess()
+
+        bts._measure_launchd_now(["com.vnx.alpha-job"], runner=_runner, which_fn=lambda _name: None)
+        assert calls == []
+
+    def test_which_fn_present_measures_normally(self) -> None:
+        """Sanity: injecting a which_fn that DOES find launchctl behaves
+        exactly like the default (real shutil.which on this dev machine)."""
+        runner = _fake_runner({"com.vnx.alpha-job": {"pid": None, "last_exit_status": 0}})
+        result = bts._measure_launchd_now(
+            ["com.vnx.alpha-job"], runner=runner, which_fn=lambda name: f"/usr/bin/{name}",
+        )
+        assert result["measured"] is True
+        assert result["applicable"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -354,10 +401,18 @@ class TestMeasureLaunchdLiveness:
         assert result["overall"] == "unknown"
         assert result["jobs"]["com.vnx.alpha-job"]["state"] == "unknown"
 
-    def test_unparseable_plist_forces_overall_fail_even_if_all_valid_jobs_are_loaded(self, tmp_path: Path) -> None:
-        """A plist that fails to parse names a producer this module cannot
-        even identify -- that alone must not be masked by every OTHER,
-        successfully-parsed job happening to be loaded."""
+    def test_unparseable_plist_alone_yields_unknown_not_fail(self, tmp_path: Path) -> None:
+        """Corrected behaviour (OI found via PR #1755 CI): an unparseable
+        plist names a producer this module cannot even identify -- that is
+        a "we don't know", not a "we know and it's broken". It stays LOUD
+        (unparseable_plists is never emptied out) but must not by itself
+        force overall to "fail": a plist with invalid XML is a standing,
+        cross-platform, this-PR-cannot-fix-it fact, and forcing "fail" for
+        it forever would make every single measurement on every machine
+        report unhealthy for a reason no amount of retrying changes --
+        exactly the noise that makes a REAL "fail" (an actually not-loaded,
+        measured job) easy to ignore. See TestMeasuredNotLoadedStillWinsOverUnparseable
+        below for the case where a genuine finding still forces "fail"."""
         launchd_dir = tmp_path / "launchd"
         launchd_dir.mkdir(parents=True)
         (launchd_dir / "broken.plist").write_text("not a plist at all", encoding="utf-8")
@@ -368,9 +423,27 @@ class TestMeasureLaunchdLiveness:
 
         result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
 
-        assert result["overall"] == "fail"
+        assert result["overall"] == "unknown"
         assert result["unparseable_plists"] == ["broken.plist"]
         assert result["jobs"]["com.vnx.good-job"]["state"] == "loaded"
+
+    def test_measured_not_loaded_job_still_forces_fail_even_with_unparseable_plist(self, tmp_path: Path) -> None:
+        """A REAL, measured, not-loaded job is a genuine finding and must
+        still win: 'we don't know about the broken plist' does not get to
+        launder away 'we DO know this other job is down'."""
+        launchd_dir = tmp_path / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / "broken.plist").write_text("not a plist at all", encoding="utf-8")
+        _write_plist(launchd_dir, "com.vnx.good-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        runner = _fake_runner({})  # com.vnx.good-job NOT loaded
+
+        result = bts._measure_launchd_liveness(state_dir, launchd_dir=launchd_dir, runner=runner)
+
+        assert result["overall"] == "fail"
+        assert result["unparseable_plists"] == ["broken.plist"]
+        assert result["jobs"]["com.vnx.good-job"]["state"] == "not_loaded"
 
     def test_zero_discovered_jobs_is_unknown_not_ok(self, tmp_path: Path) -> None:
         """An empty register must never silently read as 'nothing to report,
@@ -425,3 +498,44 @@ class TestMeasureLaunchdLiveness:
 
         assert result["jobs"]["com.vnx.alpha-job"]["since"] is None
         assert result["jobs"]["com.vnx.alpha-job"]["since_measured"] is False
+
+
+class TestMeasureLaunchdLivenessNotApplicable:
+    """PR #1755 CI failure: on a Linux CI runner launchctl does not exist at
+    all, so every job's loaded/not-loaded state is structurally unknowable
+    there -- that must read 'unknown' (per-job 'not_applicable'), never
+    'fail'. which_fn is the injection seam that makes this reproducible on
+    any dev machine, macOS included."""
+
+    def test_not_applicable_platform_yields_unknown_overall_and_not_applicable_jobs(self, tmp_path: Path) -> None:
+        launchd_dir = tmp_path / "launchd"
+        _write_plist(launchd_dir, "com.vnx.alpha-job")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = bts._measure_launchd_liveness(
+            state_dir, launchd_dir=launchd_dir, which_fn=lambda _name: None,
+        )
+
+        assert result["overall"] == "unknown"
+        assert result["jobs"]["com.vnx.alpha-job"]["state"] == "not_applicable"
+
+    def test_real_repo_register_with_no_launchctl_is_unknown_not_fail(self, tmp_path: Path) -> None:
+        """The exact CI reproduction: the REAL scripts/launchd directory
+        (including its one currently-unparseable plist,
+        com.vnx.gate-obligation-runner.plist) plus 'launchctl does not
+        exist' must together read 'unknown', not 'fail' -- this is what
+        made tests/test_build_t0_brief_output.py::TestFormatBriefOutputPath
+        assert rc == 0 fail with rc == 1 on the Linux CI runner AND,
+        independently, on this macOS dev machine (there via genuinely
+        not-loaded real jobs, a SEPARATE true-ambient-state fact -- see
+        TestMeasureLaunchdLiveness's unparseable-plist tests for that half)."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = bts._measure_launchd_liveness(state_dir, which_fn=lambda _name: None)
+
+        assert result["overall"] == "unknown"
+        assert "com.vnx.gate-obligation-runner.plist" in result.get("unparseable_plists", [])
+        for label, info in result["jobs"].items():
+            assert info["state"] == "not_applicable", f"{label}: {info}"

--- a/tests/test_system_health_monotonic.py
+++ b/tests/test_system_health_monotonic.py
@@ -92,12 +92,12 @@ class TestStatusCannotBeHealthierThanBeacon:
         assert health["status"] != "healthy"
 
     def test_ok_beacon_allows_healthy_status(self, tmp_path: Path) -> None:
-        # daemon_liveness is injected as neutral "ok" so this test isolates
-        # beacon behavior instead of depending on which real daemons happen
-        # to be running on the machine executing the suite. Same reasoning
-        # for expected_beacon_components=() (D3a): the real repo's 9
-        # beacon-writer names would otherwise show up as "absent" against
-        # this bare tmp_path and force overall to "fail".
+        # daemon_liveness/launchd_liveness are injected as neutral "ok" so
+        # this test isolates beacon behavior instead of depending on which
+        # real daemons/launchd jobs happen to be loaded on the machine
+        # executing the suite. Same reasoning for expected_beacon_components=()
+        # (D3a): the real repo's 9 beacon-writer names would otherwise show up
+        # as "absent" against this bare tmp_path and force overall to "fail".
         state_dir = _state_dir_with_terminal_marker(tmp_path)
         HealthBeacon(state_dir.parent, "good_comp", expected_interval_seconds=3600).heartbeat(
             status="ok", details={}
@@ -105,6 +105,7 @@ class TestStatusCannotBeHealthierThanBeacon:
         health = bts._build_system_health(
             state_dir, db_initialized=True,
             daemon_liveness={"overall": "ok", "daemons": {}},
+            launchd_liveness={"overall": "ok", "jobs": {}},
             expected_beacon_components=(),
         )
         assert health["beacon_health"]["overall"] == "ok"
@@ -177,7 +178,11 @@ class TestDaemonLivenessMonotonic:
         # expected_beacon_components=() isolates from this repo's real
         # beacon-writer register (D3a) -- this test writes no beacon at all,
         # so without the override every one of the real names would read
-        # "absent" and force status to "degraded".
+        # "absent" and force status to "degraded". launchd_liveness is
+        # injected neutral for the same reason daemon_liveness always was --
+        # without it, the real (unmocked) launchctl measurement would run
+        # against whatever com.vnx.* jobs happen to be loaded on the machine
+        # running the suite.
         state_dir = _state_dir_with_terminal_marker(tmp_path)
         daemon_liveness = {
             "overall": "ok",
@@ -185,6 +190,7 @@ class TestDaemonLivenessMonotonic:
         }
         health = bts._build_system_health(
             state_dir, db_initialized=True, daemon_liveness=daemon_liveness,
+            launchd_liveness={"overall": "ok", "jobs": {}},
             expected_beacon_components=(),
         )
         assert health["status"] == "healthy"
@@ -196,6 +202,7 @@ class TestDaemonLivenessMonotonic:
         daemon_liveness = {"overall": "unknown", "daemons": {}, "reason": "psutil unavailable"}
         health = bts._build_system_health(
             state_dir, db_initialized=True, daemon_liveness=daemon_liveness,
+            launchd_liveness={"overall": "unknown", "jobs": {}, "reason": "launchctl unavailable"},
             expected_beacon_components=(),
         )
         assert health["status"] == "healthy"
@@ -208,6 +215,155 @@ class TestDaemonLivenessMonotonic:
         health = bts._build_system_health(state_dir, db_initialized=True)
         assert "daemon_liveness" in health
         assert health["daemon_liveness"]["overall"] in ("ok", "fail", "unknown")
+
+
+class TestLaunchdLivenessMonotonic:
+    """Golf 1B: the second producer class daemon_liveness does not cover --
+    scripts/launchd/*.plist-declared batch jobs. Same monotonicity contract
+    as TestDaemonLivenessMonotonic above, applied to the new signal."""
+
+    def test_injected_launchd_fail_forbids_healthy_status(self, tmp_path: Path) -> None:
+        """THE red test this dispatch asked for: a producer measured as NOT
+        running next to status=healthy is exactly the bug OI-1511 named."""
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        launchd_liveness = {
+            "overall": "fail",
+            "jobs": {"com.vnx.ledger-health": {"expected": True, "state": "not_loaded", "since": None, "since_measured": False}},
+        }
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "ok", "daemons": {}},
+            launchd_liveness=launchd_liveness,
+            expected_beacon_components=(),
+        )
+        assert health["launchd_liveness"]["overall"] == "fail"
+        assert health["status"] != "healthy", (
+            f"status={health['status']!r} sits next to launchd_liveness.overall='fail' "
+            "-- a summary reported healthier than its own nested signal"
+        )
+
+    def test_injected_launchd_ok_allows_healthy_status(self, tmp_path: Path) -> None:
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "ok", "daemons": {}},
+            launchd_liveness={"overall": "ok", "jobs": {"com.vnx.ledger-health": {"expected": True, "state": "loaded", "since": "2026-09-04T06:00:00Z", "since_measured": True}}},
+            expected_beacon_components=(),
+        )
+        assert health["status"] == "healthy"
+
+    def test_unknown_launchd_liveness_does_not_force_degraded(self, tmp_path: Path) -> None:
+        """'unknown' (launchctl itself could not be queried) is a third
+        branch -- it must not be silently treated as a failure."""
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "ok", "daemons": {}},
+            launchd_liveness={"overall": "unknown", "jobs": {}, "reason": "launchctl unavailable"},
+            expected_beacon_components=(),
+        )
+        assert health["status"] == "healthy"
+
+    def test_real_measurement_runs_when_not_injected(self, tmp_path: Path) -> None:
+        """Default (no launchd_liveness param) exercises the real
+        discover-plists + launchctl-list measurement -- must not raise, and
+        must surface a launchd_liveness key with a recognized overall value
+        regardless of what is actually loaded on the machine running this
+        suite (CI has no launchctl at all -- that must read 'unknown', never
+        raise)."""
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        health = bts._build_system_health(state_dir, db_initialized=True)
+        assert "launchd_liveness" in health
+        assert health["launchd_liveness"]["overall"] in ("ok", "fail", "unknown")
+
+    def test_never_silently_omitted_when_measurement_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Niet-gemeten is een derde tak, geen derde waarde -- en zeker geen
+        afwezig veld. Unlike the pre-existing beacon_health/daemon_liveness
+        pattern (which silently drops the key entirely when the underlying
+        measurement raises), launchd_liveness must ALWAYS be present: an
+        absent key looks like 'nobody wired this in', an explicit 'unknown'
+        says 'we tried and could not tell' -- those are different claims."""
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated total measurement failure")
+
+        monkeypatch.setattr(bts, "_measure_launchd_liveness", _boom)
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "ok", "daemons": {}},
+            expected_beacon_components=(),
+        )
+        assert "launchd_liveness" in health
+        assert health["launchd_liveness"]["overall"] == "unknown"
+        assert health["status"] == "healthy"
+
+
+class TestProducerLivenessComposedField:
+    """The single 'first-class producer liveness field' this dispatch asked
+    for: producer_liveness folds daemon_liveness (supervised, always-on
+    daemons) and launchd_liveness (scheduled batch jobs) into ONE overall
+    value via _combine_liveness_overall, so a caller does not have to know
+    both sub-signals exist and combine them by hand."""
+
+    def test_either_producer_class_failing_forbids_producer_liveness_ok(self, tmp_path: Path) -> None:
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "fail", "daemons": {"dispatcher": {"state": "absent"}}},
+            launchd_liveness={"overall": "ok", "jobs": {}},
+            expected_beacon_components=(),
+        )
+        assert health["producer_liveness"]["overall"] == "fail"
+
+    def test_launchd_failing_alone_forbids_producer_liveness_ok(self, tmp_path: Path) -> None:
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "ok", "daemons": {}},
+            launchd_liveness={"overall": "fail", "jobs": {"com.vnx.ledger-health": {"state": "not_loaded"}}},
+            expected_beacon_components=(),
+        )
+        assert health["producer_liveness"]["overall"] == "fail"
+
+    def test_both_ok_yields_producer_liveness_ok(self, tmp_path: Path) -> None:
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "ok", "daemons": {}},
+            launchd_liveness={"overall": "ok", "jobs": {}},
+            expected_beacon_components=(),
+        )
+        assert health["producer_liveness"]["overall"] == "ok"
+
+    def test_both_unknown_yields_producer_liveness_unknown_not_ok(self, tmp_path: Path) -> None:
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness={"overall": "unknown", "daemons": {}, "reason": "psutil unavailable"},
+            launchd_liveness={"overall": "unknown", "jobs": {}, "reason": "launchctl unavailable"},
+            expected_beacon_components=(),
+        )
+        assert health["producer_liveness"]["overall"] == "unknown"
+
+    def test_producer_liveness_carries_both_sub_overalls(self, tmp_path: Path) -> None:
+        """A summary, not a re-embedding of the full per-daemon/per-job
+        dicts (those already sit as sibling keys -- see the size-budget note
+        on the production code): producer_liveness carries each class's
+        overall value, not its full breakdown."""
+        state_dir = _state_dir_with_terminal_marker(tmp_path)
+        daemon_liveness = {"overall": "ok", "daemons": {"dispatcher": {"state": "running"}}}
+        launchd_liveness = {"overall": "fail", "jobs": {"com.vnx.ledger-health": {"state": "not_loaded"}}}
+        health = bts._build_system_health(
+            state_dir, db_initialized=True,
+            daemon_liveness=daemon_liveness,
+            launchd_liveness=launchd_liveness,
+            expected_beacon_components=(),
+        )
+        assert health["producer_liveness"]["daemon_overall"] == "ok"
+        assert health["producer_liveness"]["launchd_overall"] == "fail"
+        assert "daemons" not in health["producer_liveness"]
+        assert "jobs" not in health["producer_liveness"]
 
 
 class TestBriefCarriesDaemonLiveness:
@@ -239,3 +395,37 @@ class TestBriefCarriesDaemonLiveness:
         }
         brief = bts._state_to_brief(state)
         assert brief["system_health"]["status"] == "degraded"
+
+    def test_state_to_brief_includes_launchd_liveness(self) -> None:
+        """Second-reader gap (D2's own note above): a field that lands only
+        in the builder and not in the backward-compat brief is a half
+        repair."""
+        state = {
+            "generated_at": "2026-09-04T10:00:00Z",
+            "system_health": {
+                "status": "degraded",
+                "uptime_seconds": 0,
+                "db_initialized": True,
+                "beacon_health": {"overall": "fail"},
+                "launchd_liveness": {"overall": "fail", "jobs": {"com.vnx.ledger-health": {"state": "not_loaded"}}},
+            },
+        }
+        brief = bts._state_to_brief(state)
+        assert brief["system_health"].get("launchd_liveness") == {
+            "overall": "fail", "jobs": {"com.vnx.ledger-health": {"state": "not_loaded"}},
+        }
+
+    def test_state_to_brief_includes_producer_liveness(self) -> None:
+        state = {
+            "generated_at": "2026-09-04T10:00:00Z",
+            "system_health": {
+                "status": "degraded",
+                "uptime_seconds": 0,
+                "db_initialized": True,
+                "producer_liveness": {"overall": "fail", "daemon_overall": "ok", "launchd_overall": "fail"},
+            },
+        }
+        brief = bts._state_to_brief(state)
+        assert brief["system_health"].get("producer_liveness") == {
+            "overall": "fail", "daemon_overall": "ok", "launchd_overall": "fail",
+        }


### PR DESCRIPTION
## Summary

Golf 1B: the fourth and last open criterion of the `ledger-is-falsifiable` objective — daemon-liveness of producers must be a first-class field in `t0_state.json`, not inferred from absence.

`daemon_liveness` (D2, #1732) already covers the always-on daemons `vnx_supervisor_simple.sh`'s `start_all()` starts (tri-state running/absent/unknown, feeds `worst_status`). It only parses that one shell function. The seven `com.vnx.*` launchd-scheduled batch jobs declared in `scripts/launchd/*.plist` had **zero visibility** in `t0_state.json` — a "process exists" proxy cannot see a job that is only ever loaded-and-scheduled, never a long-lived PID.

Measured live while building this module, `launchctl list` showed 4 of the 7 real jobs loaded (2 with a nonzero last-exit-status: `gate-obligation-runner`=11, `ledger-health`=1) and 3 not loaded at all. This is a real, current gap, not a hypothetical one.

## Changes

- `_scan_launchd_dir` / `_discover_launchd_jobs` — explicit register of expected launchd labels, read from each plist's own `Label` key (never guessed off the filename).
- `_measure_launchd_now` — live `launchctl list` query (reuses `job_exit_capture._parse_launchctl_list` instead of a second hand-rolled parser).
- `_last_job_exit_by_label` — "since when" from `job_exits.ndjson`'s existing launchd-harvest history; explicitly `None` (`since_measured=False`) when no harvest history exists — never fabricated, never conflated with "not loaded".
- `launchd_liveness` — new `system_health` field, same tri-state discipline as `daemon_liveness` (`loaded`/`not_loaded`/`unknown`), feeds `worst_status`. Unlike the pre-existing `beacon_health`/`daemon_liveness` pattern, it is **never silently omitted** when the measurement raises — an absent key looks like "nobody wired this in"; an explicit `unknown` says "we tried and could not tell".
- `producer_liveness` — single first-class summary folding `daemon_liveness` + `launchd_liveness` via `_combine_liveness_overall` (fail > ok > unknown — mirrors the still-unmerged `stop_conditions.py` `CheckStatus`/`_combine` rule from PR #1754, rebuilt here since that module isn't on this branch's `main`). Deliberately a summary (each sub-signal's `overall` only), not a re-embedding of the full per-daemon/per-job dicts — see the size-budget note below.
- `_slim_health_for_index` — `t0_index.json`'s ≤5KB budget could not absorb the new fields' full per-item breakdowns wholesale (measured live: 3559 → 8024 bytes). The index now carries each nested signal's `overall` only; full per-daemon/per-job/per-beacon detail stays in `system_health`/`t0_state.json`.
- `_state_to_brief` now carries `launchd_liveness`/`producer_liveness` (the "second reader" gap D2's own tests already guard against).

### A real defect surfaced along the way

`scripts/launchd/com.vnx.gate-obligation-runner.plist` contains a literal `--` inside an XML comment (`"...the --project-id value..."`), which is invalid XML (comments may never contain `--`). `_scan_launchd_dir` now reports this via `unparseable_plists` instead of a swallowed debug line, and it forces `launchd_liveness.overall` to `"fail"` — the plist itself is untouched (out of scope for this dispatch; a test (`TestScanLaunchdDir::test_real_repo_gate_obligation_runner_plist_is_currently_unparseable`) documents the current state and will need updating once someone fixes the `--`).

## Verification

- **Red** (final test suite against unmodified `build_t0_state.py`): 42 failed, 9 passed.
- **Green**: 102 passed, 0 failed — `tests/test_build_t0_state_launchd_liveness.py` (new, 27 tests) + `tests/test_system_health_monotonic.py` (extended, 24 tests) + `tests/test_daemon_register.py` (29 pre-existing, unaffected) + `tests/test_t0_index_split.py` (34 pre-existing, confirms the ≤5KB/≤50-key budget still holds — 1175/5120 bytes in the real-measurement case).
- `ruff check` clean (only a pre-existing, unrelated `E741` at line 1817 outside this diff).
- `scripts/check_no_file_derived_data_paths.py` (central-mode path gate): PASS.
- 3 pre-existing, unrelated failures confirmed via `git stash` on unmodified `origin/main` before touching anything (a local sqlite migration issue on this machine: `migration auto_apply failed: no such column: project_id`) — `test_build_t0_state_exception_handling.py::test_build_t0_state_runs_clean_on_main`, `test_future_state_reconciliation.py::test_health_beacon_receives_fail_when_writes_fail`, `test_project_status_hook.py::test_project_status_md_generated`. Not touched by this PR.

### `stop_conditions.py` / PR #1754 status

Not on this branch's `main` (PR #1754 is still open, `mergedAt: null`). Per the dispatch instructions, the same tri-state discipline (a third branch, never a third value, never collapsed into either "healthy" or "broken") was rebuilt directly in `build_t0_state.py` as `_combine_liveness_overall`, rather than imported.

> Buiten de dispatch-deur om geproduceerd via een Agent-subagent, operator-besluit 2026-09-04. Tijdelijke afwijking: de gegovernde dispatch-paden zijn traag en de deur is zelf onderwerp van reparatie. PR en CI blijven onverkort gelden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR