### PR TITLE
fix(gate-recorder): guard the takeover-annotation writer (OI-1630)

### DIFF
--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -18,7 +18,7 @@ from atomic_io import atomic_write_json
 from auto_merge_policy import codex_final_gate_required
 from review_contract import ReviewContract
 from gemini_prompt_renderer import render_gemini_prompt
-from gate_recorder import get_pr_head_sha
+from gate_recorder import get_pr_head_sha, write_result_guarded
 from governance_emit import _classify_lane_log_text
 from claude_github_receipt import (
     ClaudeGitHubReviewReceipt,
@@ -689,14 +689,26 @@ class GateRequestHandlerMixin:
         no multi-hop path to report, so the field is NEVER absent on a
         takeover record.
 
-        Both writes go through ``atomic_write_json`` (temp file in the same
-        directory + ``os.replace``), never a bare ``write_text``. These are
-        EVIDENCE files: a torn write here passes the existence check a reader
-        does first and only fails on the content it trusts -- worse than no
-        record at all, because it surfaces exactly when the record is
-        needed. Not suppressed with a `# vnx-atomic-write` marker: that
-        marker is for writes where a torn write is harmless, which a gate
-        evidence record is not.
+        The request write goes through ``atomic_write_json`` (temp file in
+        the same directory + ``os.replace``), never a bare ``write_text``.
+        That file is an EVIDENCE file: a torn write here passes the
+        existence check a reader does first and only fails on the content it
+        trusts -- worse than no record at all, because it surfaces exactly
+        when the record is needed. Not suppressed with a
+        `# vnx-atomic-write` marker: that marker is for writes where a torn
+        write is harmless, which a gate evidence record is not.
+
+        The result write (OI-1630) routes through
+        ``gate_recorder.write_result_guarded`` instead of a bare
+        ``atomic_write_json``. This method reads the on-disk result, merges
+        the takeover fields onto it, and writes the merge back -- a
+        read-modify-write with no lock across the gap. A concurrent GUARDED
+        writer (the real gate run this same takeover request just kicked
+        off) can land a decided, evidenced verdict in that gap; without the
+        guard, this method's stale copy of the pre-verdict record would
+        stomp it on the way back to disk. The guard refuses that stomp the
+        same way it already refuses every other writer of a
+        ``review_gates/results/`` record.
         """
         gate = payload.get("gate", "")
         if takeover_path is None:
@@ -729,7 +741,22 @@ class GateRequestHandlerMixin:
                     result_payload = None
                 if result_payload is not None:
                     result_payload.update(annotations)
-                    atomic_write_json(result_file, result_payload)
+                    _on_disk, written = write_result_guarded(
+                        result_file, result_payload, gate=gate, pr_ref=str(pr_number),
+                    )
+                    if not written:
+                        # gate_recorder.write_result_guarded already logged the
+                        # refusal; this makes the takeover-stamping caller's own
+                        # awareness explicit (OI-1630) -- a decided, evidenced
+                        # verdict that landed concurrently stands unannotated
+                        # rather than being stomped by this stale copy.
+                        logger.warning(
+                            "gate_request_handler: takeover-annotation write "
+                            "REFUSED for gate=%s pr=%s -- an existing terminal, "
+                            "evidenced result stands; this stamp never reached "
+                            "results/",
+                            gate, pr_number,
+                        )
         return payload
 
     def _chain_exhausted_path(self, gate: str, pr_number: int) -> Path:

--- a/tests/test_gate_recorder_overwrite_guard.py
+++ b/tests/test_gate_recorder_overwrite_guard.py
@@ -39,6 +39,7 @@ from gate_recorder import (
     record_terminal_result,
     write_result_guarded,
 )
+from gate_request_handler import GateRequestHandlerMixin
 
 
 def _make_pass(**overrides):
@@ -493,3 +494,143 @@ class TestCorruptExistingResultFailsClosed:
         assert written is True
         assert result == payload
         assert json.loads(out.read_text(encoding="utf-8")) == payload
+
+
+# ---------------------------------------------------------------------------
+# Writer 4 (OI-1630): gate_request_handler._stamp_takeover_annotations
+#
+# The four writers above all build their "new" payload independently of
+# whatever is on disk, so a pre-seeded decided verdict and the writer's own
+# attempted write are two genuinely different records -- the guard's normal
+# shape. _stamp_takeover_annotations is structurally different: it READS the
+# existing result, merges takeover-provenance fields onto it, and writes the
+# merge straight back with a bare atomic_write_json, un-guarded and
+# un-locked. Seeding a conflicting record ahead of time proves nothing here,
+# because the writer would just read *that* record and re-merge onto it --
+# no downgrade in sight. The actual defect only shows up across the gap
+# between this writer's read and its write: a concurrent GUARDED writer (the
+# real gate run this same takeover request just kicked off) can land a
+# decided, evidenced verdict in that window, and this writer's stale,
+# pre-verdict copy stomps it on the way back to disk. The tests below inject
+# exactly that race at the one seam available in a single-threaded test: the
+# read call itself.
+# ---------------------------------------------------------------------------
+
+
+class _StubHandler(GateRequestHandlerMixin):
+    """Minimal stand-in for ReviewGateManager: only the two path helpers
+    ``_stamp_takeover_annotations`` calls. The method under test is real
+    production code."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self.requests_dir = state_dir / "review_gates" / "requests"
+        self.results_dir = state_dir / "review_gates" / "results"
+        self.requests_dir.mkdir(parents=True, exist_ok=True)
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+
+    def _request_path(self, gate: str, pr_number: int) -> Path:
+        return self.requests_dir / f"pr-{pr_number}-{gate}.json"
+
+    def _result_path(self, gate: str, pr_number: int) -> Path:
+        return self.results_dir / f"pr-{pr_number}-{gate}.json"
+
+
+_STALE_NOT_EXECUTABLE = {
+    "gate": "glm_gate",
+    "pr_number": 1762,
+    "status": "not_executable",
+    "reason": "provider_not_installed",
+    "contract_hash": "",
+    "report_path": "",
+}
+
+_RACED_DECIDED_PASS = {
+    "gate": "glm_gate",
+    "pr_number": 1762,
+    "status": "pass",
+    "contract_hash": "realevidencehash1",
+    "report_path": "/tmp/glm-report.md",
+    "dispatch_id": "glm-gate-pr1762-9",
+}
+
+
+class TestStampTakeoverAnnotationsOverwriteGuard:
+
+    def _stamp(self, handler, payload, pr_number):
+        return handler._stamp_takeover_annotations(
+            payload,
+            pr_number=pr_number,
+            takeover_from="codex_gate",
+            failure_reason=(
+                "codex_gate unavailable (lane_exhausted): quota -- "
+                "glm_gate substituted as reader"
+            ),
+            takeover_reason="lane_exhausted",
+            takeover_source_status="unavailable",
+        )
+
+    def test_refuses_a_verdict_that_lands_in_the_read_write_gap(self, tmp_path, monkeypatch):
+        """OI-1630 reproduction, live shape from pr-1762 (OI-1624): a
+        not_executable placeholder sits in the slot when this writer reads
+        it; before it writes its stale merge back, the real gate run this
+        takeover request kicked off lands a decided, evidenced pass. The
+        pass must survive."""
+        handler = _StubHandler(tmp_path / "state")
+        request_file = handler._request_path("glm_gate", 1762)
+        result_file = handler._result_path("glm_gate", 1762)
+        request_file.write_text(json.dumps(_STALE_NOT_EXECUTABLE), encoding="utf-8")
+        result_file.write_text(json.dumps(_STALE_NOT_EXECUTABLE), encoding="utf-8")
+
+        real_read_text = Path.read_text
+
+        def racing_read_text(self_path, *args, **kwargs):
+            text = real_read_text(self_path, *args, **kwargs)
+            if self_path == result_file:
+                self_path.write_text(json.dumps(_RACED_DECIDED_PASS), encoding="utf-8")
+            return text
+
+        monkeypatch.setattr(Path, "read_text", racing_read_text)
+        self._stamp(handler, dict(_STALE_NOT_EXECUTABLE), 1762)
+        monkeypatch.undo()
+
+        on_disk = json.loads(result_file.read_text(encoding="utf-8"))
+        assert on_disk == _RACED_DECIDED_PASS, (
+            "a takeover-annotation write must never stomp a decided, "
+            "evidenced verdict that landed concurrently (OI-1630)"
+        )
+
+    def test_merges_normally_onto_its_own_fresh_not_executable(self, tmp_path):
+        """The common, non-racing case: _dispatch_one_review just wrote a
+        fresh not_executable result for the takeover's new reader, and
+        stamping the takeover provenance onto that SAME record must still
+        land -- the guard only refuses a downgrade, it must not freeze the
+        slot shut."""
+        handler = _StubHandler(tmp_path / "state")
+        request_file = handler._request_path("glm_gate", 1700)
+        result_file = handler._result_path("glm_gate", 1700)
+        fresh = {**_STALE_NOT_EXECUTABLE, "pr_number": 1700}
+        request_file.write_text(json.dumps(fresh), encoding="utf-8")
+        result_file.write_text(json.dumps(fresh), encoding="utf-8")
+
+        self._stamp(handler, dict(fresh), 1700)
+
+        on_disk = json.loads(result_file.read_text(encoding="utf-8"))
+        assert on_disk["status"] == "not_executable"
+        assert on_disk["takeover"] is True
+        assert on_disk["takeover_from"] == "codex_gate"
+
+    def test_no_result_file_yet_only_annotates_the_request(self, tmp_path):
+        """No result has been written for this gate/pr at all -- the common
+        first-round shape. Nothing to merge onto, so the result slot must
+        stay untouched (never created out of thin air by the annotation
+        step)."""
+        handler = _StubHandler(tmp_path / "state")
+        request_file = handler._request_path("glm_gate", 1800)
+        result_file = handler._result_path("glm_gate", 1800)
+        request_file.write_text(json.dumps({**_STALE_NOT_EXECUTABLE, "pr_number": 1800}), encoding="utf-8")
+        assert not result_file.exists()
+
+        returned = self._stamp(handler, {**_STALE_NOT_EXECUTABLE, "pr_number": 1800}, 1800)
+
+        assert not result_file.exists()
+        assert returned["takeover"] is True


### PR DESCRIPTION
## Summary

- `gate_request_handler._stamp_takeover_annotations` reads an existing `review_gates/results/pr-<N>-<gate>.json` record, merges takeover-provenance fields onto it, and wrote the merge straight back with a bare `atomic_write_json` — the last writer of that store that OI-1469/OI-1470/OI-1472 never routed through `gate_recorder.write_result_guarded`.
- Unlike the writers already guarded, this one does a read-modify-write with **no lock across the gap**: a concurrent guarded writer (the real gate run this same takeover request just kicked off) can land a decided, evidenced verdict between this method's read and its write, and this method's stale pre-verdict copy stomps it on the way back to disk.
- Fixed by routing the result-file write through `write_result_guarded`, identical to every other writer of that store.

## Investigation of the OI-1624 hypothesis

The dispatch asked me to establish whether pr-1762's contradictory records (`glm_gate=unavailable` alongside `kimi_gate=pass`, same commit `2f098dcf`) came through this writer before treating it as evidence.

Checked the live records in the central store:
- Neither `pr-1762-glm_gate.json` nor `pr-1762-kimi_gate.json` carries a `takeover`/`takeover_from` field, and `failure_reason` is `""` on both — the shape this writer stamps is absent from both records.
- The configured takeover chain is `codex_gate -> kimi_gate -> glm_gate -> deepseek_gate`. glm_gate was requested at 18:21:30, kimi_gate at 18:37:36 — glm ran *first*, kimi *second*. A takeover would only ever hop kimi's failure onto glm, never the reverse order these two requests actually fired in.

Conclusion: pr-1762's contradiction did **not** come through `_stamp_takeover_annotations`. It is two independent review-stack gates with different, legitimate outcomes on the same commit. The fix in this PR stands on its own reasoning (a real, demonstrated race) regardless of that outcome.

## Changes

- `scripts/lib/gate_request_handler.py`: `_stamp_takeover_annotations`'s result-file write now goes through `gate_recorder.write_result_guarded` instead of a bare `atomic_write_json`; logs a warning on refusal, matching the existing `_mark_gate_unavailable` convention. Docstring updated to describe the race this closes.
- `tests/test_gate_recorder_overwrite_guard.py`: new `TestStampTakeoverAnnotationsOverwriteGuard` class (3 tests) exercising the real production method:
  - `test_refuses_a_verdict_that_lands_in_the_read_write_gap` — injects a concurrent write between this method's read and write via a `Path.read_text` monkeypatch, proving a decided/evidenced pass that lands mid-write survives.
  - `test_merges_normally_onto_its_own_fresh_not_executable` — positive control: the common non-racing case still annotates correctly.
  - `test_no_result_file_yet_only_annotates_the_request` — positive control: no result file yet, nothing is fabricated.

## Verification

**RED (bug reproduced, fix reverted via `git stash` on `scripts/lib/gate_request_handler.py` only):**
```
tests/test_gate_recorder_overwrite_guard.py::TestStampTakeoverAnnotationsOverwriteGuard::test_refuses_a_verdict_that_lands_in_the_read_write_gap FAILED
...
E       AssertionError: a takeover-annotation write must never stomp a decided, evidenced verdict that landed concurrently (OI-1630)
E         Differing items:
E         {'report_path': ''} != {'report_path': '/tmp/glm-report.md'}
E         {'status': 'not_executable'} != {'status': 'pass'}
E         {'contract_hash': ''} != {'contract_hash': 'realevidencehash1'}
1 failed, 23 passed in 0.23s
```

**GREEN (fix restored):**
```
$ python3 -m pytest tests/test_gate_recorder_overwrite_guard.py -v
...
24 passed in 0.19s
```

**Direct-neighbor suites (unaffected):**
```
$ python3 -m pytest tests/test_beta3_e1_review_gate_chain.py tests/test_dlv5_review_gate_takeover.py \
  tests/test_gate_recorder_overwrite_guard.py tests/test_gate_recorder_provenance.py \
  tests/test_gate_recorder_register.py tests/test_gate_request_handler_w3f.py \
  tests/test_oi1472_residual_guard_writers.py tests/test_oi1576_merge_door_takeover_evidence.py \
  tests/test_pr_merge_review_gate.py tests/test_review_gate_dispatch_id.py \
  tests/test_review_gate_manager.py tests/test_review_gate_role.py -q
196 passed in 3.27s
```

Did not run the full `pytest tests/` suite per dispatch instructions — only the touched files and their direct neighbors.

## Open Items

None.

**Dispatch-ID**: 20260905-201002-oi1630-request-wachter
**Model**: sonnet
**Provider**: claude