### PR TITLE
fix(cost): daily spend cap for paid provider lanes (golf 2B)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -85,6 +85,10 @@ from envelope_adapters_claude import (  # noqa: E402
     CodexAdapter,
 )
 from envelope_adapters_provider import ProviderAdapter  # noqa: E402
+from paid_lane_budget import (  # noqa: E402
+    PaidLaneBudgetExceededError,
+    enforce_daily_budget,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -575,6 +579,37 @@ def run_envelope_plan(
         instruction,
         bundle_dir=Path(plan.instruction_file).parent,
     )
+
+    # PAID-LANE DAILY BUDGET (golf 2B) — refuse before any worktree/worker
+    # cost is incurred when today's cumulative spend on a metered-API lane
+    # (DEEPSEEK_API_KEY / OPENROUTER_API_KEY) already meets the daily cap.
+    # No-op for claude/codex/gemini/kimi/local-gemma (subscription/OAuth/free
+    # lanes) and for litellm:moonshot (its own key, not in scope here). This
+    # is THE choke point for the door: dispatch_cli.py calls run_envelope_plan
+    # directly for every provider-lane dispatch, so gating here covers the
+    # door without touching dispatch_cli.py itself.
+    try:
+        enforce_daily_budget(plan.provider.value, state_dir=state_dir)
+    except PaidLaneBudgetExceededError as _budget_exc:
+        _budget_fail_result = _AdapterResult(
+            returncode=1,
+            completion_text="",
+            status="failure",
+            error=str(_budget_exc),
+        )
+        _budget_fail_start = _budget_fail_end = datetime.now(timezone.utc)
+        report_path, receipt_path = _govern(
+            enriched_spec, _budget_fail_result, _budget_fail_start, _budget_fail_end,
+            integrity=integrity,
+        )
+        return EnvelopeResult(
+            status="failure",
+            returncode=1,
+            report_path=report_path,
+            receipt_path=receipt_path,
+            completion_text="",
+            error=str(_budget_exc),
+        )
 
     from dispatch_worktree_isolation import (  # noqa: PLC0415
         create_dispatch_worktree,

--- a/scripts/lib/paid_lane_budget.py
+++ b/scripts/lib/paid_lane_budget.py
@@ -1,0 +1,309 @@
+"""paid_lane_budget.py — daily spend cap for metered-API provider lanes.
+
+The gap this closes: ``DEEPSEEK_API_KEY`` and ``OPENROUTER_API_KEY`` sit in the
+environment with no expenditure ceiling anywhere in the fabric. The ONLY cost
+cap that existed before this module was ``receipt_classifier.py``'s own
+``DEFAULT_DAILY_BUDGET_USD`` — and that covers exactly one consumer (the
+receipt classifier's own LLM calls), not the dispatch-lane traffic that
+actually spends against these two keys (deepseek-harness, glm-harness,
+litellm:deepseek, litellm:zai — glm-harness alone produced 8 real charges on
+2026-09-04, ~$0.37 total).
+
+Design choice — deliberately NOT ``receipt_classifier``'s pattern
+-------------------------------------------------------------------
+``receipt_classifier.py`` tracks spend in a dedicated counter file
+(``receipt_classifier_cost.json``), incremented by an explicit ``track_cost()``
+call placed at the ONE spot inside that module where its own provider call
+returns. That shape fits there because the classifier is the only writer of
+that file and the only reader of that number.
+
+This module instead computes today's spend by scanning the receipts ledger
+(``t0_receipts.ndjson``) — the SAME append-only file every paid-lane dispatch
+already writes its ``cost_usd`` into via ``governance_emit.emit_dispatch_receipt``
+(see ``scripts/lib/cost_tracker.py::recent_cost_per_hour`` for existing
+precedent: reading the ledger for cost aggregation is an established pattern
+here, not a new one).
+
+A second, independently-maintained counter file would be a second place that
+has to be kept in sync with the ledger by hand at every call site that spends
+money — and every call site would need to remember to call ``track_cost()``.
+There are at least two such call sites for paid lanes (the door's provider
+lane in ``dispatch_envelope.run_envelope_plan`` and the standalone CLI entry
+in ``provider_dispatch.py``'s ``main()``), and history in this fabric shows
+that a second record of a fact nobody re-derives from the first is exactly
+where drift creeps in when a writer crashes between updating the two. The
+receipts ledger is already the fabric's single source of truth for what a
+dispatch actually cost (ADR-005/ADR-035); reading it directly means the
+budget check can never disagree with the ledger, and needs no write path of
+its own to go stale.
+
+The trade-off: an is-this-provider-a-paid-lane classification here is
+DELIBERATELY based on which env key a provider's spawn handler draws on
+(architecture), never on whether the ledger happens to show nonzero
+``cost_usd`` for that provider historically. A lane whose cost computation
+hits a pricing-registry miss stamps ``cost_usd: 0.0`` on its receipt even
+though real money moved (see ``provider_dispatch._compute_cost``'s "Registry
+miss" fallback) — a lane that does not REPORT a cost is not the same as a
+lane that HAS no cost, and must not be silently exempted from the cap because
+its own receipts happen to read zero.
+
+Call sites (both un-evadable pre-flight points, before any worker spawns):
+  - ``dispatch_envelope.run_envelope_plan`` — the door's provider lane
+    (``dispatch_cli.py`` calls this directly for every kimi/glm/deepseek
+    dispatch fired through ``vnx dispatch``).
+  - ``provider_dispatch.main()`` — the standalone CLI entry point used by
+    callers that invoke the provider lane directly as a subprocess (e.g.
+    ``plan_gate_panel.py``), bypassing the door.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+logger = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------
+
+ENV_DAILY_BUDGET = "VNX_PAID_LANE_DAILY_BUDGET_USD"
+ENV_OVERRIDE = "VNX_OVERRIDE_PAID_LANE_DAILY_BUDGET"
+ENV_STATE_DIR = "VNX_STATE_DIR"
+
+# Conservative default: today's real paid-lane spend (8 glm-harness runs +
+# 1 deepseek-harness run, 2026-09-04) totalled ~$0.37. $5.00/day leaves
+# comfortable headroom for legitimate use while bounding a runaway loop to a
+# two-digit-dollar mistake instead of an unbounded one. Operator-tunable via
+# ENV_DAILY_BUDGET.
+DEFAULT_DAILY_BUDGET_USD = 5.00
+
+RECEIPTS_FILE_NAME = "t0_receipts.ndjson"
+
+# provider (or litellm sub_provider) -> the env var whose key it spends
+# against. Mirrors provider_dispatch.py's _SUB_PROVIDER_KEY_REQS plus the
+# deepseek-harness/glm-harness special cases provider_dispatch._check_constraints
+# resolves before matching (deepseek-harness -> sub_provider "deepseek",
+# glm-harness -> sub_provider "zai" routed via OpenRouter). Kept as an
+# independent literal set here (not imported from provider_dispatch) so this
+# module has no reverse dependency on the file it is meant to gate — the two
+# are cross-referenced by comment instead, deliberately narrow in scope to the
+# two keys named in the gap this module closes (kimi/moonshot use their own
+# key and route CLI-OAuth-only; claude/codex/gemini are subscription/OAuth
+# lanes with no per-token key here).
+_PAID_SUB_PROVIDER_KEYS = {
+    "deepseek": "DEEPSEEK_API_KEY",
+    "zai": "OPENROUTER_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+_PAID_TOP_LEVEL_PROVIDER_KEYS = {
+    "deepseek-harness": "DEEPSEEK_API_KEY",
+    "glm-harness": "OPENROUTER_API_KEY",
+}
+
+
+class PaidLaneBudgetExceededError(RuntimeError):
+    """Raised when a paid-lane dispatch is refused for exceeding the daily cap."""
+
+    def __init__(self, provider: str, spent_usd: float, budget_usd: float) -> None:
+        self.provider = provider
+        self.spent_usd = spent_usd
+        self.budget_usd = budget_usd
+        super().__init__(
+            f"paid_lane_daily_budget_exceeded: provider={provider} "
+            f"spent_today_usd={spent_usd:.6f} daily_budget_usd={budget_usd:.6f} — "
+            f"refusing further paid-lane spend today "
+            f"(operator override: {ENV_OVERRIDE}=1)"
+        )
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def paid_lane_env_key(provider: Optional[str]) -> Optional[str]:
+    """Return the env var a `provider` string draws on, or None when it is not
+    one of the two metered lanes this module caps.
+
+    Classification is by ARCHITECTURE (which key the spawn handler requires),
+    never by observed historical cost — see module docstring.
+    """
+    if not provider:
+        return None
+    normalized = provider.strip().lower()
+    if normalized in _PAID_TOP_LEVEL_PROVIDER_KEYS:
+        return _PAID_TOP_LEVEL_PROVIDER_KEYS[normalized]
+    if normalized.startswith("litellm:"):
+        parts = normalized.split(":", 2)
+        sub_provider = parts[1] if len(parts) > 1 else ""
+        if sub_provider in _PAID_SUB_PROVIDER_KEYS:
+            return _PAID_SUB_PROVIDER_KEYS[sub_provider]
+    return None
+
+
+def is_paid_lane(provider: Optional[str]) -> bool:
+    return paid_lane_env_key(provider) is not None
+
+
+def get_daily_budget_usd() -> float:
+    raw = os.environ.get(ENV_DAILY_BUDGET)
+    if raw is None or raw == "":
+        return DEFAULT_DAILY_BUDGET_USD
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_DAILY_BUDGET_USD
+
+
+def default_state_dir() -> Path:
+    """Resolve VNX_STATE_DIR: explicit env var first, else the canonical
+    central resolver (vnx_paths.resolve_paths(), VNX_HOME + project-marker
+    aware — never a repo-relative or __file__-anchored guess; the
+    central-mode path gate in CI rejects that shape, and it would fork state
+    away from the real central store in a central install). Callers that
+    already hold a resolved state_dir (dispatch_envelope.run_envelope_plan,
+    provider_dispatch._resolve_state_dir) should pass it in directly instead
+    of relying on this fallback — this exists for standalone/test callers.
+    An unresolvable project fails loud (ADR-007: fail-closed, not a guess).
+    """
+    raw = os.environ.get(ENV_STATE_DIR)
+    if raw:
+        return Path(raw)
+    from vnx_paths import resolve_paths
+
+    return Path(resolve_paths()["VNX_STATE_DIR"])
+
+
+def _receipt_date_utc(raw_ts) -> Optional[str]:
+    """Return the receipt's UTC calendar date as YYYY-MM-DD, or None if the
+    timestamp is missing/unparseable. Handles both the ISO-8601 'Z' string
+    form every current writer stamps and a bare epoch number (legacy/other
+    event shapes seen on the same ledger) so a format quirk on an unrelated
+    event type can never masquerade as "no spend today".
+    """
+    if raw_ts is None:
+        return None
+    if isinstance(raw_ts, (int, float)):
+        try:
+            return datetime.fromtimestamp(raw_ts, tz=timezone.utc).strftime("%Y-%m-%d")
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(raw_ts, str):
+        text = raw_ts.strip()
+        if not text:
+            return None
+        # Fast path: every current writer stamps "%Y-%m-%dT%H:%M:%SZ" —
+        # the date is the first 10 characters.
+        if len(text) >= 10 and text[4] == "-" and text[7] == "-":
+            return text[:10]
+        try:
+            return datetime.fromisoformat(text.rstrip("Z")).replace(
+                tzinfo=timezone.utc
+            ).strftime("%Y-%m-%d")
+        except ValueError:
+            return None
+    return None
+
+
+def _today_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def spent_today_usd(state_dir: Path) -> float:
+    """Sum cost_usd across today's (UTC) receipts for paid-lane providers.
+
+    Reads the append-only receipts ledger directly (see module docstring for
+    why this is preferred over a separately-maintained counter). Missing or
+    unparseable lines/timestamps are skipped, never treated as an excuse to
+    abort the whole scan — a single malformed line must not blind the cap to
+    every other real charge on the same day.
+    """
+    receipts_path = Path(state_dir) / RECEIPTS_FILE_NAME
+    if not receipts_path.is_file():
+        return 0.0
+
+    today = _today_str()
+    total = 0.0
+    try:
+        with receipts_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    receipt = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(receipt, dict):
+                    continue
+                if not is_paid_lane(receipt.get("provider")):
+                    continue
+                if _receipt_date_utc(receipt.get("timestamp")) != today:
+                    continue
+                cost = receipt.get("cost_usd")
+                if cost is None:
+                    # Reported-zero-because-unknown vs genuinely-free is not
+                    # distinguishable from the ledger alone (module docstring)
+                    # — count it as 0.0, the best-available reading, rather
+                    # than raising or dropping the receipt from the scan.
+                    continue
+                try:
+                    total += float(cost)
+                except (TypeError, ValueError):
+                    continue
+    except OSError as exc:
+        logger.warning("paid_lane_budget: failed to read %s: %s", receipts_path, exc)
+        return total
+    return round(total, 8)
+
+
+def is_budget_exhausted(provider: Optional[str], state_dir: Optional[Path] = None) -> bool:
+    """True when `provider` is a paid lane AND today's cumulative spend for
+    paid lanes already meets/exceeds the daily budget. Always False for a
+    non-paid-lane provider (mirrors receipt_classifier: a budget of 0 or
+    below means "always exhausted", fail-closed).
+    """
+    if not is_paid_lane(provider):
+        return False
+    budget = get_daily_budget_usd()
+    if budget <= 0:
+        return True
+    spent = spent_today_usd(state_dir or default_state_dir())
+    return spent >= budget
+
+
+def enforce_daily_budget(provider: Optional[str], state_dir: Optional[Path] = None) -> None:
+    """Raise PaidLaneBudgetExceededError when the daily cap is already spent
+    for a paid-lane `provider`. No-op for non-paid-lane providers.
+
+    Honors an explicit operator override (ENV_OVERRIDE=1), logged loudly —
+    the same escape-hatch convention every other blocking constraint in this
+    fabric uses (see provider_constraints.md), never a silent bypass.
+    """
+    if not is_paid_lane(provider):
+        return
+    budget = get_daily_budget_usd()
+    resolved_dir = state_dir or default_state_dir()
+    spent = spent_today_usd(resolved_dir)
+    exhausted = budget <= 0 or spent >= budget
+    if not exhausted:
+        return
+    if os.environ.get(ENV_OVERRIDE) == "1":
+        logger.warning(
+            "paid_lane_budget: OVERRIDDEN provider=%s spent_today_usd=%.6f "
+            "daily_budget_usd=%.6f (%s=1)",
+            provider, spent, budget, ENV_OVERRIDE,
+        )
+        return
+    raise PaidLaneBudgetExceededError(provider, spent, budget)

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -3105,6 +3105,33 @@ def main(argv: list[str] | None = None) -> int:
                 args.dispatch_id, _recorded_mandate,
             )
 
+    # PAID-LANE DAILY BUDGET (golf 2B) — the standalone-CLI side door onto the
+    # provider lane (e.g. plan_gate_panel.py invokes this file as a subprocess
+    # directly, bypassing dispatch_cli.py's door). run_envelope_plan carries
+    # the matching gate for door-routed dispatches (dispatch_envelope.py); this
+    # is the second, independent entry point that also spends against
+    # DEEPSEEK_API_KEY / OPENROUTER_API_KEY and needed its own pre-flight.
+    try:
+        from paid_lane_budget import (  # noqa: PLC0415
+            PaidLaneBudgetExceededError,
+            enforce_daily_budget,
+        )
+
+        enforce_daily_budget(provider, state_dir=_resolve_state_dir())
+    except PaidLaneBudgetExceededError as _budget_exc:
+        print(f"provider_dispatch: {_budget_exc}", file=sys.stderr)
+        try:
+            _emit_refusal_receipt(
+                args, provider, getattr(args, "model", None) or "unknown",
+                str(_budget_exc),
+            )
+        except Exception as _ref_exc:
+            logger.error(
+                "provider_dispatch: refusal receipt failed for budget exceeded dispatch=%s: %s",
+                args.dispatch_id, _ref_exc,
+            )
+        return 1
+
     try:
         if provider == "claude":
             # Benchmark exemption: the measurement harness is exempt from the single-entry

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -16,14 +16,14 @@
     },
     {
       "file": "tests/test_dispatch_door_row.py",
-      "line": 538,
+      "line": 569,
       "mechanism": "direct-call",
       "module_target": "envelope_types",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_door_row.py",
-      "line": 543,
+      "line": 574,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
@@ -358,6 +358,90 @@
       "symbol": "_govern"
     },
     {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 29,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 29,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 99,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 104,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 105,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 128,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 150,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 157,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 158,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 177,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 184,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_paid_lane_budget.py",
+      "line": 185,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
       "file": "tests/test_dispatch_envelope_plan.py",
       "line": 30,
       "mechanism": "direct-call",
@@ -660,14 +744,14 @@
     },
     {
       "file": "tests/test_failclass_registry.py",
-      "line": 1087,
+      "line": 1273,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_failclass_registry.py",
-      "line": 1119,
+      "line": 1305,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_resolve_phantom_diff"

--- a/tests/test_dispatch_envelope_paid_lane_budget.py
+++ b/tests/test_dispatch_envelope_paid_lane_budget.py
@@ -1,0 +1,189 @@
+"""tests/test_dispatch_envelope_paid_lane_budget.py — golf 2B wiring.
+
+dispatch_cli.py (the door) calls run_envelope_plan directly for every
+kimi/glm/deepseek dispatch fired through `vnx dispatch` — this is the REAL
+production path for paid-lane spend (dispatch_cli.py itself is out of scope
+for this change; run_envelope_plan is the un-evadable choke point it calls
+into). This is the RED/GREEN behavior test: a paid-lane provider whose daily
+budget is already exhausted must be refused BEFORE a worktree is even
+created — not just logged, and not after money-shaped work already started.
+
+Mirrors tests/test_dispatch_envelope_plan.py::TestEnvelopeWorktreeIsolation's
+mocking pattern (create_dispatch_worktree / ProviderAdapter.run / _govern).
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from dispatch_envelope import ProviderAdapter, run_envelope_plan  # noqa: E402
+from dispatch_internal import issue_permit  # noqa: E402
+from dispatch_plan import ExecutionPlan  # noqa: E402
+from dispatch_spec import Isolation, Provider  # noqa: E402
+import paid_lane_budget as plb  # noqa: E402
+
+_FAKE_WT_PATH = Path("/tmp/fake-worktrees/budget-test")
+
+
+def _today_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT12:00:00Z")
+
+
+def _write_exhausted_ledger(state_dir: Path, *, provider: str = "glm-harness", cost_usd: float = 999.0) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    ledger = state_dir / "t0_receipts.ndjson"
+    with ledger.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"provider": provider, "cost_usd": cost_usd, "timestamp": _today_ts()}) + "\n")
+
+
+def _make_plan(tmp_path: Path, provider: Provider, dispatch_id: str) -> ExecutionPlan:
+    instruction_file = tmp_path / f"instruction-{dispatch_id}.md"
+    instruction_file.write_text("# Test dispatch\nDo something.", encoding="utf-8")
+    sha256 = hashlib.sha256(instruction_file.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+    return ExecutionPlan(
+        dispatch_id=dispatch_id,
+        project_id="vnx-dev",
+        provider=provider,
+        model="model-under-test",
+        lane="provider",
+        adapter="provider",
+        target_id="T1",
+        billing="provider_metered",
+        serialization_class=None,
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="n/a",
+        deadline_seconds=3600,
+        base_ref="main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="D1",
+        instruction_sha256=sha256,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _budget_env(monkeypatch):
+    monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "1.00")
+    monkeypatch.delenv(plb.ENV_OVERRIDE, raising=False)
+    yield
+
+
+class TestRunEnvelopePlanBudgetRefusal:
+    def test_glm_harness_over_budget_refuses_before_worktree_creation(self, tmp_path):
+        plan = _make_plan(tmp_path, Provider.GLM_HARNESS, "budget-envelope-glm")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        _write_exhausted_ledger(state_dir)
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+
+        adapter_calls: list = []
+
+        def spy_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
+            adapter_calls.append({"cwd": cwd})
+            from envelope_types import _AdapterResult
+            return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+        with patch("dispatch_worktree_isolation.create_dispatch_worktree") as mock_create, \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove, \
+             patch.object(ProviderAdapter, "run", spy_adapter_run), \
+             patch("dispatch_envelope._govern", return_value=(None, fake_receipt)) as mock_govern:
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        assert result.status == "failure"
+        assert result.returncode == 1
+        assert result.error is not None
+        assert "budget" in result.error.lower()
+        assert adapter_calls == [], "ProviderAdapter.run must NOT be called over budget"
+        mock_create.assert_not_called(), "worktree must not be created for a refused dispatch"
+        mock_remove.assert_not_called()
+        mock_govern.assert_called_once()
+
+    def test_litellm_deepseek_over_budget_refuses(self, tmp_path):
+        """The cap is shared: a glm-harness overspend also blocks litellm:deepseek."""
+        plan = _make_plan(tmp_path, Provider.LITELLM_DEEPSEEK, "budget-envelope-ds")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        _write_exhausted_ledger(state_dir, provider="glm-harness")
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+
+        with patch("dispatch_worktree_isolation.create_dispatch_worktree") as mock_create, \
+             patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        assert result.status == "failure"
+        mock_create.assert_not_called()
+
+
+class TestRunEnvelopePlanBudgetDoesNotOverBlock:
+    def test_under_budget_still_creates_worktree_and_runs(self, tmp_path):
+        plan = _make_plan(tmp_path, Provider.GLM_HARNESS, "budget-envelope-ok")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        adapter_calls: list = []
+
+        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
+            adapter_calls.append({"cwd": cwd})
+            from envelope_types import _AdapterResult
+            return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+        _fake_consumer_root = tmp_path / "consumer-root"
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=_fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(ProviderAdapter, "run", fake_adapter_run), \
+             patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        assert result.status == "success"
+        mock_create.assert_called_once()
+        assert adapter_calls, "ProviderAdapter.run should have been called (under budget)"
+
+    def test_kimi_unaffected_by_exhausted_paid_lane_budget(self, tmp_path):
+        """kimi is CLI-OAuth, not DEEPSEEK_API_KEY/OPENROUTER_API_KEY — must
+        not be blocked by an exhausted paid-lane budget."""
+        plan = _make_plan(tmp_path, Provider.KIMI, "budget-envelope-kimi")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        _write_exhausted_ledger(state_dir)
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+
+        def fake_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None, role=None):
+            from envelope_types import _AdapterResult
+            return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+        _fake_consumer_root = tmp_path / "consumer-root"
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=_fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(ProviderAdapter, "run", fake_adapter_run), \
+             patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        assert result.status == "success"
+        mock_create.assert_called_once()

--- a/tests/test_paid_lane_budget.py
+++ b/tests/test_paid_lane_budget.py
@@ -1,0 +1,243 @@
+"""tests/test_paid_lane_budget.py — golf 2B: daily spend cap for metered lanes.
+
+Covers scripts/lib/paid_lane_budget.py in isolation:
+  - provider -> paid-lane-key classification (architectural, not observed cost)
+  - get_daily_budget_usd() env parsing + fail-closed <=0 semantics
+  - spent_today_usd() reading the receipts ledger: date filter, provider
+    filter, malformed-line tolerance, missing-cost tolerance
+  - is_budget_exhausted() / enforce_daily_budget() incl. the operator override
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import paid_lane_budget as plb  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# paid_lane_env_key / is_paid_lane — classification is architectural
+# ---------------------------------------------------------------------------
+
+class TestPaidLaneClassification:
+    @pytest.mark.parametrize(
+        "provider,expected_key",
+        [
+            ("deepseek-harness", "DEEPSEEK_API_KEY"),
+            ("glm-harness", "OPENROUTER_API_KEY"),
+            ("litellm:deepseek", "DEEPSEEK_API_KEY"),
+            ("litellm:zai", "OPENROUTER_API_KEY"),
+            ("litellm:openrouter", "OPENROUTER_API_KEY"),
+            ("litellm:openrouter:openai/gpt-4o-mini", "OPENROUTER_API_KEY"),
+            # case-insensitive
+            ("GLM-HARNESS", "OPENROUTER_API_KEY"),
+        ],
+    )
+    def test_paid_providers_map_to_their_key(self, provider, expected_key):
+        assert plb.paid_lane_env_key(provider) == expected_key
+        assert plb.is_paid_lane(provider) is True
+
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            "claude", "codex", "gemini", "kimi", "local-gemma",
+            "litellm:moonshot",  # own key (MOONSHOT_API_KEY), out of scope
+            "litellm", "litellm:bedrock", "litellm:anthropic", "litellm:ollama",
+            None, "", "   ",
+        ],
+    )
+    def test_non_paid_providers_are_not_classified_paid(self, provider):
+        assert plb.paid_lane_env_key(provider) is None
+        assert plb.is_paid_lane(provider) is False
+
+    def test_a_lane_that_reports_zero_cost_is_still_classified_paid(self):
+        """The classification must never derive from observed cost_usd — a
+        pricing-registry miss stamps cost_usd=0.0 on a real charge (see module
+        docstring). is_paid_lane looks only at the provider string.
+        """
+        assert plb.is_paid_lane("glm-harness") is True
+        assert plb.is_paid_lane("litellm:deepseek") is True
+
+
+# ---------------------------------------------------------------------------
+# get_daily_budget_usd
+# ---------------------------------------------------------------------------
+
+class TestDailyBudget:
+    def test_default_budget(self, monkeypatch):
+        monkeypatch.delenv(plb.ENV_DAILY_BUDGET, raising=False)
+        assert plb.get_daily_budget_usd() == plb.DEFAULT_DAILY_BUDGET_USD
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "1.50")
+        assert plb.get_daily_budget_usd() == 1.50
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "not-a-number")
+        assert plb.get_daily_budget_usd() == plb.DEFAULT_DAILY_BUDGET_USD
+
+    def test_negative_env_clamps_to_zero(self, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "-5")
+        assert plb.get_daily_budget_usd() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# spent_today_usd — reads the receipts ledger directly (see module docstring
+# for why: cost_tracker.py::recent_cost_per_hour is the existing precedent
+# for reading t0_receipts.ndjson for cost aggregation).
+# ---------------------------------------------------------------------------
+
+def _write_receipts(path: Path, receipts: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for r in receipts:
+            fh.write(json.dumps(r) + "\n")
+
+
+def _today_ts(hour: int = 12) -> str:
+    return datetime.now(timezone.utc).strftime(f"%Y-%m-%dT{hour:02d}:00:00Z")
+
+
+def _yesterday_ts() -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%dT12:00:00Z")
+
+
+class TestSpentTodayUsd:
+    def test_missing_ledger_is_zero(self, tmp_path):
+        assert plb.spent_today_usd(tmp_path) == 0.0
+
+    def test_empty_ledger_is_zero(self, tmp_path):
+        (tmp_path / plb.RECEIPTS_FILE_NAME).write_text("")
+        assert plb.spent_today_usd(tmp_path) == 0.0
+
+    def test_finds_a_known_real_paid_lane_spend(self, tmp_path):
+        """Nul-is-eerst-een-meetfout: prove the scan finds a KNOWN nonzero
+        spend before trusting any zero result elsewhere in this file. Mirrors
+        the shape of a real glm-harness receipt (cost_usd: 0.04359888, from
+        2026-09-04 production data).
+        """
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 0.04359888, "timestamp": _today_ts()},
+        ])
+        assert plb.spent_today_usd(tmp_path) == pytest.approx(0.04359888)
+
+    def test_sums_multiple_paid_lane_receipts_today(self, tmp_path):
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 0.04, "timestamp": _today_ts(8)},
+            {"provider": "glm-harness", "cost_usd": 0.05, "timestamp": _today_ts(9)},
+            {"provider": "deepseek-harness", "cost_usd": 0.03, "timestamp": _today_ts(10)},
+        ])
+        assert plb.spent_today_usd(tmp_path) == pytest.approx(0.12)
+
+    def test_ignores_non_paid_lane_providers(self, tmp_path):
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "claude", "cost_usd": 999.0, "timestamp": _today_ts()},
+            {"provider": "kimi", "cost_usd": 999.0, "timestamp": _today_ts()},
+            {"provider": "glm-harness", "cost_usd": 0.05, "timestamp": _today_ts()},
+        ])
+        assert plb.spent_today_usd(tmp_path) == pytest.approx(0.05)
+
+    def test_ignores_receipts_from_a_prior_day(self, tmp_path):
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 50.0, "timestamp": _yesterday_ts()},
+            {"provider": "glm-harness", "cost_usd": 0.05, "timestamp": _today_ts()},
+        ])
+        assert plb.spent_today_usd(tmp_path) == pytest.approx(0.05)
+
+    def test_tolerates_malformed_lines(self, tmp_path):
+        ledger = tmp_path / plb.RECEIPTS_FILE_NAME
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.open("w", encoding="utf-8") as fh:
+            fh.write("{not valid json\n")
+            fh.write(json.dumps({"provider": "glm-harness", "cost_usd": 0.07, "timestamp": _today_ts()}) + "\n")
+            fh.write("\n")
+        assert plb.spent_today_usd(tmp_path) == pytest.approx(0.07)
+
+    def test_missing_cost_usd_counts_as_zero_not_a_crash(self, tmp_path):
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": None, "timestamp": _today_ts()},
+            {"provider": "glm-harness", "cost_usd": 0.02, "timestamp": _today_ts()},
+        ])
+        assert plb.spent_today_usd(tmp_path) == pytest.approx(0.02)
+
+    def test_numeric_epoch_timestamp_is_handled(self, tmp_path):
+        today_epoch = datetime.now(timezone.utc).replace(
+            hour=12, minute=0, second=0, microsecond=0
+        ).timestamp()
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 0.09, "timestamp": today_epoch},
+        ])
+        assert plb.spent_today_usd(tmp_path) == pytest.approx(0.09)
+
+
+# ---------------------------------------------------------------------------
+# is_budget_exhausted / enforce_daily_budget
+# ---------------------------------------------------------------------------
+
+class TestBudgetEnforcement:
+    def test_non_paid_lane_never_exhausted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "0")
+        assert plb.is_budget_exhausted("claude", tmp_path) is False
+        # enforce_daily_budget must be a no-op (no raise) for a non-paid lane
+        # even at budget=0.
+        plb.enforce_daily_budget("kimi", tmp_path)
+
+    def test_zero_budget_is_always_exhausted_for_paid_lane(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "0")
+        assert plb.is_budget_exhausted("glm-harness", tmp_path) is True
+
+    def test_under_budget_not_exhausted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "5.00")
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 0.37, "timestamp": _today_ts()},
+        ])
+        assert plb.is_budget_exhausted("glm-harness", tmp_path) is False
+        plb.enforce_daily_budget("glm-harness", tmp_path)  # must not raise
+
+    def test_over_budget_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "1.00")
+        monkeypatch.delenv(plb.ENV_OVERRIDE, raising=False)
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 1.50, "timestamp": _today_ts()},
+        ])
+        assert plb.is_budget_exhausted("glm-harness", tmp_path) is True
+        with pytest.raises(plb.PaidLaneBudgetExceededError) as excinfo:
+            plb.enforce_daily_budget("glm-harness", tmp_path)
+        assert "glm-harness" in str(excinfo.value)
+        assert "1.50" in str(excinfo.value) or "1.500000" in str(excinfo.value)
+
+    def test_exactly_at_budget_is_exhausted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "1.00")
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 1.00, "timestamp": _today_ts()},
+        ])
+        assert plb.is_budget_exhausted("glm-harness", tmp_path) is True
+
+    def test_a_different_paid_lane_shares_the_same_cap(self, tmp_path, monkeypatch):
+        """The cap is on total paid-lane spend, not per-provider — a deepseek
+        overspend must block a subsequent glm-harness dispatch too.
+        """
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "1.00")
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "deepseek-harness", "cost_usd": 1.20, "timestamp": _today_ts()},
+        ])
+        assert plb.is_budget_exhausted("litellm:zai", tmp_path) is True
+
+    def test_operator_override_suppresses_the_raise(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "1.00")
+        monkeypatch.setenv(plb.ENV_OVERRIDE, "1")
+        _write_receipts(tmp_path / plb.RECEIPTS_FILE_NAME, [
+            {"provider": "glm-harness", "cost_usd": 5.00, "timestamp": _today_ts()},
+        ])
+        import logging
+        with caplog.at_level(logging.WARNING, logger="paid_lane_budget"):
+            plb.enforce_daily_budget("glm-harness", tmp_path)  # must not raise
+        assert any("OVERRIDDEN" in rec.message for rec in caplog.records)

--- a/tests/test_provider_dispatch_paid_lane_budget.py
+++ b/tests/test_provider_dispatch_paid_lane_budget.py
@@ -1,0 +1,148 @@
+"""tests/test_provider_dispatch_paid_lane_budget.py — golf 2B wiring.
+
+provider_dispatch.main() is the standalone-CLI side door onto the provider
+lane (e.g. plan_gate_panel.py invokes this file as a subprocess directly,
+bypassing dispatch_cli.py's door). This is the RED/GREEN behavior test: a
+paid-lane provider whose daily budget is already exhausted must be refused
+BEFORE the actual spawn handler runs — not just logged.
+
+Mirrors tests/test_provider_dispatch_entry.py's pattern of patching the
+provider's `_dispatch_*` function and asserting call/no-call.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import provider_dispatch  # noqa: E402
+import paid_lane_budget as plb  # noqa: E402
+
+
+def _today_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT12:00:00Z")
+
+
+def _write_exhausted_ledger(state_dir: Path, *, provider: str = "glm-harness", cost_usd: float = 999.0) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    ledger = state_dir / "t0_receipts.ndjson"
+    with ledger.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"provider": provider, "cost_usd": cost_usd, "timestamp": _today_ts()}) + "\n")
+
+
+def _argv(provider: str, dispatch_id: str) -> list[str]:
+    return [
+        "--provider", provider,
+        "--terminal-id", "T1",
+        "--dispatch-id", dispatch_id,
+        "--instruction", "noop",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _budget_env(monkeypatch):
+    """The autouse _vnx_data_dir_isolation fixture (conftest.py) already pins
+    VNX_STATE_DIR to a fresh per-test tmp dir with no ledger present, so every
+    test starts at spend=0. Pin the budget explicitly for readability.
+    """
+    monkeypatch.setenv(plb.ENV_DAILY_BUDGET, "1.00")
+    monkeypatch.delenv(plb.ENV_OVERRIDE, raising=False)
+    yield
+
+
+class TestPaidLaneBudgetRefusesSpawn:
+    def test_glm_harness_over_budget_refuses_without_spawning(self, capsys):
+        state_dir = Path(os.environ["VNX_STATE_DIR"])
+        _write_exhausted_ledger(state_dir)
+
+        with patch("provider_dispatch._dispatch_glm_harness") as mock_dispatch:
+            rc = provider_dispatch.main(_argv("glm-harness", "budget-test-glm"))
+
+        assert rc == 1
+        mock_dispatch.assert_not_called()
+        err = capsys.readouterr().err
+        assert "budget" in err.lower()
+
+    def test_litellm_zai_over_budget_refuses_without_spawning(self, capsys):
+        """The cap is shared across paid lanes: a glm-harness overspend also
+        blocks a litellm:zai dispatch, not just glm-harness itself."""
+        state_dir = Path(os.environ["VNX_STATE_DIR"])
+        _write_exhausted_ledger(state_dir, provider="glm-harness")
+
+        with patch("provider_dispatch._dispatch_litellm") as mock_dispatch:
+            rc = provider_dispatch.main(_argv("litellm:zai", "budget-test-zai"))
+
+        assert rc == 1
+        mock_dispatch.assert_not_called()
+
+    def test_deepseek_harness_over_budget_refuses_without_spawning(self, capsys):
+        state_dir = Path(os.environ["VNX_STATE_DIR"])
+        _write_exhausted_ledger(state_dir, provider="deepseek-harness")
+
+        with patch("provider_dispatch._dispatch_deepseek_harness") as mock_dispatch:
+            rc = provider_dispatch.main(_argv("deepseek-harness", "budget-test-ds"))
+
+        assert rc == 1
+        mock_dispatch.assert_not_called()
+
+    def test_refusal_writes_a_ledger_receipt(self):
+        """Every refusal must land in t0_receipts.ndjson (provider_dispatch's
+        own established contract for every pre-flight refusal — module
+        docstring of _emit_refusal_receipt)."""
+        state_dir = Path(os.environ["VNX_STATE_DIR"])
+        _write_exhausted_ledger(state_dir)
+        ledger = state_dir / "t0_receipts.ndjson"
+        lines_before = ledger.read_text().count("\n")
+
+        with patch("provider_dispatch._dispatch_glm_harness"):
+            provider_dispatch.main(_argv("glm-harness", "budget-test-receipt"))
+
+        lines_after = ledger.read_text().count("\n")
+        assert lines_after == lines_before + 1
+        last_line = [ln for ln in ledger.read_text().splitlines() if ln.strip()][-1]
+        receipt = json.loads(last_line)
+        assert receipt["dispatch_id"] == "budget-test-receipt"
+        assert receipt["status"] == "blocked"
+
+
+class TestPaidLaneBudgetDoesNotOverBlock:
+    def test_under_budget_still_dispatches(self):
+        """Sanity: with no prior spend recorded, a paid lane still runs (the
+        gate must not block by default, only once the cap is actually met)."""
+        with patch("provider_dispatch._dispatch_glm_harness", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(_argv("glm-harness", "budget-test-ok"))
+
+        assert rc == 0
+        mock_dispatch.assert_called_once()
+
+    def test_non_paid_lane_unaffected_by_exhausted_paid_lane_budget(self):
+        """kimi draws on its own CLI-OAuth lane, not DEEPSEEK_API_KEY/
+        OPENROUTER_API_KEY — an exhausted paid-lane budget must not block it."""
+        state_dir = Path(os.environ["VNX_STATE_DIR"])
+        _write_exhausted_ledger(state_dir)
+
+        with patch("provider_dispatch._dispatch_kimi", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(_argv("kimi", "budget-test-kimi"))
+
+        assert rc == 0
+        mock_dispatch.assert_called_once()
+
+    def test_operator_override_allows_dispatch_through(self, monkeypatch):
+        state_dir = Path(os.environ["VNX_STATE_DIR"])
+        _write_exhausted_ledger(state_dir)
+        monkeypatch.setenv(plb.ENV_OVERRIDE, "1")
+
+        with patch("provider_dispatch._dispatch_glm_harness", return_value=0) as mock_dispatch:
+            rc = provider_dispatch.main(_argv("glm-harness", "budget-test-override"))
+
+        assert rc == 0
+        mock_dispatch.assert_called_once()


### PR DESCRIPTION
## Summary

`DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` sat in the environment with no expenditure ceiling anywhere in the fabric. The only prior cost cap — `receipt_classifier.py`'s own `DEFAULT_DAILY_BUDGET_USD = 0.20` — covers exactly one consumer (the receipt classifier's own LLM calls), not the dispatch-lane traffic that actually spends against these two keys. Today alone: 8 glm-harness runs + 1 deepseek-harness run, ~$0.37 total, nothing capping a runaway loop from doing that a thousand times.

- Adds `scripts/lib/paid_lane_budget.py`: a daily spend cap for the two metered lanes.
- Wired into **both** real entry points onto the provider lane:
  - `dispatch_envelope.run_envelope_plan` — the door's choke point (`dispatch_cli.py` calls this directly for every kimi/glm/deepseek dispatch fired through `vnx dispatch`).
  - `provider_dispatch.main()` — the standalone-CLI side door (e.g. `plan_gate_panel.py` invokes this file as a subprocess directly, bypassing the door).
- Default `$5.00/day`, tunable via `VNX_PAID_LANE_DAILY_BUDGET_USD`, with a logged operator override `VNX_OVERRIDE_PAID_LANE_DAILY_BUDGET=1` (mirrors the fleet-wide `VNX_OVERRIDE_<ID>` convention).

## Design choice — deliberately NOT `receipt_classifier`'s own pattern

`receipt_classifier.py` tracks spend in a dedicated counter file, incremented by an explicit `track_cost()` call at the one spot its own provider call returns. This module instead computes today's spend by **scanning the receipts ledger** (`t0_receipts.ndjson`) directly — the same append-only file every paid-lane dispatch already writes its `cost_usd` into via `governance_emit.emit_dispatch_receipt` (`scripts/lib/cost_tracker.py::recent_cost_per_hour` is existing precedent for reading the ledger for cost aggregation).

A second, independently-maintained counter file would be a second place that has to be kept in sync with the ledger by hand at every paid-lane call site — and there are at least two such call sites here. The receipts ledger is already the fabric's single source of truth for what a dispatch cost; reading it directly means the cap can never disagree with it and needs no write path of its own to go stale.

Classification of "is this provider a paid lane" is **architectural** (which env key the spawn handler draws on: `deepseek-harness`/`litellm:deepseek` → `DEEPSEEK_API_KEY`; `glm-harness`/`litellm:zai`/`litellm:openrouter` → `OPENROUTER_API_KEY`), never derived from observed `cost_usd` — a pricing-registry miss can stamp `cost_usd: 0.0` on a receipt for a lane that really did spend money, so "this lane's ledger entries read $0" must never be read as "this lane is free."

## Verification

**Nul-is-eerst-een-meetfout check** (before trusting any zero result): ran `spent_today_usd()` against the real production ledger (`~/.vnx-data/vnx-dev/state/t0_receipts.ndjson`) before writing any test. It found `$0.36887483` — matching a manual scan of today's 8 glm-harness + 1 deepseek-harness receipts exactly. Re-verified against the final committed code with the same result.

**Red run** (wiring reverted via `git stash` on just the two integration files, module + tests left in place):
```
5 failed, 6 passed in 2.75s
FAILED tests/test_provider_dispatch_paid_lane_budget.py::TestPaidLaneBudgetRefusesSpawn::test_glm_harness_over_budget_refuses_without_spawning
FAILED tests/test_provider_dispatch_paid_lane_budget.py::TestPaidLaneBudgetRefusesSpawn::test_deepseek_harness_over_budget_refuses_without_spawning
FAILED tests/test_provider_dispatch_paid_lane_budget.py::TestPaidLaneBudgetRefusesSpawn::test_refusal_writes_a_ledger_receipt
FAILED tests/test_dispatch_envelope_paid_lane_budget.py::TestRunEnvelopePlanBudgetRefusal::test_glm_harness_over_budget_refuses_before_worktree_creation
FAILED tests/test_dispatch_envelope_paid_lane_budget.py::TestRunEnvelopePlanBudgetRefusal::test_litellm_deepseek_over_budget_refuses
```
Each failure showed the actual gap: a paid lane over budget still called the real spawn handler / still created a worktree.

**Green run** (wiring restored):
```
52 passed in 0.93s
```
(`tests/test_paid_lane_budget.py` + `tests/test_provider_dispatch_paid_lane_budget.py` + `tests/test_dispatch_envelope_paid_lane_budget.py`)

**Neighbor regression check**: ran every existing `test_provider_dispatch_*` and `test_dispatch_envelope_*` test module. `test_dispatch_envelope_characterization.py::TestLayer2Census::test_census_matches_fixture` needed `tests/data/dispatch_envelope_census.json` regenerated (`python3 tests/dispatch_envelope_census_scanner.py`) for the two new coupling sites — done, now green. Separately, 39 pre-existing failures in `test_provider_dispatch_governance_integration.py`/`test_provider_dispatch_intelligence.py`/etc. reproduce **identically** with this branch's changes fully reverted (`NotADirectoryError` on `.git/worktrees`, an artifact of running the suite inside a nested worktree) — confirmed via a byte-diff of the two failure lists.

**CI gates checked locally**: `scripts/ci_lint_patterns.py` (no `# noqa:` silent-except/atomic-write suppressions) and `scripts/check_no_file_derived_data_paths.py` (central-mode path gate) both pass clean against every touched/new file — the first draft of `paid_lane_budget.py` tripped the path gate with a `__file__`-anchored `.vnx-data` fallback (the same shape `receipt_classifier.py` is grandfathered for); removed it in favor of failing loud through the canonical resolver instead of adding a new grandfathered exception.

**Confirmed via `git diff HEAD` + `git show HEAD:<path>` diff** that the working tree is byte-identical to the commit for all three touched/new core files before pushing.

## Files touched

- `scripts/lib/paid_lane_budget.py` (new)
- `scripts/lib/dispatch_envelope.py` (`run_envelope_plan` pre-flight)
- `scripts/lib/provider_dispatch.py` (`main()` pre-flight)
- `tests/test_paid_lane_budget.py`, `tests/test_provider_dispatch_paid_lane_budget.py`, `tests/test_dispatch_envelope_paid_lane_budget.py` (new)
- `tests/data/dispatch_envelope_census.json` (regenerated fixture)

## Missing readsite (out of scope, per instruction)

`scripts/lib/dispatch_cli.py` was explicitly off-limits (a parallel agent is working on it). It does not need its own gate call — it calls `run_envelope_plan` directly for every provider-lane dispatch, and that function now enforces the cap before any worktree/worker cost is incurred, so the door's traffic is covered without touching it. No missing readsite identified inside `dispatch_cli.py` itself.

## Operator note

`scripts/gate_obligation_runner.py`, `scripts/lib/gate_obligations.py`, and `scripts/build_t0_state.py` were left untouched per instruction (open PRs on those files).

---

Buiten de dispatch-deur om geproduceerd via een Agent-subagent, operator-besluit 2026-09-04. Tijdelijke afwijking: de gegovernde dispatch-paden zijn traag en de deur is zelf onderwerp van reparatie. PR en CI blijven onverkort gelden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR