### PR TITLE
fix(hooks): producer-freshness findings surface at SessionStart, not just the coarse beacon (OI-1460)

### DIFF
--- a/hooks/sessionstart.sh
+++ b/hooks/sessionstart.sh
@@ -188,6 +188,62 @@ $_BEACON_BAD"
       BEACON_SECTION="BEACON HEALTH UNAVAILABLE this session (UNMEASURED, not zero) — data dir unresolved or scripts/health_check.py missing."
     fi
 
+    # ── Producer freshness findings (OI-1460: a melder existed, no consumer read it) ──
+    # scripts/lib/producer_freshness.py already detects the exact failure
+    # OI-1460 names: "Geen enkele controle gaat af wanneer een poort STOPT met
+    # produceren" — it groups activity per producer KEY (per gate name, per
+    # metric, per dispatch-id prefix) and flags a key whose newest record is
+    # older than its own cadence. It runs on a schedule and writes every
+    # finding to producer_freshness.ndjson, plus a heartbeat on every run. But
+    # nothing previously read that back: hooks/monitor_tripwire.sh only checks
+    # the HEARTBEAT FILE'S AGE (is the monitor itself alive), and the Beacon
+    # health block above only shows producer_freshness_monitor's own derived
+    # health (ok/stale) as one beacon among many — never WHAT the sweep found.
+    # Measured live 2026-09-04 in this repo's own store: the beacon read
+    # [stale] with details.findings_count=10, and inside
+    # producer_freshness.ndjson for that same run one of the ten was
+    # review_gate_obligations/codex_gate silent for 24.88 days — a real gate
+    # that stopped producing, invisible without opening the NDJSON by hand.
+    # Reuses the existing CLI (scripts/producer_freshness_monitor.py) via
+    # subprocess, same convention as health_check.py/session_state_freshness.py
+    # above: --latest-findings runs NO new sweep and writes nothing, it only
+    # reads back whatever the last scheduled sweep already persisted — cheap
+    # enough for this hot path, unlike a full sweep (directory globs, sqlite
+    # queries, a launchd harvest) which stays a scheduled batch job.
+    PRODUCER_FINDINGS_SECTION=""
+    _PF_MONITOR_PY="$_HOOK_DIR/../scripts/producer_freshness_monitor.py"
+    if [ -n "$_VNX_STATE_DIR" ] && [ -n "$_VNX_PY" ] && [ -f "$_PF_MONITOR_PY" ]; then
+      _PF_JSON="$("$_VNX_PY" "$_PF_MONITOR_PY" --state-dir "$_VNX_STATE_DIR" --latest-findings 2>/dev/null || true)"
+      if [ -n "$_PF_JSON" ] && command -v jq &>/dev/null; then
+        _PF_PARSE_OK=$(echo "$_PF_JSON" | jq -e '.swept | type == "boolean"' >/dev/null 2>&1 && echo yes || echo no)
+        if [ "$_PF_PARSE_OK" = "yes" ]; then
+          _PF_SWEPT=$(echo "$_PF_JSON" | jq -r '.swept')
+          if [ "$_PF_SWEPT" = "true" ]; then
+            _PF_COUNT=$(echo "$_PF_JSON" | jq -r '.findings_count // 0')
+            _PF_RUN_ID=$(echo "$_PF_JSON" | jq -r '.run_id // "unknown"')
+            if [ "$_PF_COUNT" -gt 0 ] 2>/dev/null; then
+              _PF_LINES=$(echo "$_PF_JSON" | jq -r '
+                .findings[] | "  - [\(.kind)] \(.producer)/\(.key): " +
+                (if .silence_days then "\(.silence_days)d silent (cadence \(.cadence_seconds // "unknown")s)" else "never written" end)
+              ' 2>/dev/null || true)
+              PRODUCER_FINDINGS_SECTION="Producer freshness: ${_PF_COUNT} silent producer key(s) at last sweep (run ${_PF_RUN_ID})
+$_PF_LINES"
+            else
+              PRODUCER_FINDINGS_SECTION="Producer freshness: last sweep (run ${_PF_RUN_ID}) found 0 silent producer keys"
+            fi
+          else
+            PRODUCER_FINDINGS_SECTION="PRODUCER FRESHNESS UNAVAILABLE this session (UNMEASURED, not zero) — no sweep has ever been persisted under ${_VNX_STATE_DIR}/producer_freshness.ndjson. scripts/producer_freshness_monitor.py may never have run against this store."
+          fi
+        else
+          PRODUCER_FINDINGS_SECTION="PRODUCER FRESHNESS UNAVAILABLE this session (UNMEASURED, not zero) — producer_freshness_monitor.py did not return a swept field."
+        fi
+      else
+        PRODUCER_FINDINGS_SECTION="PRODUCER FRESHNESS UNAVAILABLE this session (UNMEASURED, not zero) — producer_freshness_monitor.py produced no output, or jq is missing."
+      fi
+    else
+      PRODUCER_FINDINGS_SECTION="PRODUCER FRESHNESS UNAVAILABLE this session (UNMEASURED, not zero) — state dir unresolved or scripts/producer_freshness_monitor.py missing."
+    fi
+
     # ── State artifact freshness (golf 3A, absence-is-loud #1, OI-1512 fix-forward) ──
     # T0 reads a handful of point-in-time snapshots at SessionStart (t0_state.json,
     # open_items.json, terminal_state.json, dashboard_status.json,
@@ -265,6 +321,8 @@ $FRESHNESS_SECTION
 $T0_STATE_SECTION
 
 $BEACON_SECTION
+
+$PRODUCER_FINDINGS_SECTION
 
 CRITICAL: After every completion receipt, check quality advisory + open items before proceeding.
 Skills must NOT use @ prefix in Role field. Skill registry: skills/skills.yaml (repo) or \$VNX_SKILLS_DIR/skills.yaml (consumer).${T0_SKILL_BODY:+

--- a/scripts/lib/producer_freshness.py
+++ b/scripts/lib/producer_freshness.py
@@ -578,6 +578,93 @@ def append_report(state_dir: Path, report: Dict[str, Any]) -> Path:
     return path
 
 
+# A single sweep run can, in principle, touch every producer's every stale
+# key — but in practice (see configs/producer_freshness.yaml) a run's finding
+# block is a handful to a few dozen lines. 2000 mirrors
+# build_t0_state.py's _JOB_EXITS_TAIL_LINES: producer_freshness.ndjson is
+# append-only and grows forever (one sweep every 8h, forever), so a reader
+# that answers "what did the LAST run find" must bound its own read instead
+# of loading the whole file, without needing the run boundary to fall inside
+# an arbitrarily small window.
+_LATEST_FINDINGS_TAIL_LINES = 2000
+
+
+def latest_findings(state_dir: Path, *, limit: Optional[int] = None) -> Dict[str, Any]:
+    """Read back the most recent sweep's findings WITHOUT running a new sweep
+    (OI-1460: the sweep already detects a producer/gate that stopped writing —
+    this is the read-back half nothing previously called).
+
+    Three states, mirroring this module's existing "niet-gemeten is een derde
+    tak" convention (health_beacon.py's absent/unknown, evaluate_producer's
+    missing/stale):
+
+      - the report file does not exist at all (the monitor has never
+        completed a run against this state dir) -> ``"swept": False``
+      - the file exists and its last sweep found zero findings ->
+        ``"swept": True, "findings": []``
+      - the file exists and its last sweep found N findings ->
+        ``"swept": True, "findings": [...]`` (length N, or ``limit`` if given)
+
+    ``append_report`` always writes one ``producer_freshness_sweep`` record
+    immediately followed by that same run's ``producer_freshness_finding``
+    records, under one ``fcntl`` lock — so within the tail window, every
+    finding for the LATEST sweep record is a finding whose ``run_id`` matches
+    that sweep, appearing anywhere in the tail (before or after the sweep
+    line depends only on how many prior runs' records the tail window still
+    holds) -- filtering by run_id, not by file position, is what keeps a
+    superseded run's findings from leaking into the result once a later,
+    cleaner sweep has appended its own (now un-findinged) record.
+
+    Malformed lines (a partial final line from a crash mid-append, same
+    "torn tail" hazard ``ndjson_io.iter_ndjson`` already guards elsewhere) are
+    skipped rather than raised — mirrors
+    ``build_t0_state.py._last_job_exit_by_label``'s tolerance for the same
+    NDJSON-tail-read shape.
+    """
+    path = Path(state_dir) / REPORT_FILENAME
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return {"swept": False, "run_id": None, "timestamp": None, "findings_count": 0, "findings": []}
+
+    latest_sweep: Optional[Dict[str, Any]] = None
+    findings_by_run: Dict[str, List[Dict[str, Any]]] = {}
+    for line in text.splitlines()[-_LATEST_FINDINGS_TAIL_LINES:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        event_type = record.get("event_type")
+        if event_type == "producer_freshness_sweep":
+            if latest_sweep is None or str(record.get("timestamp") or "") >= str(latest_sweep.get("timestamp") or ""):
+                latest_sweep = record
+        elif event_type == "producer_freshness_finding":
+            run_id = record.get("run_id")
+            findings_by_run.setdefault(run_id, []).append(record)
+
+    if latest_sweep is None:
+        return {"swept": False, "run_id": None, "timestamp": None, "findings_count": 0, "findings": []}
+
+    run_id = latest_sweep.get("run_id")
+    findings = findings_by_run.get(run_id, [])
+    findings_count = latest_sweep.get("findings_count", len(findings))
+    if limit is not None:
+        findings = findings[:limit]
+    return {
+        "swept": True,
+        "run_id": run_id,
+        "timestamp": latest_sweep.get("timestamp"),
+        "status": latest_sweep.get("status"),
+        "findings_count": findings_count,
+        "findings": findings,
+    }
+
+
 def write_heartbeat(state_dir: Path, report: Dict[str, Any]) -> Path:
     """Write the sweep heartbeat via the canonical HealthBeacon.
 
@@ -618,5 +705,6 @@ __all__ = [
     "evaluate_producer",
     "run_sweep",
     "append_report",
+    "latest_findings",
     "write_heartbeat",
 ]

--- a/scripts/producer_freshness_monitor.py
+++ b/scripts/producer_freshness_monitor.py
@@ -17,6 +17,16 @@ Exit codes (house style, cf. check_intelligence_health.py):
 ``--no-write`` performs a read-only sweep (acceptance runs against the live
 store): nothing is appended, no heartbeat is written, no harvest cache is
 touched; the report goes to stdout only.
+
+``--latest-findings`` (OI-1460) is a SEPARATE, cheaper read-only mode: it runs
+NO sweep at all (no directory globs, no sqlite queries, no launchd harvest) —
+it only reads back whatever the last completed sweep already persisted to
+``producer_freshness.ndjson`` via ``producer_freshness.latest_findings()``.
+This is the mode ``hooks/sessionstart.sh`` shells out to on every session
+(same "reuse the existing CLI via subprocess" convention as its beacon-health
+section calling ``scripts/health_check.py``): a full sweep is a scheduled
+batch job, not something a session-start hot path should re-run on every
+``claude`` launch.
 """
 from __future__ import annotations
 
@@ -81,6 +91,15 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--no-write", action="store_true", help="read-only sweep; report to stdout only")
     parser.add_argument("--skip-job-exits", action="store_true", help="do not harvest launchd exit codes")
     parser.add_argument("--human", action="store_true", help="human-readable output")
+    parser.add_argument(
+        "--latest-findings",
+        action="store_true",
+        help=(
+            "read back the last persisted sweep's findings (OI-1460) and exit — "
+            "runs NO new sweep, writes NOTHING, does not require --config/PyYAML. "
+            "The cheap path a SessionStart hook can afford to call every session."
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -88,6 +107,16 @@ def main(argv: Optional[List[str]] = None) -> int:
     except ImportError as exc:
         emit_json({"ok": False, "error": {"code": "dependency", "message": str(exc)}})
         return EXIT_DEPENDENCY
+
+    if args.latest_findings:
+        try:
+            state_dir = Path(args.state_dir) if args.state_dir else _default_state_dir()
+        except (OSError, RuntimeError, KeyError) as exc:
+            emit_json({"ok": False, "error": {"code": "io", "message": f"state dir: {exc}"}})
+            return EXIT_IO
+        result = pf.latest_findings(state_dir)
+        emit_json(result)
+        return EXIT_OK
 
     try:
         registry = pf.load_registry(Path(args.config))

--- a/tests/test_producer_freshness.py
+++ b/tests/test_producer_freshness.py
@@ -570,6 +570,47 @@ def test_cli_no_write_persists_findings_in_report(fake_state: Path) -> None:
     assert heartbeat.exists(), "heartbeat must be written on every run"
 
 
+def test_cli_latest_findings_reads_back_without_a_new_sweep(fake_state: Path, capsys) -> None:
+    """--latest-findings is the cheap read-back path a SessionStart hook can
+    afford to call every session: it must NOT run a sweep (no file touched
+    beyond the read) and must report the findings a PRIOR --config sweep
+    persisted."""
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+
+    rc = cli.main(
+        [
+            "--config",
+            str(REPO_ROOT / "configs" / "producer_freshness.yaml"),
+            "--state-dir",
+            str(fake_state),
+        ]
+    )
+    assert rc == cli.EXIT_OK
+    capsys.readouterr()  # drain the first sweep's stdout
+
+    before = {p: p.stat().st_mtime for p in fake_state.rglob("*") if p.is_file()}
+    rc = cli.main(["--state-dir", str(fake_state), "--latest-findings"])
+    after = {p: p.stat().st_mtime for p in fake_state.rglob("*") if p.is_file()}
+    assert rc == cli.EXIT_OK
+    assert before == after, "--latest-findings must not write or touch any file"
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["swept"] is True
+    assert out["findings_count"] > 0
+    assert any(f["producer"] == "governance_metrics" for f in out["findings"])
+
+
+def test_cli_latest_findings_swept_false_on_an_empty_store(tmp_path: Path, capsys) -> None:
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    rc = cli.main(["--state-dir", str(state_dir), "--latest-findings"])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["swept"] is False
+
+
 # ---------------------------------------------------------------------------
 # 20260816: "PRs merged since the last gate result" — scan_newest + event filter
 # ---------------------------------------------------------------------------
@@ -738,3 +779,195 @@ def test_review_gate_results_freshness_empty_dir_is_missing(tmp_path: Path) -> N
     assert section["findings"][0]["key"] == "results"
     assert section["findings"][0]["kind"] == "missing"
     assert section["findings"][0]["expected_key_absent"] is True
+
+
+# ---------------------------------------------------------------------------
+# latest_findings() — OI-1460: the sweep already detects silent producers
+# (findings_count lands in the heartbeat's `details`, and every finding is
+# appended to producer_freshness.ndjson), but nothing reads that back for a
+# human/session to see. hooks/monitor_tripwire.sh only checks the heartbeat's
+# OWN age; hooks/sessionstart.sh's beacon digest only shows the coarse
+# ok/stale verdict of that same heartbeat. Neither ever surfaces WHICH
+# producer/key went silent, or for how long. Measured live 2026-09-04 in this
+# repo's own store: the last real sweep (run_id 91dc22bbd480) found 10
+# findings, including review_gate_obligations/codex_gate silent 24.88 days --
+# sitting in producer_freshness.ndjson, unread by anything. latest_findings()
+# is the read-back half of the fix: it answers "what did the last sweep find"
+# without running a new sweep, so a cheap SessionStart hook can shell out to
+# it the same way it already shells out to health_check.py.
+# ---------------------------------------------------------------------------
+
+
+def test_latest_findings_swept_false_when_report_file_missing(tmp_path: Path) -> None:
+    """'Never swept' must not read as 'swept, zero findings' -- absence of the
+    report file is its own state, not a favorable default."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = pf.latest_findings(state_dir)
+
+    assert result["swept"] is False
+    assert result["run_id"] is None
+    assert result["findings"] == []
+
+
+def test_latest_findings_swept_true_zero_findings_on_a_clean_run(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    report = {
+        "run_id": "clean0000001",
+        "timestamp": "2026-09-04T10:00:00Z",
+        "state_dir": str(state_dir),
+        "producers_evaluated": 3,
+        "keys_evaluated": 12,
+        "findings_count": 0,
+        "status": "ok",
+        "producers": [],
+        "findings": [],
+    }
+    pf.append_report(state_dir, report)
+
+    result = pf.latest_findings(state_dir)
+
+    assert result["swept"] is True
+    assert result["run_id"] == "clean0000001"
+    assert result["findings"] == []
+    assert result["findings_count"] == 0
+
+
+def test_latest_findings_returns_only_the_most_recent_runs_findings(tmp_path: Path) -> None:
+    """Two sweeps are appended (older run stale on codex_gate, newer run
+    clean on codex_gate but stale on a different key). Only the NEWER run's
+    findings must come back -- an old finding must not linger forever just
+    because the file is append-only."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    old_report = {
+        "run_id": "oldrun000001",
+        "timestamp": "2026-09-01T10:00:00Z",
+        "state_dir": str(state_dir),
+        "producers_evaluated": 1,
+        "keys_evaluated": 1,
+        "findings_count": 1,
+        "status": "stale",
+        "producers": [],
+        "findings": [
+            {
+                "producer": "review_gate_obligations",
+                "key": "codex_gate",
+                "kind": "stale",
+                "last_seen": "2026-08-01T00:00:00Z",
+                "silence_seconds": 30 * DAY,
+                "silence_days": 30.0,
+                "cadence_seconds": DAY,
+            }
+        ],
+    }
+    new_report = {
+        "run_id": "newrun000002",
+        "timestamp": "2026-09-04T10:00:00Z",
+        "state_dir": str(state_dir),
+        "producers_evaluated": 1,
+        "keys_evaluated": 1,
+        "findings_count": 1,
+        "status": "stale",
+        "producers": [],
+        "findings": [
+            {
+                "producer": "governance_metrics",
+                "key": "oi_resolution_rate",
+                "kind": "stale",
+                "last_seen": "2026-06-21T00:00:00Z",
+                "silence_seconds": 75 * DAY,
+                "silence_days": 75.0,
+                "cadence_seconds": 3 * DAY,
+            }
+        ],
+    }
+    pf.append_report(state_dir, old_report)
+    pf.append_report(state_dir, new_report)
+
+    result = pf.latest_findings(state_dir)
+
+    assert result["swept"] is True
+    assert result["run_id"] == "newrun000002"
+    assert len(result["findings"]) == 1
+    assert result["findings"][0]["producer"] == "governance_metrics"
+    assert result["findings"][0]["key"] == "oi_resolution_rate"
+    keys_seen = {(f["producer"], f["key"]) for f in result["findings"]}
+    assert ("review_gate_obligations", "codex_gate") not in keys_seen, (
+        "a finding from a superseded run must not leak into the latest read"
+    )
+
+
+def test_latest_findings_limit_caps_the_returned_list(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    findings = [
+        {
+            "producer": "governance_metrics",
+            "key": f"metric_{i}",
+            "kind": "stale",
+            "last_seen": "2026-06-21T00:00:00Z",
+            "silence_seconds": 75 * DAY,
+            "silence_days": 75.0,
+            "cadence_seconds": 3 * DAY,
+        }
+        for i in range(5)
+    ]
+    report = {
+        "run_id": "capped000001",
+        "timestamp": "2026-09-04T10:00:00Z",
+        "state_dir": str(state_dir),
+        "producers_evaluated": 1,
+        "keys_evaluated": 5,
+        "findings_count": 5,
+        "status": "stale",
+        "producers": [],
+        "findings": findings,
+    }
+    pf.append_report(state_dir, report)
+
+    result = pf.latest_findings(state_dir, limit=2)
+
+    assert result["findings_count"] == 5, "the true count must survive even when the list is capped"
+    assert len(result["findings"]) == 2
+
+
+def test_latest_findings_ignores_a_torn_final_line(tmp_path: Path) -> None:
+    """A crash mid-append can leave a truncated final line. latest_findings()
+    must not raise, and must still resolve the last COMPLETE sweep."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    report = {
+        "run_id": "torntest0001",
+        "timestamp": "2026-09-04T10:00:00Z",
+        "state_dir": str(state_dir),
+        "producers_evaluated": 1,
+        "keys_evaluated": 1,
+        "findings_count": 1,
+        "status": "stale",
+        "producers": [],
+        "findings": [
+            {
+                "producer": "governance_metrics",
+                "key": "rework_rate",
+                "kind": "stale",
+                "last_seen": "2026-08-12T00:00:00Z",
+                "silence_seconds": 23.67 * DAY,
+                "silence_days": 23.67,
+                "cadence_seconds": 3 * DAY,
+            }
+        ],
+    }
+    pf.append_report(state_dir, report)
+    path = state_dir / pf.REPORT_FILENAME
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write('{"event_type": "producer_freshness_sweep", "run_id": "torn')  # no newline, no close
+
+    result = pf.latest_findings(state_dir)
+
+    assert result["swept"] is True
+    assert result["run_id"] == "torntest0001"
+    assert len(result["findings"]) == 1

--- a/tests/test_sessionstart_hook_producer_freshness.py
+++ b/tests/test_sessionstart_hook_producer_freshness.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""tests/test_sessionstart_hook_producer_freshness.py — OI-1460 ("absence must
+be loud"): hooks/sessionstart.sh must surface WHICH producer/gate went silent,
+not just the coarse ok/stale verdict of the sweep's own heartbeat.
+
+Defect this closes: scripts/lib/producer_freshness.py already detects the
+exact failure OI-1460 names ("Geen enkele controle gaat af wanneer een poort
+STOPT met produceren") — it groups activity per producer key and flags a key
+whose newest record is older than its cadence. It runs on a schedule, writes
+its findings to producer_freshness.ndjson, and writes a heartbeat on every
+run (hooks/monitor_tripwire.sh watches that heartbeat's age). None of that
+detection ever reaches a human or a T0 session: monitor_tripwire.sh checks
+only the heartbeat FILE'S AGE, and hooks/sessionstart.sh's existing "Beacon
+health" section (see test_sessionstart_hook_beacon_health.py) only prints the
+beacon's derived health (ok/stale/fail) for `producer_freshness_monitor` as
+ONE beacon among many — never the findings recorded INSIDE that run. A melder
+exists; there was no consumer.
+
+Measured live 2026-09-04 against this repo's own store (never trusted from a
+handoff, per this project's own "een getal zonder herkomst is een claim"
+rule): the persisted heartbeat at ~/.vnx-data/vnx-dev/health/
+producer_freshness_monitor.json reads `"status": "stale"`,
+`"details": {"findings_count": 10, ...}` — and the underlying
+producer_freshness.ndjson for that same run_id (91dc22bbd480) carries, among
+the ten, `review_gate_obligations/codex_gate` silent for 24.88 days. A T0
+session at SessionStart sees "[stale] producer_freshness_monitor: last_run
+..., age ...s" in the existing Beacon health block and nothing else — the
+codex_gate finding itself is invisible without opening
+producer_freshness.ndjson by hand.
+
+Harness pattern (env isolation, `_run_hook`, `_make_terminal_project`) copied
+from tests/test_sessionstart_hook_beacon_health.py, the sibling test for the
+same hook's beacon-health section — same VNX_DATA_HOME redirection, same
+"never touch this repo's own .vnx-data or the live ~/.vnx-data/<project>/
+store" rule. Findings are written via the real
+scripts/lib/producer_freshness.py `append_report()` (never a hand-rolled
+NDJSON fixture) so a schema drift in the writer would break these tests too,
+not just the reader.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "hooks" / "sessionstart.sh"
+LIB = REPO / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import vnx_paths  # noqa: E402
+import producer_freshness as pf  # noqa: E402
+
+_VNX_ENV_VARS = (
+    "VNX_DATA_DIR",
+    "VNX_STATE_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_DATA_HOME",
+    "VNX_PROJECT_ID",
+    "VNX_HOME",
+    "VNX_BIN",
+    "VNX_EXECUTABLE",
+    "VNX_CANONICAL_ROOT",
+    "VNX_PROJECT_ROOT",
+)
+
+
+def _clean_env(monkeypatch) -> None:
+    for var in _VNX_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_terminal_project(tmp_path: Path, name: str = "project") -> Path:
+    root = tmp_path / name
+    (root / ".vnx").mkdir(parents=True)
+    t0_dir = root / ".claude" / "terminals" / "T0"
+    t0_dir.mkdir(parents=True)
+    return t0_dir
+
+
+def _run_hook(cwd: Path, env: dict) -> dict:
+    r = subprocess.run(
+        ["bash", str(HOOK)],
+        capture_output=True, text=True, cwd=str(cwd), env=env, timeout=10,
+    )
+    assert r.returncode == 0, f"hook must exit 0: rc={r.returncode}\nstdout={r.stdout}\nstderr={r.stderr}"
+    return json.loads(r.stdout)
+
+
+def _state_dir(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("VNX_DATA_HOME", str(tmp_path / "vnx-data-home"))
+    return Path(vnx_paths.resolve_paths()["VNX_STATE_DIR"])
+
+
+class TestProducerFreshnessFindingsSurfaceAtSessionStart:
+    """Klaar-wanneer: a real silent-producer finding is visible in the
+    injected additionalContext, by producer, key and how long it has been
+    silent — not just the coarse health of the sweep's own heartbeat."""
+
+    def test_a_silent_gate_finding_surfaces_by_name_and_age(self, tmp_path, monkeypatch):
+        """The exact OI-1460/OI-1460-evidence shape: a review-gate obligation
+        (codex_gate) silent for 24.88 days. Must appear in the injected
+        context naming the producer, the key and the silence duration —
+        not merely 'producer_freshness_monitor: [stale]'."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+
+        report = {
+            "run_id": "91dc22bbd480",
+            "timestamp": "2026-09-04T16:00:05Z",
+            "state_dir": str(state_dir),
+            "producers_evaluated": 7,
+            "keys_evaluated": 143,
+            "findings_count": 1,
+            "status": "stale",
+            "producers": [],
+            "findings": [
+                {
+                    "producer": "review_gate_obligations",
+                    "key": "codex_gate",
+                    "kind": "stale",
+                    "last_seen": "2026-08-10T12:00:00Z",
+                    "silence_seconds": 24.88 * 86400,
+                    "silence_days": 24.88,
+                    "cadence_seconds": 86400,
+                }
+            ],
+        }
+        pf.append_report(state_dir, report)
+        pf.write_heartbeat(state_dir, report)
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+
+        assert "codex_gate" in ctx, ctx
+        assert "24.88" in ctx, ctx
+        assert "review_gate_obligations" in ctx, ctx
+
+    def test_a_clean_sweep_says_so_explicitly(self, tmp_path, monkeypatch):
+        """A sweep that ran and found nothing must say so explicitly — silence
+        here would be indistinguishable from 'nobody ever swept'."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+
+        report = {
+            "run_id": "cleanrun0001",
+            "timestamp": "2026-09-04T16:00:05Z",
+            "state_dir": str(state_dir),
+            "producers_evaluated": 7,
+            "keys_evaluated": 143,
+            "findings_count": 0,
+            "status": "ok",
+            "producers": [],
+            "findings": [],
+        }
+        pf.append_report(state_dir, report)
+        pf.write_heartbeat(state_dir, report)
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+
+        assert "Producer freshness" in ctx, ctx
+        assert "0 silent producer" in ctx, ctx
+
+    def test_never_swept_is_a_third_state_not_silent_ok(self, tmp_path, monkeypatch):
+        """No producer_freshness.ndjson at all (the monitor has never run in
+        this store) must not read as a clean sweep — 'unmeasured' is its own
+        branch, same convention as the beacon digest's D3b 'absence is loud'
+        rule. The state dir is created (but left otherwise empty) so this
+        assertion is not satisfied by an unrelated 'store not found' section
+        that also happens to use the words UNAVAILABLE/UNMEASURED."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        env = dict(os.environ)
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+
+        assert "PRODUCER FRESHNESS UNAVAILABLE" in ctx, ctx
+        assert "UNMEASURED" in ctx, ctx
+
+    def test_older_superseded_finding_does_not_leak_into_context(self, tmp_path, monkeypatch):
+        """Only the LATEST sweep's findings may surface — a finding from a run
+        that has since been re-swept clean must not linger forever in the
+        session context just because the NDJSON file is append-only."""
+        _clean_env(monkeypatch)
+        t0_dir = _make_terminal_project(tmp_path)
+        state_dir = _state_dir(tmp_path, monkeypatch)
+        env = dict(os.environ)
+
+        old_report = {
+            "run_id": "oldrun0000001",
+            "timestamp": "2026-09-01T10:00:00Z",
+            "state_dir": str(state_dir),
+            "producers_evaluated": 1,
+            "keys_evaluated": 1,
+            "findings_count": 1,
+            "status": "stale",
+            "producers": [],
+            "findings": [
+                {
+                    "producer": "review_gate_obligations",
+                    "key": "kimi_gate",
+                    "kind": "stale",
+                    "last_seen": "2026-08-01T00:00:00Z",
+                    "silence_seconds": 30 * 86400,
+                    "silence_days": 30.0,
+                    "cadence_seconds": 86400,
+                }
+            ],
+        }
+        new_report = {
+            "run_id": "newrun0000002",
+            "timestamp": "2026-09-04T16:00:05Z",
+            "state_dir": str(state_dir),
+            "producers_evaluated": 1,
+            "keys_evaluated": 1,
+            "findings_count": 0,
+            "status": "ok",
+            "producers": [],
+            "findings": [],
+        }
+        pf.append_report(state_dir, old_report)
+        pf.write_heartbeat(state_dir, old_report)
+        pf.append_report(state_dir, new_report)
+        pf.write_heartbeat(state_dir, new_report)
+
+        out = _run_hook(t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+
+        assert "kimi_gate" not in ctx, ctx
+        assert "0 silent producer" in ctx, ctx
+
+    def test_hook_is_valid_bash(self):
+        result = subprocess.run(["bash", "-n", str(HOOK)], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Wat en waarom

Operator-opdracht (2026-09-04): "afwezigheid moet luid zijn". Twee gaten waren aangewezen (OI-1460 en OI-1454/OI-1507); dit PR sluit OI-1460, gemeten als het zwaarste — zie onder.

`scripts/lib/producer_freshness.py` detecteert al precies wat OI-1460 beschrijft: "Geen enkele controle gaat af wanneer een poort STOPT met produceren". Het groepeert activiteit per producer-key (per gate-naam, per metric, per dispatch-id-prefix) en vlagt een key wiens nieuwste record ouder is dan zijn eigen cadence. Het draait op een launchd-schema (`scripts/launchd/com.vnx.producer-freshness-monitor.plist`) en schrijft elke vondst naar `producer_freshness.ndjson`, plus een heartbeat op elke run.

Niets las dat terug. `hooks/monitor_tripwire.sh` checkt alleen de LEEFTIJD van het heartbeat-bestand zelf (leeft de monitor). `hooks/sessionstart.sh`'s bestaande beacon-digest toonde alleen de afgeleide gezondheid (ok/stale) van `producer_freshness_monitor` als ÉÉN beacon tussen de rest — nooit WAT de sweep vond. De melder bestond; er was geen consument.

## Gemeten (live, tegen de eigen store van dit project, alleen lezend)

`~/.vnx-data/vnx-dev/health/producer_freshness_monitor.json` las `"status": "stale"` met `"details": {"findings_count": 10, ...}`. In `producer_freshness.ndjson` voor diezelfde run (`91dc22bbd480`) zat onder de tien: `review_gate_obligations/codex_gate` **24,88 dagen stil** — een echte gate die is opgehouden met produceren, onzichtbaar zonder de NDJSON met de hand te openen.

Dit weerlegt de aanname dat er geen melder was: de melder bestaat en werkt correct (leeftijden kloppen met bestands-mtimes, geverifieerd tegen `all_beacons()`'s eigen classificatielogica). Het defect is het ontbreken van een consument, exact zoals de opdracht voorschreef te checken.

## Wat er nu verandert

- `scripts/lib/producer_freshness.py`: nieuwe `latest_findings(state_dir, limit=None)` — leest de laatst gepersisteerde sweep terug (torn-tail-tolerant, tail-bounded op 2000 regels net als `build_t0_state.py`'s `_JOB_EXITS_TAIL_LINES`) zonder een nieuwe sweep te draaien. Onderscheidt drie staten: nooit geveegd / geveegd met 0 vondsten / geveegd met N vondsten — dezelfde "niet-gemeten is een derde tak"-conventie die de rest van dit bestand al volgt.
- `scripts/producer_freshness_monitor.py`: nieuwe `--latest-findings` CLI-vlag — alleen-lezen, geen schrijf, geen nieuwe sweep, geen `--config`/PyYAML nodig. Dit is het goedkope pad dat een SessionStart-hook zich kan veroorloven elke sessie aan te roepen (een volledige sweep blijft een geplande batchjob).
- `hooks/sessionstart.sh`: nieuwe "Producer freshness"-sectie, shell-out naar bovenstaande CLI (zelfde "hergebruik de bestaande CLI via subprocess"-conventie als de beacon-digest en state-freshness secties ernaast). Toont per vondst producer/key/stilte-duur, of expliciet "0 silent producer keys", of expliciet UNAVAILABLE/UNMEASURED wanneer nooit geveegd.

Een T0-sessie ziet nu, zonder iets te hoeven openen:

```
Producer freshness: 10 silent producer key(s) at last sweep (run 91dc22bbd480)
  - [stale] review_gate_obligations/ci_gate: 1.4d silent (cadence 86400.0s)
  - [stale] review_gate_obligations/codex_gate: 24.88d silent (cadence 86400.0s)
  - [stale] review_gate_obligations/glm_gate: 1.21d silent (cadence 86400.0s)
  ...
```

(Bovenstaande is de daadwerkelijke output van de echte hook tegen de echte productie-store — alleen-lezend, geverifieerd via ongewijzigde mtimes na de run.)

## Rode / groene testruns (letterlijk)

RED (vóór implementatie — `latest_findings` bestaat nog niet):
```
$ python3 -m pytest tests/test_producer_freshness.py -k "latest_findings" -q
...
E       AttributeError: module 'producer_freshness' has no attribute 'latest_findings'
7 failed, 22 deselected in 0.38s
```

RED (gedrag op de ECHTE hook — geen findings-sectie, alleen de coarse beacon):
```
$ python3 -m pytest tests/test_sessionstart_hook_producer_freshness.py -q
...
E       assert '0 silent producer' in 'T0 Master Orchestrator Active — project\n...Beacon health: 1 components, all ok\n...'
4 failed, 1 passed in 0.86s
```

GREEN (na implementatie):
```
$ python3 -m pytest tests/test_producer_freshness.py -q
29 passed in 0.43s

$ python3 -m pytest tests/test_sessionstart_hook_producer_freshness.py -q
5 passed in 1.23s

$ python3 -m pytest tests/test_producer_freshness.py tests/test_sessionstart_hook_producer_freshness.py tests/test_sessionstart_hook_beacon_health.py tests/test_sessionstart_hook.py tests/test_sessionstart_hook_dead_vars.py tests/test_sessionstart_hook_central_store.py tests/test_sessionstart_hook_state_freshness.py tests/test_monitor_tripwire.py -q
73 passed in 9.16s

$ python3 -m pytest tests/test_gate_obligations.py tests/test_beacon_register.py tests/test_health_beacon.py -q
109 passed in 9.75s
```

## Welk gat ik koos en waarom

Twee gaten waren aangewezen:
1. **OI-1460** — een poort die stopt met produceren wordt niet gemeld (dit PR).
2. **OI-1454/OI-1507** — `is_available()` meet aanwezigheid, niet bereikbaarheid (litellm-proxy poort 4141 met dode OpenRouter-sleutel antwoordde netjes; drie van vier adapters meldden `available=True` terwijl nul werkten).

Ik koos OI-1460 omdat de meting het zwaarste maakte: de detectiemachinery voor gat 1 bestond AL en draaide AL (launchd-geschema, `producer_freshness.ndjson` groeit sinds juli) — en had op het moment van meten AL 10 echte, correcte vondsten geproduceerd die nergens landden. Het dichten van dit gat was dus zuiver het bouwen van de ontbrekende consument, geen nieuwe detector — een kleinere, scherper afgebakende ingreep met een bewezen-werkend fundament eronder. Gat 2 heeft wel al gedeeltelijke dekking (`dispatch_cli.py::_check_reachability` doet al een live `/v1/models`-probe met auth-header voor de litellm- en deepseek-lanes), maar de concrete code-locaties uit OI-1454 (`scripts/lib/adapters/*.py`, `scripts/lib/classifier_providers/*.py`) zitten buiten mijn bestandsbereik voor deze opdracht (monitoring/beacon/health/liveness) zonder een tweede, aparte detector te bouwen — dat is precies "allebei half doen", wat de opdracht uitsluit.

## Wat ik gemeten heb dat van de opdracht afweek

- De opdracht suggereerde dat de beacon-melder zelf misschien kapot was (precedent: eerder meldde een melder een component als stale terwijl die 513 keer had gedraaid en het beaconbestand niet bestond). Geverifieerd: dat is hier NIET het geval — `health_beacon.all_beacons()` en `producer_freshness.py` rekenen correct, leeftijden kloppen met bestands-mtimes. Het gat zit in de afwezigheid van een consument voor de findings, niet in de melder zelf.
- `dispatch_cli.py::_check_reachability` bleek al een substantiële, live reachability-probe voor de litellm-proxy te bevatten (auth-header, 401/403-detectie, lege-modellijst-WARN) — het presence-vs-reachability-gat voor gat 2 is dus smaller dan de opdrachttekst suggereert; het overgebleven gat zit specifiek in de adapter-laag (`is_available()`), niet in de dispatch-deur zelf.

## Bestandsbereik

Alleen monitoring/beacon/health/liveness-code en eigen tests, zoals opgedragen. Niets onder `docs/**` of `scripts/lib/provider_spawns/` aangeraakt.

Gedraaid buiten de VNX dispatch-deur om, operator-besluit 2026-09-04 (verlengd) — geen `vnx dispatch`-receipt voor deze wijziging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR