### PR TITLE
fix(hooks): state artifacts carry their age, T0 refuses to orchestrate on stale state

### DIFF
--- a/hooks/sessionstart.sh
+++ b/hooks/sessionstart.sh
@@ -96,15 +96,22 @@ print(p['VNX_DATA_DIR'])
     fi
 
     if [ -n "$_VNX_STATE_DIR" ] && [ -d "$_VNX_STATE_DIR" ]; then
-      # Terminal states from shadow state files
-      for _t in T1 T2 T3; do
-        _sf="$_VNX_STATE_DIR/terminal_state_${_t}.json"
-        if [ -f "$_sf" ]; then
-          _status=$(jq -r '.status // "unknown"' "$_sf" 2>/dev/null || echo "unknown")
-          _task=$(jq -r '.current_task // "idle"' "$_sf" 2>/dev/null || echo "idle")
-          T0_TERMINAL_STATES="${T0_TERMINAL_STATES}${_t}: ${_status} (${_task})\n"
-        fi
-      done
+      # Terminal states from the shadow state file (scripts/lib/terminal_state_shadow.py).
+      # Golf 3A fix: this used to glob terminal_state_${_t}.json (a per-terminal
+      # suffixed filename) but the actual writer (TERMINAL_STATE_FILENAME in
+      # terminal_state_shadow.py) has only ever written the SINGULAR
+      # terminal_state.json, with a `.terminals.<id>` map inside it. The suffixed
+      # glob matched nothing, on any project — this section silently fell
+      # through to "No terminal state data" every session, discovered via this
+      # dispatch's own measurement discipline, not reported by anything.
+      _tsf="$_VNX_STATE_DIR/terminal_state.json"
+      if [ -f "$_tsf" ]; then
+        for _t in T1 T2 T3; do
+          _status=$(jq -r --arg t "$_t" '.terminals[$t].status // "unknown"' "$_tsf" 2>/dev/null || echo "unknown")
+          _last_activity=$(jq -r --arg t "$_t" '.terminals[$t].last_activity // "unknown"' "$_tsf" 2>/dev/null || echo "unknown")
+          T0_TERMINAL_STATES="${T0_TERMINAL_STATES}${_t}: ${_status} (last_activity: ${_last_activity})\n"
+        done
+      fi
 
       # Open items digest (compact)
       _oi_file="$_VNX_STATE_DIR/open_items.json"
@@ -181,6 +188,51 @@ $_BEACON_BAD"
       BEACON_SECTION="BEACON HEALTH UNAVAILABLE this session (UNMEASURED, not zero) — data dir unresolved or scripts/health_check.py missing."
     fi
 
+    # ── State artifact freshness (golf 3A, absence-is-loud #1, OI-1512 fix-forward) ──
+    # T0 reads a handful of point-in-time snapshots at SessionStart (t0_state.json,
+    # open_items.json, terminal_state.json, dashboard_status.json,
+    # t0_recommendations.json) with nothing surfacing how old they are. Measured
+    # 2026-08-29: a session orchestrated a merge against a 22-day-old t0_state.json
+    # (dashboard_status.json 63 days, t0_recommendations.json 73 days) and nobody
+    # noticed until the merge itself. scripts/lib/session_state_freshness.py reads
+    # each file's own declared timestamp (falling back to mtime), same precedent as
+    # t0_state_health.py, and classifies missing/stale/fresh/unknown — three real
+    # branches, never conflating "never populated" with "went stale". Reused here via
+    # subprocess exactly like health_check.py above, not reimplemented inline.
+    FRESHNESS_SECTION=""
+    _FRESHNESS_PY="$_HOOK_DIR/../scripts/lib/session_state_freshness.py"
+    if [ -n "$_VNX_STATE_DIR" ] && [ -n "$_VNX_PY" ] && [ -f "$_FRESHNESS_PY" ]; then
+      _FRESHNESS_JSON="$("$_VNX_PY" "$_FRESHNESS_PY" --state-dir "$_VNX_STATE_DIR" --json 2>/dev/null || true)"
+      if [ -n "$_FRESHNESS_JSON" ] && command -v jq &>/dev/null; then
+        _FRESHNESS_PARSE_OK=$(echo "$_FRESHNESS_JSON" | jq -e '.artifacts | type == "object"' >/dev/null 2>&1 && echo yes || echo no)
+        if [ "$_FRESHNESS_PARSE_OK" = "yes" ]; then
+          _FRESHNESS_THRESHOLD=$(echo "$_FRESHNESS_JSON" | jq -r '.threshold_hours')
+          _FRESHNESS_ANY_STALE=$(echo "$_FRESHNESS_JSON" | jq -r '.any_stale')
+          _FRESHNESS_LINES=$(echo "$_FRESHNESS_JSON" | jq -r '
+            .artifacts | to_entries | sort_by(.key)[] |
+            if .value.status == "missing" then "  - [missing] \(.key): not found"
+            elif .value.status == "unknown" then "  - [unknown] \(.key): timestamp unreadable"
+            elif .value.status == "stale" then "  - [STALE] \(.key): age \(.value.age_human) (source: \(.value.source))"
+            else "  - [fresh] \(.key): age \(.value.age_human) (source: \(.value.source))"
+            end
+          ')
+          if [ "$_FRESHNESS_ANY_STALE" = "true" ]; then
+            FRESHNESS_SECTION="STATE FRESHNESS: BLOCKED — one or more session-start artifacts are older than ${_FRESHNESS_THRESHOLD}h (one working session; see scripts/lib/session_state_freshness.py for the measured commit-cadence this threshold is based on). DO NOT dispatch, merge, or close deliverables on the strength of this state — refresh it, or independently re-verify the specific facts it claims, before acting on it.
+$_FRESHNESS_LINES"
+          else
+            FRESHNESS_SECTION="STATE FRESHNESS: ok — no session-start artifact older than ${_FRESHNESS_THRESHOLD}h
+$_FRESHNESS_LINES"
+          fi
+        else
+          FRESHNESS_SECTION="STATE FRESHNESS UNAVAILABLE this session (UNMEASURED, not zero) — session_state_freshness.py did not return an artifacts object."
+        fi
+      else
+        FRESHNESS_SECTION="STATE FRESHNESS UNAVAILABLE this session (UNMEASURED, not zero) — session_state_freshness.py produced no output, or jq is missing."
+      fi
+    else
+      FRESHNESS_SECTION="STATE FRESHNESS UNAVAILABLE this session (UNMEASURED, not zero) — state dir unresolved or scripts/lib/session_state_freshness.py missing."
+    fi
+
     # ── T0 Orchestrator playbook body (in-context injection) ────────────
     # t0-orchestrator is intentionally not model-invocable
     # (disable-model-invocation: true, A-4 hardening), so its content has to
@@ -207,6 +259,8 @@ Model-invocable skills: @horizon @planner @panel @fabric-reference
 Operator-only skills (not model-invocable): @t0-orchestrator @architect
 Full registry: skills/skills.yaml (repo) or \$VNX_SKILLS_DIR/skills.yaml (consumer)
 Use /t0-orchestrator for orchestration decisions and receipt processing
+
+$FRESHNESS_SECTION
 
 $T0_STATE_SECTION
 

--- a/scripts/lib/session_state_freshness.py
+++ b/scripts/lib/session_state_freshness.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""scripts/lib/session_state_freshness.py — age visibility for the artifacts
+T0 reads at SessionStart (golf 3A, "absence-is-loud" criterion 1, OI-1512
+fix-forward).
+
+Measured 2026-09-04 (see the golf-3A dispatch report for the full readout):
+on 2026-08-29 a T0 session orchestrated a merge against `t0_state.json` that
+was 22 days old, while `dashboard_status.json` (63 days) and
+`t0_recommendations.json` (73 days) were even older — and nothing in the
+SessionStart context said so. The incident was caught only when the merge
+was attempted, not when the session opened. Re-measured directly on this
+dev store (2026-09-04): `dashboard_status.json.timestamp` = 2026-06-27
+(matches the 63-day figure) and `t0_recommendations.json.timestamp` =
+2026-06-17 (matches 73 days), confirming both files carry a self-declared
+timestamp that nothing was reading for staleness.
+
+This module is deliberately NOT a periodic monitor. `producer_freshness.py`
++ `configs/producer_freshness.yaml` already own that job for tables and
+directories that get written to on a cadence (dispatches, review gates,
+governance metrics) — see that module's docstring for the incidents it
+catches. The five artifacts here are a different class: point-in-time
+SNAPSHOTS that `hooks/sessionstart.sh` (or the T0 role file's own
+Read-Only State Sources list) reads once at the top of a session. Grouping
+them into the producer registry would mean waiting for the next monitor
+sweep to notice; this module runs synchronously, inline, in the hook that
+fires on every single SessionStart, so the answer is in front of the reader
+before they do anything else.
+
+SESSION_STALE_AFTER_HOURS = 24 is deliberate, not a guess. Measured against
+this repo's own commit cadence over the 14 days before this fix (`git log
+--since="14 days ago" --format="%at" origin/main`, gaps between consecutive
+commits): 108 of 111 gaps (97.3%) were <= 24h; the p90 gap was 7.5h; the
+three gaps that exceeded 24h (35.7h, 36.1h, 74.8h) all landed across a
+weekend/day-off boundary, not mid-session. 24h is therefore tight enough to
+catch a state file that predates the day's work entirely (the 22/63/73-day
+incident is nowhere near this boundary), while comfortably covering a single
+long-running autonomous session (T0's own "F60 / overnight feature work"
+policy, bounded to one night, not multiple days).
+
+Three outcomes per artifact, not two ("nul telling is eerst een meetfout" /
+"niet-gemeten is een derde tak, geen derde waarde" — the same discipline
+applies to a missing FILE, not just a missing field):
+
+  - "missing"  — the file does not exist. Not evidence of staleness; some
+    projects legitimately never populate every artifact.
+  - "stale"    — the file exists and its age exceeds SESSION_STALE_AFTER_HOURS.
+  - "fresh"    — the file exists and is within the threshold.
+  - "unknown"  — the file exists but no timestamp could be read from its
+    declared field OR its mtime (corrupt/unreadable) — reported distinctly
+    so it is never silently counted as fresh.
+
+Age source per artifact: the file's own declared timestamp field when
+present (verified against this dev store below), falling back to mtime —
+same precedent as `scripts/lib/t0_state_health.py::_state_build_time`. This
+is the file's own REGENERATION age (when was this snapshot last rebuilt),
+not a business-semantic field buried in its content (e.g. a terminal's
+`last_activity` describes when that terminal was busy, which is legitimate
+data, not evidence the snapshot itself is old).
+
+  t0_state.json          generated_at   (confirmed present, 2026-09-04)
+  open_items.json        last_updated   (confirmed present, 2026-09-04)
+  dashboard_status.json  timestamp      (confirmed present, 2026-09-04)
+  t0_recommendations.json timestamp     (confirmed present, 2026-09-04)
+  terminal_state.json    (mtime only — no top-level timestamp field; the
+                           per-terminal `last_activity` values inside it are
+                           business data, not the snapshot's own build time)
+
+Read-only. Never writes. `assess_artifact_freshness()` takes `state_dir` as
+already resolved by the caller (same convention as `scripts/health_check.py`
+takes `--state-dir`) — this module does not re-resolve VNX paths.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+# One calendar day. See module docstring for the measurement behind this
+# number — do not change it without re-measuring the commit-gap cadence it
+# is based on.
+SESSION_STALE_AFTER_HOURS = 24.0
+
+# name -> (filename under state_dir, content timestamp field or None for mtime-only)
+ARTIFACTS: Dict[str, Tuple[str, Optional[str]]] = {
+    "t0_state": ("t0_state.json", "generated_at"),
+    "open_items": ("open_items.json", "last_updated"),
+    "terminal_state": ("terminal_state.json", None),
+    "dashboard_status": ("dashboard_status.json", "timestamp"),
+    "t0_recommendations": ("t0_recommendations.json", "timestamp"),
+}
+
+
+def _parse_ts(value: Any) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp (``Z`` or ``+00:00``) to aware UTC.
+
+    Returns ``None`` on missing/unparseable input — this is an advisory read
+    and must never raise into the caller.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _human_age(age_hours: float) -> str:
+    """Render a fractional hour count as a short human age."""
+    if age_hours < 1:
+        minutes = int(round(age_hours * 60))
+        return f"{minutes} minute{'s' if minutes != 1 else ''}"
+    if age_hours < 48:
+        hours = int(round(age_hours))
+        return f"{hours} hour{'s' if hours != 1 else ''}"
+    days = age_hours / 24.0
+    rendered = int(round(days))
+    return f"{rendered} day{'s' if rendered != 1 else ''}"
+
+
+def _content_timestamp(path: Path, field: str) -> Optional[datetime]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return _parse_ts(data.get(field))
+
+
+def _artifact_timestamp(path: Path, field: Optional[str]) -> Tuple[Optional[datetime], Optional[str]]:
+    """Return ``(timestamp, source)``. ``source`` is ``"content"`` when the
+    declared field parsed, ``"mtime"`` when falling back to the file's own
+    mtime, or ``None`` when neither is readable."""
+    if field is not None:
+        ts = _content_timestamp(path, field)
+        if ts is not None:
+            return ts, "content"
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc), "mtime"
+    except OSError:
+        return None, None
+
+
+def assess_artifact_freshness(
+    state_dir: Path,
+    now: Optional[datetime] = None,
+    threshold_hours: float = SESSION_STALE_AFTER_HOURS,
+) -> Dict[str, Any]:
+    """Assess every artifact in :data:`ARTIFACTS` under ``state_dir``.
+
+    Returns a dict with ``threshold_hours``, one entry per artifact under
+    ``artifacts`` (``status`` in ``missing``/``stale``/``fresh``/``unknown``,
+    plus ``age_hours``/``age_human``/``source``), and the summary flags
+    ``any_stale`` / ``any_missing`` / ``any_unknown``.
+    """
+    now = now if now is not None else datetime.now(timezone.utc)
+    state_dir = Path(state_dir)
+    artifacts: Dict[str, Any] = {}
+    any_stale = False
+    any_missing = False
+    any_unknown = False
+
+    for name, (filename, field) in ARTIFACTS.items():
+        path = state_dir / filename
+        if not path.exists():
+            artifacts[name] = {
+                "status": "missing",
+                "age_hours": None,
+                "age_human": None,
+                "source": None,
+            }
+            any_missing = True
+            continue
+
+        ts, source = _artifact_timestamp(path, field)
+        if ts is None:
+            artifacts[name] = {
+                "status": "unknown",
+                "age_hours": None,
+                "age_human": None,
+                "source": source,
+            }
+            any_unknown = True
+            continue
+
+        age_hours = max(0.0, (now - ts).total_seconds() / 3600.0)
+        status = "stale" if age_hours > threshold_hours else "fresh"
+        if status == "stale":
+            any_stale = True
+        artifacts[name] = {
+            "status": status,
+            "age_hours": round(age_hours, 2),
+            "age_human": _human_age(age_hours),
+            "source": source,
+        }
+
+    return {
+        "threshold_hours": threshold_hours,
+        "artifacts": artifacts,
+        "any_stale": any_stale,
+        "any_missing": any_missing,
+        "any_unknown": any_unknown,
+    }
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-dir", required=True, help="Resolved VNX_STATE_DIR")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    result = assess_artifact_freshness(Path(args.state_dir))
+    if args.json:
+        print(json.dumps(result))
+    else:
+        threshold = result["threshold_hours"]
+        print(f"Session state freshness (threshold {threshold:.0f}h):")
+        for name, info in sorted(result["artifacts"].items()):
+            status = info["status"]
+            if status == "missing":
+                print(f"  [missing] {name}: not found")
+            elif status == "unknown":
+                print(f"  [unknown] {name}: timestamp unreadable")
+            else:
+                marker = "STALE" if status == "stale" else "fresh"
+                print(f"  [{marker}] {name}: age {info['age_human']} (source: {info['source']})")
+    return 1 if result["any_stale"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sessionstart_hook_central_store.py
+++ b/tests/test_sessionstart_hook_central_store.py
@@ -104,8 +104,19 @@ class TestCentralStoreResolution:
         )
 
         expected_state_dir.mkdir(parents=True, exist_ok=True)
-        (expected_state_dir / "terminal_state_T1.json").write_text(
-            json.dumps({"status": "busy", "current_task": "UNIQUE-TASK-MARKER-9f2a"}),
+        # Golf 3A fix-forward: this fixture used to write the singular-terminal
+        # filename `terminal_state_T1.json` with a top-level `current_task`
+        # field. Measured against the real writer
+        # (scripts/lib/terminal_state_shadow.py:TERMINAL_STATE_FILENAME) while
+        # fixing hooks/sessionstart.sh's own dead read of that same filename:
+        # the writer has only ever produced the SINGULAR `terminal_state.json`
+        # with a `.terminals.<id>` map (no `current_task` field — the hook
+        # reads `.status` / `.last_activity` per terminal). This test's own
+        # purpose is central-store PATH resolution (D4), not the terminal-state
+        # schema, so the fixture is corrected to match reality rather than the
+        # dead-code path both the hook and this fixture used to share.
+        (expected_state_dir / "terminal_state.json").write_text(
+            json.dumps({"terminals": {"T1": {"status": "busy", "last_activity": "UNIQUE-TASK-MARKER-9f2a"}}}),
             encoding="utf-8",
         )
         (expected_state_dir / "open_items.json").write_text(

--- a/tests/test_sessionstart_hook_state_freshness.py
+++ b/tests/test_sessionstart_hook_state_freshness.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""tests/test_sessionstart_hook_state_freshness.py — golf 3A ("absence-is-loud"
+criterion 1, OI-1512 fix-forward): hooks/sessionstart.sh must make the age of
+the artifacts it loads for T0 visible, and must refuse — via an unmissable
+textual directive, the only mechanism a SessionStart hook has — to let T0
+orchestrate on state older than one working session without saying so.
+
+Defect this closes: on 2026-08-29 a T0 session orchestrated a merge against a
+`t0_state.json` that was 22 days old (`dashboard_status.json` was 63 days,
+`t0_recommendations.json` 73 days) and the SessionStart context said nothing
+about it — the age was invisible until the merge was attempted. Re-measured
+directly against this hook (not trusted from the incident report, per this
+project's own "een getal zonder herkomst is een claim" rule): before this
+fix, hooks/sessionstart.sh does not read t0_state.json, dashboard_status.json
+or t0_recommendations.json at all, and its ONLY per-terminal read
+(`terminal_state_${_t}.json`) targets a filename `terminal_state_shadow.py`
+never writes (it writes the singular `terminal_state.json`) — a second dead
+read discovered by the same measurement discipline this dispatch demands.
+
+Harness pattern (env isolation, `_run_hook`, `_make_terminal_project`) copied
+from tests/test_sessionstart_hook_beacon_health.py, the sibling test for the
+same hook's beacon-health section — same VNX_DATA_HOME redirection, same
+"never touch this repo's own .vnx-data or the live ~/.vnx-data/<project>/
+store" rule.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "hooks" / "sessionstart.sh"
+LIB = REPO / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import vnx_paths  # noqa: E402
+from session_state_freshness import SESSION_STALE_AFTER_HOURS  # noqa: E402
+
+_VNX_ENV_VARS = (
+    "VNX_DATA_DIR",
+    "VNX_STATE_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_DATA_HOME",
+    "VNX_PROJECT_ID",
+    "VNX_HOME",
+    "VNX_BIN",
+    "VNX_EXECUTABLE",
+    "VNX_CANONICAL_ROOT",
+    "VNX_PROJECT_ROOT",
+)
+
+
+def _clean_env(monkeypatch) -> None:
+    for var in _VNX_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_terminal_project(tmp_path: Path, name: str = "project") -> Path:
+    root = tmp_path / name
+    (root / ".vnx").mkdir(parents=True)
+    t0_dir = root / ".claude" / "terminals" / "T0"
+    t0_dir.mkdir(parents=True)
+    return t0_dir
+
+
+def _run_hook(cwd: Path, env: dict) -> dict:
+    r = subprocess.run(
+        ["bash", str(HOOK)],
+        capture_output=True, text=True, cwd=str(cwd), env=env, timeout=10,
+    )
+    assert r.returncode == 0, f"hook must exit 0: rc={r.returncode}\nstdout={r.stdout}\nstderr={r.stderr}"
+    return json.loads(r.stdout)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _state_dir(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("VNX_DATA_HOME", str(tmp_path / "vnx-data-home"))
+    return Path(vnx_paths.resolve_paths()["VNX_STATE_DIR"])
+
+
+class TestStateFreshnessDigestSurfacesAge:
+    """Klaar-wanneer: age is visible, and staleness is a directive T0 cannot
+    scroll past, not a footnote."""
+
+    def test_stale_t0_state_produces_a_blocked_directive(self, tmp_path, monkeypatch):
+        """The exact incident shape: t0_state.json built 22 days ago (the
+        measured 2026-08-29 figure). Must surface as STALE with an unmissable
+        BLOCKED directive, not silence."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+
+        old_ts = datetime.now(timezone.utc) - timedelta(days=22)
+        _write_json(state_dir / "t0_state.json", {"generated_at": _iso(old_ts), "schema_version": 1})
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "STATE FRESHNESS: BLOCKED" in ctx, ctx
+        assert "[STALE] t0_state" in ctx, ctx
+        assert "22 day" in ctx, ctx
+
+    def test_fresh_state_says_ok_explicitly_not_silently(self, tmp_path, monkeypatch):
+        """A healthy fleet must say so explicitly — silence would be
+        indistinguishable from 'freshness unavailable' (same discipline as
+        the beacon digest's 'all ok' branch)."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+
+        now_ts = datetime.now(timezone.utc) - timedelta(minutes=5)
+        _write_json(state_dir / "t0_state.json", {"generated_at": _iso(now_ts)})
+        _write_json(state_dir / "open_items.json", {"last_updated": _iso(now_ts).replace("Z", "")})
+        _write_json(state_dir / "dashboard_status.json", {"timestamp": _iso(now_ts)})
+        _write_json(state_dir / "t0_recommendations.json", {"timestamp": _iso(now_ts).replace("Z", "")})
+        _write_json(state_dir / "terminal_state.json", {"terminals": {}})
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "STATE FRESHNESS: ok" in ctx, ctx
+        assert "BLOCKED" not in ctx, ctx
+
+    def test_missing_artifact_is_a_third_branch_not_stale_not_fresh(self, tmp_path, monkeypatch):
+        """Ontbrekend is niet hetzelfde als oud, en niet hetzelfde als vers —
+        a project that never populated dashboard_status.json must not read as
+        either 'the data says it's fine' or 'the data is dangerously old'."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+
+        now_ts = datetime.now(timezone.utc) - timedelta(minutes=1)
+        _write_json(state_dir / "t0_state.json", {"generated_at": _iso(now_ts)})
+        # dashboard_status.json, t0_recommendations.json, open_items.json,
+        # terminal_state.json deliberately absent.
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "[missing] dashboard_status: not found" in ctx, ctx
+        # A missing artifact alone (nothing genuinely stale) must not trip
+        # the BLOCKED directive — that would conflate "never populated" with
+        # "went stale under our feet".
+        assert "STATE FRESHNESS: BLOCKED" not in ctx, ctx
+
+    def test_threshold_boundary_23h_fresh_25h_stale(self, tmp_path, monkeypatch):
+        """SESSION_STALE_AFTER_HOURS = 24 is exercised at its own boundary,
+        not just on an incident-scale outlier."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+        assert SESSION_STALE_AFTER_HOURS == 24.0  # guards the boundary picked below
+
+        fresh_ts = datetime.now(timezone.utc) - timedelta(hours=23)
+        stale_ts = datetime.now(timezone.utc) - timedelta(hours=25)
+        _write_json(state_dir / "t0_state.json", {"generated_at": _iso(fresh_ts)})
+        _write_json(state_dir / "open_items.json", {"last_updated": _iso(stale_ts).replace("Z", "")})
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "[fresh] t0_state" in ctx, ctx
+        assert "[STALE] open_items" in ctx, ctx
+
+    def test_terminal_state_reads_the_real_schema_not_a_dead_suffix_path(self, tmp_path, monkeypatch):
+        """Regression for the second dead read this dispatch's own measurement
+        found: terminal_state_shadow.py writes the singular
+        `terminal_state.json` with a `.terminals.<id>` map — the pre-fix hook
+        looked for `terminal_state_T1.json`, which the writer never produces,
+        so this section always fell through to 'No terminal state data'."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+
+        _write_json(state_dir / "terminal_state.json", {
+            "terminals": {
+                "T1": {"status": "busy", "last_activity": "2026-09-04T10:00:00+00:00"},
+                "T2": {"status": "idle", "last_activity": "2026-08-30T08:18:15+00:00"},
+            }
+        })
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "No terminal state data" not in ctx, ctx
+        assert "T1: busy" in ctx, ctx
+
+    def test_hook_is_valid_bash(self):
+        result = subprocess.run(["bash", "-n", str(HOOK)], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Golf 3A ("absence-is-loud" objective, criterion 1). Before this PR, `hooks/sessionstart.sh` gave T0 no way to know how old the artifacts it reads at SessionStart were — the 2026-08-29 incident (a merge orchestrated against a 22-day-old `t0_state.json`) went unnoticed until the merge itself was attempted.

**Measured before writing anything** (per this dispatch's own instruction — the OI-1512 premise it warned about, "grep on `build_t0_state` in the hook gives zero hits," is itself stale: the hook mentions `build_t0_state` three times, but only in comments; none of them call it — `t0_state.json` is actually built by a *different* SessionStart hook, `build_t0_state_hook.sh`):

- `hooks/sessionstart.sh` reads `terminal_state_${_t}.json` (T1/T2/T3) and `open_items.json` directly, and pulls beacon health live via `scripts/health_check.py`.
- The `terminal_state_${_t}.json` read is dead code on every project: the actual writer (`scripts/lib/terminal_state_shadow.py::TERMINAL_STATE_FILENAME`) has only ever produced the singular `terminal_state.json` with a `.terminals.<id>` map. This section always fell through to "No terminal state data."
- `t0_state.json`, `dashboard_status.json`, `t0_recommendations.json` — the three artifacts the historical incident actually names — are not read by this hook at all today. Re-measured directly on the dev store: `dashboard_status.json.timestamp` = 2026-06-27 and `t0_recommendations.json.timestamp` = 2026-06-17, matching the incident's 63-day/73-day figures exactly, confirming both already carry a self-declared timestamp nothing was reading for staleness.

## Changes

- **`scripts/lib/session_state_freshness.py`** (new): reads each artifact's own declared timestamp (`t0_state.json`/`generated_at`, `open_items.json`/`last_updated`, `dashboard_status.json`/`timestamp`, `t0_recommendations.json`/`timestamp`), falling back to mtime for `terminal_state.json` (no top-level timestamp field) — same precedent as the existing `scripts/lib/t0_state_health.py`. Classifies each artifact as `missing` / `stale` / `fresh` / `unknown` — three real branches, never conflating "never populated" with "went stale."
  - `SESSION_STALE_AFTER_HOURS = 24` is measured, not guessed: over the 14 days before this fix, 108/111 (97.3%) of gaps between consecutive commits on this repo were ≤24h (p90 = 7.5h); the 3 gaps that exceeded 24h (35.7h/36.1h/74.8h) all landed across a weekend/day-off boundary, not mid-session. 24h is tight enough to catch the 22/63/73-day incident pattern while comfortably covering a single long overnight autonomous session.
- **`hooks/sessionstart.sh`**:
  - T0 branch now shells out to `session_state_freshness.py` (same subprocess pattern as the existing beacon-health call to `health_check.py`) and injects a `STATE FRESHNESS` section right after the headline — the first thing T0 sees. "ok" when nothing is stale; an unmissable `STATE FRESHNESS: BLOCKED` directive (never a hard crash — this is a hook, not an enforcement gate) telling T0 not to dispatch/merge/close on the strength of stale state when something is.
  - Fixes the dead `terminal_state_${_t}.json` read: now reads the real `terminal_state.json` file and its `.terminals.<id>.status` / `.last_activity` fields.
- **`tests/test_sessionstart_hook_state_freshness.py`** (new): 6 tests — stale-triggers-BLOCKED, fresh-says-ok, missing-is-a-third-branch, the 23h/25h threshold boundary, the terminal_state regression, and a bash-syntax check.
- **`tests/test_sessionstart_hook_central_store.py`**: fixed its own fixture, which encoded the same dead `terminal_state_T1.json` filename/schema production code carried — corrected to match the real writer schema (its actual purpose, central-store path resolution, is unaffected).

## Verification

**Red before / green after** (the hard requirement): `tests/test_sessionstart_hook_state_freshness.py` run against the unmodified hook first — **5 of 6 failed** (a session on a 22-day-old `t0_state.json` produced zero warning in the additionalContext, reproducing the incident's exact shape). After the fix: **6 of 6 pass**.

Full neighbor suite after the fix, all green:
```
tests/test_sessionstart_hook.py                    10 passed
tests/test_sessionstart_hook_beacon_health.py       13 passed
tests/test_sessionstart_hook_central_store.py        3 passed
tests/test_sessionstart_hook_dead_vars.py            1 passed
tests/test_sessionstart_hook_state_freshness.py      6 passed
tests/test_t0_state_health.py                       17 passed
                                                     50 passed
```
Also ran `tests/test_t0_role_audit_static.py`, `tests/test_oi1478_fleet_role_drift.py`, `tests/test_role_sync.py` (79 passed) and `tests/test_terminal_state_shadow.py` (5 passed) as further-neighbor sanity checks, since those construct or reference the sessionstart hook / the terminal-state schema. `bash -n hooks/sessionstart.sh` clean. `scripts/ci_lint_patterns.py` clean on all 4 touched/added files. Verified no repo-local `.vnx-data/state/` literal and no `VNX_STATE_DIR=` pin against the two CI path gates (`vnx-ci.yml` "Legacy path gate" and the #1043 footgun gate) — neither pattern appears in the new/changed files.

Confirmed with `git diff HEAD` (empty) and `git show HEAD:hooks/sessionstart.sh` (greped for the new section) that the pushed commit matches the working tree exactly.

## Open Items

None from this PR's own scope. One item flagged for a separate producer-side follow-up (explicitly out of scope here — dispatch instructions kept me off `scripts/build_t0_state.py`, which has an open PR #1755):

- `session_state_freshness.py` currently reads `generated_at` from `t0_state.json` fine (that field already exists). No producer-side change is needed for the artifacts this PR covers — all four content-timestamp fields (`t0_state.generated_at`, `open_items.last_updated`, `dashboard_status.timestamp`, `t0_recommendations.timestamp`) already exist in production output; this PR is read-only against them.
- Not fixed here, and worth a separate look: `terminal_state.json`'s per-terminal `last_activity` field is a different kind of age (when a terminal was last busy, not when the file was last regenerated) and is surfaced as-is in the terminal-state line, not run through the freshness classifier — that's a deliberate scope boundary (see module docstring), not an oversight, but worth flagging in case it's not obvious in review.

Buiten de dispatch-deur om geproduceerd via een Agent-subagent, operator-besluit 2026-09-04. Tijdelijke afwijking: de gegovernde dispatch-paden zijn traag en de deur is zelf onderwerp van reparatie. PR en CI blijven onverkort gelden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR