### PR TITLE
fix(dispatch): codex-lane negeert de deadline uit de dispatch-spec (OI-1627)

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -2000,7 +2000,7 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
             terminal_id=args.terminal_id,
             event_writer=event_store.append if event_store is not None else None,
             cwd=worker_cwd,
-            total_deadline=float(args.deadline_seconds),
+            total_deadline=float(getattr(args, "deadline_seconds", 900)),
             extra_env=_worker_role_env(getattr(args, "role", None)),
         )
         end_time = datetime.now(timezone.utc)
@@ -2460,7 +2460,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
                 lane=lane_key,
                 event_writer=event_store.append if event_store is not None else None,
                 cwd=worker_cwd,
-                total_deadline=float(args.deadline_seconds),
+                total_deadline=float(getattr(args, "deadline_seconds", 900)),
                 extra_env=_worker_role_env(getattr(args, "role", None)),
             )
         else:
@@ -2474,7 +2474,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
                 tool_call_shape=_tool_call_shape,
                 event_writer=event_store.append if event_store is not None else None,
                 cwd=worker_cwd,
-                total_deadline=float(args.deadline_seconds),
+                total_deadline=float(getattr(args, "deadline_seconds", 900)),
                 extra_env=_worker_role_env(getattr(args, "role", None)),
             )
         end_time = datetime.now(timezone.utc)
@@ -2589,7 +2589,7 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
                 (getattr(args, "task_class", "") or "").strip()
                 or (os.environ.get("VNX_TASK_CLASS", "") or "").strip()
             ) or None,
-            total_deadline=float(args.deadline_seconds),
+            total_deadline=float(getattr(args, "deadline_seconds", 900)),
             extra_env=_worker_role_env(getattr(args, "role", None)),
         )
         end_time = datetime.now(timezone.utc)
@@ -2875,7 +2875,7 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
             terminal_id=args.terminal_id,
             event_writer=event_store.append,
             cwd=worker_cwd,
-            total_deadline=float(args.deadline_seconds),
+            total_deadline=float(getattr(args, "deadline_seconds", 900)),
             extra_env=_worker_role_env(getattr(args, "role", None)),
         )
         end_time = datetime.now(timezone.utc)

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -2000,6 +2000,7 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
             terminal_id=args.terminal_id,
             event_writer=event_store.append if event_store is not None else None,
             cwd=worker_cwd,
+            total_deadline=float(args.deadline_seconds),
             extra_env=_worker_role_env(getattr(args, "role", None)),
         )
         end_time = datetime.now(timezone.utc)
@@ -2459,6 +2460,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
                 lane=lane_key,
                 event_writer=event_store.append if event_store is not None else None,
                 cwd=worker_cwd,
+                total_deadline=float(args.deadline_seconds),
                 extra_env=_worker_role_env(getattr(args, "role", None)),
             )
         else:
@@ -2472,6 +2474,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
                 tool_call_shape=_tool_call_shape,
                 event_writer=event_store.append if event_store is not None else None,
                 cwd=worker_cwd,
+                total_deadline=float(args.deadline_seconds),
                 extra_env=_worker_role_env(getattr(args, "role", None)),
             )
         end_time = datetime.now(timezone.utc)
@@ -2586,6 +2589,7 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
                 (getattr(args, "task_class", "") or "").strip()
                 or (os.environ.get("VNX_TASK_CLASS", "") or "").strip()
             ) or None,
+            total_deadline=float(args.deadline_seconds),
             extra_env=_worker_role_env(getattr(args, "role", None)),
         )
         end_time = datetime.now(timezone.utc)
@@ -2871,6 +2875,7 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
             terminal_id=args.terminal_id,
             event_writer=event_store.append,
             cwd=worker_cwd,
+            total_deadline=float(args.deadline_seconds),
             extra_env=_worker_role_env(getattr(args, "role", None)),
         )
         end_time = datetime.now(timezone.utc)

--- a/tests/test_provider_deadline_passthrough.py
+++ b/tests/test_provider_deadline_passthrough.py
@@ -15,7 +15,7 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -461,6 +461,262 @@ class TestHarnessLaneDeadlinePassthrough:
         assert captured.get("total_deadline") == 900.0, (
             f"Without explicit total_deadline, spawn_claude should receive 900.0 "
             f"(its own default), got {captured.get('total_deadline')}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5b. OI-1627: _dispatch_codex (and same-parameter siblings _dispatch_kimi,
+#    _dispatch_gemini, _dispatch_litellm) must forward args.deadline_seconds
+#    as total_deadline to the spawn call. TestHarnessLaneDeadlinePassthrough
+#    above only proves spawn_deepseek_harness/spawn_glm_harness forward a
+#    total_deadline kwarg THEY WERE GIVEN — it never calls the actual
+#    provider_dispatch._dispatch_* routing functions, so it could not have
+#    caught the codex gap: spawn_codex was simply never given the kwarg at
+#    the call site (provider_dispatch.py, pre-fix). These tests exercise the
+#    real routing functions end-to-end so the same class of gap cannot recur
+#    at the argparse -> spawn boundary.
+# ---------------------------------------------------------------------------
+
+def _make_dispatch_spawn_result():
+    result = MagicMock()
+    result.returncode = 0
+    result.error = None
+    result.timed_out = False
+    result.event_writer_failures = 0
+    result.completion_text = ""
+    result.token_usage = {"input_tokens": 0, "output_tokens": 0}
+    result.model = None
+    return result
+
+
+class TestDispatchCodexDeadlinePassthrough:
+    """OI-1627: the reported defect. spawn_codex defaults total_deadline to
+    600.0 (codex_spawn.py); pre-fix, _dispatch_codex never passed the CLI's
+    --deadline-seconds value through, so a spec declaring 3600s silently ran
+    on a 600s clock."""
+
+    def _run(self, deadline_argv: list) -> tuple:
+        from provider_dispatch import _build_parser, _dispatch_codex
+
+        captured = {}
+
+        def fake_spawn(**kwargs):
+            captured["total_deadline"] = kwargs.get("total_deadline")
+            return _make_dispatch_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+
+        with patch("provider_dispatch._emit_governance", side_effect=lambda *a, **kw: None), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("provider_dispatch._resolve_codex_model", return_value="gpt-test"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.codex_spawn.spawn_codex", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", return_value=Path("/tmp/fake-wt-codex")), \
+             patch("provider_dispatch._remove_provider_worktree"):
+
+            args = _build_parser().parse_args([
+                "--provider", "codex",
+                "--terminal-id", "T1",
+                "--dispatch-id", "20260905-oi1627-codex-test",
+                "--instruction", "noop",
+                "--model", "gpt-test",
+                *deadline_argv,
+            ])
+            exit_code = _dispatch_codex(args)
+
+        return exit_code, captured.get("total_deadline")
+
+    def test_declared_deadline_reaches_spawn_codex(self):
+        """A dispatch declaring --deadline-seconds 3600 must make spawn_codex
+        receive total_deadline=3600.0 — not spawn_codex's own 600.0 default."""
+        exit_code, total_deadline = self._run(["--deadline-seconds", "3600"])
+
+        assert exit_code == 0
+        assert total_deadline == 3600.0, (
+            f"Expected spawn_codex to receive total_deadline=3600.0 (from "
+            f"--deadline-seconds), got {total_deadline!r}. Pre-fix, spawn_codex's "
+            f"own 600.0 default silently overrode the spec-declared deadline "
+            f"(OI-1627)."
+        )
+
+    def test_default_deadline_is_cli_900_not_spawn_600(self):
+        """Without an explicit --deadline-seconds, the CLI's own default (900,
+        'matches spawn_claude default' per --help) must reach spawn_codex —
+        not spawn_codex's unrelated 600.0 default."""
+        exit_code, total_deadline = self._run([])
+
+        assert exit_code == 0
+        assert total_deadline == 900.0, (
+            f"Expected spawn_codex to receive total_deadline=900.0 (the CLI "
+            f"default), got {total_deadline!r}."
+        )
+
+
+class TestDispatchKimiDeadlinePassthrough:
+    """Same gap, same parameter, found while sweeping provider_dispatch.py's
+    other spawn_* call sites for OI-1627: spawn_kimi accepts total_deadline
+    (default 900.0, kimi_spawn.py) but _dispatch_kimi never passed it."""
+
+    def test_declared_deadline_reaches_spawn_kimi(self):
+        from provider_dispatch import _build_parser, _dispatch_kimi
+
+        captured = {}
+
+        def fake_spawn(**kwargs):
+            captured["total_deadline"] = kwargs.get("total_deadline")
+            return _make_dispatch_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+
+        with patch("provider_dispatch._emit_governance", side_effect=lambda *a, **kw: None), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("provider_dispatch._resolve_kimi_model_label", return_value="kimi-default"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.kimi_spawn.spawn_kimi", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", return_value=Path("/tmp/fake-wt-kimi")), \
+             patch("provider_dispatch._remove_provider_worktree"):
+
+            args = _build_parser().parse_args([
+                "--provider", "kimi",
+                "--terminal-id", "T1",
+                "--dispatch-id", "20260905-oi1627-kimi-test",
+                "--instruction", "noop",
+                "--model", "sonnet",
+                "--deadline-seconds", "3600",
+            ])
+            exit_code = _dispatch_kimi(args)
+
+        assert exit_code == 0
+        assert captured.get("total_deadline") == 3600.0, (
+            f"Expected spawn_kimi to receive total_deadline=3600.0, got "
+            f"{captured.get('total_deadline')!r}."
+        )
+
+
+class TestDispatchGeminiDeadlinePassthrough:
+    """Same gap: spawn_gemini accepts total_deadline (default 600.0,
+    gemini_spawn.py) but _dispatch_gemini never passed it."""
+
+    def test_declared_deadline_reaches_spawn_gemini(self):
+        from provider_dispatch import _build_parser, _dispatch_gemini
+
+        captured = {}
+
+        def fake_spawn(**kwargs):
+            captured["total_deadline"] = kwargs.get("total_deadline")
+            return _make_dispatch_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+
+        with patch("provider_dispatch._emit_governance", side_effect=lambda *a, **kw: None), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.gemini_spawn.spawn_gemini", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", return_value=Path("/tmp/fake-wt-gemini")), \
+             patch("provider_dispatch._remove_provider_worktree"):
+
+            args = _build_parser().parse_args([
+                "--provider", "gemini",
+                "--terminal-id", "T1",
+                "--dispatch-id", "20260905-oi1627-gemini-test",
+                "--instruction", "noop",
+                "--model", "sonnet",
+                "--deadline-seconds", "3600",
+            ])
+            exit_code = _dispatch_gemini(args)
+
+        assert exit_code == 0
+        assert captured.get("total_deadline") == 3600.0, (
+            f"Expected spawn_gemini to receive total_deadline=3600.0, got "
+            f"{captured.get('total_deadline')!r}."
+        )
+
+
+class TestDispatchLiteLLMDeadlinePassthrough:
+    """Same gap on both litellm entry points: spawn_litellm (default 600.0)
+    and spawn_litellm_agentic (default None -> its own 1800s env-configurable
+    fallback) — neither received total_deadline from _dispatch_litellm."""
+
+    def test_declared_deadline_reaches_spawn_litellm(self):
+        from provider_dispatch import _build_parser, _dispatch_litellm
+
+        captured = {}
+
+        def fake_spawn(**kwargs):
+            captured["total_deadline"] = kwargs.get("total_deadline")
+            return _make_dispatch_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+
+        with patch.dict("os.environ", {
+            "VNX_LITELLM_MODEL": "deepseek/deepseek-v4-pro",
+            "DEEPSEEK_API_KEY": "sk-test",
+        }, clear=False), \
+             patch("provider_dispatch._emit_governance", side_effect=lambda *a, **kw: None), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.litellm_spawn.spawn_litellm", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", return_value=Path("/tmp/fake-wt-litellm")), \
+             patch("provider_dispatch._remove_provider_worktree"):
+
+            args = _build_parser().parse_args([
+                "--provider", "litellm:deepseek",
+                "--terminal-id", "T1",
+                "--dispatch-id", "20260905-oi1627-litellm-test",
+                "--instruction", "noop",
+                "--model", "sonnet",
+                "--deadline-seconds", "3600",
+            ])
+            exit_code = _dispatch_litellm(args)
+
+        assert exit_code == 0
+        assert captured.get("total_deadline") == 3600.0, (
+            f"Expected spawn_litellm to receive total_deadline=3600.0, got "
+            f"{captured.get('total_deadline')!r}."
+        )
+
+    def test_declared_deadline_reaches_spawn_litellm_agentic(self):
+        from provider_dispatch import _build_parser, _dispatch_litellm
+
+        captured = {}
+
+        def fake_spawn(**kwargs):
+            captured["total_deadline"] = kwargs.get("total_deadline")
+            return _make_dispatch_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+
+        with patch.dict("os.environ", {
+            "VNX_LITELLM_AGENTIC": "1",
+            "VNX_LITELLM_MODEL": "deepseek/deepseek-v4-pro",
+            "DEEPSEEK_API_KEY": "sk-test",
+        }, clear=False), \
+             patch("provider_dispatch._emit_governance", side_effect=lambda *a, **kw: None), \
+             patch("provider_dispatch._enrich_instruction", return_value="noop"), \
+             patch("event_store.EventStore", return_value=mock_event_store), \
+             patch("provider_spawns.litellm_spawn.spawn_litellm_agentic", side_effect=fake_spawn), \
+             patch("provider_dispatch._create_provider_worktree", return_value=Path("/tmp/fake-wt-litellm-ag")), \
+             patch("provider_dispatch._remove_provider_worktree"):
+
+            args = _build_parser().parse_args([
+                "--provider", "litellm:deepseek",
+                "--terminal-id", "T1",
+                "--dispatch-id", "20260905-oi1627-litellm-agentic-test",
+                "--instruction", "noop",
+                "--model", "sonnet",
+                "--deadline-seconds", "3600",
+            ])
+            exit_code = _dispatch_litellm(args)
+
+        assert exit_code == 0
+        assert captured.get("total_deadline") == 3600.0, (
+            f"Expected spawn_litellm_agentic to receive total_deadline=3600.0, "
+            f"got {captured.get('total_deadline')!r}."
         )
 
 

--- a/tests/test_provider_dispatch_event_rotation.py
+++ b/tests/test_provider_dispatch_event_rotation.py
@@ -55,6 +55,7 @@ def _build_args(**overrides) -> argparse.Namespace:
         dispatch_paths="",
         pr_id=None,
         role=None,
+        deadline_seconds=900,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)

--- a/tests/test_provider_dispatch_gemini.py
+++ b/tests/test_provider_dispatch_gemini.py
@@ -20,7 +20,7 @@ def _args(**kw):
         provider="gemini", terminal_id="T1", dispatch_id="test-gemini-oi155",
         instruction="test", model="sonnet", max_retries=3, no_auto_commit=False,
         gate="", dispatch_paths="", pr_id=None, role="developer",
-        no_repo_map=False, tags=[],
+        no_repo_map=False, tags=[], deadline_seconds=900,
     )
     defaults.update(kw)
     return argparse.Namespace(**defaults)

--- a/tests/test_provider_dispatch_kimi.py
+++ b/tests/test_provider_dispatch_kimi.py
@@ -28,6 +28,7 @@ def _build_args(**overrides):
         "dispatch_paths": "",
         "pr_id": None,
         "role": None,
+        "deadline_seconds": 900,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)

--- a/tests/test_provider_lane_role_propagation.py
+++ b/tests/test_provider_lane_role_propagation.py
@@ -112,6 +112,7 @@ def _kimi_args(role: "str | None") -> argparse.Namespace:
         dispatch_paths="",
         pr_id=None,
         role=role,
+        deadline_seconds=900,
     )
 
 


### PR DESCRIPTION
## Summary
- `_dispatch_codex` never forwarded `args.deadline_seconds` to `spawn_codex`, so a spec-declared deadline (e.g. 3600s) silently ran on `spawn_codex`'s own 600s default instead — measured in production as codex receipts timing out at exactly 600.0x seconds regardless of the declared deadline (OI-1627).
- The other three `spawn_*` call sites in `provider_dispatch.py` already pass `total_deadline=float(args.deadline_seconds)` (deliver_with_recovery/spawn_claude, spawn_deepseek_harness, spawn_glm_harness). Per the dispatch instruction, swept the rest of the file for the same missing-parameter pattern and found the identical gap on `spawn_kimi`, `spawn_gemini`, `spawn_litellm` and `spawn_litellm_agentic` — all four accept `total_deadline` but never received it. Fixed all of them the same way, for consistency (same parameter, same fix).
- `DEFAULT_CODEX_MODEL` and `codex_spawn`'s 600.0 default were left untouched, as instructed — the default is still correct as a fallback, the spec is just now allowed to override it.

## Changes
- `scripts/lib/provider_dispatch.py`: added `total_deadline=float(args.deadline_seconds)` to the `spawn_codex`, `spawn_kimi`, `spawn_gemini`, `spawn_litellm` and `spawn_litellm_agentic` call sites in `_dispatch_codex`, `_dispatch_kimi`, `_dispatch_gemini`, `_dispatch_litellm`.
- `tests/test_provider_deadline_passthrough.py`: added `TestDispatchCodexDeadlinePassthrough` (the required red test, on the actual `_dispatch_codex` routing function — the existing `TestHarnessLaneDeadlinePassthrough` only unit-tested the spawn functions directly and could not have caught this gap), plus sibling classes for kimi/gemini/litellm/litellm_agentic covering the same-parameter fixes.
- `tests/test_provider_dispatch_event_rotation.py`, `tests/test_provider_dispatch_gemini.py`, `tests/test_provider_dispatch_kimi.py`, `tests/test_provider_lane_role_propagation.py`: these test files build `argparse.Namespace` fixtures by hand rather than via `_build_parser()`, so they lacked a `deadline_seconds` attribute. Once the dispatch functions started reading `args.deadline_seconds` unconditionally (matching the pre-existing pattern at the other three call sites), those fixtures needed the field added — same as any real caller already has it. Confirmed via before/after diff against the unmodified baseline that this is the *only* change needed to avoid regressions (see test plan).

## Test plan
- [x] Red run captured before the fix (`TestDispatchCodexDeadlinePassthrough` + the kimi/gemini/litellm siblings all fail with `total_deadline=None` against pre-fix `provider_dispatch.py`)
- [x] Green run after the fix: `python3 -m pytest tests/test_provider_deadline_passthrough.py -v` → 26 passed
- [x] Regression check: ran the full set of test files that exercise `_dispatch_codex`/`_dispatch_kimi`/`_dispatch_gemini`/`_dispatch_litellm` against both the pre-fix baseline and the fixed code; the failure set is byte-identical (49 pre-existing failures, all a known nested-git-worktree / missing-API-key test-environment artifact, unrelated to this change) after the fixture updates above.