### PR TITLE
fix(codex): quota exhaustion discarded as no_verdict, not classified (OI-1628)

### DIFF
--- a/scripts/lib/failure_classification.py
+++ b/scripts/lib/failure_classification.py
@@ -96,6 +96,19 @@ FAILURE_CLASSES = frozenset({
 # stable contract — a future variant that does not match one of these phrases
 # falls through to `unknown` below and must be added here explicitly once
 # observed, never silently absorbed back into a contentless placeholder.
+#
+# OI-1628, measured 2026-09-05 on three live dispatches
+# (~/.codex/sessions/2026/09/05/rollout-*.jsonl): codex reports its own
+# quota exhaustion inside a `task_complete` event's `error` object —
+# {"message": "You've hit your usage limit. ...", "codex_error_info":
+# "usage_limit_exceeded"}. "hit your usage limit" is deliberately narrower
+# than the bare phrase "usage limit": kimi's own 403 auth-rejection prose
+# ("reached your usage limit" / "usage limit for this billing cycle",
+# already GEMETEN OI-1433 2026-08-22) shares the "usage limit" substring
+# with a different verb, so the broad form would reclassify kimi's
+# auth_rejected as credit_exhausted. "hit your usage limit" was already
+# vetted codex-specific in governance_emit.py's _LANE_EXHAUSTED_MARKERS
+# (2026-08-26) — it did not yet exist in this receipt-facing taxonomy.
 CREDIT_EXHAUSTED_KEYWORDS = (
     "insufficient balance",
     "insufficient_balance",
@@ -103,6 +116,8 @@ CREDIT_EXHAUSTED_KEYWORDS = (
     "requires more credits",
     "add more credits",
     "openrouter_credits",
+    "hit your usage limit",
+    "usage_limit_exceeded",
 )
 
 # P3 (dispatch 20260821-q3-failure-class-split): three real, distinguishable

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -248,10 +248,32 @@ def _normalize_complete_events(
     payload: dict,
     make: Callable,
 ) -> Optional[CanonicalEvent]:
-    """Handle error, turn.completed, result/message, token_count events."""
+    """Handle error, turn.completed, task_complete, result/message, token_count events."""
     if etype == "error":
         msg = payload.get("message", payload.get("error", payload.get("text", "")))
         return make("error", {"message": str(msg) if msg else str(payload)[:200]})
+    if etype == "task_complete":
+        # OI-1628, measured 2026-09-05 on three live dispatches
+        # (~/.codex/sessions/2026/09/05/rollout-*.jsonl): codex reports quota/
+        # usage-limit exhaustion as an `error` object nested inside its own
+        # `task_complete` event, not as a top-level `error` event type, e.g.
+        #   {"type": "task_complete", "error": {"message": "You've hit your
+        #    usage limit. ...", "codex_error_info": "usage_limit_exceeded"}}
+        # Before this branch, task_complete matched none of the cases here
+        # and fell through to the unknown-type passthrough below (mapped to
+        # "info"), discarding the error text before failure classification
+        # ever saw it.
+        err = payload.get("error")
+        if isinstance(err, dict) and err:
+            msg = err.get("message") or err.get("codex_error_info") or str(err)
+            info = err.get("codex_error_info")
+            if info and str(info) not in str(msg):
+                msg = f"{msg} (codex_error_info: {info})"
+            return make("error", {"message": str(msg)})
+        tc = _extract_token_count_payload(raw)
+        token_count = _normalize_token_count(tc) if tc else None
+        data: dict = {"token_count": token_count} if token_count else {}
+        return make("complete", data)
     if etype == "turn.completed":
         tc = _extract_token_count_payload(raw)
         token_count = _normalize_token_count(tc) if tc else None
@@ -541,6 +563,14 @@ def _drain_stream(
     stopped_early = False
     last_token_usage: Optional[Dict[str, Any]] = None
     last_stuck_log = 0.0
+    # OI-1628: capture the first in-stream "error" canonical event's message
+    # so it reaches CodexSpawnResult.error (and from there classify_failure).
+    # Previously this loop only inspected an error event's "reason" key (set
+    # by the drainer mixin's own synthetic timeout/stall errors) to flip
+    # timed_out — a real codex error/task_complete error's "message" text was
+    # read by no one, so the caller always fell back to the generic "codex
+    # stderr tail" surfacing below regardless of what the stream said.
+    captured_error: Optional[str] = None
 
     try:
         for canonical_event in normalizer.drain_stream(
@@ -559,9 +589,14 @@ def _drain_stream(
                 if tc:
                     last_token_usage = tc
             if canonical_event.event_type == "error":
-                reason = (canonical_event.data or {}).get("reason", "")
+                error_data = canonical_event.data or {}
+                reason = error_data.get("reason", "")
                 if "timeout" in (reason or "").lower():
                     timed_out = True
+                if captured_error is None:
+                    msg = error_data.get("message") or reason
+                    if msg:
+                        captured_error = str(msg)
 
             stop, last_stuck_log, writer_failed = _process_one_event(
                 canonical_event, terminal_id, dispatch_id,
@@ -588,7 +623,7 @@ def _drain_stream(
         _wait_proc(proc)
         return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, str(exc), _event_writer_failures
 
-    return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, None, _event_writer_failures
+    return completion_parts, events_written, session_id, timed_out, stopped_early, last_token_usage, captured_error, _event_writer_failures
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_spawn_fail_closed.py
+++ b/tests/test_codex_spawn_fail_closed.py
@@ -192,6 +192,62 @@ class TestCodexSpawnTimeout:
 
 
 # ---------------------------------------------------------------------------
+# OI-1628: a task_complete-derived "error" canonical event's message must
+# reach CodexSpawnResult.error, not vanish (previously only "reason" was
+# read, to flip timed_out — a real error message was captured by no one and
+# the caller fell back to the generic "codex stderr tail" surfacing).
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnQuotaExhaustion:
+    """spawn_codex surfaces a codex quota/usage-limit error into result.error."""
+
+    def test_task_complete_usage_limit_error_reaches_result_error(self):
+        error_event = CanonicalEvent(
+            dispatch_id="test-quota",
+            terminal_id="T1",
+            provider="codex",
+            event_type="error",
+            data={
+                "message": (
+                    "You've hit your usage limit. Upgrade to Pro "
+                    "(https://chatgpt.com/explore/pro), visit "
+                    "https://chatgpt.com/codex/settings/usage to purchase "
+                    "more credits or try again at 2:27 PM. "
+                    "(codex_error_info: usage_limit_exceeded)"
+                )
+            },
+            observability_tier=1,
+        )
+
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 1
+            proc.wait = MagicMock(return_value=1)
+            proc.poll = MagicMock(return_value=1)
+            stdin_mock = MagicMock()
+            proc.stdin = stdin_mock
+            proc.stderr = _mock_stderr(b"Reading prompt from stdin...\n")
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter([error_event]),
+            ):
+                result = spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id="test-quota",
+                    terminal_id="T1",
+                )
+
+        assert result.error is not None, "Expected result.error to be populated"
+        assert "usage_limit_exceeded" in result.error, (
+            f"Expected the captured quota message in result.error, got: {result.error!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Test 4: on_event=False stops stream early
 # ---------------------------------------------------------------------------
 

--- a/tests/test_failure_classification.py
+++ b/tests/test_failure_classification.py
@@ -765,6 +765,64 @@ class TestP3FailureClassSplit(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# TestOI1628CodexQuotaExhaustion — dispatch 20260905-100002-oi1628-quota-klasse
+#
+# Codex reports its own quota exhaustion via a `task_complete` event's nested
+# `error` object: {"message": "You've hit your usage limit. ...",
+# "codex_error_info": "usage_limit_exceeded"}. Before this dispatch,
+# CREDIT_EXHAUSTED_KEYWORDS carried no phrase matching that text, so it fell
+# through every other bucket to `unknown` — or, once codex_spawn.py's stderr
+# tail fallback appended its own text, to `no_verdict` (the exact receipt
+# shape measured live: failure_class="no_verdict", failure_reason="codex
+# stderr tail: Reading prompt from stdin...").
+# ---------------------------------------------------------------------------
+
+class TestOI1628CodexQuotaExhaustion(unittest.TestCase):
+    """OI-1628: codex usage-limit exhaustion must classify as credit_exhausted."""
+
+    _CODEX_QUOTA_REASON = (
+        "You've hit your usage limit. Upgrade to Pro "
+        "(https://chatgpt.com/explore/pro), visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits "
+        "or try again at 2:27 PM. (codex_error_info: usage_limit_exceeded)"
+    )
+
+    def test_codex_usage_limit_recognized_as_credit_exhausted(self):
+        from failure_classification import classify_failure
+
+        result = classify_failure(
+            status="failure",
+            error=self._CODEX_QUOTA_REASON,
+            completion_text=None,
+            provider="codex",
+            returncode=1,
+        )
+        self.assertEqual(result["failure_class"], "credit_exhausted")
+
+    def test_codex_usage_limit_wins_over_stderr_tail_no_verdict_marker(self):
+        """Real receipt shape: spawn_codex() always appends the generic
+        "codex stderr tail" fallback text after any captured error when
+        returncode != 0 (codex_spawn.py). credit_exhausted must still win
+        over the no_verdict markers ("codex stderr tail", "reading prompt
+        from stdin") sitting later in the same string — this is the exact
+        live-observed combination (OI-1628)."""
+        from failure_classification import classify_failure
+
+        combined = (
+            self._CODEX_QUOTA_REASON
+            + " | codex stderr tail: Reading prompt from stdin..."
+        )
+        result = classify_failure(
+            status="failure",
+            error=combined,
+            completion_text=None,
+            provider="codex",
+            returncode=1,
+        )
+        self.assertEqual(result["failure_class"], "credit_exhausted")
+
+
+# ---------------------------------------------------------------------------
 # TestP3VocabularySeparation — dispatch 20260821-q3-failure-class-split
 #
 # The dispatch measured a real two-vocabulary hazard:

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -80,6 +80,20 @@ def _kimi_403_failure_reason() -> str:
     )
 
 
+def _codex_quota_failure_reason() -> str:
+    # OI-1628: the exact shape a codex quota-exhaustion receipt carries once
+    # both codex_spawn.py's task_complete handling and
+    # failure_classification.py's credit_exhausted keywords are fixed —
+    # grounded on the real task_complete event measured 2026-09-05 on three
+    # live dispatches (~/.codex/sessions/2026/09/05/rollout-*.jsonl).
+    return (
+        "openai-api: credit/balance exhausted — You've hit your usage limit. "
+        "Upgrade to Pro (https://chatgpt.com/explore/pro), visit "
+        "https://chatgpt.com/codex/settings/usage to purchase more credits "
+        "or try again at 2:27 PM. (codex_error_info: usage_limit_exceeded)"
+    )
+
+
 def _gate_result(pr_number, gate, *, status, reason=None, blocking_findings=None, recorded_at="2026-09-04T00:00:00Z"):
     d = {"pr_number": pr_number, "gate": gate, "status": status, "recorded_at": recorded_at}
     if reason is not None:
@@ -270,6 +284,30 @@ class TestProviderExhausted:
                 "failure_reason": _kimi_403_failure_reason(),
                 "dispatch_id": f"d{i}",
                 "timestamp": "2026-09-04T00:00:00Z",
+            }
+            for i in range(3)
+        ]
+        _write_receipt_lines(receipts, records)
+        result = check_provider_exhausted(receipts, threshold=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_codex_quota_realistic_failure_reason_fixture(self, tmp_path):
+        # OI-1628: before this dispatch's fix, codex's usage-limit exhaustion
+        # classified as failure_class="no_verdict" — not in
+        # EXHAUSTION_FAILURE_CLASSES — so this check never fired for codex no
+        # matter how many consecutive quota failures piled up. Grounds the
+        # check against the exact receipt shape once classify_failure()
+        # correctly labels it credit_exhausted (fixture, not the live store).
+        receipts = tmp_path / "t0_receipts.ndjson"
+        records = [
+            {
+                "event_type": "task_complete",
+                "provider": "codex",
+                "status": "failure",
+                "failure_class": "credit_exhausted",
+                "failure_reason": _codex_quota_failure_reason(),
+                "dispatch_id": f"d{i}",
+                "timestamp": "2026-09-05T00:00:00Z",
             }
             for i in range(3)
         ]

--- a/tests/unit/test_codex_event_normalizer.py
+++ b/tests/unit/test_codex_event_normalizer.py
@@ -192,6 +192,54 @@ class TestErrorEvents:
         assert event.data["message"] == "unknown command"
 
 
+# ── task_complete → error (when it carries one) or complete ─────────────────
+# OI-1628: codex reports quota/usage-limit exhaustion inside its own
+# `task_complete` event's `error` object, not as a top-level `error` event
+# type. Measured 2026-09-05 on three live dispatches
+# (~/.codex/sessions/2026/09/05/rollout-*.jsonl), real shape reproduced below.
+
+class TestTaskCompleteEvents:
+    def test_task_complete_with_usage_limit_error_maps_to_error(self, adapter):
+        raw = {
+            "event_msg": {
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "01a07082-f05c-7530-8f40-e5e3aaa998e3",
+                    "last_agent_message": None,
+                    "error": {
+                        "message": (
+                            "You've hit your usage limit. Upgrade to Pro "
+                            "(https://chatgpt.com/explore/pro), visit "
+                            "https://chatgpt.com/codex/settings/usage to "
+                            "purchase more credits or try again at 2:27 PM."
+                        ),
+                        "codex_error_info": "usage_limit_exceeded",
+                    },
+                    "started_at": 1788594024,
+                    "completed_at": 1788594229,
+                }
+            }
+        }
+        event = adapter._normalize(raw)
+        assert_canonical(event, "error")
+        assert "hit your usage limit" in event.data["message"]
+        assert "usage_limit_exceeded" in event.data["message"]
+
+    def test_task_complete_without_error_maps_to_complete(self, adapter):
+        raw = {
+            "event_msg": {
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "01a07084-56f1-7191-85ba-5fc808983260",
+                    "last_agent_message": "Done.",
+                    "error": None,
+                }
+            }
+        }
+        event = adapter._normalize(raw)
+        assert_canonical(event, "complete")
+
+
 # ── turn.completed → complete (with token_count) ──────────────────────────────
 
 class TestCompleteEvents:


### PR DESCRIPTION
## Summary
- Codex reports quota/usage-limit exhaustion inside a `task_complete` event's nested `error` object (`{"error": {"message": "You've hit your usage limit. ...", "codex_error_info": "usage_limit_exceeded"}}`), measured 2026-09-05 on three live dispatches (`~/.codex/sessions/2026/09/05/rollout-*.jsonl`).
- `codex_spawn.py`'s normalizer had no case for `task_complete`, so the event fell through to the unknown-type passthrough (mapped to `"info"`) and the error text was discarded before failure classification ever saw it.
- Even once normalized to an `"error"` canonical event, `_drain_stream`'s loop only read an error event's `"reason"` key (to flip the `timed_out` flag) and never captured its `"message"` into `CodexSpawnResult.error` — so the caller always fell back to the generic "codex stderr tail" surfacing regardless of what the stream actually said.
- `failure_classification.py`'s `CREDIT_EXHAUSTED_KEYWORDS` had no phrase matching codex's quota text either, so even a correctly-surfaced message would classify as `unknown`/`no_verdict`.
- Net effect (measured live 3x): `check_provider_exhausted` never fires for codex, since `no_verdict` is not in `EXHAUSTION_FAILURE_CLASSES` — the dispatch door gives green light to an exhausted provider.

## Changes
- `scripts/lib/provider_spawns/codex_spawn.py`
  - `_normalize_complete_events`: added a `task_complete` branch — emits an `"error"` canonical event (mirroring the existing top-level `etype == "error"` handling) when the payload carries a non-empty `error` object, otherwise treats it like `turn.completed` (`"complete"`).
  - `_drain_stream`: captures the first in-stream `"error"` canonical event's `"message"` (falling back to `"reason"`) into a new `captured_error` local, now returned as the function's `error` value instead of a hardcoded `None` on the non-exception path.
- `scripts/lib/failure_classification.py`
  - Added `"hit your usage limit"` and `"usage_limit_exceeded"` to `CREDIT_EXHAUSTED_KEYWORDS`, with a comment on when/where observed. `"hit your usage limit"` is deliberately narrower than the bare phrase `"usage limit"` — kimi's own 403 auth-rejection prose ("reached your usage limit" / "usage limit for this billing cycle", already GEMETEN OI-1433) shares that substring with a different verb; the narrow phrase was already vetted codex-specific in `governance_emit.py`'s `_LANE_EXHAUSTED_MARKERS` (2026-08-26) but hadn't been added to this receipt-facing taxonomy yet.
- Tests (all written and confirmed RED before, GREEN after, per dispatch instruction):
  - `tests/unit/test_codex_event_normalizer.py`: `TestTaskCompleteEvents` — task_complete-with-error → `"error"`; task_complete-without-error → `"complete"`.
  - `tests/test_codex_spawn_fail_closed.py`: `TestCodexSpawnQuotaExhaustion` — end-to-end through `spawn_codex()`, message reaches `result.error`.
  - `tests/test_failure_classification.py`: `TestOI1628CodexQuotaExhaustion` — quota text classifies as `credit_exhausted`, including the real receipt shape where the stderr-tail fallback text and the quota text are combined (`no_verdict` markers present too — `credit_exhausted` must win, and does, since it's checked first).
  - `tests/test_stop_conditions.py`: `test_codex_quota_realistic_failure_reason_fixture` — fixture-based (not live-store) closing check that `check_provider_exhausted` now triggers on a codex `credit_exhausted` receipt streak.

## Verification
Both real gaps confirmed present on pristine `main` (reverted my two lib fixes via `git checkout --`, ran the new tests, all 5 behavioral tests RED), then reapplied and confirmed GREEN:

Before fix (RED):
```
FAILED tests/unit/test_codex_event_normalizer.py::TestTaskCompleteEvents::test_task_complete_with_usage_limit_error_maps_to_error
FAILED tests/unit/test_codex_event_normalizer.py::TestTaskCompleteEvents::test_task_complete_without_error_maps_to_complete
FAILED tests/test_codex_spawn_fail_closed.py::TestCodexSpawnQuotaExhaustion::test_task_complete_usage_limit_error_reaches_result_error
FAILED tests/test_failure_classification.py::TestOI1628CodexQuotaExhaustion::test_codex_usage_limit_recognized_as_credit_exhausted
FAILED tests/test_failure_classification.py::TestOI1628CodexQuotaExhaustion::test_codex_usage_limit_wins_over_stderr_tail_no_verdict_marker
5 failed, 1 passed in 0.31s
```

After fix (GREEN):
```
python3 -m pytest tests/unit/test_codex_event_normalizer.py tests/test_codex_spawn_fail_closed.py tests/test_failure_classification.py tests/test_stop_conditions.py tests/test_codex_spawn_byte_identity.py tests/test_codex_adapter_tokens.py tests/test_failclass_registry.py -q
4 failed, 257 passed in 2.65s
```
The 4 remaining failures (`TestIntermediateTokenCountEvents::test_zero_token_count_falls_through_to_unknown`, `TestUnknownEvents::{test_unknown_type_produces_error,test_empty_event_produces_error,test_event_with_only_id}`) are pre-existing and unrelated: confirmed identical failures on pristine `main` (same normalizer's unknown-type fallback maps to `"info"`, not `"error"` — a pre-existing test/behavior drift, out of scope for OI-1628). Also spot-checked a wider batch of 21 codex/provider-dispatch-adjacent test files; the 36 failures there (worktree-lock `NotADirectoryError` from running inside a nested worktree, missing SQLite tables, `project_id` fallback warnings) reproduce identically on pristine `main` — pre-existing environment limitations of this worktree, not caused by this change.

## Open Items
None — both gaps closed, keyword collision with kimi's own usage-limit prose checked and avoided, `check_provider_exhausted` verified against a fixture.

Dispatch-ID: 20260905-100002-oi1628-quota-klasse