### PR TITLE
fix(launchd): well-formed XML + PATH-parity guard (OI-1621)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1867,10 +1867,15 @@ def _scan_launchd_dir(launchd_dir: Optional[Path] = None) -> "tuple[List[str], L
     can surface it as a loud finding instead of a debug-log line nobody
     reads. This is exactly the failure mode this dispatch exists to prevent:
     measured live while building this module,
-    ``scripts/launchd/com.vnx.gate-obligation-runner.plist`` contains a
+    ``scripts/launchd/com.vnx.gate-obligation-runner.plist`` contained a
     literal ``--`` inside an XML comment ("...the --project-id value...")
     which is invalid XML (comments may never contain ``--``) -- a real,
-    currently-broken plist in this repo, not a hypothetical one.
+    currently-broken plist in this repo, not a hypothetical one. OI-1621
+    fixed that specific file (the comment no longer says "--project-id");
+    the fail-soft path itself stays, since any future plist edit can
+    reintroduce an unparseable file the same way -- see
+    ``scripts/lib/path_parity.check_repo_launchd_templates`` and
+    ``tests/test_launchd_plist_guard.py`` for the regression guard.
     """
     directory = launchd_dir if launchd_dir is not None else (_PROJECT_ROOT / "scripts" / "launchd")
     labels: List[str] = []

--- a/scripts/launchd/com.vnx.gate-obligation-runner.plist
+++ b/scripts/launchd/com.vnx.gate-obligation-runner.plist
@@ -24,7 +24,7 @@
     the store from that id and, independently, the GitHub owner/repo whose PRs
     its obligations live in. A consumer installing this template for their own
     project MUST set VNX_PROJECT_ID to their project id: vnx init substitutes
-    the ${VNX_PROJECT_ID} placeholder with the --project-id value, so manual
+    the ${VNX_PROJECT_ID} placeholder with the project id argument, so manual
     installs must edit it by hand. Hardcoding a store path here would make a
     copied template run on the original project's obligations
     (OI-1253 fix-forward).

--- a/scripts/lib/path_parity.py
+++ b/scripts/lib/path_parity.py
@@ -16,8 +16,10 @@ The check probes ``python3`` twice:
 That bare probe is diagnostic only (``raw_probe``, always ``info``): a
 minimal PATH on a macOS host without Xcode Command Line Tools legitimately
 resolves Xcode's bundled ``/usr/bin/python3`` (3.9.x on this fleet), which no
-real background job ever runs on — every scheduled consumer pins its own
-interpreter (see ``discover_launchd_consumers``/``discover_crontab_consumers``
+real background job ever runs on — every scheduled consumer either pins its
+own interpreter, or declares its own ``EnvironmentVariables.PATH``/crontab
+``PATH=`` line precisely so a bare ``python3`` never falls back to that
+Xcode stub (see ``discover_launchd_consumers``/``discover_crontab_consumers``
 below). Comparing the bare probes can therefore never reach parity on this
 kind of machine, which is a property of macOS, not a defect anyone can fix —
 so it never drives ``parity``.
@@ -31,6 +33,25 @@ interpreter falls outside this project's ``requires-python`` range
 (``pyproject.toml``). Consumers that invoke a script outside this repo, or a
 non-Python program, are recorded but never flagged — this project's
 ``requires-python`` bound is not their bound to police.
+
+A launchd consumer's own ``EnvironmentVariables.PATH`` (when declared) IS the
+search path a bare ``python3`` in its ``ProgramArguments`` resolves against
+at runtime — ``_launchd_search_path`` reads it, mirroring how
+``discover_crontab_consumers`` already honors a crontab's leading ``PATH=``
+line. OI-1621: before this, every launchd consumer was scanned under the
+hardcoded ``BACKGROUND_PATH`` regardless of its own declared PATH, which
+false-flagged ``com.vnx.gate-obligation-runner``/``com.vnx.ledger-health`` —
+both deliberately declare a homebrew-first PATH so their bare ``python3``
+resolves a modern interpreter, but the scan ignored that declaration and
+checked the Xcode-CLT stub instead.
+
+``check_repo_launchd_templates`` runs the same static resolution over this
+repo's own plist TEMPLATES (``scripts/launchd/*.plist``, not the installed
+copies) plus a well-formed-XML check — a regression guard so a future
+template edit cannot silently reintroduce either OI-1621 defect: invalid XML
+(a literal ``--`` inside an XML comment, which XML forbids, once broke
+``com.vnx.gate-obligation-runner.plist``) or an interpreter pin/PATH that
+falls outside ``requires-python``.
 
 The library is pure/injectable for tests; the CLI is used by
 scripts/hooks/path_parity_check.sh at SessionStart.
@@ -49,7 +70,7 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from xml.parsers.expat import ExpatError
+from xml.parsers.expat import ExpatError, ParserCreate
 
 _LOG = logging.getLogger(__name__)
 
@@ -297,6 +318,29 @@ def resolve_interpreter_version(
     return version
 
 
+def _launchd_search_path(data: Dict[str, Any]) -> str:
+    """The PATH launchd will actually hand this job.
+
+    A launchd agent's own ``EnvironmentVariables.PATH`` (when it declares
+    one) IS the search path a bare ``python3`` in its ``ProgramArguments``
+    resolves against at runtime — mirrors how ``discover_crontab_consumers``
+    already honors a crontab's leading ``PATH=`` line rather than assuming
+    the launchd/cron default everywhere.
+
+    OI-1621: before this, every launchd consumer was scanned under the
+    hardcoded ``BACKGROUND_PATH`` regardless of what its own plist declared,
+    so a job that deliberately sets ``EnvironmentVariables.PATH`` to a
+    homebrew-first PATH (precisely to avoid resolving macOS's ancient
+    Xcode-CLT ``/usr/bin/python3``) was still scanned as if it hadn't —
+    flagging ``com.vnx.gate-obligation-runner``/``com.vnx.ledger-health`` as
+    a false ``consumer_interpreter_out_of_range`` even though their real,
+    declared PATH resolves a fine interpreter.
+    """
+    env_vars = data.get("EnvironmentVariables")
+    declared = env_vars.get("PATH") if isinstance(env_vars, dict) else None
+    return declared if isinstance(declared, str) and declared.strip() else BACKGROUND_PATH
+
+
 def discover_launchd_consumers(agents_dir: Path) -> List[Dict[str, Any]]:
     """Enumerate ``com.vnx.*.plist`` launchd agents as ``{label, argv, source}``.
 
@@ -324,7 +368,7 @@ def discover_launchd_consumers(agents_dir: Path) -> List[Dict[str, Any]]:
                 "label": data.get("Label") or plist.stem,
                 "argv": list(argv),
                 "source": str(plist),
-                "search_path": BACKGROUND_PATH,
+                "search_path": _launchd_search_path(data),
             }
         )
     return consumers
@@ -538,6 +582,114 @@ def scan_consumers(
         "requires_python": requires_python,
         "consumers": resolved,
         "mismatches": mismatches,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Repo launchd TEMPLATE guard — scripts/launchd/*.plist itself, not the
+# installed copies under ~/Library/LaunchAgents (OI-1621).
+# ─────────────────────────────────────────────────────────────────────────
+
+_VNX_HOME_PLACEHOLDER = "${VNX_HOME}"
+
+
+def check_repo_launchd_templates(
+    templates_dir: Path,
+    repo_root: Path,
+    requires_python: Optional[str],
+    runner: Any = None,
+) -> Dict[str, Any]:
+    """Guard for the launchd plist TEMPLATES this repo ships under
+    ``scripts/launchd/`` — a regression check, not a live-host scan (that is
+    ``discover_launchd_consumers`` + ``scan_consumers`` above). Enforces two
+    properties every template must hold before it is ever installed:
+
+      1. well-formed XML — OI-1621: ``com.vnx.gate-obligation-runner.plist``
+         once carried a literal ``--`` inside an XML comment, which XML
+         forbids on every parser, not just a strict one.
+      2. any interpreter a template's ``ProgramArguments`` resolves to (after
+         substituting the ``${VNX_HOME}`` placeholder the install scripts
+         themselves substitute — ``reload_plist.sh``, ``vnx init``) falls
+         inside this project's ``requires_python`` range.
+
+    A template using an install-time placeholder this function cannot
+    statically resolve (e.g. ``headless-trigger``'s ``__VNX_PYTHON__``, which
+    no installer in this repo currently substitutes) is reported
+    not-relevant, same as ``resolve_consumer_interpreter``'s existing
+    "cannot judge" cases — never silently treated as in-range.
+
+    A file that fails the XML check is skipped for the interpreter check
+    (nothing to resolve from unparseable content) but is still surfaced in
+    ``xml_errors`` — one broken template must not blank out the rest of the
+    scan, the same fail-soft discipline as ``discover_launchd_consumers``.
+    """
+    templates_dir = Path(templates_dir)
+    repo_root = Path(repo_root).resolve()
+    xml_errors: List[Dict[str, str]] = []
+    consumers: List[Dict[str, Any]] = []
+
+    if not templates_dir.is_dir():
+        return {
+            "ok": False,
+            "xml_errors": [{"file": str(templates_dir), "error": "not a directory"}],
+            "mismatches": [],
+            "consumers": [],
+        }
+
+    version_cache: Dict[str, Optional[str]] = {}
+    for plist in sorted(templates_dir.glob("*.plist")):
+        parser = ParserCreate()
+        try:
+            with open(plist, "rb") as fh:
+                parser.ParseFile(fh)
+        except ExpatError as exc:
+            xml_errors.append({"file": plist.name, "error": str(exc)})
+            continue
+
+        try:
+            with open(plist, "rb") as fh:
+                data = plistlib.load(fh)
+        except (plistlib.InvalidFileException, OSError, ValueError) as exc:
+            xml_errors.append({"file": plist.name, "error": f"plistlib: {exc}"})
+            continue
+
+        argv = data.get("ProgramArguments")
+        if not argv:
+            continue
+
+        resolved_argv = [str(arg).replace(_VNX_HOME_PLACEHOLDER, str(repo_root)) for arg in argv]
+        search_path = _launchd_search_path(data)
+        outcome = resolve_consumer_interpreter(resolved_argv, repo_root, search_path)
+        entry: Dict[str, Any] = {
+            "file": plist.name,
+            "label": data.get("Label") or plist.stem,
+            **outcome,
+        }
+        if outcome["relevant"] and outcome["interpreter"]:
+            version = resolve_interpreter_version(outcome["interpreter"], runner=runner, cache=version_cache)
+            entry["version"] = version
+            entry["in_range"] = version_in_range(version, requires_python) if version else None
+        consumers.append(entry)
+
+    mismatches = [
+        {
+            "kind": "template_interpreter_out_of_range",
+            "file": c["file"],
+            "label": c["label"],
+            "interpreter": c.get("interpreter"),
+            "version": c.get("version"),
+            "requires_python": requires_python,
+        }
+        for c in consumers
+        if c.get("relevant") and c.get("in_range") is False
+    ]
+
+    return {
+        "ok": not xml_errors and not mismatches,
+        "requires_python": requires_python,
+        "xml_errors": xml_errors,
+        "mismatches": mismatches,
+        "consumers": consumers,
     }
 
 

--- a/tests/test_build_t0_state_launchd_liveness.py
+++ b/tests/test_build_t0_state_launchd_liveness.py
@@ -167,15 +167,15 @@ class TestDiscoverLaunchdJobs:
         """Nul-is-eerst-een-meetfout: prove the real scripts/launchd/ directory
         is actually found and parsed, not just that an empty/fake dir works.
 
-        Only 6 of the 7 real plist files parse as valid XML today --
-        com.vnx.gate-obligation-runner.plist contains a literal "--" inside
-        an XML comment (invalid XML; see TestScanLaunchdDir below), so it
-        is legitimately excluded from _discover_launchd_jobs's labels list
-        and picked up instead via _scan_launchd_dir's unparseable half."""
+        OI-1621 fixed the one plist that used to fail this: all 7 real plist
+        files now parse as valid XML -- com.vnx.gate-obligation-runner.plist
+        no longer carries the literal "--" inside an XML comment that used
+        to make it invalid XML (see TestScanLaunchdDir below)."""
         labels = bts._discover_launchd_jobs()
         assert "com.vnx.producer-freshness-monitor" in labels
         assert "com.vnx.ledger-health" in labels
-        assert len(labels) >= 6
+        assert "com.vnx.gate-obligation-runner" in labels
+        assert len(labels) >= 7
 
 
 class TestScanLaunchdDir:
@@ -204,16 +204,17 @@ class TestScanLaunchdDir:
         assert labels == ["com.vnx.good-job"]
         assert unparseable == []
 
-    def test_real_repo_gate_obligation_runner_plist_is_currently_unparseable(self) -> None:
-        """Documents a real, currently-live defect this dispatch surfaced
-        while measuring the register: scripts/launchd/com.vnx.gate-
-        obligation-runner.plist has a literal '--' inside an XML comment
-        ('...the --project-id value...'), which XML forbids inside comments.
-        Once that file is fixed this test's second assertion flips -- update
-        it then, don't silently loosen it now."""
+    def test_real_repo_gate_obligation_runner_plist_is_now_parseable(self) -> None:
+        """OI-1621: scripts/launchd/com.vnx.gate-obligation-runner.plist used
+        to carry a literal '--' inside an XML comment ('...the --project-id
+        value...'), which XML forbids inside comments -- this test used to
+        assert the resulting unparseable state. The comment was reworded to
+        drop the double-dash (no longer '--project-id', now 'the project id
+        argument') so the plist is well-formed XML and its label is found
+        like every other real launchd template."""
         labels, unparseable = bts._scan_launchd_dir()
-        assert "com.vnx.gate-obligation-runner.plist" in unparseable
-        assert "com.vnx.gate-obligation-runner" not in labels
+        assert "com.vnx.gate-obligation-runner.plist" not in unparseable
+        assert "com.vnx.gate-obligation-runner" in labels
 
 
 # ---------------------------------------------------------------------------
@@ -558,21 +559,26 @@ class TestMeasureLaunchdLivenessNotApplicable:
         assert result["jobs"]["com.vnx.alpha-job"]["state"] == "not_applicable"
 
     def test_real_repo_register_with_no_launchctl_is_unknown_not_fail(self, tmp_path: Path) -> None:
-        """The exact CI reproduction: the REAL scripts/launchd directory
-        (including its one currently-unparseable plist,
-        com.vnx.gate-obligation-runner.plist) plus 'launchctl does not
-        exist' must together read 'unknown', not 'fail' -- this is what
-        made tests/test_build_t0_brief_output.py::TestFormatBriefOutputPath
-        assert rc == 0 fail with rc == 1 on the Linux CI runner AND,
-        independently, on this macOS dev machine (there via genuinely
-        not-loaded real jobs, a SEPARATE true-ambient-state fact -- see
-        TestMeasureLaunchdLiveness's unparseable-plist tests for that half)."""
+        """The exact CI reproduction: the REAL scripts/launchd directory plus
+        'launchctl does not exist' must together read 'unknown', not 'fail'
+        -- this is what made tests/test_build_t0_brief_output.py::
+        TestFormatBriefOutputPath assert rc == 0 fail with rc == 1 on the
+        Linux CI runner AND, independently, on this macOS dev machine (there
+        via genuinely not-loaded real jobs, a SEPARATE true-ambient-state
+        fact -- see TestMeasureLaunchdLiveness's unparseable-plist tests for
+        that half).
+
+        OI-1621 fixed com.vnx.gate-obligation-runner.plist's XML, so the
+        real register no longer carries an unparseable plist -- this test's
+        ``unparseable_plists`` assertion flipped from "in" to empty when that
+        landed."""
         state_dir = tmp_path / "state"
         state_dir.mkdir()
 
         result = bts._measure_launchd_liveness(state_dir, which_fn=_absent_which)
 
         assert result["overall"] == "unknown"
-        assert "com.vnx.gate-obligation-runner.plist" in result.get("unparseable_plists", [])
+        assert result.get("unparseable_plists", []) == []
+        assert "com.vnx.gate-obligation-runner" in result["jobs"]
         for label, info in result["jobs"].items():
             assert info["state"] == "not_applicable", f"{label}: {info}"

--- a/tests/test_launchd_plist_guard.py
+++ b/tests/test_launchd_plist_guard.py
@@ -1,0 +1,219 @@
+"""tests/test_launchd_plist_guard.py — OI-1621 regression guard.
+
+OI-1621 measured two real, currently-live defects:
+
+  1. ``scripts/launchd/com.vnx.gate-obligation-runner.plist`` was not
+     well-formed XML — a literal ``--`` inside an XML comment (invalid on
+     every XML parser, not just a strict one).
+  2. The SessionStart PATH-parity hook flagged
+     ``com.vnx.gate-obligation-runner.vnx-dev`` and ``com.vnx.ledger-health``
+     as broken: both resolve ``/usr/bin/python3`` (3.9) against this
+     project's ``requires-python`` (``>=3.11,<3.14``) — but that was the
+     SCANNER's fault (``discover_launchd_consumers`` hardcoded
+     ``BACKGROUND_PATH`` for every launchd consumer instead of honoring the
+     plist's own declared ``EnvironmentVariables.PATH``, which both jobs set
+     to a homebrew-first PATH precisely to avoid the Xcode-CLT stub).
+
+This module is the guard against both regressing: it walks every plist
+TEMPLATE this repo ships under ``scripts/launchd/`` (not the installed
+copies) and asserts (a) well-formed XML, (b) any interpreter a template's
+``ProgramArguments`` resolves to falls inside this project's
+``requires-python`` -- read from ``pyproject.toml``, never hardcoded here.
+
+The narrow scanner-plumbing regression tests for defect 2 live alongside
+``discover_launchd_consumers``/``scan_consumers`` in ``tests/test_path_parity.py``;
+this file is the broader, whole-directory sweep plus the XML check.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import path_parity  # noqa: E402
+
+LAUNCHD_TEMPLATES_DIR = REPO_ROOT / "scripts" / "launchd"
+
+
+def _real_requires_python() -> Optional[str]:
+    requires_python = path_parity.parse_requires_python(REPO_ROOT / "pyproject.toml")
+    assert requires_python, "pyproject.toml must declare requires-python for this guard to mean anything"
+    return requires_python
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Defect 1 — well-formed XML, every plist in the directory, always
+# deterministic (no environment/host dependency at all).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_real_repo_launchd_plists_are_well_formed_xml() -> None:
+    plists = sorted(LAUNCHD_TEMPLATES_DIR.glob("*.plist"))
+    assert len(plists) >= 6, f"expected the known launchd templates, found {len(plists)}: {plists}"
+
+    result = path_parity.check_repo_launchd_templates(LAUNCHD_TEMPLATES_DIR, REPO_ROOT, _real_requires_python())
+    assert result["xml_errors"] == [], result["xml_errors"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# check_repo_launchd_templates — the guard function itself, proven against
+# synthetic fixtures so it can be shown to actually fail, not just report
+# green because nothing was checked (nul-is-eerst-een-meetfout).
+# ─────────────────────────────────────────────────────────────────────────
+
+_INVALID_XML_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- a literal -- inside a comment, forbidden by XML -->
+  <key>Label</key><string>com.vnx.broken</string>
+  <key>ProgramArguments</key>
+  <array><string>/bin/bash</string><string>-c</string><string>echo hi</string></array>
+</dict>
+</plist>
+"""
+
+
+def _plist_shaped_like_gate_obligation_runner(env_path: Optional[str]) -> str:
+    env_block = (
+        f"""
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>{env_path}</string>
+  </dict>"""
+        if env_path
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.vnx.fake-runner</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>cd ${{VNX_HOME}} &amp;&amp; exec python3 fake_script.py</string>
+  </array>{env_block}
+</dict>
+</plist>
+"""
+
+
+def test_check_repo_launchd_templates_reports_invalid_xml(tmp_path: Path) -> None:
+    templates_dir = tmp_path / "launchd"
+    templates_dir.mkdir()
+    (templates_dir / "com.vnx.broken.plist").write_text(_INVALID_XML_PLIST, encoding="utf-8")
+
+    result = path_parity.check_repo_launchd_templates(templates_dir, tmp_path, ">=3.11,<3.14")
+
+    assert result["ok"] is False
+    assert len(result["xml_errors"]) == 1
+    assert result["xml_errors"][0]["file"] == "com.vnx.broken.plist"
+
+
+def test_check_repo_launchd_templates_flags_out_of_range_interpreter(tmp_path: Path, monkeypatch) -> None:
+    """Negative control: a template whose bare python3 falls back to the
+    launchd default PATH (no declared EnvironmentVariables.PATH at all)
+    must turn the guard red when that default resolves an out-of-range
+    interpreter — the exact shape of the real OI-1621 scanner bug, now
+    reproduced as a genuine template defect instead of a scanner defect."""
+    templates_dir = tmp_path / "launchd"
+    templates_dir.mkdir()
+    (templates_dir / "com.vnx.fake-runner.plist").write_text(
+        _plist_shaped_like_gate_obligation_runner(env_path=None), encoding="utf-8"
+    )
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    def fake_which(name, path=None):
+        assert name == "python3"
+        assert path == path_parity.BACKGROUND_PATH
+        return "/usr/bin/python3.9"
+
+    monkeypatch.setattr(path_parity.shutil, "which", fake_which)
+
+    result = path_parity.check_repo_launchd_templates(templates_dir, repo_root, ">=3.11,<3.14")
+
+    assert result["ok"] is False
+    assert result["xml_errors"] == []
+    assert len(result["mismatches"]) == 1
+    mismatch = result["mismatches"][0]
+    assert mismatch["kind"] == "template_interpreter_out_of_range"
+    assert mismatch["file"] == "com.vnx.fake-runner.plist"
+    assert mismatch["version"] == "3.9"
+
+
+def test_check_repo_launchd_templates_passes_when_interpreter_in_range(tmp_path: Path, monkeypatch) -> None:
+    """Positive control paired with the negative one above: a template that
+    DOES declare its own homebrew-first PATH resolves an in-range
+    interpreter and the guard stays green."""
+    templates_dir = tmp_path / "launchd"
+    templates_dir.mkdir()
+    (templates_dir / "com.vnx.fake-runner.plist").write_text(
+        _plist_shaped_like_gate_obligation_runner(env_path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"),
+        encoding="utf-8",
+    )
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    def fake_which(name, path=None):
+        assert name == "python3"
+        assert path == "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+        return "/opt/homebrew/opt/python@3.12/bin/python3.12"
+
+    monkeypatch.setattr(path_parity.shutil, "which", fake_which)
+
+    result = path_parity.check_repo_launchd_templates(templates_dir, repo_root, ">=3.11,<3.14")
+
+    assert result["ok"] is True
+    assert result["mismatches"] == []
+    assert result["consumers"][0]["in_range"] is True
+
+
+def test_check_repo_launchd_templates_missing_directory_is_not_ok(tmp_path: Path) -> None:
+    result = path_parity.check_repo_launchd_templates(tmp_path / "no-such-dir", tmp_path, ">=3.11,<3.14")
+    assert result["ok"] is False
+    assert result["xml_errors"] != []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The real repo directory, end-to-end, with a controlled (monkeypatched)
+# interpreter resolution — proves the fixed templates + fixed scanner
+# together clear the guard, without depending on what happens to be
+# installed on whichever machine runs this suite.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_real_repo_launchd_templates_clear_the_guard(monkeypatch) -> None:
+    requires_python = _real_requires_python()
+
+    def fake_which(name, path=None):
+        if name != "python3":
+            return None
+        if path == path_parity.BACKGROUND_PATH:
+            # The Xcode-CLT stub every declared-PATH template exists to avoid.
+            return "/usr/bin/python3.9"
+        return "/opt/homebrew/opt/python@3.12/bin/python3.12"
+
+    monkeypatch.setattr(path_parity.shutil, "which", fake_which)
+
+    result = path_parity.check_repo_launchd_templates(LAUNCHD_TEMPLATES_DIR, REPO_ROOT, requires_python)
+
+    assert result["xml_errors"] == []
+    assert result["mismatches"] == [], result["mismatches"]
+    assert result["ok"] is True
+
+    # nul-is-eerst-een-meetfout: prove the scan actually found and judged the
+    # two OI-1621 consumers, not that it silently checked nothing.
+    checked_labels = {
+        c["label"] for c in result["consumers"] if c.get("relevant") and c.get("in_range") is not None
+    }
+    assert "com.vnx.gate-obligation-runner" in checked_labels
+    assert "com.vnx.ledger-health" in checked_labels
+    for c in result["consumers"]:
+        if c["label"] in ("com.vnx.gate-obligation-runner", "com.vnx.ledger-health"):
+            assert c["in_range"] is True, c

--- a/tests/test_path_parity.py
+++ b/tests/test_path_parity.py
@@ -187,6 +187,89 @@ def test_discover_launchd_consumers_missing_dir_returns_empty(tmp_path) -> None:
     assert path_parity.discover_launchd_consumers(tmp_path / "nope") == []
 
 
+def test_discover_launchd_consumers_defaults_search_path_without_declared_path(tmp_path) -> None:
+    """No ``EnvironmentVariables`` key at all (``_FAKE_PLIST`` above) must
+    still fall back to the launchd/cron default -- the pre-existing
+    behavior this OI-1621 fix must not regress."""
+    agents_dir = tmp_path / "LaunchAgents"
+    agents_dir.mkdir()
+    (agents_dir / "com.vnx.fake.plist").write_text(_FAKE_PLIST)
+
+    consumers = path_parity.discover_launchd_consumers(agents_dir)
+    assert consumers[0]["search_path"] == path_parity.BACKGROUND_PATH
+
+
+_FAKE_PLIST_WITH_DECLARED_PATH = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>com.vnx.fake-declared-path</string>
+<key>ProgramArguments</key><array>
+<string>/bin/bash</string>
+<string>-c</string>
+<string>cd /repo &amp;&amp; exec python3 script.py</string>
+</array>
+<key>EnvironmentVariables</key><dict>
+<key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+</dict>
+</dict></plist>
+"""
+
+
+def test_discover_launchd_consumers_honors_declared_environment_path(tmp_path) -> None:
+    """OI-1621 regression: a launchd agent that declares its own
+    ``EnvironmentVariables.PATH`` (exactly the shape of the real
+    com.vnx.gate-obligation-runner/com.vnx.ledger-health plists) must have
+    THAT path threaded through as ``search_path`` -- not the hardcoded
+    ``BACKGROUND_PATH`` -- because that declared PATH is what launchd
+    actually hands the job at runtime."""
+    agents_dir = tmp_path / "LaunchAgents"
+    agents_dir.mkdir()
+    (agents_dir / "com.vnx.fake-declared-path.plist").write_text(_FAKE_PLIST_WITH_DECLARED_PATH)
+
+    consumers = path_parity.discover_launchd_consumers(agents_dir)
+    assert len(consumers) == 1
+    assert consumers[0]["search_path"] == "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+    assert consumers[0]["search_path"] != path_parity.BACKGROUND_PATH
+
+
+def test_gate_obligation_runner_shaped_consumer_resolves_via_declared_path_not_background(
+    tmp_path, monkeypatch
+) -> None:
+    """End-to-end OI-1621 reproduction: a bare-``python3`` launchd job
+    declaring a homebrew-first PATH must be judged against THAT PATH's
+    interpreter, not the Xcode-CLT stub ``BACKGROUND_PATH`` would resolve.
+
+    Simulates two competing interpreters at two competing search paths (a
+    modern one at the declared homebrew-first PATH, an old one at
+    BACKGROUND_PATH) via a monkeypatched ``shutil.which`` -- deterministic,
+    no dependency on what is actually installed on the machine running this
+    test. Before the OI-1621 fix (search_path hardcoded to BACKGROUND_PATH
+    in discover_launchd_consumers) this reproduces the false
+    consumer_interpreter_out_of_range finding; after the fix it is clean."""
+    agents_dir = tmp_path / "LaunchAgents"
+    agents_dir.mkdir()
+    (agents_dir / "com.vnx.fake-declared-path.plist").write_text(_FAKE_PLIST_WITH_DECLARED_PATH)
+
+    def fake_which(name, path=None):
+        assert name == "python3"
+        if path == path_parity.BACKGROUND_PATH:
+            return "/usr/bin/python3.9"  # the Xcode-CLT stub OI-852/OI-1621 warn about
+        return "/opt/homebrew/opt/python@3.12/bin/python3.12"
+
+    monkeypatch.setattr(path_parity.shutil, "which", fake_which)
+
+    consumers = path_parity.discover_launchd_consumers(agents_dir)
+    # "/repo" matches the literal text baked into _FAKE_PLIST_WITH_DECLARED_PATH's
+    # inline -c script above -- resolve_consumer_interpreter's in-repo check is a
+    # literal substring match, not path resolution.
+    result = path_parity.scan_consumers(consumers, Path("/repo"), ">=3.11,<3.14")
+
+    assert result["parity"] is True
+    assert result["mismatches"] == []
+    assert result["consumers"][0]["interpreter"] == "/opt/homebrew/opt/python@3.12/bin/python3.12"
+    assert result["consumers"][0]["in_range"] is True
+
+
 def test_discover_crontab_consumers_parses_schedule_and_declared_path() -> None:
     text = (
         "PATH=/opt/homebrew/bin:/usr/bin:/bin\n"


### PR DESCRIPTION
## Summary

OI-1621 measured two real, currently-live defects and adds a regression guard for both.

**Defect 1 — invalid XML.** `scripts/launchd/com.vnx.gate-obligation-runner.plist` was not well-formed XML: a literal `--` inside an XML comment (`"...the --project-id value..."`), which XML forbids. Fixed by rewording to `"the project id argument"` — matches the wording `com.vnx.ledger-health.plist` already used for the identical sentence, which is how this asymmetry surfaced in the first place.

**Defect 2 — false PATH/interpreter-parity finding.** The SessionStart hook reported `com.vnx.gate-obligation-runner.vnx-dev` and `com.vnx.ledger-health` as broken (resolving `/usr/bin/python3` = 3.9, outside `requires-python >=3.11,<3.14`). Root cause was the *scanner*, not the jobs: `discover_launchd_consumers` in `scripts/lib/path_parity.py` hardcoded `BACKGROUND_PATH` for every launchd consumer, ignoring a plist's own declared `EnvironmentVariables.PATH` — even though both jobs deliberately declare a homebrew-first PATH precisely to avoid the ancient Xcode-CLT `python3`. `discover_crontab_consumers` already honored a crontab's `PATH=` line; `discover_launchd_consumers` now does the equivalent via a new `_launchd_search_path` helper.

**Regression guard.** `check_repo_launchd_templates` (new function in `scripts/lib/path_parity.py`) walks every `*.plist` under `scripts/launchd/` and enforces (a) well-formed XML and (b) every resolvable interpreter falls inside `requires-python`, read from `pyproject.toml` — no hardcoded version. New `tests/test_launchd_plist_guard.py` covers it with synthetic red/green fixtures plus an end-to-end run against the real directory (interpreter resolution deterministically mocked via `shutil.which`, so the guard doesn't depend on what happens to be installed on the CI runner).

`tests/test_build_t0_state_launchd_liveness.py` (Golf 1B, PR #1755) had two tests that explicitly asserted the broken-XML state — their own docstrings said *"Once that file is fixed this test's second assertion flips — update it then"*. Flipped as instructed, not silently loosened.

## Process note

Run as a subagent via the Agent tool, deliberately outside the VNX dispatch door (operator decision 2026-09-04, extended) — three parallel agents worked the same issue domain, each with a distinct, non-overlapping file scope (`scripts/launchd/**` + the parity/plist measurement code + my own new test, for this PR).

## Changes
- `scripts/launchd/com.vnx.gate-obligation-runner.plist` — reworded the comment to drop the invalid `--`
- `scripts/lib/path_parity.py` — `_launchd_search_path` helper (honors a plist's declared `EnvironmentVariables.PATH`), `discover_launchd_consumers` now uses it, new `check_repo_launchd_templates` guard function, docstring updates
- `scripts/build_t0_state.py` — updated `_scan_launchd_dir` docstring (no longer describes the plist as currently broken)
- `tests/test_path_parity.py` — 3 new tests: declared-PATH plumbing (positive + default-fallback) and an end-to-end OI-1621 reproduction (red pre-fix, green post-fix, verified both ways)
- `tests/test_launchd_plist_guard.py` (new) — the directory-wide guard: XML well-formedness + interpreter-in-range, synthetic fixtures + real-directory run
- `tests/test_build_t0_state_launchd_liveness.py` — flipped the two tests anchored on the pre-fix broken-XML state, per their own "update it then" docstrings

## Verification

Red-then-green proven for both the scanner fix and the new guard (see PR discussion / commit for full pytest output). Final state, targeted + direct-neighbour tests:

```
python3 -m pytest tests/test_launchd_plist_guard.py tests/test_path_parity.py \
  tests/test_path_parity_hook.py tests/test_build_t0_state_launchd_liveness.py \
  tests/test_gate_obligation_runner.py -q
........................................................................ [ 55%]
.........................................................                [100%]
129 passed in 3.45s
```

`git diff HEAD` empty before push; fix content re-read back from the commit object (`git show HEAD:<path>`), not just the working tree.

## Open Items
None.

**Model**: sonnet
**Provider**: claude
Dispatch-ID: agent-aa27eadbd0e76c0d3-OI-1621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR