### PR TITLE
fix(providers): kimi/codex/gemini spawns now scrub secrets before Popen (OI-1619)

### DIFF
--- a/scripts/lib/env_scrub_patterns.py
+++ b/scripts/lib/env_scrub_patterns.py
@@ -19,8 +19,20 @@ still matches only itself. ``CLAUDE_CODE_OAUTH_TOKEN``, ``ANTHROPIC_API_KEY``,
 scrubbed even if the glob set is narrowed later — the first three because an inherited
 value can silently displace a valid CLI login ahead of it in the auth precedence order
 (measured 2026-08-31), not only because they are secrets.
+
+OI-1619 (2026-09-04): the same gap existed a level below SubprocessAdapter — the three
+provider lanes that Popen a worker CLI directly instead of going through
+SubprocessAdapter.deliver() (``provider_spawns/kimi_spawn.py``, ``codex_spawn.py``,
+``gemini_spawn.py``) each built their child env as ``{**os.environ, **(extra_env or
+{})}`` with no scrub call at all — not even the narrower per-lane pattern
+``litellm_spawn.py`` uses for its own external-model lane. ``scrub_env()`` below is the
+free-function counterpart of SubprocessAdapter.deliver()'s inline fnmatch loop, for
+callers that Popen directly and have no SubprocessAdapter to route through.
 """
 from __future__ import annotations
+
+import fnmatch
+from typing import Dict, Iterable, Mapping
 
 DEFAULT_SCRUB_KEY_PATTERNS: frozenset = frozenset({
     "*_PASS",
@@ -33,3 +45,20 @@ DEFAULT_SCRUB_KEY_PATTERNS: frozenset = frozenset({
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
 })
+
+
+def scrub_env(env: Mapping[str, str], patterns: Iterable[str]) -> Dict[str, str]:
+    """Return a copy of *env* with every key matching *patterns* removed.
+
+    *patterns* are fnmatch-style globs matched with ``fnmatch.fnmatchcase`` against
+    each key name — the same matching rule SubprocessAdapter.deliver() applies inline
+    (subprocess_adapter.py), so a direct-Popen spawn lane (one with no
+    SubprocessAdapter to route through — see OI-1619 above) scrubs identically to the
+    claude lane rather than inventing a second rule. A literal name with no wildcard
+    character still matches only itself.
+    """
+    scrubbed = dict(env)
+    for _key in list(scrubbed.keys()):
+        if any(fnmatch.fnmatchcase(_key, _pattern) for _pattern in patterns):
+            scrubbed.pop(_key, None)
+    return scrubbed

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -32,6 +32,7 @@ if _LIB_DIR not in sys.path:
 
 from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
+from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS, scrub_env  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -379,7 +380,11 @@ def _launch_codex_proc(
     Returns (None, CodexSpawnResult(returncode=127)) when binary is missing.
     """
     cmd = _build_cmd(model)
-    env = {**os.environ, **(extra_env or {})}
+    # OI-1619: codex is a real worker subprocess (untrusted-model-driven) — the
+    # parent env must be scrubbed of secrets before it crosses into it. This lane
+    # Popens directly (no SubprocessAdapter to route the scrub through), so the
+    # free-function counterpart applies here explicitly.
+    env = scrub_env({**os.environ, **(extra_env or {})}, DEFAULT_SCRUB_KEY_PATTERNS)
     cwd_str = str(cwd) if cwd is not None else None
 
     try:

--- a/scripts/lib/provider_spawns/gemini_spawn.py
+++ b/scripts/lib/provider_spawns/gemini_spawn.py
@@ -34,6 +34,7 @@ if _LIB_DIR not in sys.path:
 
 from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
+from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS, scrub_env  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -314,7 +315,11 @@ def spawn_gemini(
     if "VNX_GEMINI_STALL_THRESHOLD" not in os.environ:
         chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
 
-    env = {**os.environ, **(extra_env or {})}
+    # OI-1619: gemini is a real worker subprocess (untrusted-model-driven) — the
+    # parent env must be scrubbed of secrets before it crosses into it. This lane
+    # Popens directly (no SubprocessAdapter to route the scrub through), so the
+    # free-function counterpart applies here explicitly.
+    env = scrub_env({**os.environ, **(extra_env or {})}, DEFAULT_SCRUB_KEY_PATTERNS)
     cwd_str = str(cwd) if cwd is not None else None
 
     if os.environ.get("VNX_GEMINI_STREAM", "0").strip() == "1":

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -68,6 +68,7 @@ if _LIB_DIR not in sys.path:
 
 from _streaming_drainer import StreamingDrainerMixin, _kill_process, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
+from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS, scrub_env  # noqa: E402
 # OI-1087: the read-only task-class list lives in ONE place — phantom_guard's
 # REVIEW_TASK_CLASSES is the fabric's SSOT for "a verdict, not a diff, is the
 # expected deliverable". The fabrication guard below keys off the same list so
@@ -713,6 +714,10 @@ def _isolate_kimi_env(env: Dict[str, str]) -> Dict[str, str]:
     Stripped unconditionally (after any extra_env merge): a standalone uv tool
     has no legitimate use for an inherited VIRTUAL_ENV/PYTHONPATH/PYTHONHOME, and
     leaving them in lets a foreign venv's site-packages shadow kimi's own deps.
+
+    Secret scrubbing (OI-1619) is a SEPARATE concern applied by the caller via
+    ``scrub_env(..., DEFAULT_SCRUB_KEY_PATTERNS)`` — this function only owns venv
+    isolation, never conflate the two when reading a call site.
     """
     return {k: v for k, v in env.items() if k not in _VENV_POLLUTION_VARS}
 
@@ -1206,7 +1211,13 @@ def spawn_kimi(
     if "VNX_KIMI_STALL_THRESHOLD" not in os.environ:
         chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
 
-    env = _isolate_kimi_env({**os.environ, **(extra_env or {})})
+    # OI-1619: the kimi CLI is a real worker subprocess (untrusted-model-driven,
+    # same threat model as the claude/litellm lanes) — the parent env must be
+    # scrubbed of secrets before it crosses into it, not just venv-isolated.
+    env = scrub_env(
+        _isolate_kimi_env({**os.environ, **(extra_env or {})}),
+        DEFAULT_SCRUB_KEY_PATTERNS,
+    )
     cwd_str = str(cwd) if cwd is not None else None
 
     cmd = _build_kimi_cmd(prompt, model, cwd)

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -15,9 +15,19 @@ invoked. No Anthropic SDK, no direct API calls. LiteLLM is isolated to
 _litellm_runner.py subprocess.
 
 CREDENTIAL SAFETY (audit S2): every Popen env for these subprocesses is built via
-_scrubbed_env(), which strips ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN after
-merging the parent env — an external/untrusted model driven through the agentic
-runner's run_command tool cannot read the Anthropic account's own credentials.
+_scrubbed_env(), which delegates to env_scrub_patterns.scrub_env() with
+_LITELLM_SCRUB_PATTERNS (OI-1619 followup, 2026-09-04) after merging the parent env —
+an external/untrusted model driven through the agentic runner's run_command tool
+cannot read the Anthropic account's own credentials, and (unlike this lane's original
+hand-rolled two-key allowlist) cannot read any other *_PASS/*_SECRET/*_TOKEN-shaped
+secret either. _LITELLM_SCRUB_PATTERNS is DEFAULT_SCRUB_KEY_PATTERNS minus the
+blanket `*_KEY` glob: this lane's OWN child process legitimately reads a provider API
+key from env to authenticate outbound (DEEPSEEK_API_KEY / MOONSHOT_API_KEY /
+OPENROUTER_API_KEY — see _PROVIDER_KEY_REQS in _litellm_runner.py /
+_litellm_agentic_runner.py), so the blanket glob would break every litellm-routed
+dispatch's own auth. ANTHROPIC_API_KEY stays covered regardless via its own explicit
+literal in the shared pattern set, independent of the glob — see _LITELLM_SCRUB_PATTERNS
+below for the measured detail.
 """
 
 from __future__ import annotations
@@ -38,6 +48,7 @@ if _LIB_DIR not in sys.path:
 
 from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
+from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS, scrub_env  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -51,18 +62,39 @@ _TIER_STREAMING = 1
 # runner via completion(), the agentic runner via its run_command tool (shell=True, no
 # allowlist; audit S1). Full os.environ inheritance would hand the Anthropic account's own
 # credentials to that subprocess, readable/exfiltratable by an external/untrusted model
-# through run_command. Neither key is ever needed by a litellm-routed child, so both are
-# scrubbed from every Popen env unconditionally (not caller-optional — there is no legitimate
-# case where a litellm child needs them).
-_CREDENTIAL_SCRUB_KEYS = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
+# through run_command. Neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN is ever
+# needed by a litellm-routed child.
+#
+# OI-1619 followup (2026-09-04): this used to be a hand-rolled, exact-key-only allowlist
+# (ANTHROPIC_API_KEY + CLAUDE_CODE_OAUTH_TOKEN) — narrower than the shared
+# DEFAULT_SCRUB_KEY_PATTERNS glob set the sibling kimi/codex/gemini lanes were fixed to
+# use, so a VNX_SMTP_PASS-shaped secret crossed straight through here while those three
+# were already scrubbing it (measured via tests/test_litellm_spawn_credential_scrub.py's
+# new red-then-green case). _scrubbed_env() now delegates to the SAME scrub_env()
+# mechanism those three use, rather than carrying a second, hand-rolled rule.
+#
+# It does NOT reuse DEFAULT_SCRUB_KEY_PATTERNS verbatim, though — measured: swapping it
+# in unscoped turned test_extra_env_cannot_reintroduce_credentials red, because this
+# lane's OWN child process legitimately reads a provider API key from env to
+# authenticate outbound (DEEPSEEK_API_KEY / MOONSHOT_API_KEY / OPENROUTER_API_KEY — see
+# _PROVIDER_KEY_REQS in _litellm_runner.py / _litellm_agentic_runner.py, both *_KEY
+# shaped). Unlike the OAuth-only kimi/codex/gemini CLIs (which read zero *_KEY-shaped
+# vars themselves), the blanket `*_KEY` glob would strip this lane's own required
+# credentials and break every litellm-routed dispatch's auth. So this pattern set is
+# DEFAULT_SCRUB_KEY_PATTERNS computed MINUS that one glob — everything else (`*_PASS`,
+# `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, and the explicit literals) still applies.
+# ANTHROPIC_API_KEY stays covered regardless: it is ALSO listed as its own explicit
+# literal in DEFAULT_SCRUB_KEY_PATTERNS, independent of the `*_KEY` glob (measured via
+# fnmatch.fnmatchcase against every pattern in the shared set) — dropping only the glob
+# loses no coverage this lane relied on.
+_LITELLM_SCRUB_PATTERNS: frozenset = DEFAULT_SCRUB_KEY_PATTERNS - {"*_KEY"}
 
 
 def _scrubbed_env(extra_env: Optional[Dict[str, str]]) -> Dict[str, str]:
-    """Merge extra_env over the parent env, then strip Anthropic-account credentials."""
+    """Merge extra_env over the parent env, then strip every secret-shaped key this
+    lane does not itself need (see _LITELLM_SCRUB_PATTERNS above)."""
     env = {**os.environ, **(extra_env or {})}
-    for _key in _CREDENTIAL_SCRUB_KEYS:
-        env.pop(_key, None)
-    return env
+    return scrub_env(env, _LITELLM_SCRUB_PATTERNS)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -15,19 +15,19 @@ invoked. No Anthropic SDK, no direct API calls. LiteLLM is isolated to
 _litellm_runner.py subprocess.
 
 CREDENTIAL SAFETY (audit S2): every Popen env for these subprocesses is built via
-_scrubbed_env(), which delegates to env_scrub_patterns.scrub_env() with
-_LITELLM_SCRUB_PATTERNS (OI-1619 followup, 2026-09-04) after merging the parent env —
-an external/untrusted model driven through the agentic runner's run_command tool
-cannot read the Anthropic account's own credentials, and (unlike this lane's original
-hand-rolled two-key allowlist) cannot read any other *_PASS/*_SECRET/*_TOKEN-shaped
-secret either. _LITELLM_SCRUB_PATTERNS is DEFAULT_SCRUB_KEY_PATTERNS minus the
-blanket `*_KEY` glob: this lane's OWN child process legitimately reads a provider API
-key from env to authenticate outbound (DEEPSEEK_API_KEY / MOONSHOT_API_KEY /
-OPENROUTER_API_KEY — see _PROVIDER_KEY_REQS in _litellm_runner.py /
-_litellm_agentic_runner.py), so the blanket glob would break every litellm-routed
-dispatch's own auth. ANTHROPIC_API_KEY stays covered regardless via its own explicit
-literal in the shared pattern set, independent of the glob — see _LITELLM_SCRUB_PATTERNS
-below for the measured detail.
+_scrubbed_env(), which delegates to env_scrub_patterns.scrub_env() with the FULL
+DEFAULT_SCRUB_KEY_PATTERNS (OI-1619 followup round 2, 2026-09-04) after merging the
+parent env — an external/untrusted model driven through the agentic runner's
+run_command tool cannot read the Anthropic account's own credentials, cannot read any
+other *_PASS/*_SECRET/*_TOKEN-shaped secret, and (round 2) cannot read any *_KEY-shaped
+secret EXCEPT the specific provider keys this lane's own child process needs to
+authenticate outbound. That need-based exception is scoped to exactly
+_litellm_runner.py's _PROVIDER_KEY_REQS values (DEEPSEEK_API_KEY / MOONSHOT_API_KEY /
+OPENROUTER_API_KEY, imported as the SSOT) — round 1 of this fix instead excepted the
+WHOLE `*_KEY` glob, which let ANY *_KEY-shaped secret (OPENAI_API_KEY, SUPABASE_KEY,
+whatever else happens to be in the parent env) survive for exactly the lane an external
+model can direct via run_command; see _NEEDED_PROVIDER_KEYS below for the measured
+detail.
 """
 
 from __future__ import annotations
@@ -47,6 +47,7 @@ if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
 from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
+from adapters._litellm_runner import _PROVIDER_KEY_REQS  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
 from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS, scrub_env  # noqa: E402
 
@@ -65,36 +66,42 @@ _TIER_STREAMING = 1
 # through run_command. Neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN is ever
 # needed by a litellm-routed child.
 #
-# OI-1619 followup (2026-09-04): this used to be a hand-rolled, exact-key-only allowlist
-# (ANTHROPIC_API_KEY + CLAUDE_CODE_OAUTH_TOKEN) — narrower than the shared
+# OI-1619 followup round 1 (2026-09-04): this used to be a hand-rolled, exact-key-only
+# allowlist (ANTHROPIC_API_KEY + CLAUDE_CODE_OAUTH_TOKEN) — narrower than the shared
 # DEFAULT_SCRUB_KEY_PATTERNS glob set the sibling kimi/codex/gemini lanes were fixed to
 # use, so a VNX_SMTP_PASS-shaped secret crossed straight through here while those three
 # were already scrubbing it (measured via tests/test_litellm_spawn_credential_scrub.py's
-# new red-then-green case). _scrubbed_env() now delegates to the SAME scrub_env()
-# mechanism those three use, rather than carrying a second, hand-rolled rule.
+# red-then-green case). _scrubbed_env() now delegates to the SAME scrub_env() mechanism
+# those three use, rather than carrying a second, hand-rolled rule.
 #
-# It does NOT reuse DEFAULT_SCRUB_KEY_PATTERNS verbatim, though — measured: swapping it
-# in unscoped turned test_extra_env_cannot_reintroduce_credentials red, because this
-# lane's OWN child process legitimately reads a provider API key from env to
-# authenticate outbound (DEEPSEEK_API_KEY / MOONSHOT_API_KEY / OPENROUTER_API_KEY — see
-# _PROVIDER_KEY_REQS in _litellm_runner.py / _litellm_agentic_runner.py, both *_KEY
-# shaped). Unlike the OAuth-only kimi/codex/gemini CLIs (which read zero *_KEY-shaped
-# vars themselves), the blanket `*_KEY` glob would strip this lane's own required
-# credentials and break every litellm-routed dispatch's auth. So this pattern set is
-# DEFAULT_SCRUB_KEY_PATTERNS computed MINUS that one glob — everything else (`*_PASS`,
-# `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, and the explicit literals) still applies.
-# ANTHROPIC_API_KEY stays covered regardless: it is ALSO listed as its own explicit
-# literal in DEFAULT_SCRUB_KEY_PATTERNS, independent of the `*_KEY` glob (measured via
-# fnmatch.fnmatchcase against every pattern in the shared set) — dropping only the glob
-# loses no coverage this lane relied on.
-_LITELLM_SCRUB_PATTERNS: frozenset = DEFAULT_SCRUB_KEY_PATTERNS - {"*_KEY"}
+# Round 1 excepted the WHOLE `*_KEY` glob from the pattern set (because this lane's own
+# child process legitimately reads a provider API key from env to authenticate outbound
+# — unlike the OAuth-only kimi/codex/gemini CLIs, which read zero *_KEY-shaped vars).
+# That was too broad, found in review: it let ANY *_KEY-shaped secret survive for
+# exactly the lane an external/untrusted model can direct via run_command (audit S1) —
+# OPENAI_API_KEY, SUPABASE_KEY, whatever else happens to be in the parent env, not just
+# the three keys this lane actually needs.
+#
+# Round 2: keep `*_KEY` IN the pattern set (full DEFAULT_SCRUB_KEY_PATTERNS, no
+# subtraction), and instead carve out a NEED-BASED exception — restore only the exact
+# values _litellm_runner.py's _PROVIDER_KEY_REQS declares (imported as the SSOT, not
+# re-hardcoded here, so a new provider added there is picked up automatically).
+# ANTHROPIC_API_KEY is never in that need-based set, so it stays scrubbed regardless —
+# no interaction with the exception below.
+_NEEDED_PROVIDER_KEYS: frozenset = frozenset(_PROVIDER_KEY_REQS.values())
 
 
 def _scrubbed_env(extra_env: Optional[Dict[str, str]]) -> Dict[str, str]:
-    """Merge extra_env over the parent env, then strip every secret-shaped key this
-    lane does not itself need (see _LITELLM_SCRUB_PATTERNS above)."""
+    """Merge extra_env over the parent env, then strip every secret-shaped key,
+    restoring only the specific provider keys this lane's own child process needs
+    (see _NEEDED_PROVIDER_KEYS above) — a need-based exception, not a blanket
+    `*_KEY` carve-out."""
     env = {**os.environ, **(extra_env or {})}
-    return scrub_env(env, _LITELLM_SCRUB_PATTERNS)
+    scrubbed = scrub_env(env, DEFAULT_SCRUB_KEY_PATTERNS)
+    for _key in _NEEDED_PROVIDER_KEYS:
+        if _key in env:
+            scrubbed[_key] = env[_key]
+    return scrubbed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm_spawn_credential_scrub.py
+++ b/tests/test_litellm_spawn_credential_scrub.py
@@ -31,6 +31,13 @@ _LEAKED_OAUTH_TOKEN = "oauth-real-production-session-token"
 # _scrubbed_env() now routes through the FULL DEFAULT_SCRUB_KEY_PATTERNS set, not
 # just its own hand-rolled two-key allowlist.
 _LEAKED_SMTP_PASS = "fake-test-smtp-secret-not-real"
+# OI-1619 followup round 2 (coordinator review): a fabricated *_KEY-shaped secret
+# this lane does NOT need — not deepseek/moonshot/openrouter's own key. Proves the
+# need-based exception is scoped to exactly the lane's required keys, not a blanket
+# `*_KEY` carve-out that would let ANY such secret (OPENAI_API_KEY, SUPABASE_KEY,
+# whatever else happens to be in the parent env) survive for a subprocess an external
+# model can direct via run_command (audit S1).
+_LEAKED_UNNEEDED_KEY = "fake-test-unneeded-api-key-not-real"
 
 
 def _leaked_credentials_env() -> dict:
@@ -72,6 +79,21 @@ class TestScrubbedEnvHelper:
         ):
             env = ls._scrubbed_env(None)
         assert "VNX_SMTP_PASS" not in env
+        assert env["PATH"] == "/usr/bin"
+
+    def test_unneeded_key_shaped_secret_is_scrubbed(self):
+        """OI-1619 followup round 2 (coordinator review): a prior version of this
+        function excepted the WHOLE `*_KEY` glob from the pattern set, so any
+        *_KEY-shaped secret survived — not just the three provider keys this lane
+        actually needs (_PROVIDER_KEY_REQS). This must be scrubbed like any other
+        secret; only the lane's own needed keys get the exception."""
+        with patch.dict(
+            "os.environ",
+            {"SOMETHING_UNNEEDED_API_KEY": _LEAKED_UNNEEDED_KEY, "PATH": "/usr/bin"},
+            clear=True,
+        ):
+            env = ls._scrubbed_env(None)
+        assert "SOMETHING_UNNEEDED_API_KEY" not in env
         assert env["PATH"] == "/usr/bin"
 
     def test_own_provider_keys_survive_the_broader_scrub(self):

--- a/tests/test_litellm_spawn_credential_scrub.py
+++ b/tests/test_litellm_spawn_credential_scrub.py
@@ -26,6 +26,11 @@ from provider_spawns import litellm_spawn as ls  # noqa: E402
 
 _LEAKED_ANTHROPIC_KEY = "sk-ant-real-production-key"
 _LEAKED_OAUTH_TOKEN = "oauth-real-production-session-token"
+# OI-1619 followup: a fabricated (never-real) secret shaped like the exact literal
+# VNX_SMTP_PASS finding that motivated the sibling kimi/codex/gemini fix — proves
+# _scrubbed_env() now routes through the FULL DEFAULT_SCRUB_KEY_PATTERNS set, not
+# just its own hand-rolled two-key allowlist.
+_LEAKED_SMTP_PASS = "fake-test-smtp-secret-not-real"
 
 
 def _leaked_credentials_env() -> dict:
@@ -55,6 +60,39 @@ class TestScrubbedEnvHelper:
         assert "ANTHROPIC_API_KEY" not in env
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
         assert env["DEEPSEEK_API_KEY"] == "sk-deepseek-own-key"
+
+    def test_vnx_smtp_pass_shaped_secret_is_scrubbed(self):
+        """OI-1619 followup: _scrubbed_env()'s OWN pre-existing allowlist
+        (ANTHROPIC_API_KEY + CLAUDE_CODE_OAUTH_TOKEN, exact-key only) never covered
+        this shape — this is the same defect class the sibling kimi/codex/gemini fix
+        closed, one lane over. A litellm-routed external model's run_command tool
+        (audit S1) could read it out of its own subprocess env."""
+        with patch.dict(
+            "os.environ", {"VNX_SMTP_PASS": _LEAKED_SMTP_PASS, "PATH": "/usr/bin"}, clear=True,
+        ):
+            env = ls._scrubbed_env(None)
+        assert "VNX_SMTP_PASS" not in env
+        assert env["PATH"] == "/usr/bin"
+
+    def test_own_provider_keys_survive_the_broader_scrub(self):
+        """OI-1619 followup regression guard: the naive fix (swap in the FULL
+        DEFAULT_SCRUB_KEY_PATTERNS unscoped) would strip every *_KEY-shaped var,
+        including the provider API keys _litellm_runner.py / _litellm_agentic_runner.py
+        themselves read from env to authenticate outbound (_PROVIDER_KEY_REQS) — that
+        would break every litellm-routed dispatch's own auth. This must never regress."""
+        with patch.dict(
+            "os.environ",
+            {
+                "DEEPSEEK_API_KEY": "sk-deepseek-own-key",
+                "MOONSHOT_API_KEY": "sk-moonshot-own-key",
+                "OPENROUTER_API_KEY": "sk-openrouter-own-key",
+            },
+            clear=True,
+        ):
+            env = ls._scrubbed_env(None)
+        assert env["DEEPSEEK_API_KEY"] == "sk-deepseek-own-key"
+        assert env["MOONSHOT_API_KEY"] == "sk-moonshot-own-key"
+        assert env["OPENROUTER_API_KEY"] == "sk-openrouter-own-key"
 
 
 class TestOneShotSpawnPopenEnv:
@@ -89,6 +127,38 @@ class TestOneShotSpawnPopenEnv:
         assert env is not None, "Popen must receive an explicit env dict"
         assert "ANTHROPIC_API_KEY" not in env
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
+    def test_final_popen_env_excludes_vnx_smtp_pass_shaped_secret(self):
+        """OI-1619 followup: the Popen boundary, not just the _scrubbed_env() unit."""
+        captured = {}
+
+        class _FakeProc:
+            returncode = 0
+            stdin = MagicMock()
+            stdout = MagicMock()
+            stderr = MagicMock()
+
+            def wait(self, timeout=None):
+                return 0
+
+        def _fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _FakeProc()
+
+        with patch.dict(
+            "os.environ", {"VNX_SMTP_PASS": _LEAKED_SMTP_PASS, "PATH": "/usr/bin"}, clear=True,
+        ), patch("provider_spawns.litellm_spawn.subprocess.Popen", _fake_popen):
+            ls._start_litellm_subprocess(
+                runner_path="/fake/runner.py",
+                payload_json="{}",
+                extra_env=None,
+                cwd=None,
+            )
+
+        env = captured.get("env")
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "VNX_SMTP_PASS" not in env
+        assert env.get("PATH") == "/usr/bin"
 
 
 class TestAgenticSpawnPopenEnv:

--- a/tests/test_provider_spawn_env_scrub.py
+++ b/tests/test_provider_spawn_env_scrub.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""test_provider_spawn_env_scrub.py — OI-1619 regression.
+
+kimi_spawn.py, codex_spawn.py, and gemini_spawn.py each Popen a real worker CLI
+directly (no SubprocessAdapter to route through — that's the claude lane's job,
+covered separately by test_spawn_scrub_env_keys_contract.py). All three built their
+child env as ``{**os.environ, **(extra_env or {})}`` with ZERO scrubbing: any secret
+present in the parent process (``VNX_SMTP_PASS`` measured present in-process, same
+finding class as the claude-lane gap fixed 2026-09-03) crossed straight into the
+kimi/codex/gemini subprocess. Unlike litellm_spawn.py (which already had its own,
+narrower ``_scrubbed_env()`` — ANTHROPIC_API_KEY + CLAUDE_CODE_OAUTH_TOKEN only), these
+three had no scrub call of any kind.
+
+The fix: ``env_scrub_patterns.scrub_env()`` (a small fnmatch-based free function
+mirroring SubprocessAdapter.deliver()'s inline scrub loop, for callers that Popen
+directly and have no SubprocessAdapter to route through) applied with
+``DEFAULT_SCRUB_KEY_PATTERNS`` at the one place each of the three files builds its
+Popen env.
+
+Each test below drives the real top-level spawn_*() entry point end-to-end (not an
+internal helper) with ``subprocess.Popen`` faked to capture the ``env=`` kwarg and then
+raise ``FileNotFoundError`` — the same "binary not found" path every one of these three
+functions already handles as a clean, immediate return (returncode=127), so the test
+never needs to fake the streaming/drain machinery downstream. This proves the actual
+GEDRAG (a secret demonstrably not reaching the child env), not a string or line number.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from provider_spawns import codex_spawn as cs  # noqa: E402
+from provider_spawns import gemini_spawn as gs  # noqa: E402
+from provider_spawns import kimi_spawn as ks  # noqa: E402
+
+_FAKE_SMTP_PASS = "fake-test-smtp-secret-not-real"
+_FAKE_WORKER_TOKEN = "fake-test-worker-token-not-real"
+
+
+def _leaked_secrets_env() -> dict:
+    """A fabricated (never-real) parent env carrying two secret shapes:
+    an exact literal name (``VNX_SMTP_PASS``, listed explicitly in
+    DEFAULT_SCRUB_KEY_PATTERNS) and a glob-matched name (``*_TOKEN``). ``PATH`` is a
+    benign var that must survive the scrub — an over-eager scrub is as much a defect
+    as an absent one.
+    """
+    return {
+        "VNX_SMTP_PASS": _FAKE_SMTP_PASS,
+        "SOME_SERVICE_TOKEN": _FAKE_WORKER_TOKEN,
+        "PATH": "/usr/bin",
+    }
+
+
+def _capture_env_via_not_found_popen(captured: dict):
+    """A fake Popen that records the env= kwarg then raises FileNotFoundError —
+    the "binary not found" path every one of the three spawn functions already
+    handles as an immediate, clean return, so the caller never touches the
+    streaming/drain machinery that follows a real Popen success.
+    """
+    def _fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        raise FileNotFoundError("fake binary intentionally absent for this test")
+    return _fake_popen
+
+
+class TestKimiSpawnEnvScrub:
+    def test_leaked_secrets_absent_from_final_popen_env(self):
+        captured: dict = {}
+        with patch.dict("os.environ", _leaked_secrets_env(), clear=True), \
+                patch("provider_spawns.kimi_spawn.subprocess.Popen", _capture_env_via_not_found_popen(captured)):
+            result = ks.spawn_kimi(prompt="test", dispatch_id="d-scrub-kimi", terminal_id="T1")
+
+        assert result.returncode == 127, "expected the fake-missing-binary path"
+        env = captured.get("env")
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "VNX_SMTP_PASS" not in env
+        assert "SOME_SERVICE_TOKEN" not in env
+        assert env.get("PATH") == "/usr/bin"
+
+
+class TestCodexSpawnEnvScrub:
+    def test_leaked_secrets_absent_from_final_popen_env(self):
+        captured: dict = {}
+        with patch.dict("os.environ", _leaked_secrets_env(), clear=True), \
+                patch("provider_spawns.codex_spawn.subprocess.Popen", _capture_env_via_not_found_popen(captured)):
+            result = cs.spawn_codex(
+                prompt="test", model=None, dispatch_id="d-scrub-codex", terminal_id="T1",
+            )
+
+        assert result.returncode == 127, "expected the fake-missing-binary path"
+        env = captured.get("env")
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "VNX_SMTP_PASS" not in env
+        assert "SOME_SERVICE_TOKEN" not in env
+        assert env.get("PATH") == "/usr/bin"
+
+
+class TestGeminiSpawnEnvScrub:
+    def test_leaked_secrets_absent_from_final_popen_env(self):
+        captured: dict = {}
+        with patch.dict("os.environ", _leaked_secrets_env(), clear=True), \
+                patch("provider_spawns.gemini_spawn.subprocess.Popen", _capture_env_via_not_found_popen(captured)):
+            result = gs.spawn_gemini(
+                prompt="test", model="gemini-2.5-pro", dispatch_id="d-scrub-gemini", terminal_id="T1",
+            )
+
+        assert result.returncode == 127, "expected the fake-missing-binary path"
+        env = captured.get("env")
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "VNX_SMTP_PASS" not in env
+        assert "SOME_SERVICE_TOKEN" not in env
+        assert env.get("PATH") == "/usr/bin"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_provider_spawn_env_scrub_contract.py
+++ b/tests/test_provider_spawn_env_scrub_contract.py
@@ -24,15 +24,30 @@ This test is the STATIC backstop: an AST scan over every git-tracked, non-test .
 file under ``scripts/lib/provider_spawns/`` (the directory every provider spawn lane
 lives in — extraction convention shared by every file there, see each module's own
 "Extracted in Wave 4.6" header) for a ``subprocess.Popen(...)`` / ``subprocess.run(...)``
-call carrying an ``env=`` kwarg whose value does not resolve to a call to
-``scrub_env(...)`` (this fix) or ``_scrubbed_env(...)`` (litellm_spawn.py's own,
-narrower, pre-existing, documented scrub — see its own CREDENTIAL SAFETY docstring;
-recognising it here is NOT a judgment that its narrower coverage is sufficient, only
-that it is a deliberate, existing scrub call, not the "no scrub at all" defect this
-guard exists to catch). A brand-new provider_spawns file added later that Popens a
-worker CLI with a raw ``{**os.environ, ...}`` env and no scrub call is caught by this
-scan automatically, the same "catch the lane that doesn't exist yet" property the
-phantom-guard and claude-scrub call-site guards both have.
+call carrying an ``env=`` kwarg whose value does not resolve to ``scrub_env(...)``,
+directly or through exactly one named local helper (e.g. litellm_spawn.py's own
+``_scrubbed_env()``, which delegates to ``scrub_env()`` with its own, narrower
+pattern set — see its own CREDENTIAL SAFETY docstring). A brand-new provider_spawns
+file added later that Popens a worker CLI with a raw ``{**os.environ, ...}`` env and
+no scrub call is caught by this scan automatically, the same "catch the lane that
+doesn't exist yet" property the phantom-guard and claude-scrub call-site guards both
+have.
+
+Round 1 of this guard trusted ANY function named ``scrub_env`` or ``_scrubbed_env`` by
+NAME alone — a real gap, found in review: litellm_spawn.py's ``_scrubbed_env()``
+originally hand-rolled its own two-key strip (``ANTHROPIC_API_KEY`` +
+``CLAUDE_CODE_OAUTH_TOKEN``, exact-key only) with no call to the shared
+``scrub_env()`` at all, and the guard called it safe purely because of its name — it
+would have said the same about ANY function named ``_scrubbed_env``, including one
+that scrubbed nothing. This round replaces the name allowlist with a PROPERTY check:
+``_call_resolves_to_scrub_env()`` requires the call target to be ``scrub_env`` itself,
+OR a locally-defined function whose OWN body (walked via ``ast.walk``, any depth
+within that one function) contains a real call to ``scrub_env(...)``. One hop of
+named-helper indirection is resolved; a helper that calls a second, differently-named
+helper that itself calls ``scrub_env`` is NOT resolved and fails closed as unsafe
+(over-flag rather than under-flag — the safe failure direction for a security guard).
+litellm_spawn.py's real ``_scrubbed_env()`` (a single function whose body directly
+calls ``scrub_env(env, _LITELLM_SCRUB_PATTERNS)``) resolves cleanly under this rule.
 
 A ``subprocess.Popen(...)``/``subprocess.run(...)`` call with NO ``env=`` kwarg at all
 (e.g. kimi_spawn.py's internal ``git status``/``git diff`` calls, which inherit the
@@ -59,7 +74,7 @@ REPO = Path(__file__).resolve().parent.parent
 TARGET_DIR = REPO / "scripts" / "lib" / "provider_spawns"
 
 _POPEN_METHODS = frozenset({"Popen", "run"})
-_SAFE_SCRUB_CALL_NAMES = frozenset({"scrub_env", "_scrubbed_env"})
+_SCRUB_ENV_NAME = "scrub_env"
 _ENV_KWARG = "env"
 
 
@@ -111,19 +126,57 @@ def _is_subprocess_popen_or_run(node: ast.Call) -> bool:
     )
 
 
-def _collect_safe_assigned_names(tree: ast.Module) -> set[str]:
+def _function_defs_by_name(tree: ast.Module) -> "dict[str, ast.AST]":
+    """Map of function name -> its FunctionDef/AsyncFunctionDef node, module-wide
+    (last definition wins on a name collision — a theoretical, not real, edge case
+    in this repo's small provider_spawns modules)."""
+    defs: "dict[str, ast.AST]" = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            defs[node.name] = node
+    return defs
+
+
+def _calls_scrub_env(node: ast.AST) -> bool:
+    """True iff a direct call to ``scrub_env(...)`` appears anywhere in *node*'s
+    subtree (any statement, any nesting depth within that one function body)."""
+    return any(
+        isinstance(sub, ast.Call) and _call_target_name(sub) == _SCRUB_ENV_NAME
+        for sub in ast.walk(node)
+    )
+
+
+def _call_resolves_to_scrub_env(call_name: str, funcs: "dict[str, ast.AST]") -> bool:
+    """PROPERTY check, not a name allowlist: *call_name* is safe when it IS
+    ``scrub_env`` itself, or when it names a function defined in this module whose
+    OWN body actually calls ``scrub_env(...)`` — e.g. litellm_spawn.py's
+    ``_scrubbed_env()``, which delegates to ``scrub_env()`` with its own pattern set.
+    A function with any other name, or one that does not itself call ``scrub_env``
+    (however it's named), resolves to False. Only one hop of named-helper
+    indirection is resolved — a helper that calls a second, differently-named helper
+    which itself calls ``scrub_env`` is NOT resolved and fails closed as unsafe."""
+    if call_name == _SCRUB_ENV_NAME:
+        return True
+    func = funcs.get(call_name)
+    if func is None:
+        return False
+    return _calls_scrub_env(func)
+
+
+def _collect_safe_assigned_names(tree: ast.Module, funcs: "dict[str, ast.AST]") -> set[str]:
     """Names of local variables whose assigned expression contains (anywhere in its
-    subtree) a call to a known-safe scrub function. Deliberately module-wide and
-    scope-blind — same "good enough, no false negatives in this repo today" tradeoff
-    documented in test_spawn_scrub_env_keys_contract.py's
-    ``_subprocess_adapter_var_names``.
+    subtree) a call that resolves to ``scrub_env`` under ``_call_resolves_to_scrub_env``.
+    Deliberately module-wide and scope-blind — same "good enough, no false negatives
+    in this repo today" tradeoff documented in
+    test_spawn_scrub_env_keys_contract.py's ``_subprocess_adapter_var_names``.
     """
     names: set[str] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assign):
             continue
         contains_safe_call = any(
-            isinstance(sub, ast.Call) and _call_target_name(sub) in _SAFE_SCRUB_CALL_NAMES
+            isinstance(sub, ast.Call)
+            and _call_resolves_to_scrub_env(_call_target_name(sub) or "", funcs)
             for sub in ast.walk(node.value)
         )
         if not contains_safe_call:
@@ -142,9 +195,11 @@ def _env_kwarg_value(call: ast.Call) -> "tuple[bool, Optional[ast.AST]]":
     return False, None
 
 
-def _env_value_is_safe(value: ast.AST, safe_names: set[str]) -> bool:
-    if isinstance(value, ast.Call) and _call_target_name(value) in _SAFE_SCRUB_CALL_NAMES:
-        return True
+def _env_value_is_safe(value: ast.AST, safe_names: set[str], funcs: "dict[str, ast.AST]") -> bool:
+    if isinstance(value, ast.Call):
+        name = _call_target_name(value)
+        if name and _call_resolves_to_scrub_env(name, funcs):
+            return True
     if isinstance(value, ast.Name):
         return value.id in safe_names
     return False
@@ -173,7 +228,8 @@ def _find_popen_env_sites(
                 f"cannot parse {rel} while scanning for Popen/run env= call sites: {exc}"
             ) from exc
 
-        safe_names = _collect_safe_assigned_names(tree)
+        funcs = _function_defs_by_name(tree)
+        safe_names = _collect_safe_assigned_names(tree, funcs)
         sites: list[tuple[int, bool]] = []
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call) or not _is_subprocess_popen_or_run(node):
@@ -181,7 +237,7 @@ def _find_popen_env_sites(
             has_env, value = _env_kwarg_value(node)
             if not has_env:
                 continue
-            is_safe = _env_value_is_safe(value, safe_names)
+            is_safe = _env_value_is_safe(value, safe_names, funcs)
             sites.append((node.lineno, is_safe))
         if sites:
             found[str(rel)] = sites
@@ -192,16 +248,19 @@ _KNOWN_CALL_SITE_FILES = frozenset({
     "scripts/lib/provider_spawns/kimi_spawn.py",
     "scripts/lib/provider_spawns/codex_spawn.py",
     "scripts/lib/provider_spawns/gemini_spawn.py",
+    "scripts/lib/provider_spawns/litellm_spawn.py",
 })
 
 
 class TestEveryProviderSpawnPopenSupplessScrubbedEnv:
     """The wachter: every real, git-tracked subprocess.Popen()/subprocess.run() call
     under scripts/lib/provider_spawns/ that carries an env= kwarg must resolve that
-    kwarg to a call to scrub_env(...) or _scrubbed_env(...). This does not enumerate a
-    fixed baseline of files (unlike a growth-tripwire test) — a brand-new provider
-    spawn lane is picked up automatically by the git-tracked-.py scan and held to the
-    same bar, without this test needing to be edited."""
+    kwarg to scrub_env(...), directly or through one named local helper whose own
+    body actually calls it (see _call_resolves_to_scrub_env — a property check, not
+    a name allowlist). This does not enumerate a fixed baseline of files (unlike a
+    growth-tripwire test) — a brand-new provider spawn lane is picked up
+    automatically by the git-tracked-.py scan and held to the same bar, without this
+    test needing to be edited."""
 
     def test_known_call_sites_are_found(self):
         sites = _find_popen_env_sites(REPO, TARGET_DIR)
@@ -210,7 +269,7 @@ class TestEveryProviderSpawnPopenSupplessScrubbedEnv:
 
     def test_every_popen_env_kwarg_resolves_to_a_scrub_call(self):
         sites = _find_popen_env_sites(REPO, TARGET_DIR)
-        assert sites, "expected at least the three known call-site files"
+        assert sites, "expected at least the four known call-site files"
         problems = []
         for rel, calls in sites.items():
             for lineno, is_safe in calls:
@@ -218,9 +277,10 @@ class TestEveryProviderSpawnPopenSupplessScrubbedEnv:
                     problems.append(f"{rel}:{lineno}")
         assert not problems, (
             "subprocess.Popen()/subprocess.run() call(s) under provider_spawns/ pass "
-            "an env= kwarg that does not resolve to scrub_env(...) or "
-            "_scrubbed_env(...) — the worker subprocess would inherit the full "
-            "ambient environment, secrets included:\n" + "\n".join(problems)
+            "an env= kwarg that does not resolve (directly, or through one named "
+            "local helper that itself calls it) to scrub_env(...) — the worker "
+            "subprocess would inherit the full ambient environment, secrets "
+            "included:\n" + "\n".join(problems)
         )
 
 
@@ -248,7 +308,18 @@ _GOOD_VAR_CALL_SITE = (
     "proc = subprocess.Popen(cmd, env=env)\n"
 )
 
-_GOOD_LITELLM_STYLE_SITE = (
+_GOOD_INDIRECT_HELPER_SITE = (
+    "import os\n"
+    "import subprocess\n"
+    "from env_scrub_patterns import scrub_env\n"
+    "def _my_arbitrarily_named_helper(extra_env):\n"
+    "    env = {**os.environ, **(extra_env or {})}\n"
+    "    return scrub_env(env, frozenset({'*_PASS'}))\n"
+    "env = _my_arbitrarily_named_helper(None)\n"
+    "proc = subprocess.Popen(cmd, env=env)\n"
+)
+
+_BAD_SCRUBBED_ENV_NAMED_HELPER_THAT_NEVER_CALLS_SCRUB_ENV = (
     "import os\n"
     "import subprocess\n"
     "def _scrubbed_env(extra_env):\n"
@@ -290,10 +361,14 @@ class TestCallSiteGuardCanActuallyFail:
             for _lineno, is_safe in calls:
                 assert is_safe
 
-    def test_a_compliant_litellm_style_underscore_scrub_call_site_passes(self, tmp_path):
+    def test_a_compliant_indirect_helper_with_an_arbitrary_name_passes(self, tmp_path):
+        """PROPERTY, not name: a locally-defined helper whose own body actually calls
+        scrub_env(...) is trusted regardless of what it's called — this is what makes
+        litellm_spawn.py's real _scrubbed_env() (a different name, same property)
+        resolve, without hardcoding that one name into the guard."""
         _git_init(tmp_path)
         (tmp_path / "provider_spawns").mkdir()
-        (tmp_path / "provider_spawns" / "good.py").write_text(_GOOD_LITELLM_STYLE_SITE, encoding="utf-8")
+        (tmp_path / "provider_spawns" / "good.py").write_text(_GOOD_INDIRECT_HELPER_SITE, encoding="utf-8")
         _git_add(tmp_path, "provider_spawns/good.py")
 
         sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
@@ -301,6 +376,29 @@ class TestCallSiteGuardCanActuallyFail:
         for calls in sites.values():
             for _lineno, is_safe in calls:
                 assert is_safe
+
+    def test_a_helper_merely_named_scrubbed_env_that_never_calls_scrub_env_turns_the_assertion_red(self, tmp_path):
+        """The literal loophole Round 1 of this guard had: it trusted ANY function
+        named scrub_env or _scrubbed_env by NAME alone. litellm_spawn.py's real
+        _scrubbed_env() happened to be safe, but the guard could not tell that apart
+        from a same-named function that scrubs nothing at all — this fixture IS that
+        function. The property check must reject it precisely because its body never
+        calls scrub_env(...), regardless of its name."""
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "bad.py").write_text(
+            _BAD_SCRUBBED_ENV_NAMED_HELPER_THAT_NEVER_CALLS_SCRUB_ENV, encoding="utf-8",
+        )
+        _git_add(tmp_path, "provider_spawns/bad.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        problems = [
+            (rel, lineno)
+            for rel, calls in sites.items()
+            for lineno, is_safe in calls
+            if not is_safe
+        ]
+        assert problems == [("provider_spawns/bad.py", 8)]
 
     def test_a_raw_os_environ_merge_with_no_scrub_call_turns_the_assertion_red(self, tmp_path):
         """The literal historic defect: kimi/codex/gemini built

--- a/tests/test_provider_spawn_env_scrub_contract.py
+++ b/tests/test_provider_spawn_env_scrub_contract.py
@@ -1,0 +1,426 @@
+"""tests/test_provider_spawn_env_scrub_contract.py — a call-site guard over
+``scripts/lib/provider_spawns/`` for OI-1619, mirroring
+tests/test_spawn_scrub_env_keys_contract.py's AST-scan pattern (itself mirroring
+tests/test_phantom_guard_context_contract.py's, PR #1748/OI-1614) rather than
+inventing a second mechanism.
+
+Defect this closes: kimi_spawn.py, codex_spawn.py, and gemini_spawn.py each Popen a
+real worker CLI directly — they have no SubprocessAdapter to route through, so they
+are NOT covered by test_spawn_scrub_env_keys_contract.py's guard (which only owns
+``spawn_claude(...)`` and ``<SubprocessAdapter-instance>.deliver(...)`` call sites).
+All three built their child env as ``{**os.environ, **(extra_env or {})}`` with ZERO
+scrub call of any kind — not even litellm_spawn.py's own narrower
+``_scrubbed_env()``. Measured 2026-09-04 (mirrors the claude-lane finding of
+2026-09-03): a secret present in the parent process (``VNX_SMTP_PASS``) would cross
+straight into the kimi/codex/gemini subprocess.
+
+The fix (env_scrub_patterns.py) adds ``scrub_env()`` — a small fnmatch-based free
+function mirroring SubprocessAdapter.deliver()'s inline scrub loop, for a caller that
+Popens directly and has no adapter to route the scrub through — and calls it with
+``DEFAULT_SCRUB_KEY_PATTERNS`` at the one place each of kimi_spawn.py, codex_spawn.py,
+and gemini_spawn.py builds its Popen env.
+
+This test is the STATIC backstop: an AST scan over every git-tracked, non-test .py
+file under ``scripts/lib/provider_spawns/`` (the directory every provider spawn lane
+lives in — extraction convention shared by every file there, see each module's own
+"Extracted in Wave 4.6" header) for a ``subprocess.Popen(...)`` / ``subprocess.run(...)``
+call carrying an ``env=`` kwarg whose value does not resolve to a call to
+``scrub_env(...)`` (this fix) or ``_scrubbed_env(...)`` (litellm_spawn.py's own,
+narrower, pre-existing, documented scrub — see its own CREDENTIAL SAFETY docstring;
+recognising it here is NOT a judgment that its narrower coverage is sufficient, only
+that it is a deliberate, existing scrub call, not the "no scrub at all" defect this
+guard exists to catch). A brand-new provider_spawns file added later that Popens a
+worker CLI with a raw ``{**os.environ, ...}`` env and no scrub call is caught by this
+scan automatically, the same "catch the lane that doesn't exist yet" property the
+phantom-guard and claude-scrub call-site guards both have.
+
+A ``subprocess.Popen(...)``/``subprocess.run(...)`` call with NO ``env=`` kwarg at all
+(e.g. kimi_spawn.py's internal ``git status``/``git diff`` calls, which inherit the
+ambient env implicitly like any ordinary trusted-tool shell-out) is out of this guard's
+scope — the defect class it exists for is a WORKER-CLI subprocess receiving a
+merged/inherited env explicitly, not every subprocess call in the directory.
+
+claude_spawn.py, glm_harness_spawn.py, and deepseek_harness_spawn.py never call
+subprocess.Popen/run directly (they route through SubprocessAdapter.deliver(), already
+covered by test_spawn_scrub_env_keys_contract.py) so they never match this guard's
+Popen/run+env= pattern — no special-casing needed for them.
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+TARGET_DIR = REPO / "scripts" / "lib" / "provider_spawns"
+
+_POPEN_METHODS = frozenset({"Popen", "run"})
+_SAFE_SCRUB_CALL_NAMES = frozenset({"scrub_env", "_scrubbed_env"})
+_ENV_KWARG = "env"
+
+
+def _git_tracked_py_files(root: Path, subdir: Path) -> list[Path]:
+    """Absolute paths to every git-tracked ``.py`` file under *subdir* (relative to
+    *root*). Tracked-ness, not a directory namelist, keeps a build artifact / nested
+    worktree / CI rollout copy out of the scan. Fails CLOSED — raises
+    ``RuntimeError`` — when git is unavailable (OI-1597 precedent), rather than
+    silently falling back to an incomplete namelist.
+    """
+    rel_subdir = subdir.relative_to(root)
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--", f"{rel_subdir}/*.py"],
+            cwd=str(root), capture_output=True, timeout=10,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"git is not available to determine tracked .py files under {subdir}"
+        ) from exc
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"`git ls-files` failed under {root} (not a git work tree?): {stderr}")
+    stdout = result.stdout.decode("utf-8")
+    return [root / rel for rel in stdout.split("\0") if rel]
+
+
+def _call_target_name(node: ast.AST) -> Optional[str]:
+    """The bare callee name of an ast.Call — 'foo' for both foo(...) and mod.foo(...)."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_subprocess_popen_or_run(node: ast.Call) -> bool:
+    """True for ``subprocess.Popen(...)`` / ``subprocess.run(...)`` specifically —
+    not any unrelated object's same-named ``.Popen``/``.run`` method."""
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in _POPEN_METHODS
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    )
+
+
+def _collect_safe_assigned_names(tree: ast.Module) -> set[str]:
+    """Names of local variables whose assigned expression contains (anywhere in its
+    subtree) a call to a known-safe scrub function. Deliberately module-wide and
+    scope-blind — same "good enough, no false negatives in this repo today" tradeoff
+    documented in test_spawn_scrub_env_keys_contract.py's
+    ``_subprocess_adapter_var_names``.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        contains_safe_call = any(
+            isinstance(sub, ast.Call) and _call_target_name(sub) in _SAFE_SCRUB_CALL_NAMES
+            for sub in ast.walk(node.value)
+        )
+        if not contains_safe_call:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                names.add(target.id)
+    return names
+
+
+def _env_kwarg_value(call: ast.Call) -> "tuple[bool, Optional[ast.AST]]":
+    """(has_env_kwarg, value_node) for the ``env=`` keyword on *call*, if any."""
+    for kw in call.keywords:
+        if kw.arg == _ENV_KWARG:
+            return True, kw.value
+    return False, None
+
+
+def _env_value_is_safe(value: ast.AST, safe_names: set[str]) -> bool:
+    if isinstance(value, ast.Call) and _call_target_name(value) in _SAFE_SCRUB_CALL_NAMES:
+        return True
+    if isinstance(value, ast.Name):
+        return value.id in safe_names
+    return False
+
+
+def _find_popen_env_sites(
+    root: Path, target_dir: Path,
+) -> dict[str, list[tuple[int, bool]]]:
+    """Map of relative-path -> list of (lineno, is_safe) for every
+    ``subprocess.Popen(...)``/``subprocess.run(...)`` call THAT CARRIES AN ``env=``
+    kwarg, over the git-tracked .py files rooted at *target_dir*. A call with no
+    ``env=`` kwarg at all is not a site (out of this guard's scope — see module
+    docstring).
+
+    An unparseable or non-UTF-8 file raises a clean AssertionError naming the file,
+    instead of letting the raw SyntaxError/UnicodeDecodeError traceback escape.
+    """
+    found: dict[str, list[tuple[int, bool]]] = {}
+    for full_path in _git_tracked_py_files(root, target_dir):
+        rel = full_path.relative_to(root)
+        try:
+            source = full_path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(full_path))
+        except (SyntaxError, UnicodeDecodeError, ValueError) as exc:
+            raise AssertionError(
+                f"cannot parse {rel} while scanning for Popen/run env= call sites: {exc}"
+            ) from exc
+
+        safe_names = _collect_safe_assigned_names(tree)
+        sites: list[tuple[int, bool]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_subprocess_popen_or_run(node):
+                continue
+            has_env, value = _env_kwarg_value(node)
+            if not has_env:
+                continue
+            is_safe = _env_value_is_safe(value, safe_names)
+            sites.append((node.lineno, is_safe))
+        if sites:
+            found[str(rel)] = sites
+    return found
+
+
+_KNOWN_CALL_SITE_FILES = frozenset({
+    "scripts/lib/provider_spawns/kimi_spawn.py",
+    "scripts/lib/provider_spawns/codex_spawn.py",
+    "scripts/lib/provider_spawns/gemini_spawn.py",
+})
+
+
+class TestEveryProviderSpawnPopenSupplessScrubbedEnv:
+    """The wachter: every real, git-tracked subprocess.Popen()/subprocess.run() call
+    under scripts/lib/provider_spawns/ that carries an env= kwarg must resolve that
+    kwarg to a call to scrub_env(...) or _scrubbed_env(...). This does not enumerate a
+    fixed baseline of files (unlike a growth-tripwire test) — a brand-new provider
+    spawn lane is picked up automatically by the git-tracked-.py scan and held to the
+    same bar, without this test needing to be edited."""
+
+    def test_known_call_sites_are_found(self):
+        sites = _find_popen_env_sites(REPO, TARGET_DIR)
+        missing = _KNOWN_CALL_SITE_FILES - set(sites)
+        assert not missing, f"expected call site(s) not found by the scan: {missing}"
+
+    def test_every_popen_env_kwarg_resolves_to_a_scrub_call(self):
+        sites = _find_popen_env_sites(REPO, TARGET_DIR)
+        assert sites, "expected at least the three known call-site files"
+        problems = []
+        for rel, calls in sites.items():
+            for lineno, is_safe in calls:
+                if not is_safe:
+                    problems.append(f"{rel}:{lineno}")
+        assert not problems, (
+            "subprocess.Popen()/subprocess.run() call(s) under provider_spawns/ pass "
+            "an env= kwarg that does not resolve to scrub_env(...) or "
+            "_scrubbed_env(...) — the worker subprocess would inherit the full "
+            "ambient environment, secrets included:\n" + "\n".join(problems)
+        )
+
+
+def _git_init(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=str(root), check=True)
+
+
+def _git_add(root: Path, *relative_paths: str) -> None:
+    subprocess.run(["git", "add", "--", *relative_paths], cwd=str(root), check=True)
+
+
+_GOOD_DIRECT_CALL_SITE = (
+    "import subprocess\n"
+    "from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS, scrub_env\n"
+    "proc = subprocess.Popen(\n"
+    "    cmd, env=scrub_env({**__import__('os').environ}, DEFAULT_SCRUB_KEY_PATTERNS),\n"
+    ")\n"
+)
+
+_GOOD_VAR_CALL_SITE = (
+    "import os\n"
+    "import subprocess\n"
+    "from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS, scrub_env\n"
+    "env = scrub_env({**os.environ}, DEFAULT_SCRUB_KEY_PATTERNS)\n"
+    "proc = subprocess.Popen(cmd, env=env)\n"
+)
+
+_GOOD_LITELLM_STYLE_SITE = (
+    "import os\n"
+    "import subprocess\n"
+    "def _scrubbed_env(extra_env):\n"
+    "    env = {**os.environ, **(extra_env or {})}\n"
+    "    env.pop('ANTHROPIC_API_KEY', None)\n"
+    "    return env\n"
+    "env = _scrubbed_env(None)\n"
+    "proc = subprocess.Popen(cmd, env=env)\n"
+)
+
+
+class TestCallSiteGuardCanActuallyFail:
+    """Een wachter die je niet hebt zien falen, bewaakt niets. ``_find_popen_env_sites``
+    and ``_env_value_is_safe`` are exercised directly against isolated fixture trees
+    (never the real repo) so this guard's MECHANISM is proven, not just today's three
+    call sites."""
+
+    def test_a_compliant_direct_scrub_call_site_passes(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "good.py").write_text(_GOOD_DIRECT_CALL_SITE, encoding="utf-8")
+        _git_add(tmp_path, "provider_spawns/good.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        assert sites, "expected the scan to find the call site"
+        for calls in sites.values():
+            for _lineno, is_safe in calls:
+                assert is_safe
+
+    def test_a_compliant_var_scrub_call_site_passes(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "good.py").write_text(_GOOD_VAR_CALL_SITE, encoding="utf-8")
+        _git_add(tmp_path, "provider_spawns/good.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        assert sites
+        for calls in sites.values():
+            for _lineno, is_safe in calls:
+                assert is_safe
+
+    def test_a_compliant_litellm_style_underscore_scrub_call_site_passes(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "good.py").write_text(_GOOD_LITELLM_STYLE_SITE, encoding="utf-8")
+        _git_add(tmp_path, "provider_spawns/good.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        assert sites
+        for calls in sites.values():
+            for _lineno, is_safe in calls:
+                assert is_safe
+
+    def test_a_raw_os_environ_merge_with_no_scrub_call_turns_the_assertion_red(self, tmp_path):
+        """The literal historic defect: kimi/codex/gemini built
+        env = {**os.environ, **(extra_env or {})} and Popen'd it directly, with no
+        scrub call anywhere in the module."""
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "bad.py").write_text(
+            "import os\n"
+            "import subprocess\n"
+            "env = {**os.environ, **(extra_env or {})}\n"
+            "proc = subprocess.Popen(cmd, env=env)\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "provider_spawns/bad.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        problems = [
+            (rel, lineno)
+            for rel, calls in sites.items()
+            for lineno, is_safe in calls
+            if not is_safe
+        ]
+        assert problems == [("provider_spawns/bad.py", 4)]
+
+    def test_a_direct_unscrubbed_env_kwarg_turns_the_assertion_red(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "bad.py").write_text(
+            "import os\n"
+            "import subprocess\n"
+            "proc = subprocess.Popen(cmd, env={**os.environ})\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "provider_spawns/bad.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        problems = [
+            (rel, lineno)
+            for rel, calls in sites.items()
+            for lineno, is_safe in calls
+            if not is_safe
+        ]
+        assert problems == [("provider_spawns/bad.py", 3)]
+
+    def test_a_popen_call_with_no_env_kwarg_is_ignored(self, tmp_path):
+        """kimi_spawn.py's internal `git status`/`git diff` calls carry no env=
+        kwarg at all — inheriting the ambient env implicitly for a trusted internal
+        tool is a different concern than the worker-CLI defect this guard owns."""
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "unrelated.py").write_text(
+            "import subprocess\n"
+            "proc = subprocess.run(['git', 'status'], capture_output=True)\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "provider_spawns/unrelated.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        assert sites == {}
+
+    def test_a_non_subprocess_popen_call_is_ignored(self, tmp_path):
+        """A same-named .Popen()/.run() method on an unrelated object must not be
+        flagged — this guard owns exactly `subprocess.Popen`/`subprocess.run`."""
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "unrelated.py").write_text(
+            "class FakeRunner:\n"
+            "    def run(self, cmd, env=None):\n"
+            "        pass\n"
+            "FakeRunner().run(cmd, env={'UNSAFE': '1'})\n",
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "provider_spawns/unrelated.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        assert sites == {}
+
+    def test_a_docstring_mention_does_not_trip_it(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "mentions_only.py").write_text(
+            '"""Eventually calls subprocess.Popen(cmd, env=scrub_env(...))."""\n',
+            encoding="utf-8",
+        )
+        _git_add(tmp_path, "provider_spawns/mentions_only.py")
+
+        sites = _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+        assert sites == {}
+
+    def test_an_untracked_file_does_not_trip_it(self, tmp_path):
+        """A fourth-lane call site that exists on disk but was never `git add`-ed (a
+        build artifact, a nested worktree, a scratch file) is invisible to the scan —
+        same property the beacon/phantom-guard/claude-scrub guards all rely on
+        (OI-1597)."""
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "existing.py").write_text(_GOOD_DIRECT_CALL_SITE, encoding="utf-8")
+        _git_add(tmp_path, "provider_spawns/existing.py")
+        baseline_files = set(_find_popen_env_sites(tmp_path, tmp_path / "provider_spawns"))
+
+        (tmp_path / "provider_spawns" / "untracked_bad.py").write_text(
+            "import os\n"
+            "import subprocess\n"
+            "proc = subprocess.Popen(cmd, env={**os.environ})\n",
+            encoding="utf-8",
+        )
+        # Deliberately never git add-ed.
+        matched_files = set(_find_popen_env_sites(tmp_path, tmp_path / "provider_spawns"))
+        assert matched_files == baseline_files
+
+    def test_an_unparseable_file_gives_a_clean_assertion_not_a_traceback(self, tmp_path):
+        _git_init(tmp_path)
+        (tmp_path / "provider_spawns").mkdir()
+        (tmp_path / "provider_spawns" / "broken.py").write_text("def broken(:\n    pass\n", encoding="utf-8")
+        _git_add(tmp_path, "provider_spawns/broken.py")
+
+        with pytest.raises(AssertionError, match="broken.py"):
+            _find_popen_env_sites(tmp_path, tmp_path / "provider_spawns")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Operator-afwijking

Deze agent draaide bewust BUITEN de VNX dispatch-deur om, als parallelle subagent via de Agent-tool (operator-besluit 04-09, verlengd) — niet via `vnx dispatch`.

## Summary

- `kimi_spawn.py`, `codex_spawn.py`, and `gemini_spawn.py` (all under `scripts/lib/provider_spawns/`, not `scripts/lib/` directly — the OI's assumed paths had shifted since a prior module extraction) each built their worker-CLI subprocess env as `{**os.environ, **(extra_env or {})}` with **zero scrubbing**. Any secret present in the parent process — `VNX_SMTP_PASS` included, the exact incident cited in the OI — crossed straight into the kimi/codex/gemini subprocess.
- This is the same defect class as the claude-lane gap fixed 2026-09-03 (`env_scrub_patterns.py`, `test_spawn_scrub_env_keys_contract.py`), but a level below `SubprocessAdapter`: these three Popen a worker CLI directly and have no adapter to route a scrub through.
- Verified `codex_spawn.py` and `gemini_spawn.py` independently before assuming they matched the kimi report — both had the identical `env = {**os.environ, **(extra_env or {})}` pattern, no scrub call anywhere upstream (`_worker_role_env` in `provider_dispatch.py` only sets `VNX_WORKER_ROLE`). **Neither was already safe.**
- **UPDATE (coordinator review, second commit):** `litellm_spawn.py`'s own `_scrubbed_env()` — narrower (only `ANTHROPIC_API_KEY` + `CLAUDE_CODE_OAUTH_TOKEN`, exact-key) — was originally left untouched as an out-of-scope, documented, pre-existing narrower scrub. Coordinator review found the guard itself had a real gap: it trusted ANY function named `scrub_env`/`_scrubbed_env` by NAME alone, so it called litellm's narrower helper "safe" without checking it actually routed through the shared pattern set. File scope extended to `litellm_spawn.py` + its test to close this.
- **UPDATE (coordinator review, third commit):** the second commit's fix (`DEFAULT_SCRUB_KEY_PATTERNS - {"*_KEY"}`) was itself too broad — it let ANY `*_KEY`-shaped secret survive for the litellm lane, not just the three provider keys it actually needs. Narrowed to a need-based exception. See the third section below.

## Changes

- `scripts/lib/env_scrub_patterns.py` — added `scrub_env(env, patterns)`, a small fnmatch-based free function mirroring `SubprocessAdapter.deliver()`'s inline scrub loop, for callers that Popen directly and have no `SubprocessAdapter` to route through.
- `scripts/lib/provider_spawns/kimi_spawn.py` — `spawn_kimi()`'s env-build line now calls `scrub_env(_isolate_kimi_env(...), DEFAULT_SCRUB_KEY_PATTERNS)`. This transitively covers the session-export harvest call (`_harvest_session_token_usage`, `kimi export ...`) and the session-reap call, since both reuse the same already-scrubbed `env` variable.
- `scripts/lib/provider_spawns/codex_spawn.py` — `_launch_codex_proc()`'s env-build line now calls `scrub_env(..., DEFAULT_SCRUB_KEY_PATTERNS)`.
- `scripts/lib/provider_spawns/gemini_spawn.py` — `spawn_gemini()`'s env-build line now calls `scrub_env(..., DEFAULT_SCRUB_KEY_PATTERNS)` (covers both the streaming and legacy sub-paths, which share this one env build).
- `scripts/lib/provider_spawns/litellm_spawn.py` — `_scrubbed_env()` now applies the FULL `DEFAULT_SCRUB_KEY_PATTERNS` via `scrub_env()`, restoring only the exact provider keys `_litellm_runner.py`'s `_PROVIDER_KEY_REQS` declares (`_NEEDED_PROVIDER_KEYS`, imported as the SSOT). `_CREDENTIAL_SCRUB_KEYS` (dead after commit 2) removed.
- `tests/test_provider_spawn_env_scrub.py` — new, behavioral RED→GREEN tests for kimi/codex/gemini.
- `tests/test_provider_spawn_env_scrub_contract.py` — new, the AST-scan "wachter" (reworked in commit 2 to a property check instead of a name allowlist).
- `tests/test_litellm_spawn_credential_scrub.py` — extended across commits 2 and 3 with the `VNX_SMTP_PASS`-shaped case, a need-based-exception case, and regression guards for litellm's own provider keys.

## Verification — commit 1 (kimi/codex/gemini)

**Behavioral test — RED before the fix, GREEN after** (drives each `spawn_*()` entry point end-to-end with `subprocess.Popen` faked to capture `env=` and raise `FileNotFoundError`, the "binary not found" path every one of the three already handles as a clean, immediate `returncode=127` return — so the test proves the real GEDRAG, not a string or line number):

RED:
```
FAILED tests/test_provider_spawn_env_scrub.py::TestKimiSpawnEnvScrub::test_leaked_secrets_absent_from_final_popen_env
FAILED tests/test_provider_spawn_env_scrub.py::TestCodexSpawnEnvScrub::test_leaked_secrets_absent_from_final_popen_env
FAILED tests/test_provider_spawn_env_scrub.py::TestGeminiSpawnEnvScrub::test_leaked_secrets_absent_from_final_popen_env
E       AssertionError: assert 'VNX_SMTP_PASS' not in {'PATH': '/usr/bin', 'SOME_SERVICE_TOKEN': 'fake-test-worker-token-not-real', 'VNX_SMTP_PASS': 'fake-test-smtp-secret-not-real'}
3 failed in 0.21s
```

GREEN:
```
tests/test_provider_spawn_env_scrub.py::TestKimiSpawnEnvScrub::test_leaked_secrets_absent_from_final_popen_env PASSED
tests/test_provider_spawn_env_scrub.py::TestCodexSpawnEnvScrub::test_leaked_secrets_absent_from_final_popen_env PASSED
tests/test_provider_spawn_env_scrub.py::TestGeminiSpawnEnvScrub::test_leaked_secrets_absent_from_final_popen_env PASSED
3 passed in 0.17s
```

**Static guard (the wachter)** — AST scan over every git-tracked `.py` file under `scripts/lib/provider_spawns/` for a `subprocess.Popen()`/`subprocess.run()` call carrying an `env=` kwarg that doesn't resolve to a scrub call. Mirrors `test_spawn_scrub_env_keys_contract.py`'s AST-scan pattern (PR #1748/OI-1614). Confirmed it independently catches the real pre-fix repo state:
```
E         scripts/lib/provider_spawns/codex_spawn.py:386
E         scripts/lib/provider_spawns/gemini_spawn.py:358
E         scripts/lib/provider_spawns/kimi_spawn.py:494
E         scripts/lib/provider_spawns/kimi_spawn.py:884
```

Neighbour sweep: 243 + 129 passed (no full-suite run, per dispatch rule).

## Verification — commit 2 (guard property check + litellm round 1)

Coordinator falsified the guard by reverting the fix into `gemini_spawn.py` — 2 tests correctly turned red. They then found: `_SAFE_SCRUB_CALL_NAMES = frozenset({"scrub_env", "_scrubbed_env"})` trusted litellm's `_scrubbed_env()` purely by NAME, never checking it actually routed through the shared pattern set. It only stripped `ANTHROPIC_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN`, so `VNX_SMTP_PASS` crossed straight through that lane while the guard said green.

RED:
```
FAILED tests/test_litellm_spawn_credential_scrub.py::TestScrubbedEnvHelper::test_vnx_smtp_pass_shaped_secret_is_scrubbed
FAILED tests/test_litellm_spawn_credential_scrub.py::TestOneShotSpawnPopenEnv::test_final_popen_env_excludes_vnx_smtp_pass_shaped_secret
E       AssertionError: assert 'VNX_SMTP_PASS' not in {'PATH': '/usr/bin', 'VNX_SMTP_PASS': 'fake-test-smtp-secret-not-real'}
2 failed, 4 passed in 0.20s
```

GREEN: 7 passed in 0.23s.

Guard reworked to a property check (`_call_resolves_to_scrub_env`): safe when the call IS `scrub_env`, or names a local function whose OWN body actually calls `scrub_env(...)` (one hop resolved, deeper chains fail closed as unsafe). Fixture `test_a_helper_merely_named_scrubbed_env_that_never_calls_scrub_env_turns_the_assertion_red` proves the literal loophole is now rejected. Independent falsification: reverted only `litellm_spawn.py` back to pre-followup source (kept the new guard code) — real-repo scan failed on both its Popen sites, confirming the new guard catches the bug on the property, not the coincidence of a trusted name. Full guard suite: 13/13.

## Verification — commit 3 (need-based `*_KEY` exception)

Coordinator reviewed commit 2 and confirmed the `ANTHROPIC_API_KEY`-stays-covered claim, and confirmed the property-based guard is a real improvement — but found `DEFAULT_SCRUB_KEY_PATTERNS - {"*_KEY"}` was itself too broad: it excepted the WHOLE `*_KEY` glob, so ANY `*_KEY`-shaped secret (`OPENAI_API_KEY`, `SUPABASE_KEY`, whatever else happens to be in the parent env) would survive for exactly the lane an external model can direct via `run_command` — precisely the class this PR exists to close.

Measured: `_litellm_runner.py`'s `_PROVIDER_KEY_REQS` is a static three-entry dict (`deepseek`/`moonshot`/`openrouter`). Confirmed no import cycle empirically — both in isolation and through the real path:
```python
from adapters._litellm_runner import _PROVIDER_KEY_REQS
# OK {'deepseek': 'DEEPSEEK_API_KEY', 'moonshot': 'MOONSHOT_API_KEY', 'openrouter': 'OPENROUTER_API_KEY'}

os.environ['VNX_PROVIDER_T1'] = 'litellm/deepseek'
from adapters import resolve_adapter
resolve_adapter('T1')  # -> LiteLLMAdapter, OK
import provider_spawns.litellm_spawn as ls
ls._NEEDED_PROVIDER_KEYS  # frozenset({'MOONSHOT_API_KEY', 'DEEPSEEK_API_KEY', 'OPENROUTER_API_KEY'}), OK
```
(`adapters/__init__.py` only imports `provider_adapter.py` at module level, which has zero project imports; `_litellm_runner.py` itself imports only stdlib — no cycle to report.)

`_scrubbed_env()` now applies the FULL `DEFAULT_SCRUB_KEY_PATTERNS` (no `*_KEY` subtraction) and restores only the exact values from `_PROVIDER_KEY_REQS` (imported as the SSOT — a new provider added there is picked up automatically, nothing re-hardcoded here).

Per-model narrowing (restricting the exception to only the key the currently running model needs) was explicitly optional in the coordinator's ask ("geen eis") and would require threading `model` through `_scrubbed_env()`'s call chain, including a public test call site (`_start_litellm_subprocess`) — skipped as unnecessary complexity for a non-requirement.

RED (before this fix, `SOMETHING_UNNEEDED_API_KEY` — not one of the three provider keys):
```
FAILED tests/test_litellm_spawn_credential_scrub.py::TestScrubbedEnvHelper::test_unneeded_key_shaped_secret_is_scrubbed
E       AssertionError: assert 'SOMETHING_UNNEEDED_API_KEY' not in {'PATH': '/usr/bin', 'SOMETHING_UNNEEDED_API_KEY': 'fake-test-unneeded-api-key-not-real'}
1 failed, 7 passed in 0.23s
```

GREEN (fix restored — the counter-proof, `test_own_provider_keys_survive_the_broader_scrub`, stays green unchanged):
```
tests/test_litellm_spawn_credential_scrub.py::TestScrubbedEnvHelper::test_strips_both_credential_keys PASSED
tests/test_litellm_spawn_credential_scrub.py::TestScrubbedEnvHelper::test_extra_env_cannot_reintroduce_credentials PASSED
tests/test_litellm_spawn_credential_scrub.py::TestScrubbedEnvHelper::test_vnx_smtp_pass_shaped_secret_is_scrubbed PASSED
tests/test_litellm_spawn_credential_scrub.py::TestScrubbedEnvHelper::test_unneeded_key_shaped_secret_is_scrubbed PASSED
tests/test_litellm_spawn_credential_scrub.py::TestScrubbedEnvHelper::test_own_provider_keys_survive_the_broader_scrub PASSED
tests/test_litellm_spawn_credential_scrub.py::TestOneShotSpawnPopenEnv::test_final_popen_env_excludes_anthropic_credentials PASSED
tests/test_litellm_spawn_credential_scrub.py::TestOneShotSpawnPopenEnv::test_final_popen_env_excludes_vnx_smtp_pass_shaped_secret PASSED
tests/test_litellm_spawn_credential_scrub.py::TestAgenticSpawnPopenEnv::test_final_popen_env_excludes_anthropic_credentials PASSED
8 passed in 0.17s
```

**Full regression sweep after all three commits (still no full-suite run, per dispatch rule):**
```
57 passed — test_litellm_spawn_credential_scrub.py, test_provider_spawn_env_scrub_contract.py,
            test_provider_spawn_env_scrub.py, test_spawn_scrub_env_keys_contract.py,
            test_glm_harness_spawn_credential_scrub.py, test_litellm_spawn_fail_closed.py,
            test_litellm_spawn_byte_identity.py
```
`test_provider_dispatch_openrouter_arbitrary.py`, `test_wave7_deepseek_smoke.py`: 4 pre-existing failures (`model-not-in-current-registry` constraint violation, unrelated to env-scrub) — confirmed identical before and after every commit by re-running against each prior commit; not introduced by this PR.

`ruff check` clean on every file this PR touches (one pre-existing, untouched `F401 time` unused-import in `litellm_spawn.py`, confirmed via diff not on a line I added). `scripts/ci_lint_patterns.py --files-from-stdin` clean throughout.

Pre-push check on every commit: `git diff HEAD` empty, `git show HEAD:<path> | grep <symbol>` confirms the fix is inside the commit.

## Env-herkomst van codex_spawn.py en gemini_spawn.py (expliciete uitspraak)

**Beide waren NIET geschrobd vóór deze PR** — dezelfde klasse als kimi, niet een lichtere variant. Vastgesteld met:

```
grep -n "os.environ\|env=\|Popen\|subprocess.run" scripts/lib/provider_spawns/codex_spawn.py
grep -n "os.environ\|env=\|Popen\|subprocess.run" scripts/lib/provider_spawns/gemini_spawn.py
```

gevolgd door het lezen van elke functie tussen env-build en Popen, en het naspeuren van `extra_env` terug naar `provider_dispatch.py`'s `_worker_role_env()` (zet alleen `VNX_WORKER_ROLE`, geen scrub). Beide bouwden `env = {**os.environ, **(extra_env or {})}` zonder enige scrub-aanroep, direct in Popen gegeven.

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR
