### PR TITLE
feat(registry): register gpt-6-astra under provider openai

### DIFF
--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -147,6 +147,29 @@ providers:
         price_source: "unverified: registry-authored"
         price_checked_at: "2026-06-07"
         task_classes: ["coding", "review"]
+      # Allowlist extension by operator decision 2026-09-05
+      # (dispatch-20260905-084500-registry-gpt6-astra): GPT-6 Astra released
+      # 2026-09-03, broad rollout 2026-09-05. Deliberate addition, not an
+      # automatic pickup — gpt-5.5/gpt-5.4 stay registered; DEFAULT_CODEX_MODEL
+      # in scripts/lib/provider_spawns/codex_spawn.py stays put.
+      # Cost notes that shaped this entry:
+      #   - prompts above 272K input tokens are billed at 2x input and 1.5x
+      #     output for the WHOLE request; the flat rates below apply under that
+      #     threshold and the surcharge is not modelled here.
+      #   - the codex lane at this operator runs on a ChatGPT login, not API
+      #     credits, so these prices are bookkeeping (chargeback/comparison),
+      #     not a meter that bills.
+      gpt-6-astra:
+        litellm_name: "openai/gpt-6-astra"
+        cost_input_per_mtok: 10.00
+        cost_output_per_mtok: 50.00
+        max_tokens: 128000
+        context_window: 1050000
+        supports_streaming: true
+        supports_tool_calls: true
+        price_source: "OpenAI public pricing, geverifieerd door operator 2026-09-05"
+        price_checked_at: "2026-09-05"
+        task_classes: ["coding-premium", "review", "analysis"]
   google:
     enabled: true
     api_key_env: GEMINI_API_KEY

--- a/tests/test_constraint_enforcer.py
+++ b/tests/test_constraint_enforcer.py
@@ -517,6 +517,37 @@ class TestRoute1Requirements:
                 check_registry=True,
             )
 
+    def test_codex_gpt6_astra_passes_registry_gate(self):
+        """dispatch-20260905-084500-registry-gpt6-astra: gpt-6-astra is registered
+        under the openai section (registry key for provider 'codex') by operator
+        decision of 2026-09-05, so a codex dispatch asking for it must pass the
+        model-not-in-current-registry route check.
+
+        RED before the wave7_models.yaml entry exists (same rejection as the
+        measured 'gpt-5.2-codex' case above); GREEN after. The workers-kimi-pinned
+        warn is expected on T1 — it is not a registry rejection and must not be
+        blocking here either."""
+        violations = check_constraints(
+            provider="codex",
+            model="gpt-6-astra",
+            terminal_id="T1",
+            via="cli",
+            check_registry=True,
+        )
+        blocking = [v for v in violations if v.severity == "blocking"]
+        assert not any(v.code == "model-not-in-current-registry" for v in blocking), (
+            f"gpt-6-astra rejected by registry gate: {[v.message for v in blocking]}"
+        )
+        # enforce() raises on any blocking violation — the registry gate must not
+        # be among them.
+        ConstraintEnforcer().enforce(
+            provider="codex",
+            model="gpt-6-astra",
+            terminal_id="T1",
+            via="cli",
+            check_registry=True,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Dispatch-level _via per-sub-provider mapping (provider_dispatch.main integration)

--- a/tests/test_price_provenance.py
+++ b/tests/test_price_provenance.py
@@ -240,6 +240,11 @@ _PINNED_PRICES: dict[tuple[str, str], tuple[float, float]] = {
     ("anthropic", "fable-5"): (10.0, 50.0),
     ("openai", "gpt-5.5"): (5.0, 30.0),
     ("openai", "gpt-5.4"): (1.25, 10.0),
+    # dispatch-20260905-084500-registry-gpt6-astra: allowlist extension by
+    # operator decision 2026-09-05. Rates are the <=272K-input flat pair; above
+    # 272K input the whole request bills 2x input / 1.5x output (not modelled
+    # here). Codex lane runs on a ChatGPT login — bookkeeping, not billed.
+    ("openai", "gpt-6-astra"): (10.0, 50.0),
     ("google", "gemini-2.5-pro"): (1.25, 5.0),
     ("deepseek", "deepseek-v4-pro"): (0.435, 0.87),
     ("deepseek", "deepseek-v4-flash"): (0.14, 0.28),
@@ -285,6 +290,7 @@ _VERIFIED: set[tuple[str, str]] = {
     ("anthropic", "opus-4-6"),
     ("anthropic", "sonnet-5"),
     ("openai", "gpt-5.5"),
+    ("openai", "gpt-6-astra"),
     ("kimi_cli", "kimi-k3"),
 }
 


### PR DESCRIPTION
## Waarom

OpenAI GPT-6 Astra (release 2026-09-03, brede uitrol 2026-09-05) werd door de deur geweigerd met `REJECT [model-not-in-current-registry]: model 'gpt-6-astra' is not registered for provider 'codex' (registry key 'openai')`. De allowlist werkte zoals bedoeld; deze PR voegt de toegestane waarde toe op operator-besluit van 2026-09-05.

## Wat

- `scripts/lib/providers/wave7_models.yaml`: `gpt-6-astra` toegevoegd onder `openai.models` naast `gpt-5.5`/`gpt-5.4` (beide blijven staan), met gemeten waarden en een comment die vastlegt: (a) bewuste allowlist-uitbreiding, geen automatisme; (b) >272K input-tokens = 2x input / 1,5x output over het HELE verzoek (niet gemodelleerd); (c) de codex-lane draait op een ChatGPT-login — prijzen zijn boekhouding.
- `DEFAULT_CODEX_MODEL` in `scripts/lib/provider_spawns/codex_spawn.py` ongemoeid gelaten.
- `tests/test_constraint_enforcer.py`: nieuwe test `test_codex_gpt6_astra_passes_registry_gate` — eerst ROOD gezien (exacte reject uit de dispatch), daarna groen.
- `tests/test_price_provenance.py`: pins bijgewerkt (`_PINNED_PRICES` + `_VERIFIED`) zoals het contract van dat bestand voorschrijft.

## Verificatie

- Weigerroute gemeten vóór de wijziging: `scripts/lib/providers/constraint_enforcer.py:596-605` (`_model_in_registry`, regel 278; codex→openai mapping regel 194-195), aangeroepen vanuit `scripts/lib/dispatch_cli.py:1908` met `check_registry=True`.
- RODE run: `pytest tests/test_constraint_enforcer.py -k "gpt6_astra or model_not_in_current_registry" -x` → 1 failed, 1 passed (faalde met exact de dispatch-melding).
- GROENE runs: `pytest tests/test_constraint_enforcer.py tests/test_price_provenance.py tests/test_provider_costs.py tests/test_codex_spawn_fail_closed.py tests/test_cost_table.py` → 204 passed, 1 skipped, 1 pre-existing env-failure (`test_deepseek_via_litellm_allowed`, faalt ook op clean main zonder `DEEPSEEK_API_KEY`); `pytest tests/test_token_extraction_per_provider.py tests/test_model_ssot_and_chainlink.py tests/test_cost_loader.py tests/smart_router/test_cost_ladder.py` → 128 passed.

Dispatch-ID: 20260905-084500-registry-gpt6-astra