### PR TITLE
fix(runtime): create_attempt() stamps project_id, dispatch_attempts stops empty (OI-1625)

### DIFF
--- a/scripts/lib/dispatch_broker.py
+++ b/scripts/lib/dispatch_broker.py
@@ -404,6 +404,7 @@ class DispatchBroker:
             attempt_row = create_attempt(
                 conn,
                 dispatch_id=dispatch_id,
+                project_id=row.get("project_id"),
                 terminal_id=terminal_id,
                 attempt_number=attempt_number,
                 metadata={"actor": actor},

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1285,6 +1285,7 @@ def _persist_dispatch_row(
             attempt_row = _rc_create_attempt(
                 conn,
                 dispatch_id=spec.dispatch_id,
+                project_id=spec.project_id,
                 terminal_id=spec.target_slot,
                 attempt_number=new_count,
                 metadata={"worker_claude_override_reason": worker_claude_override_reason},

--- a/scripts/lib/headless_adapter.py
+++ b/scripts/lib/headless_adapter.py
@@ -394,6 +394,7 @@ class HeadlessAdapter:
             attempt = create_attempt(
                 conn,
                 dispatch_id=dispatch_id,
+                project_id=dispatch.get("project_id"),
                 terminal_id=terminal_id,
                 attempt_number=attempt_count,
                 metadata={"adapter": "headless", "actor": actor},

--- a/scripts/lib/runtime_state_machine.py
+++ b/scripts/lib/runtime_state_machine.py
@@ -266,27 +266,50 @@ def create_attempt(
     conn: sqlite3.Connection,
     *,
     dispatch_id: str,
+    project_id: str,
     terminal_id: str,
     attempt_number: int,
     metadata: Optional[Dict[str, Any]] = None,
     actor: str = "runtime",
 ) -> Dict[str, Any]:
-    """Create a new dispatch attempt record."""
+    """Create a new dispatch attempt record.
+
+    ADR-007: project_id is MANDATORY — no silent default, mirroring
+    register_dispatch(). Stamped on the INSERT row when the column exists
+    (mirrors register_dispatch's own _has_project_id_col guard); older stores
+    without the column are inserted exactly as before. OI-1625: the live
+    dispatch_attempts.project_id column is NOT NULL with no DEFAULT (post
+    migration 0031's adaptive-repair shape), so every prior INSERT here
+    raised sqlite3.IntegrityError and dispatch_attempts stayed permanently
+    empty despite 801+ rows in dispatches.
+    """
+    has_pid = _has_project_id_col(conn, "dispatch_attempts")
     attempt_id = _new_event_id()
     now = _now_utc()
-    conn.execute(
-        """
-        INSERT INTO dispatch_attempts
-            (attempt_id, dispatch_id, attempt_number, terminal_id, state, started_at, metadata_json)
-        VALUES (?, ?, ?, ?, 'pending', ?, ?)
-        """,
-        (attempt_id, dispatch_id, attempt_number, terminal_id, now, _dump(metadata)),
-    )
+    if has_pid:
+        conn.execute(
+            """
+            INSERT INTO dispatch_attempts
+                (attempt_id, dispatch_id, project_id, attempt_number, terminal_id, state, started_at, metadata_json)
+            VALUES (?, ?, ?, ?, ?, 'pending', ?, ?)
+            """,
+            (attempt_id, dispatch_id, project_id, attempt_number, terminal_id, now, _dump(metadata)),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT INTO dispatch_attempts
+                (attempt_id, dispatch_id, attempt_number, terminal_id, state, started_at, metadata_json)
+            VALUES (?, ?, ?, ?, 'pending', ?, ?)
+            """,
+            (attempt_id, dispatch_id, attempt_number, terminal_id, now, _dump(metadata)),
+        )
     _append_event(
         conn, event_type="attempt_created", entity_type="attempt",
         entity_id=attempt_id, from_state=None, to_state="pending", actor=actor,
         reason=f"attempt {attempt_number} for dispatch {dispatch_id}",
         metadata={"dispatch_id": dispatch_id, "terminal_id": terminal_id, "attempt_number": attempt_number},
+        project_id=project_id,
     )
     return dict(
         conn.execute("SELECT * FROM dispatch_attempts WHERE attempt_id = ?", (attempt_id,)).fetchone()

--- a/tests/test_burnin_certification.py
+++ b/tests/test_burnin_certification.py
@@ -113,7 +113,7 @@ def _make_run(registry, state_dir, dispatch_id=None, **kwargs):
     with get_connection(state_dir) as conn:
         register_dispatch(conn, dispatch_id=did, project_id="vnx-dev")
         attempt = create_attempt(
-            conn, dispatch_id=did, terminal_id="T1", attempt_number=1,
+            conn, dispatch_id=did, project_id="vnx-dev", terminal_id="T1", attempt_number=1,
         )
         conn.commit()
     defaults = {
@@ -175,7 +175,8 @@ class TestB1DurableIdentity:
         did = f"d-fields-{uuid.uuid4().hex[:8]}"
         with get_connection(state_dir) as conn:
             register_dispatch(conn, dispatch_id=did, project_id="vnx-dev")
-            attempt = create_attempt(conn, dispatch_id=did, terminal_id="T2", attempt_number=1)
+            attempt = create_attempt(
+                conn, dispatch_id=did, project_id="vnx-dev", terminal_id="T2", attempt_number=1)
             conn.commit()
         run = registry.create_run(
             dispatch_id=did,

--- a/tests/test_create_attempt_project_id.py
+++ b/tests/test_create_attempt_project_id.py
@@ -1,0 +1,187 @@
+"""tests/test_create_attempt_project_id.py — OI-1625: create_attempt() never
+stamped project_id, so every INSERT into dispatch_attempts raised
+sqlite3.IntegrityError against the live (post-migration) schema shape and
+dispatch_attempts stayed permanently empty while dispatches accumulated
+hundreds of rows (measured 2026-09-05: 0 vs 801 on
+~/.vnx-data/vnx-dev/state/runtime_coordination.db, PRAGMA user_version 33).
+
+``dispatch_attempts.project_id`` on that live store is ``TEXT NOT NULL`` with
+NO DEFAULT — unlike the static ``schemas/migrations/0031_runtime_tenant_fk_repair.sql``,
+which carries ``DEFAULT 'vnx-dev'``. The bare test schema
+(``schemas/runtime_coordination.sql`` via plain ``init_schema()``, what every
+other create_attempt test in this repo uses) predates migration 0010+ and has
+no ``project_id`` column on ``dispatch_attempts``/``dispatches`` at all, so
+none of those tests ever exercised this failure mode — hence it shipped
+unnoticed. ``_build_live_shape_db`` below reproduces the exact measured live
+DDL (``sqlite3 ... ".schema dispatch_attempts"`` against the real store) so
+this test fails for the SAME reason the live store fails, not an approximation
+of it.
+
+Two levels:
+  1. Unit: create_attempt() itself must stamp project_id on the INSERT.
+  2. Behavioral (what OI-1625 actually asks for): after a door-fired dispatch
+     (``dispatch_cli._persist_dispatch_row``, the single entry point), a row
+     must exist in dispatch_attempts with the correct project_id.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LIB = REPO / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import dispatch_cli  # noqa: E402
+from runtime_state_machine import create_attempt  # noqa: E402
+
+
+def _build_live_shape_db(db_path: Path) -> None:
+    """Reproduce the measured live vnx-dev shape: project_id TEXT NOT NULL,
+    NO DEFAULT, on dispatches/dispatch_attempts/coordination_events, at
+    PRAGMA user_version 33 — so a subsequent _rc_init_schema() call (which
+    only ever schedules versions up to 11) treats the store as already fully
+    migrated, exactly like it does against the real production DB.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            state TEXT NOT NULL DEFAULT 'proposed',
+            terminal_id TEXT,
+            track TEXT,
+            priority TEXT DEFAULT 'P2',
+            pr_ref TEXT,
+            gate TEXT,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            target_slot TEXT,
+            worker_claude_override_reason TEXT,
+            UNIQUE (dispatch_id, project_id)
+        );
+
+        CREATE TABLE dispatch_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            attempt_id TEXT NOT NULL,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            attempt_number INTEGER NOT NULL DEFAULT 1,
+            terminal_id TEXT NOT NULL,
+            state TEXT NOT NULL DEFAULT 'pending',
+            started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            ended_at TEXT,
+            failure_reason TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            UNIQUE (attempt_id, project_id),
+            FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches (dispatch_id, project_id)
+        );
+
+        CREATE TABLE coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            from_state TEXT,
+            to_state TEXT,
+            actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT,
+            metadata_json TEXT DEFAULT '{}',
+            occurred_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            project_id TEXT NOT NULL,
+            UNIQUE (event_id, project_id)
+        );
+        """
+    )
+    conn.execute("PRAGMA user_version = 33")
+    conn.commit()
+    conn.close()
+
+
+class TestCreateAttemptStampsProjectId:
+    """Unit-level: create_attempt() itself, against the live NOT-NULL-no-default shape."""
+
+    def test_create_attempt_inserts_with_project_id(self, tmp_path):
+        db_path = tmp_path / "runtime_coordination.db"
+        _build_live_shape_db(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id) VALUES (?, ?)",
+            ("d-oi1625", "vnx-dev"),
+        )
+        conn.commit()
+
+        attempt = create_attempt(
+            conn, dispatch_id="d-oi1625", project_id="vnx-dev",
+            terminal_id="T1", attempt_number=1,
+        )
+        conn.commit()
+
+        assert attempt["project_id"] == "vnx-dev"
+        row = conn.execute(
+            "SELECT project_id FROM dispatch_attempts WHERE dispatch_id = ?", ("d-oi1625",)
+        ).fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row["project_id"] == "vnx-dev"
+
+
+class TestDoorDispatchPersistsAttemptRow:
+    """Behavioral, door-level: OI-1625's actual symptom. After a door-fired
+    dispatch (dispatch_cli._persist_dispatch_row, the single entry point for
+    every dispatch), a row must exist in dispatch_attempts with the correct
+    project_id — against the exact schema shape measured on the live vnx-dev
+    store.
+    """
+
+    def test_door_dispatch_creates_attempt_row_with_project_id(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "runtime_coordination.db"
+        _build_live_shape_db(db_path)
+
+        spec = types.SimpleNamespace(
+            dispatch_id="20260905-oi1625-door-attempt",
+            project_id="vnx-dev",
+            track_id=None,
+            gate=None,
+            target_slot="T1",
+        )
+
+        attempt_id = dispatch_cli._persist_dispatch_row(spec, state_dir=state_dir)
+
+        assert attempt_id is not None, (
+            "the door swallowed a bookkeeping failure and returned None — "
+            "see state_dir/dispatch_register.ndjson for the door_bookkeeping_failed fact"
+        )
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM dispatch_attempts WHERE dispatch_id = ?",
+            (spec.dispatch_id,),
+        ).fetchone()
+        conn.close()
+
+        assert row is not None, "no dispatch_attempts row was created for the door dispatch"
+        assert row["project_id"] == "vnx-dev"
+        assert row["attempt_id"] == attempt_id
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_headless_inspect.py
+++ b/tests/test_headless_inspect.py
@@ -62,6 +62,7 @@ class _InspectTestCase(unittest.TestCase):
             attempt = create_attempt(
                 conn,
                 dispatch_id=dispatch_id,
+                project_id="vnx-dev",
                 terminal_id="T2",
                 attempt_number=1,
             )

--- a/tests/test_headless_run_registry.py
+++ b/tests/test_headless_run_registry.py
@@ -71,6 +71,7 @@ class _RegistryTestCase(unittest.TestCase):
             attempt = create_attempt(
                 conn,
                 dispatch_id=dispatch_id,
+                project_id="vnx-dev",
                 terminal_id="T2",
                 attempt_number=1,
             )

--- a/tests/test_headless_smoke.py
+++ b/tests/test_headless_smoke.py
@@ -63,6 +63,7 @@ class _SmokeTestCase(unittest.TestCase):
             attempt = create_attempt(
                 conn,
                 dispatch_id=dispatch_id,
+                project_id="vnx-dev",
                 terminal_id="T2",
                 attempt_number=1,
             )

--- a/tests/test_runtime_coordination.py
+++ b/tests/test_runtime_coordination.py
@@ -278,7 +278,7 @@ class TestDispatchAttempts(_DbTestCase):
     def test_create_attempt(self):
         with self.conn() as conn:
             att = create_attempt(
-                conn, dispatch_id="d-att", terminal_id="T2", attempt_number=1
+                conn, dispatch_id="d-att", project_id="vnx-dev", terminal_id="T2", attempt_number=1
             )
             conn.commit()
         self.assertEqual(att["dispatch_id"], "d-att")
@@ -287,7 +287,7 @@ class TestDispatchAttempts(_DbTestCase):
 
     def test_update_attempt_success(self):
         with self.conn() as conn:
-            att = create_attempt(conn, dispatch_id="d-att", terminal_id="T2", attempt_number=1)
+            att = create_attempt(conn, dispatch_id="d-att", project_id="vnx-dev", terminal_id="T2", attempt_number=1)
             conn.commit()
             updated = update_attempt(conn, attempt_id=att["attempt_id"], state="succeeded")
             conn.commit()
@@ -295,7 +295,7 @@ class TestDispatchAttempts(_DbTestCase):
 
     def test_update_attempt_failure_records_reason(self):
         with self.conn() as conn:
-            att = create_attempt(conn, dispatch_id="d-att", terminal_id="T2", attempt_number=1)
+            att = create_attempt(conn, dispatch_id="d-att", project_id="vnx-dev", terminal_id="T2", attempt_number=1)
             conn.commit()
             updated = update_attempt(
                 conn, attempt_id=att["attempt_id"],
@@ -306,7 +306,7 @@ class TestDispatchAttempts(_DbTestCase):
 
     def test_attempt_events_appended(self):
         with self.conn() as conn:
-            att = create_attempt(conn, dispatch_id="d-att", terminal_id="T2", attempt_number=1)
+            att = create_attempt(conn, dispatch_id="d-att", project_id="vnx-dev", terminal_id="T2", attempt_number=1)
             conn.commit()
             events = get_events(conn, entity_id=att["attempt_id"])
         self.assertTrue(len(events) >= 1)

--- a/tests/test_runtime_reconciler.py
+++ b/tests/test_runtime_reconciler.py
@@ -120,6 +120,7 @@ class _ReconcilerTestCase(unittest.TestCase):
             row = create_attempt(
                 conn,
                 dispatch_id=dispatch_id,
+                project_id="vnx-dev",
                 terminal_id=terminal_id,
                 attempt_number=attempt_number,
             )


### PR DESCRIPTION
## Summary

`create_attempt()` in `scripts/lib/runtime_state_machine.py` never took a `project_id` parameter and never stamped it on the INSERT into `dispatch_attempts`. Against the live schema (`dispatch_attempts.project_id TEXT NOT NULL`, no DEFAULT — measured on `~/.vnx-data/vnx-dev/state/runtime_coordination.db`, user_version 33) every call raised `sqlite3.IntegrityError`, so `dispatch_attempts` stayed permanently empty (0 rows) while `dispatches` accumulated 801 rows.

`register_dispatch()` already required `project_id` with no silent default (ADR-007). `create_attempt()` now mirrors that exactly, using the same `_has_project_id_col` guard for backward compatibility with stores that predate the project_id column.

## Changes

- `scripts/lib/runtime_state_machine.py` — `create_attempt()` gains a mandatory `project_id: str` kwarg, stamps it on the INSERT when the column exists (mirrors `register_dispatch`'s conditional-column pattern), and passes it through to `_append_event`.
- `scripts/lib/dispatch_cli.py` — `_persist_dispatch_row` (the door's single-entry attempt-creation call) now passes `project_id=spec.project_id`.
- `scripts/lib/dispatch_broker.py` — `DispatchBroker.claim()` now passes `project_id=row.get("project_id")` (read from the dispatch's own row, not a hardcoded value).
- `scripts/lib/headless_adapter.py` — `HeadlessAdapter._create_attempt()` now passes `project_id=dispatch.get("project_id")`.
- Updated every existing `create_attempt(...)` call site in the test suite to pass `project_id` (tests/test_headless_run_registry.py, test_headless_smoke.py, test_headless_inspect.py, test_burnin_certification.py, test_runtime_coordination.py, test_runtime_reconciler.py).
- New test: `tests/test_create_attempt_project_id.py` — reproduces the exact live schema shape (project_id NOT NULL, no default) and asserts both `create_attempt()` itself and a door-fired dispatch (`dispatch_cli._persist_dispatch_row`) leave a `dispatch_attempts` row with the correct `project_id`.

### On the "swallowed and silent" concern in the dispatch instruction

`_persist_dispatch_row`'s `except Exception` (and `_owner_transition`'s) already record a durable `door_bookkeeping_failed` fact via `_record_bookkeeping_failure` (OI-1617, `dispatch_register.ndjson` → folded into `dispatch_register_events` by `build_t0_state.py`, already covered by `tests/test_door_bookkeeping_facts_contract.py`). This is designed, not an oversight: bookkeeping must never block the door, but the swallow already leaves a FACT instead of vanishing into a `.debug()` call. I verified this empirically against the live ledger: 33 `door_bookkeeping_failed` records exist for today, 9 with `site=_persist_dispatch_row, error=IntegrityError: NOT NULL constraint failed: dispatch_attempts.project_id` (this exact bug), and 19 cascading `_owner_transition:{delivering,accepted,running,failed_delivery}` KeyErrors once the whole `_persist_dispatch_row` transaction rolled back for lack of a durable `dispatches` row. No change was needed there — fixing the root cause in `create_attempt()` stops the cascade instead of only logging it better.

## Verification

Red run (before fix, production files reverted to HEAD via a saved patch, new test file present):
```
tests/test_create_attempt_project_id.py::TestCreateAttemptStampsProjectId::test_create_attempt_inserts_with_project_id FAILED
tests/test_create_attempt_project_id.py::TestDoorDispatchPersistsAttemptRow::test_door_dispatch_creates_attempt_row_with_project_id FAILED
...
E       TypeError: create_attempt() got an unexpected keyword argument 'project_id'
...
WARNING  dispatch_cli:dispatch_cli.py:1159 [dispatch_cli] door bookkeeping failed site=_persist_dispatch_row dispatch=20260905-oi1625-door-attempt: NOT NULL constraint failed: dispatch_attempts.project_id
E       AssertionError: the door swallowed a bookkeeping failure and returned None
2 failed in 0.22s
```

Green run (fix reapplied):
```
tests/test_create_attempt_project_id.py::TestCreateAttemptStampsProjectId::test_create_attempt_inserts_with_project_id PASSED
tests/test_create_attempt_project_id.py::TestDoorDispatchPersistsAttemptRow::test_door_dispatch_creates_attempt_row_with_project_id PASSED
2 passed in 0.17s
```

Full targeted suite (touched files + direct neighbors):
- `tests/test_create_attempt_project_id.py` — 2 passed
- `tests/test_runtime_coordination.py`, `tests/test_runtime_reconciler.py`, `tests/test_headless_run_registry.py`, `tests/test_headless_smoke.py`, `tests/test_door_bookkeeping_facts_contract.py` — all passed (part of an 8-file batch: 222 passed, 15 failed — see below for the 15)
- `tests/test_dispatch_broker.py` — 76 passed
- `tests/test_headless_system.py` — 66 passed
- `tests/test_dispatch_door_row.py`, `tests/test_dispatch_door_authority.py` — 23 passed
- `tests/test_dispatch_cli.py` — 156 passed (6 initially failed, traced to `VNX_OVERRIDE_WORKER_CLAUDE=1` leaking from this worker's own dispatch environment into the test process — a pre-existing test-isolation gap unrelated to this change; confirmed by rerunning the same 6 with that env var stripped: 6 passed)

15 pre-existing failures in `tests/test_headless_inspect.py` (13, icon/formatting string mismatches in `format_run_line`/`list_runs`/`health_summary`) and `tests/test_burnin_certification.py::TestB4LogArtifacts` (2, path-traversal `ValueError` in `log_artifact.py`) are unrelated to this change — the source files they exercise (`log_artifact.py`, the inspect-formatting module) are not touched by this diff, and the `_create_dispatch_and_attempt`/`_create_run` setup helpers those tests share complete successfully before the unrelated assertions fail.

## Open Items

None.

**Dispatch-ID**: 20260905-100003-oi1625-attempt-project-id
**Model**: sonnet
**Provider**: claude