### PR TITLE
fix(codex): rank error terminality instead of first-error-wins (OI-1633)

### DIFF
--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -250,8 +250,14 @@ def _normalize_complete_events(
 ) -> Optional[CanonicalEvent]:
     """Handle error, turn.completed, task_complete, result/message, token_count events."""
     if etype == "error":
+        # OI-1633: a top-level `error` event is mid-stream — codex can and does
+        # recover from these (e.g. its own "Reconnecting... N/2 (stream
+        # disconnected before completion: idle timeout)" retry messages) and
+        # keep streaming afterwards. Mark it non-terminal so _drain_stream's
+        # rank-by-terminality never lets it displace a later task_complete
+        # error, which IS the end-of-turn signal.
         msg = payload.get("message", payload.get("error", payload.get("text", "")))
-        return make("error", {"message": str(msg) if msg else str(payload)[:200]})
+        return make("error", {"message": str(msg) if msg else str(payload)[:200], "terminal": False})
     if etype == "task_complete":
         # OI-1628, measured 2026-09-05 on three live dispatches
         # (~/.codex/sessions/2026/09/05/rollout-*.jsonl): codex reports quota/
@@ -269,7 +275,9 @@ def _normalize_complete_events(
             info = err.get("codex_error_info")
             if info and str(info) not in str(msg):
                 msg = f"{msg} (codex_error_info: {info})"
-            return make("error", {"message": str(msg)})
+            # OI-1633: task_complete marks the end of a turn — this IS the
+            # terminal outcome, unlike a mid-stream `error` event above.
+            return make("error", {"message": str(msg), "terminal": True})
         tc = _extract_token_count_payload(raw)
         token_count = _normalize_token_count(tc) if tc else None
         data: dict = {"token_count": token_count} if token_count else {}
@@ -570,7 +578,28 @@ def _drain_stream(
     # timed_out — a real codex error/task_complete error's "message" text was
     # read by no one, so the caller always fell back to the generic "codex
     # stderr tail" surfacing below regardless of what the stream said.
+    #
+    # OI-1633: plain first-wins is wrong once a stream can recover from a
+    # mid-stream hiccup. Codex sometimes emits a transient top-level `error`
+    # (e.g. "Reconnecting... 2/2 (stream disconnected before completion: idle
+    # timeout)") that it then recovers from, followed by the real, terminal
+    # outcome in `task_complete`. First-wins let the transient message win the
+    # receipt over a genuine quota/usage-limit failure — same root cause,
+    # opposite classification, purely because of accidental timing. Rank by
+    # terminality instead of arrival order:
+    #   - a transient (mid-stream) error must never displace a captured
+    #     terminal (task_complete) error — the process recovered from it, so
+    #     it is weaker evidence than the turn's actual outcome;
+    #   - a terminal error DOES upgrade a captured transient — it is stronger
+    #     evidence once it arrives;
+    #   - a terminal error must never be displaced by a LATER terminal error
+    #     either — the first terminal is kept, so a downstream cleanup/retry
+    #     failure can't overwrite the real root cause.
+    # Do not "fix" this by flipping to last-wins: that reintroduces the same
+    # bug in the opposite direction (a late transient would then win over an
+    # earlier terminal).
     captured_error: Optional[str] = None
+    captured_error_terminal = False
 
     try:
         for canonical_event in normalizer.drain_stream(
@@ -593,10 +622,12 @@ def _drain_stream(
                 reason = error_data.get("reason", "")
                 if "timeout" in (reason or "").lower():
                     timed_out = True
-                if captured_error is None:
-                    msg = error_data.get("message") or reason
-                    if msg:
+                msg = error_data.get("message") or reason
+                if msg:
+                    is_terminal = bool(error_data.get("terminal"))
+                    if captured_error is None or (is_terminal and not captured_error_terminal):
                         captured_error = str(msg)
+                        captured_error_terminal = is_terminal
 
             stop, last_stuck_log, writer_failed = _process_one_event(
                 canonical_event, terminal_id, dispatch_id,

--- a/tests/test_codex_spawn_fail_closed.py
+++ b/tests/test_codex_spawn_fail_closed.py
@@ -248,6 +248,122 @@ class TestCodexSpawnQuotaExhaustion:
 
 
 # ---------------------------------------------------------------------------
+# OI-1633: the first error to arrive on the stream must not automatically win
+# once a transient (mid-stream) error and a terminal (task_complete) error
+# both occur in the same run. Rank by terminality: a terminal error is
+# stronger evidence and must win over an earlier OR later transient one; a
+# terminal error must not be displaced by a later terminal either.
+# ---------------------------------------------------------------------------
+
+class TestCodexSpawnErrorRanking:
+    """spawn_codex ranks a task_complete (terminal) error above a mid-stream (transient) one."""
+
+    def _transient_reconnect_event(self, dispatch_id: str) -> CanonicalEvent:
+        """A codex top-level `error` event the process itself recovers from.
+
+        Real shape observed 2026-09-05 (15:33 run): codex emits this as a
+        top-level `error` NDJSON event, then keeps streaming and eventually
+        reaches task_complete. normalize_codex_event() marks this
+        non-terminal (terminal=False) for exactly this reason.
+        """
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id="T1",
+            provider="codex",
+            event_type="error",
+            data={
+                "message": (
+                    "Reconnecting... 2/2 (stream disconnected before "
+                    "completion: idle timeout)"
+                ),
+                "terminal": False,
+            },
+            observability_tier=1,
+        )
+
+    def _terminal_quota_event(self, dispatch_id: str) -> CanonicalEvent:
+        """A task_complete-wrapped error — the real, terminal outcome of the turn."""
+        return CanonicalEvent(
+            dispatch_id=dispatch_id,
+            terminal_id="T1",
+            provider="codex",
+            event_type="error",
+            data={
+                "message": (
+                    "You've hit your usage limit. Upgrade to Pro "
+                    "(https://chatgpt.com/explore/pro), visit "
+                    "https://chatgpt.com/codex/settings/usage to purchase "
+                    "more credits or try again at 2:27 PM. "
+                    "(codex_error_info: usage_limit_exceeded)"
+                ),
+                "terminal": True,
+            },
+            observability_tier=1,
+        )
+
+    def _run_with_events(self, dispatch_id: str, events: List[CanonicalEvent]):
+        with patch("provider_spawns.codex_spawn.subprocess.Popen") as MockPopen:
+            proc = MagicMock()
+            proc.pid = 99
+            proc.returncode = 1
+            proc.wait = MagicMock(return_value=1)
+            proc.poll = MagicMock(return_value=1)
+            proc.stdin = MagicMock()
+            proc.stderr = _mock_stderr(b"Reading prompt from stdin...\n")
+            MockPopen.return_value = proc
+
+            with patch(
+                "provider_spawns.codex_spawn._NormalizerHost.drain_stream",
+                return_value=iter(events),
+            ):
+                return spawn_codex(
+                    prompt="test",
+                    model="",
+                    dispatch_id=dispatch_id,
+                    terminal_id="T1",
+                )
+
+    def test_transient_then_terminal_keeps_terminal_reason(self):
+        """Run-1 order (transient arrives first): the terminal reason must win.
+
+        Pre-fix this was RED: first-wins captured the "Reconnecting..." text
+        and the terminal quota message was discarded.
+        """
+        events = [
+            self._transient_reconnect_event("test-rank-1"),
+            self._terminal_quota_event("test-rank-1"),
+        ]
+        result = self._run_with_events("test-rank-1", events)
+
+        assert result.error is not None
+        assert "usage_limit_exceeded" in result.error, (
+            f"expected the terminal quota reason to win, got: {result.error!r}"
+        )
+        assert "Reconnecting" not in result.error, (
+            f"transient reconnect text must not survive in the final reason, got: {result.error!r}"
+        )
+
+    def test_terminal_then_transient_keeps_terminal_reason(self):
+        """Reverse order (terminal arrives first): a later transient must not displace it.
+
+        Guards against overcorrecting into last-wins, which would fail this case.
+        """
+        events = [
+            self._terminal_quota_event("test-rank-2"),
+            self._transient_reconnect_event("test-rank-2"),
+        ]
+        result = self._run_with_events("test-rank-2", events)
+
+        assert result.error is not None
+        assert "usage_limit_exceeded" in result.error, (
+            f"expected the terminal quota reason to win, got: {result.error!r}"
+        )
+        assert "Reconnecting" not in result.error, (
+            f"a later transient must not displace the captured terminal reason, got: {result.error!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Test 4: on_event=False stops stream early
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`_drain_stream` in `scripts/lib/provider_spawns/codex_spawn.py` captured the FIRST in-stream `error` canonical event's message, unconditionally. Codex's own transient mid-stream retries (e.g. `Reconnecting... 2/2 (stream disconnected before completion: idle timeout)`) surface as top-level `error` events the process itself recovers from — but if one of those happens to arrive before the real, terminal `task_complete`-wrapped quota/usage-limit error, first-wins let the transient message win the receipt. Same root cause (quota exhaustion), opposite classification (`no_verdict` vs `credit_exhausted`), purely due to timing — observed live on two runs on 2026-09-05 (15:33 wrong, 19:55 correct).

## Changes

- `scripts/lib/provider_spawns/codex_spawn.py`:
  - `_normalize_complete_events`: top-level `error` events are now marked `terminal: False` (mid-stream, codex can recover); `task_complete`-wrapped errors are marked `terminal: True` (end-of-turn, backed by `codex_error_info`).
  - `_drain_stream`: replaced first-error-wins with a terminality rank — a transient never displaces a captured terminal; a terminal upgrades a captured transient; a terminal is never displaced by a later terminal either (first-terminal-wins). Explicit comment documents the rank and warns against "fixing" it into last-wins.
- `tests/test_codex_spawn_fail_closed.py`: new `TestCodexSpawnErrorRanking` with both event orderings (transient→terminal, terminal→transient), asserting on the actual captured reason string, not just a derived failure_class.

## Verification

Red run (pre-fix, `git stash`/revert of the codex_spawn.py fix):
```
FAILED tests/test_codex_spawn_fail_closed.py::TestCodexSpawnErrorRanking::test_transient_then_terminal_keeps_terminal_reason
AssertionError: expected the terminal quota reason to win, got: 'Reconnecting... 2/2 (stream disconnected before completion: idle timeout) | codex stderr tail: Reading prompt from stdin...'
1 failed, 1 passed in 0.18s
```

Green run (post-fix):
```
$ python3 -m pytest tests/test_codex_spawn_fail_closed.py -q
....................
20 passed in 0.62s
```

Neighbor files (no regressions vs. pre-existing baseline):
```
$ python3 -m pytest tests/test_codex_spawn_byte_identity.py tests/unit/test_codex_event_normalizer.py tests/test_streaming_drainer.py tests/test_failure_classification.py tests/test_failclass_registry.py -q
4 failed, 207 passed in 7.05s
```
The 4 failures (`TestUnknownEvents::*`, `test_zero_token_count_falls_through_to_unknown`) are pre-existing and unrelated: `normalize_codex_event`'s unknown-type passthrough maps to `"info"`, but `test_codex_event_normalizer.py` asserts `"error"`. Confirmed identical on `main` before this change (same failures with the fix reverted).

## Investigation: same first-wins pattern in other spawn handlers

Checked all spawn handlers in `scripts/lib/provider_spawns/` (note: the dispatch said "negen" handlers; measured 8 files with `spawn_*` functions — `claude_spawn.py`, `codex_spawn.py`, `deepseek_harness_spawn.py`, `gemini_spawn.py`, `glm_harness_spawn.py`, `kimi_spawn.py`, `litellm_spawn.py` (2 functions), `local_gemma_spawn.py`; 9 likely counts `__init__.py` as a file too):

- **`litellm_spawn.py:371`** (`first_error_event is None`) — same first-wins pattern. Not fixed here: no evidence of a distinguishable transient-vs-terminal event shape in litellm's stream (unlike codex's `task_complete`), so a terminality rank isn't a drop-in port, and I have no live-observed repro to write a red test against. **Open item.**
- **`kimi_spawn.py`** (`errors_captured` list, joined with `\n`) — different pattern: accumulates ALL error messages rather than picking one, so it doesn't silently drop the terminal reason, but it also has no rank distinguishing a real outcome from stream noise. Lower-priority, not fixed.
- `claude_spawn.py`, `gemini_spawn.py`, `glm_harness_spawn.py`, `deepseek_harness_spawn.py`, `local_gemma_spawn.py` — no matching pattern; `.error` is set from single-shot subprocess-level failures (timeout, non-zero exit + stderr tail, missing binary), not from a multi-event race between candidate error messages, so this bug class doesn't apply.

## Open Items

- `litellm_spawn.py`'s structurally identical first-wins pattern (`first_error_event`, line 371) is unfixed — needs its own investigation into whether litellm/GLM/deepseek streams ever emit a genuinely transient error type before a terminal one.
- 4 pre-existing failures in `tests/unit/test_codex_event_normalizer.py` (unrelated drift between the unknown-event-type contract and its test) — untouched, out of scope for this dispatch.

Dispatch-ID: 20260905-201001-oi1633-fout-rangorde