### PR TITLE
fix(horizon): drift reason splits plan-gate unread/refused; deliverable list shows titles

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -460,19 +460,44 @@ def _drift_reason(
         if derived == "blocked":
             if _has_table(conn, "track_open_items"):
                 has_pid = _has_col(conn, "track_open_items", "project_id")
+                has_resolved_at = _has_col(conn, "track_open_items", "resolved_at")
+                select_sql = "SELECT oi_id FROM track_open_items WHERE track_id = ?"
+                params: list = [track_id]
                 if has_pid:
-                    blocker = conn.execute(
-                        "SELECT 1 FROM track_open_items WHERE track_id = ? AND project_id = ? "
-                        "AND link_type = 'blocks' LIMIT 1",
-                        (track_id, project_id),
-                    ).fetchone()
-                else:
-                    blocker = conn.execute(
-                        "SELECT 1 FROM track_open_items WHERE track_id = ? AND link_type = 'blocks' LIMIT 1",
-                        (track_id,),
-                    ).fetchone()
+                    select_sql += " AND project_id = ?"
+                    params.append(project_id)
+                select_sql += " AND link_type = 'blocks'"
+                if has_resolved_at:
+                    select_sql += " AND resolved_at IS NULL"
+                select_sql += " ORDER BY oi_id ASC LIMIT 1"
+                blocker = conn.execute(select_sql, params).fetchone()
                 if blocker:
-                    return "blocked by open item"
+                    oi_id = blocker["oi_id"]
+                    # OI-823: a single "blocked by open item" reason hid two
+                    # structurally different facts behind the synthetic
+                    # OI-PLAN-<track> blocker — a plan the gate never
+                    # reviewed (queue depth, not a real problem) and a plan
+                    # the gate reviewed and REFUSED (a finding is on
+                    # record). Reuse the exact classifier cmd_objective_list
+                    # already surfaces as its unread/refused badge, so
+                    # drift's per-row reason and that badge can never
+                    # disagree. A generic (non-plan-gate) blocking open item
+                    # keeps the plain, unqualified label.
+                    if oi_id and oi_id.startswith(_PLAN_OI_PREFIX):
+                        decision_ref = None
+                        if _has_col(conn, "tracks", "decision_ref"):
+                            row = conn.execute(
+                                "SELECT decision_ref FROM tracks WHERE track_id = ? AND project_id = ?",
+                                (track_id, project_id),
+                            ).fetchone()
+                            decision_ref = row["decision_ref"] if row else None
+                        review = plan_gate_enforcement.classify_review_state(
+                            open_plan_blocker=True, decision_ref=decision_ref,
+                        )
+                        if review == plan_gate_enforcement.REFUSED:
+                            return f"blocked: plan-gate refused ({oi_id})"
+                        return f"blocked: plan-gate unread ({oi_id})"
+                    return f"blocked by open item: {oi_id}"
             unmet = conn.execute(
                 """
                 SELECT td.to_track_id
@@ -2339,6 +2364,20 @@ def _fetch_deliverable_records(
             records = []
             for r in raw:
                 meta = json.loads(r["metadata_json"] or "{}")
+                # OI-1615: state IN ('proposed', 'ready') alone is NOT unique
+                # to deliverables — it is the door's ordinary rest state for
+                # ANY accepted dispatch (dispatch_cli.py's
+                # _persist_dispatch_row). Without this check this fallback
+                # lists every plain door dispatch as a "deliverable" the
+                # moment a store hits it (a store predating migration 0027,
+                # where the `deliverables` VIEW that normally shields this
+                # path via `output_ref IS NOT NULL` does not exist yet).
+                # Same discriminator as #1747/OI-1609's
+                # build_t0_state._build_human_gate_queue fix: only a
+                # dispatch cmd_deliverable_add actually created carries
+                # metadata_json.deliverable == true.
+                if not (isinstance(meta, dict) and meta.get("deliverable") is True):
+                    continue
                 rec = {
                     "deliverable_ref": r["output_ref"] or r["dispatch_id"],
                     "output_kind": r["output_kind"] or "-",
@@ -2398,7 +2437,15 @@ def cmd_deliverable_list(args: argparse.Namespace) -> int:
         kind = r.get("output_kind") or "-"
         count = r.get("dispatch_count", 1)
         meta = r.get("metadata") or {}
+        # The text view rendered only the synthetic <kind>:dlv-<hex> ref, never
+        # the title `_fetch_deliverable_records` already parses from
+        # metadata_json (and `--json` already emits) — an operator scanning
+        # this list had no way to tell what any row was without switching to
+        # --json. Same "(missing...)" fallback text as
+        # _format_deliverable_for_plan's title handling, for consistency.
+        title = r.get("title") or "(missing — not set on this deliverable)"
         print(f"    {ref:<36} {kind:<6} {status:<12} ({count} dispatch(es))")
+        print(f"        {title}")
         print(f"        {_format_deliverable_field(meta, 'task_class')}")
         print(f"        {_format_deliverable_field(meta, 'routing_floor')}")
     print()

--- a/tests/test_planning_deliverables.py
+++ b/tests/test_planning_deliverables.py
@@ -36,8 +36,13 @@ from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
 PROJECT_ID = "test-proj"
 
 
-def _build_db(tmp_path: Path) -> Path:
-    """Return a state_dir with migrations 0022 + 0024 + 0027 applied."""
+def _build_db(tmp_path: Path, *, apply_view: bool = True) -> Path:
+    """Return a state_dir with migrations 0022 + 0024 (+ 0027 unless
+    ``apply_view=False``) applied. ``apply_view=False`` leaves the
+    ``deliverables`` VIEW absent so ``_fetch_deliverable_records`` takes the
+    raw-dispatches fallback branch (planning_cli.py's "Fallback: read raw
+    dispatches when view hasn't been applied yet") — the branch OI-1615
+    measured as still carrying the pre-#1747 discriminator bug."""
     state_dir = tmp_path / "state"
     state_dir.mkdir(parents=True)
     # events dir for track audit ledger
@@ -106,12 +111,13 @@ def _build_db(tmp_path: Path) -> Path:
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
 
-    schema_migration.apply_script_if_below(
-        conn,
-        27,
-        (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
-    )
-    conn.commit()
+    if apply_view:
+        schema_migration.apply_script_if_below(
+            conn,
+            27,
+            (_MIGRATIONS / "0027_planning_horizon_and_deliverable_view.sql").read_text(encoding="utf-8"),
+        )
+        conn.commit()
     conn.close()
     return state_dir
 
@@ -208,6 +214,37 @@ def test_deliverable_list_shows_proposed(state_with_track: tuple[Path, str], cap
     assert rc == 0
     out = capsys.readouterr().out
     assert track_id in out
+
+
+def test_deliverable_list_shows_titles(state_with_track: tuple[Path, str], capsys):
+    """The human-readable `deliverable list` view must surface each
+    deliverable's title, not just its synthetic `<kind>:dlv-<hex>` ref. The
+    title is already present on every record `_fetch_deliverable_records`
+    returns (`r["title"]`, parsed from metadata_json) and `--json` already
+    emits it (see test_deliverable_list_json) — only the text renderer never
+    printed it, leaving an operator staring at bare ids with no way to tell
+    what any of them are without switching to --json."""
+    state_dir, track_id = state_with_track
+    for title in ("Post One", "Post Two"):
+        planning_cli.main([
+            "deliverable", "add",
+            "--objective", track_id,
+            "--output-kind", "post",
+            "--title", title,
+            "--project-id", PROJECT_ID,
+            "--state-dir", str(state_dir),
+        ])
+    capsys.readouterr()  # discard add output
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Post One" in out
+    assert "Post Two" in out
 
 
 def test_deliverable_list_json(state_with_track: tuple[Path, str], capsys):
@@ -412,3 +449,70 @@ def test_ready_dispatch_is_claimable(state_with_track: tuple[Path, str], tmp_pat
     result = broker.claim(dispatch_id, terminal_id="T1")
     assert result.dispatch_row["state"] == "claimed"
     assert result.dispatch_row["dispatch_id"] == dispatch_id
+
+
+# ---------------------------------------------------------------------------
+# deliverable list — raw-dispatches fallback (pre-migration-0027 store), OI-1615
+# ---------------------------------------------------------------------------
+#
+# OI-1615 (2026-09-03): the fallback branch of `_fetch_deliverable_records`
+# (planning_cli.py, "Fallback: read raw dispatches when view hasn't been
+# applied yet") selects on `state IN ('proposed', 'ready')` alone, with no
+# check for the `metadata_json.deliverable == true` marker `cmd_deliverable_add`
+# stamps on every row it creates. That is the EXACT bug shape #1747/OI-1609
+# fixed in `build_t0_state._build_human_gate_queue`: state='proposed' is the
+# door's ordinary rest state for ANY accepted dispatch
+# (dispatch_cli.py's `_persist_dispatch_row`), not a deliverable-specific
+# signal. Dormant on the live store today because the `deliverables` VIEW is
+# active there and filters on `output_ref IS NOT NULL` (plain dispatches have
+# a NULL output_ref) — but a store that hasn't run migration 0027 yet (a
+# fresh project cutover) hits this fallback directly and would list every
+# plain door dispatch as a "deliverable".
+
+def test_deliverable_list_fallback_excludes_plain_dispatches(tmp_path: Path, capsys):
+    state_dir = _build_db(tmp_path, apply_view=False)
+    track_id = "feat-alpha"
+    tracks_lib.create_track(
+        state_dir, track_id, PROJECT_ID,
+        title="Feature Alpha", goal_state="ship Feature Alpha",
+        phase="queued",
+        # No horizon= here: migration 0027 (which adds tracks.horizon) is
+        # deliberately absent in this fixture (apply_view=False) — a pre-0027
+        # store cannot set it either.
+    )
+
+    rc = planning_cli.main([
+        "deliverable", "add",
+        "--objective", track_id,
+        "--output-kind", "post",
+        "--title", "Real deliverable",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    capsys.readouterr()
+
+    # A plain door-accepted dispatch: state='proposed' (the door's ordinary
+    # rest state), but NO deliverable marker in metadata_json — this is what
+    # dispatch_cli._persist_dispatch_row leaves behind for every accepted
+    # dispatch, not a proposed deliverable awaiting an operator promote.
+    conn = sqlite3.connect(str(state_dir / tracks_lib.DB_FILENAME))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track, metadata_json) "
+        "VALUES (?, ?, 'proposed', ?, '{}')",
+        ("plain-dispatch-001", PROJECT_ID, track_id),
+    )
+    conn.commit()
+    conn.close()
+
+    rc = planning_cli.main([
+        "deliverable", "list",
+        "--project-id", PROJECT_ID,
+        "--state-dir", str(state_dir),
+        "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    refs = {d["deliverable_ref"] for d in data}
+    assert "plain-dispatch-001" not in refs
+    assert any(d.get("title") == "Real deliverable" for d in data)

--- a/tests/test_planning_turnon.py
+++ b/tests/test_planning_turnon.py
@@ -452,3 +452,107 @@ def test_drift_never_writes_roadmap_or_calls_seeder(seeded_state, monkeypatch):
         t["track_id"]: t["phase"] for t in tracks_lib.list_tracks(state_dir, "vnx-dev")
     }
     assert after_phases == before_phases
+
+
+# ---------------------------------------------------------------------------
+# Part 4 — drift reason: plan-gate unread vs refused (OI-823)
+# ---------------------------------------------------------------------------
+#
+# `_drift_reason` collapsed every 'blocked' track behind an open
+# OI-PLAN-<track> blocker to the single string "blocked by open item" —
+# whether the plan-gate had never looked at the plan (queue depth, not a real
+# problem) or had reviewed it and REFUSED (REVISE/BLOCK, a finding on
+# record). Measured on the live store 2026-09-04: 88 of 91 divergent
+# `vnx objective drift` rows carried that identical reason, all 88 backed by
+# an OI-PLAN-<track> blocker, splitting ~72 unread / ~16 refused via
+# `plan_gate_enforcement.classify_review_state` — the SAME classifier
+# `cmd_objective_list` already uses for its unread/refused badge (see
+# tests/test_planning_cli_objective.py::TestObjectiveListReviewSplit). A
+# signal where 88/91 rows say the same thing sends no signal; this section
+# proves `objective drift`'s per-row reason distinguishes the two, and keeps
+# the ordinary non-plan-gate "blocked by open item" path distinct from both.
+
+@pytest.fixture()
+def plan_gate_seeded_state(seeded_state: tuple[Path, Path]) -> tuple[Path, Path]:
+    """seeded_state + migrations 29/30/33 so the OI-PLAN blocker (resolved_at)
+    and the durable decision_ref both exist and drift's reason can classify
+    unread vs refused (mirrors review_seeded_state in
+    tests/test_planning_cli_objective.py)."""
+    state_dir, roadmap = seeded_state
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    for ver, fname in (
+        (29, "0029_track_type_discriminator.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+        (33, "0033_track_decision_ref.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.close()
+    return state_dir, roadmap
+
+
+def test_drift_reason_distinguishes_unread_from_refused_plan_gate(plan_gate_seeded_state, capsys):
+    state_dir, _ = plan_gate_seeded_state
+
+    # feat-a: OI-PLAN blocker seeded, never reviewed -> unread.
+    tracks_lib.link_open_item(
+        state_dir, "feat-a", "vnx-dev", "OI-PLAN-feat-a", "blocks", "manual",
+    )
+    # feat-c: OI-PLAN blocker seeded AND a recorded REVISE decision -> refused.
+    tracks_lib.link_open_item(
+        state_dir, "feat-c", "vnx-dev", "OI-PLAN-feat-c", "blocks", "manual",
+    )
+    tracks_lib.set_decision_ref(
+        state_dir, "feat-c", "vnx-dev",
+        json.dumps({
+            "decision": "REVISE", "reports": [], "rejected_alternatives": [],
+            "set_at": "2026-09-04T00:00:00Z",
+        }),
+    )
+
+    rc = planning_cli.main([
+        "objective", "drift", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--json",
+    ])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    by_id = {d["track_id"]: d["reason"] for d in summary["divergent"]}
+
+    assert "feat-a" in by_id
+    assert "feat-c" in by_id
+    reason_a = by_id["feat-a"]
+    reason_c = by_id["feat-c"]
+
+    # The core complaint: two structurally different facts must not collapse
+    # to the same string.
+    assert reason_a != reason_c
+    assert "unread" in reason_a.lower()
+    assert "refused" in reason_c.lower()
+    assert "OI-PLAN-feat-a" in reason_a
+    assert "OI-PLAN-feat-c" in reason_c
+
+
+def test_drift_reason_keeps_generic_open_item_distinct_from_plan_gate(plan_gate_seeded_state, capsys):
+    """A genuine (non-plan-gate) blocking open item must still read as a
+    plain 'blocked by open item' — never absorbed into the plan-gate
+    unread/refused split, and never silently indistinguishable from it."""
+    state_dir, _ = plan_gate_seeded_state
+    tracks_lib.link_open_item(
+        state_dir, "feat-c", "vnx-dev", "OI-9001", "blocks", "manual",
+    )
+
+    rc = planning_cli.main([
+        "objective", "drift", "--project-id", "vnx-dev",
+        "--state-dir", str(state_dir), "--json",
+    ])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    by_id = {d["track_id"]: d["reason"] for d in summary["divergent"]}
+
+    assert "feat-c" in by_id
+    reason = by_id["feat-c"]
+    assert "OI-9001" in reason
+    assert "unread" not in reason.lower()
+    assert "refused" not in reason.lower()


### PR DESCRIPTION
## Summary

Two measured signal-quality bugs in the horizon/tracks CLI (`scripts/planning_cli.py`, invoked via `vnx objective drift` / `vnx deliverable list`, and pass-through wrapped by `vnx_cli/commands/horizon.py`).

**1. `vnx objective drift` reason collapses 88/91 divergent rows to one string (OI-823).**
Measured on the live `vnx-dev` store (2026-09-04): 91 divergent rows, 88 of them reading the identical reason `"blocked by open item"`. All 88 turned out to be the synthetic `OI-PLAN-<track>` plan-gate blocker, splitting **72 never-reviewed** (queue depth, not a real problem) vs **16 reviewed-and-REVISE'd** (a real finding on record), via `plan_gate_enforcement.classify_review_state` — the exact classifier `cmd_objective_list` already uses for its unread/refused badge. `_drift_reason` now reuses it: a REFUSED row reads `blocked: plan-gate refused (OI-PLAN-<track>)`, an UNREAD row reads `blocked: plan-gate unread (OI-PLAN-<track>)`, and a genuine non-plan-gate blocking open item keeps its own distinct `blocked by open item: <id>` label — never folded into either plan-gate bucket.

This was already flagged as `BESTAAT-GROOT` in `docs/investigations/20260801-oi-triage-r5.md` (OI-823) on 2026-08-01, framed as a "report as a separate class" design choice. The classifier to make that choice concrete (`plan_gate_enforcement.UNREAD`/`REFUSED`) already existed and is already wired into `cmd_objective_list` — it just was never wired into `cmd_objective_drift`.

**2. `vnx deliverable list` prints only ids, never titles.**
The text view rendered only the synthetic `<kind>:dlv-<hex>` ref, never the title. The title was already present on every record (`_fetch_deliverable_records` parses it from `metadata_json`, and `--json` already emits it) — the human-readable print loop simply never referenced it. Fixed by printing the title under the ref line.

Per the dispatch instruction I checked whether this was the same bug shape as OI-1609/#1747 (as OI-1615 claims). It is **not the same bug**: OI-1615's actual finding is that the FALLBACK branch of `_fetch_deliverable_records` (only reached on a pre-migration-0027 store, where the `deliverables` VIEW doesn't exist yet) selects on `state IN ('proposed', 'ready')` alone with no `metadata_json.deliverable == true` marker check — the exact discriminator bug #1747 fixed in `build_t0_state._build_human_gate_queue`. That claim held up on inspection (still real, dormant today only because the live store's VIEW shields the fallback via `output_ref IS NOT NULL`), so I fixed it the same way while I was already in this function, even though it's not what causes the directly observed "no titles" symptom.

## Scope note

The dispatch's file-scope list named `vnx_cli/**`, `scripts/lib/track_reconciler.py` and `scripts/lib/tracks.py` as "the horizon-/tracks-CLI and the reconciler" but did not spell out `scripts/planning_cli.py` by name. Both bugs live there — `vnx_cli/commands/horizon.py` is a thin pass-through to `planning_cli.cmd_objective_drift` / `cmd_deliverable_list`, which is where the actual logic (and the fix) has to land. I read the file-scope note as "the horizon/tracks CLI layer", which necessarily includes its implementation module; none of the parallel agents' explicit RAAK NIET AAN paths (`docs/**`, `scripts/ci/**`, `scripts/launchd/**`, `hooks/sessionstart.sh`, `scripts/lib/producer_freshness.py`, `scripts/producer_freshness_monitor.py`, `idempotency.py`, `scripts/gate_obligation_runner.py`, `scripts/lib/provider_spawns/**`) overlap this file.

Running as a subagent via the Agent tool, deliberately outside the VNX dispatch door (operator decision 2026-09-04, extended).

## Changes

- `scripts/planning_cli.py`
  - `_drift_reason`: the "blocked" branch now fetches the actual blocking `oi_id` (filtered on `resolved_at IS NULL` when that column exists, matching the reconciler's own blocker predicate) instead of a bare existence probe. An `OI-PLAN-<track>` blocker is classified via `plan_gate_enforcement.classify_review_state` into `unread`/`refused`; any other blocking open item keeps a plain `blocked by open item: <id>` label.
  - `_fetch_deliverable_records` (raw-dispatches fallback branch, pre-migration-0027 stores only): added the `metadata_json.deliverable is True` marker filter (OI-1615), matching #1747/OI-1609's fix in `build_t0_state._build_human_gate_queue`.
  - `cmd_deliverable_list`: the text-mode print loop now prints each deliverable's title (falling back to the same `"(missing — not set on this deliverable)"` text `_format_deliverable_for_plan` already uses).
- `tests/test_planning_turnon.py`: new `plan_gate_seeded_state` fixture (migrations 29/30/33 on top of `seeded_state`) + two tests proving the drift reason distinguishes unread vs refused vs a genuine generic open item.
- `tests/test_planning_deliverables.py`: `_build_db` gained an `apply_view: bool = True` param; new tests for title-in-text-output and for the fallback-path marker filter (OI-1615).

## Verification

Red then green (verbatim):
```
$ pytest tests/test_planning_turnon.py -k drift_reason
FAILED tests/test_planning_turnon.py::test_drift_reason_distinguishes_unread_from_refused_plan_gate
    AssertionError: assert 'blocked by open item' != 'blocked by open item'
FAILED tests/test_planning_turnon.py::test_drift_reason_keeps_generic_open_item_distinct_from_plan_gate
    AssertionError: assert 'OI-9001' in 'blocked by open item'
2 failed, 15 deselected

$ pytest tests/test_planning_deliverables.py -k "shows_titles or fallback_excludes_plain"
FAILED tests/test_planning_deliverables.py::test_deliverable_list_shows_titles
    AssertionError: assert 'Post One' in "...post:dlv-1ea084a7d21d ... proposed ...\n        task_class: ...\n"
FAILED tests/test_planning_deliverables.py::test_deliverable_list_fallback_excludes_plain_dispatches
    AssertionError: assert 'plain-dispatch-001' not in {'plain-dispatch-001', 'post:dlv-5b35101d6c23'}
2 failed, 9 deselected
```

After the fix:
```
$ pytest tests/test_planning_turnon.py tests/test_planning_deliverables.py -v
... 28 passed in 0.95s
```

Also ran (unmodified, verifying no regressions from the change): `tests/test_planning_cli_objective.py`, `tests/test_deliverable_task_class_routing_floor.py`, `tests/test_central_mode_path_resolution.py`, `tests/test_deliverable_close.py`, `tests/test_dispatch_door_row.py`, `tests/test_horizon_cli.py`, `tests/test_horizon_parity.py`, `tests/test_horizon_skill_alias.py`, `tests/test_irreversible_flag_transport.py`, `tests/test_objective_close.py`, `tests/test_objective_reconcile.py`, `tests/test_objective_reopen.py`, `tests/test_objective_set_goal.py`, `tests/test_oi_bridge_supervisor_tick.py`, `tests/test_oi_track_bridge.py`, `tests/test_plan_gate_batch.py`, `tests/test_plan_gate_deliverables_source.py`, `tests/test_plan_gate_goal_state_plan.py`, `tests/test_plan_gate_tiebreaker.py`, `tests/test_planning_cli_lane_hint.py`, `tests/test_planning_cli_objective_add.py`, `tests/test_track_oi_lifecycle.py`: **564 passed, 3 pre-existing failures** (`test_oi_track_bridge.py`'s `output_ref` schema-fixture gap — confirmed via `git stash` to already fail identically on `main` at `509d8bc5`, untouched by this diff).

Per instruction, did NOT run and did NOT attempt to fix the known-red files already on `test_exclusions.txt` (OI-946/OI-1227): `tests/test_planning_cli.py` (27 failed / 24 passed), `tests/test_plan_gate_panel.py` (5 failed / 130 passed), `tests/test_horizon_schema_migration_fix.py` (8 failed / 27 passed) — all confirmed already red on `main` before this change.

**Real-data verification** (read-only copy of the live `vnx-dev` `runtime_coordination.db`, never mutated): before the fix, 88/91 divergent drift rows read `"blocked by open item"`; after the fix, the same 91 rows split into **72 `"plan-gate unread"`**, **16 `"plan-gate refused"`**, 2 `"blocked by dependency"`, 1 delivery-hold. Zero rows fell into the generic non-plan-gate bucket — confirming all 88 were genuinely `OI-PLAN-*` blockers, none a real generic open-item block.

## Open Items

None. I deliberately did NOT build a backfill/link-pr script and did NOT link today's other PRs to objectives — that's explicitly the operator's own orchestration work per the dispatch instructions.

Dispatch-ID: 20260904-drift-reason-plan-gate-split-and-deliverable-titles
**Model**: opus
**Provider**: claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9dJ7KNLXGeAibMYUQuEpR