### PR TITLE
fix(dispatch): worker and envelope resolved VNX_DATA_DIR to different stores (OI-1635)

### DIFF
--- a/scripts/lib/data_dir_guard.py
+++ b/scripts/lib/data_dir_guard.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 from project_root import resolve_central_data_dir, resolve_project_id
+from project_root import resolve_data_dir as _resolve_repo_local_data_dir
 from vnx_ids import PROJECT_ID_RE
 
 
@@ -103,3 +104,64 @@ def check_data_dir_project_id_guard(
         raise RuntimeError(msg)
 
     warnings.warn(VNXDataDirMismatchWarning(msg), stacklevel=2)
+
+
+def _candidate_report_stores(data_dir: "str | Path") -> "list[Path]":
+    """Return the OTHER known VNX data-dir candidates besides *data_dir* itself.
+
+    Two resolvers exist fleet-wide for "the" data dir and can legitimately
+    disagree (OI-1635): ``project_root.resolve_data_dir()`` (repo-local
+    ``<project_root>/.vnx-data`` by default) and the central
+    ``~/.vnx-data/<project_id>`` store (``resolve_central_data_dir`` /
+    ``vnx_paths.resolve_paths()``). This returns whichever of those two do NOT
+    match the resolved *data_dir*, so a caller can check both for a stray report.
+
+    Best-effort and never raises: an unresolvable project_id/project_root drops
+    that candidate silently — this is an advisory signal, not a path resolver
+    that anything depends on for correctness.
+    """
+    resolved = Path(data_dir).expanduser().resolve()
+    candidates: "list[Path]" = []
+
+    try:
+        local = _resolve_repo_local_data_dir().resolve()
+        if local != resolved:
+            candidates.append(local)
+    except Exception:  # vnx-silent-except: advisory-only, never raise past this
+        pass
+
+    try:
+        central = resolve_central_data_dir(resolve_project_id()).resolve()
+        if central != resolved and central not in candidates:
+            candidates.append(central)
+    except Exception:  # vnx-silent-except: advisory-only, never raise past this
+        pass
+
+    return candidates
+
+
+def check_report_store_split_brain(
+    dispatch_id: str, data_dir: "str | Path"
+) -> "Optional[Path]":
+    """Detect a unified report for *dispatch_id* sitting in a DIFFERENT known
+    store than *data_dir* (OI-1635).
+
+    Returns the path of the orphaned report when one is found in another known
+    store's ``unified_reports/`` directory, else ``None``. Callers should treat
+    a hit as advisory-but-loud: it means the worker's real output likely landed
+    somewhere the governance layer never reads from, and whatever is about to
+    be written to *data_dir* is at risk of being a narrative stand-in for real
+    work sitting elsewhere, unlinked from the audit trail.
+
+    Best-effort — resolution errors are swallowed (never raises); this must
+    never block or fail a report-emit call site.
+    """
+    resolved = Path(data_dir).expanduser().resolve()
+    for candidate in _candidate_report_stores(resolved):
+        try:
+            alt_report = candidate / "unified_reports" / f"{dispatch_id}.md"
+            if alt_report.is_file():
+                return alt_report
+        except OSError:  # vnx-silent-except: advisory-only, never raise past this
+            continue
+    return None

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -689,6 +689,33 @@ def emit_unified_report(
     reports_dir.mkdir(parents=True, exist_ok=True)
 
     report_path = reports_dir / f"{dispatch_id}.md"
+
+    # OI-1635: nothing exists yet at report_path — about to write the generic
+    # completion-text wrapper below. Before doing that, check whether the
+    # worker's REAL report landed in a DIFFERENT known store (the worker and
+    # this emitter can disagree on "VNX_DATA_DIR" — see
+    # provider_dispatch._worker_role_env). A hit here means the central ledger
+    # is about to receive a narrative stand-in while the actual work sits
+    # elsewhere, unlinked from the audit trail — never silent about that.
+    if not report_path.exists():
+        try:
+            from data_dir_guard import check_report_store_split_brain
+            _orphan = check_report_store_split_brain(dispatch_id, data_dir)
+            if _orphan is not None:
+                logger.error(
+                    "VNX_REPORT_STORE_SPLIT_BRAIN: dispatch=%s about to write the "
+                    "generic wrapper at %s, but a worker report already exists at "
+                    "%s — the worker and the governance emitter resolved the VNX "
+                    "data dir to different stores; that richer report is orphaned "
+                    "from the audit trail",
+                    dispatch_id, report_path, _orphan,
+                )
+        except Exception as _split_exc:  # noqa: BLE001 — advisory guard must never break report emit
+            logger.debug(
+                "governance_emit: split-brain guard failed (non-fatal) dispatch=%s: %s",
+                dispatch_id, _split_exc,
+            )
+
     if report_path.exists() and not overwrite:
         if preserve_partial:
             try:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1611,22 +1611,68 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _worker_role_env(role: Optional[str]) -> Optional[Dict[str, str]]:
-    """Build the ``VNX_WORKER_ROLE`` env overlay for a provider-lane worker.
+    """Build the env overlay for a provider-lane worker: role + VNX_DATA_DIR.
 
-    Mirrors ``TmuxInteractiveDispatch._spawn_session`` (the claude/tmux lane): a
-    genuinely-set role in the dispatch spec is exported as ``VNX_WORKER_ROLE`` so
-    the worker-scope PreToolUse enforcement hook
+    Role half — mirrors ``TmuxInteractiveDispatch._spawn_session`` (the
+    claude/tmux lane): a genuinely-set role in the dispatch spec is exported as
+    ``VNX_WORKER_ROLE`` so the worker-scope PreToolUse enforcement hook
     (``scripts/hooks/pretooluse_worker_scope_enforce.py``) resolves the role's
     permission profile instead of the restrictive code-worker fallback (OI-1209).
     A missing role stays missing — nothing is exported and the fallback stands,
     which is the existing, desired behavior. ``normalize_role`` strips the empty
     sentinel and ``identity_unresolved`` so neither leaks into the worker env as
     a fabricated role.
+
+    Data-dir half (OI-1635): every provider-lane spawn (kimi/codex/deepseek-
+    harness/glm-harness/gemini/litellm) tells its worker, in the dispatch
+    instructions themselves, to write its completion report to literal
+    ``$VNX_DATA_DIR/unified_reports/<id>.md`` — but nothing used to actually SET
+    that env var in the worker's own process, so the worker was left to
+    independently resolve "VNX_DATA_DIR" however it saw fit. Measured
+    2026-09-05: a worker resolving via ``project_root.resolve_data_dir()`` (the
+    CLAUDE.md-documented helper) lands on the repo-local ``<project_root>/.vnx-data``
+    by default, while this module's own ``_resolve_data_dir()``/``_resolve_state_dir()``
+    (used by ``_emit_governance``/the envelope to write the receipt+report) resolve
+    the CENTRAL ``~/.vnx-data/<project_id>`` store — two different answers for the
+    same literal name, from the SAME process family. The worker's real report then
+    lands in a store the governance layer never looks at, and the central ledger
+    gets only the generic completion-text wrapper.
+
+    Fix: stamp the ALREADY-RESOLVED central ``data_dir``/``state_dir`` (computed
+    here, in the dispatcher process, BEFORE the worker's own worktree-scoped CWD
+    ever enters the picture) directly into the worker's subprocess env, exactly
+    mirroring the tmux lane's completion-command ``env_prefix`` (see
+    ``tmux_interactive_dispatch.py``'s ``VNX_STATE_DIR=... VNX_DATA_DIR=...
+    VNX_DATA_DIR_EXPLICIT=1``). Because the value is an absolute path baked in as
+    an env var — not re-derived by the worker from its own CWD — it survives
+    unchanged whether the worker resolves it via a bare ``$VNX_DATA_DIR`` shell
+    reference, via ``project_root.resolve_data_dir()``, or via
+    ``vnx_paths.resolve_paths()``: both of those helpers treat
+    ``VNX_DATA_DIR_EXPLICIT=1`` + ``VNX_DATA_DIR`` as their HIGHEST-precedence
+    override, ahead of any CWD/git-toplevel resolution. A worktree can therefore
+    never re-introduce this drift, because the worker is never asked to resolve
+    the path itself in the first place.
+
+    Best-effort: a data-dir resolution failure here must never break the spawn
+    (the existing role-only behavior is the fallback) — logged, not raised.
     """
-    resolved = normalize_role(role)
-    if not resolved:
-        return None
-    return {"VNX_WORKER_ROLE": resolved}
+    env: Dict[str, str] = {}
+    resolved_role = normalize_role(role)
+    if resolved_role:
+        env["VNX_WORKER_ROLE"] = resolved_role
+
+    try:
+        env["VNX_DATA_DIR"] = str(_resolve_data_dir())
+        env["VNX_STATE_DIR"] = str(_resolve_state_dir())
+        env["VNX_DATA_DIR_EXPLICIT"] = "1"
+    except Exception as exc:  # noqa: BLE001 — env overlay must never break a spawn
+        logger.warning(
+            "_worker_role_env: VNX_DATA_DIR resolution failed (worker env left "
+            "unset, worker will independently resolve — OI-1635 risk): %s",
+            exc,
+        )
+
+    return env or None
 
 
 def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:

--- a/tests/test_envelope_provider_adapter_role_env.py
+++ b/tests/test_envelope_provider_adapter_role_env.py
@@ -97,9 +97,12 @@ def test_spawn_receives_worker_role_overlay(provider_key, spawn_path, model):
     assert "extra_env" in kwargs, (
         f"{spawn_path} was called without an extra_env kwarg — the overlay is not threaded"
     )
-    assert kwargs["extra_env"] == {"VNX_WORKER_ROLE": "research-analyst"}, (
+    # OI-1635: the overlay also always carries VNX_DATA_DIR (see
+    # provider_dispatch._worker_role_env) — check role-key membership rather
+    # than exact dict equality.
+    assert kwargs["extra_env"].get("VNX_WORKER_ROLE") == "research-analyst", (
         f"{spawn_path} got extra_env={kwargs['extra_env']!r}, "
-        f"expected {{'VNX_WORKER_ROLE': 'research-analyst'}}"
+        f"expected VNX_WORKER_ROLE='research-analyst'"
     )
 
 
@@ -117,11 +120,16 @@ def test_kimi_spawn_receives_worker_role_overlay():
     mock_spawn.assert_called_once()
     kwargs = mock_spawn.call_args.kwargs
     assert "extra_env" in kwargs
-    assert kwargs["extra_env"] == {"VNX_WORKER_ROLE": "research-analyst"}
+    assert kwargs["extra_env"].get("VNX_WORKER_ROLE") == "research-analyst"
 
 
 def test_absent_role_threads_no_overlay():
-    """role=None must thread extra_env=None — never a fabricated default role."""
+    """role=None must thread no VNX_WORKER_ROLE key — never a fabricated default.
+
+    OI-1635: extra_env is no longer None in this case (it always carries the
+    VNX_DATA_DIR stamp — see provider_dispatch._worker_role_env), so the
+    assertion checks role-key absence rather than extra_env is None.
+    """
     plan = _plan(Provider.DEEPSEEK_HARNESS, role=None)
 
     with patch(
@@ -133,8 +141,9 @@ def test_absent_role_threads_no_overlay():
     mock_spawn.assert_called_once()
     kwargs = mock_spawn.call_args.kwargs
     assert "extra_env" in kwargs
-    assert kwargs["extra_env"] is None, (
-        f"absent role must thread extra_env=None, got {kwargs['extra_env']!r}"
+    assert kwargs["extra_env"] is not None
+    assert "VNX_WORKER_ROLE" not in kwargs["extra_env"], (
+        f"absent role must thread no VNX_WORKER_ROLE key, got {kwargs['extra_env']!r}"
     )
 
 
@@ -149,7 +158,7 @@ def test_identity_unresolved_sentinel_threads_no_overlay():
         ProviderAdapter().run(plan, "implement the change")
 
     mock_spawn.assert_called_once()
-    assert mock_spawn.call_args.kwargs["extra_env"] is None
+    assert "VNX_WORKER_ROLE" not in mock_spawn.call_args.kwargs["extra_env"]
 
 
 def test_local_gemma_receives_plan_role():
@@ -231,4 +240,4 @@ def test_explicit_role_wins_over_plan_role_for_harness():
     mock_spawn.assert_called_once()
     kwargs = mock_spawn.call_args.kwargs
     assert kwargs.get("role") == "backend-developer"
-    assert kwargs.get("extra_env") == {"VNX_WORKER_ROLE": "backend-developer"}
+    assert kwargs.get("extra_env", {}).get("VNX_WORKER_ROLE") == "backend-developer"

--- a/tests/test_provider_lane_role_propagation.py
+++ b/tests/test_provider_lane_role_propagation.py
@@ -14,6 +14,17 @@ threads it into each provider spawn's ``extra_env``, mirroring the tmux lane's
 ``if role: export`` contract. A missing role stays missing — nothing is exported
 and the fallback stands.
 
+OI-1635 (2026-09-05): ``_worker_role_env`` also stamps ``VNX_DATA_DIR`` /
+``VNX_STATE_DIR`` / ``VNX_DATA_DIR_EXPLICIT=1`` onto the SAME env overlay — the
+worker's dispatch instructions tell it to write its report to literal
+``$VNX_DATA_DIR/unified_reports/<id>.md``, but nothing used to actually set that
+var in the worker's own process, so the worker independently re-resolved it
+(landing on the repo-local default instead of the central store the governance
+emitter uses — see ``tests/test_report_store_split_brain.py`` for the
+reproduction). The assertions below were updated from exact-dict-equality to
+membership checks for this reason: the env dict now legitimately carries more
+than just the role.
+
 These tests exercise the argv/env assembly path DIRECTLY (no real spawn). The
 dispatcher builds the worker argv with ``main``-branch code, so a worker running
 on a feature branch is itself launched by the OLD spawn (OI-1201, wontfix): a
@@ -50,26 +61,38 @@ class TestWorkerRoleEnvAssembly(unittest.TestCase):
     (not empty, not a default). ``normalize_role`` also strips the empty sentinel
     and the canonical ``identity_unresolved`` marker so neither leaks into the
     worker env as a fabricated role.
+
+    OI-1635: the overlay ALSO always carries VNX_DATA_DIR/VNX_STATE_DIR/
+    VNX_DATA_DIR_EXPLICIT=1 (mirroring the tmux lane's completion-command
+    env_prefix), independent of whether a role was set — so these assertions
+    check role-key membership rather than exact dict equality.
     """
 
     def test_backend_developer_role_exported(self):
         env = pd._worker_role_env("backend-developer")
-        self.assertEqual(env, {"VNX_WORKER_ROLE": "backend-developer"})
+        self.assertEqual(env.get("VNX_WORKER_ROLE"), "backend-developer")
+        self.assertEqual(env.get("VNX_DATA_DIR"), str(pd._resolve_data_dir()))
+        self.assertEqual(env.get("VNX_DATA_DIR_EXPLICIT"), "1")
 
     def test_security_engineer_role_exported(self):
         # The value follows the spec — it is not a constant.
         env = pd._worker_role_env("security-engineer")
-        self.assertEqual(env, {"VNX_WORKER_ROLE": "security-engineer"})
+        self.assertEqual(env.get("VNX_WORKER_ROLE"), "security-engineer")
+        self.assertEqual(env.get("VNX_DATA_DIR"), str(pd._resolve_data_dir()))
 
     def test_role_absent_when_none(self):
-        self.assertIsNone(pd._worker_role_env(None))
+        env = pd._worker_role_env(None)
+        self.assertNotIn("VNX_WORKER_ROLE", env)
+        # Absent role does not suppress the data-dir stamp — that half of the
+        # overlay is unconditional (OI-1635).
+        self.assertEqual(env.get("VNX_DATA_DIR"), str(pd._resolve_data_dir()))
 
     def test_role_absent_when_empty_or_sentinel(self):
-        # Not empty, not a default: an empty/sentinel role exports NOTHING, so the
-        # hook keeps its existing fallback behavior.
-        self.assertIsNone(pd._worker_role_env(""))
-        self.assertIsNone(pd._worker_role_env("   "))
-        self.assertIsNone(pd._worker_role_env("identity_unresolved"))
+        # Not empty, not a default: an empty/sentinel role exports no
+        # VNX_WORKER_ROLE key, so the hook keeps its existing fallback behavior.
+        for role in ("", "   ", "identity_unresolved"):
+            env = pd._worker_role_env(role)
+            self.assertNotIn("VNX_WORKER_ROLE", env)
 
 
 class TestHookResolvesRoleProfile(unittest.TestCase):
@@ -150,10 +173,9 @@ class TestProviderDispatchPassesRoleEnv(unittest.TestCase):
             pd._dispatch_kimi(args)
 
         mock_spawn.assert_called_once()
-        self.assertEqual(
-            mock_spawn.call_args.kwargs.get("extra_env"),
-            {"VNX_WORKER_ROLE": "backend-developer"},
-        )
+        extra_env = mock_spawn.call_args.kwargs.get("extra_env")
+        self.assertEqual(extra_env.get("VNX_WORKER_ROLE"), "backend-developer")
+        self.assertEqual(extra_env.get("VNX_DATA_DIR"), str(pd._resolve_data_dir()))
 
     def test_kimi_receives_no_role_env_when_absent(self):
         args = _kimi_args(None)
@@ -167,9 +189,12 @@ class TestProviderDispatchPassesRoleEnv(unittest.TestCase):
             pd._dispatch_kimi(args)
 
         mock_spawn.assert_called_once()
-        # Absent, not empty and not a default: extra_env is None so the child env
-        # carries no VNX_WORKER_ROLE key at all.
-        self.assertIsNone(mock_spawn.call_args.kwargs.get("extra_env"))
+        # Absent, not empty and not a default: no VNX_WORKER_ROLE key at all.
+        # extra_env itself is no longer None (OI-1635: it always carries the
+        # VNX_DATA_DIR stamp) — this is the split from the role-only contract.
+        extra_env = mock_spawn.call_args.kwargs.get("extra_env")
+        self.assertNotIn("VNX_WORKER_ROLE", extra_env)
+        self.assertEqual(extra_env.get("VNX_DATA_DIR"), str(pd._resolve_data_dir()))
 
 
 class TestTmuxLaneRegression(unittest.TestCase):

--- a/tests/test_report_store_split_brain.py
+++ b/tests/test_report_store_split_brain.py
@@ -1,0 +1,257 @@
+"""Tests for OI-1635: the worker and the envelope can resolve VNX_DATA_DIR to
+DIFFERENT stores, so a worker's real (rich) report can sit in a store the
+governance emitter never looks at while the central ledger gets only the
+generic completion-text wrapper.
+
+Two things are pinned here:
+
+1. ``data_dir_guard.check_report_store_split_brain`` — the detector, tested
+   directly against a controlled pair of candidate stores (positive hit AND
+   negative "nothing to find" case, per "nul is eerst een meetfout": a query
+   that never fires is not proven correct by a passing test alone).
+2. ``governance_emit.emit_unified_report`` — the call site. A RED-first
+   reproduction: the worker writes its real report to store A; the emitter
+   (mirroring provider_dispatch._emit_governance / envelope_govern._govern) is
+   asked to write to store B, where nothing exists yet. Before this dispatch's
+   fix the emitter silently wrote a generic narrative wrapper at store B with
+   no signal that a richer report existed elsewhere. The guard added here logs
+   a loud, greppable ERROR (VNX_REPORT_STORE_SPLIT_BRAIN) instead — it does not
+   (and structurally cannot, from this single-call-site vantage point) merge
+   the two stores; that migration is an explicit open item, not part of this
+   fix.
+
+Also covers the OTHER direction OI-1635 calls out explicitly: a SHORTER
+completion_text must never clobber a LONGER existing on-disk report — proving
+the existing idempotent early-return in emit_unified_report already does this
+correctly (no change needed there).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import data_dir_guard  # noqa: E402
+import governance_emit  # noqa: E402
+from data_dir_guard import check_report_store_split_brain  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 1. The detector, in isolation
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateReportStores:
+    def test_positive_hit_when_other_store_has_the_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A report sitting in the repo-local store must be found when the
+        emitter is about to write to the (empty) central store — the exact
+        OI-1635 shape. This is the "case that exists" proof: a query that can
+        only ever return None is not proven correct by the negative test alone.
+        """
+        repo_local = tmp_path / "repo-local" / ".vnx-data"
+        central = tmp_path / "central" / ".vnx-data"
+        (repo_local / "unified_reports").mkdir(parents=True)
+        central.mkdir(parents=True)
+
+        orphan = repo_local / "unified_reports" / "dispatch-abc.md"
+        orphan.write_text("# real rich report\n\nactual work happened here\n")
+
+        monkeypatch.setattr(data_dir_guard, "_resolve_repo_local_data_dir", lambda: repo_local)
+        monkeypatch.setattr(data_dir_guard, "resolve_project_id", lambda: "myproj")
+        monkeypatch.setattr(data_dir_guard, "resolve_central_data_dir", lambda pid: central)
+
+        found = check_report_store_split_brain("dispatch-abc", central)
+
+        assert found == orphan.resolve()
+
+    def test_negative_when_no_other_store_has_the_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_local = tmp_path / "repo-local" / ".vnx-data"
+        central = tmp_path / "central" / ".vnx-data"
+        (repo_local / "unified_reports").mkdir(parents=True)
+        central.mkdir(parents=True)
+        # No report anywhere for this id.
+
+        monkeypatch.setattr(data_dir_guard, "_resolve_repo_local_data_dir", lambda: repo_local)
+        monkeypatch.setattr(data_dir_guard, "resolve_project_id", lambda: "myproj")
+        monkeypatch.setattr(data_dir_guard, "resolve_central_data_dir", lambda pid: central)
+
+        assert check_report_store_split_brain("dispatch-xyz", central) is None
+
+    def test_negative_when_target_dir_is_the_only_candidate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the repo-local and central resolvers agree with *data_dir*
+        itself (the normal, non-split case), there is no "other" store to
+        check at all."""
+        only = tmp_path / "only" / ".vnx-data"
+        only.mkdir(parents=True)
+
+        monkeypatch.setattr(data_dir_guard, "_resolve_repo_local_data_dir", lambda: only)
+        monkeypatch.setattr(data_dir_guard, "resolve_project_id", lambda: "myproj")
+        monkeypatch.setattr(data_dir_guard, "resolve_central_data_dir", lambda pid: only)
+
+        assert check_report_store_split_brain("dispatch-abc", only) is None
+
+    def test_resolution_errors_are_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unresolvable project_id must not raise past the guard — advisory
+        only, never a report-emit blocker."""
+
+        def _raise():
+            raise RuntimeError("no project_id here")
+
+        monkeypatch.setattr(data_dir_guard, "_resolve_repo_local_data_dir", _raise)
+        monkeypatch.setattr(data_dir_guard, "resolve_project_id", _raise)
+
+        assert check_report_store_split_brain("dispatch-abc", tmp_path / ".vnx-data") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. The call site: governance_emit.emit_unified_report
+# ---------------------------------------------------------------------------
+
+
+class TestEmitUnifiedReportSplitBrainGuard:
+    def test_logs_loud_when_writing_wrapper_over_an_orphaned_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """RED reproduction of OI-1635's worker-vs-envelope split brain.
+
+        The worker "wrote" its real, rich report to store A (simulating a
+        provider-lane worker whose own $VNX_DATA_DIR resolution landed on the
+        repo-local default instead of the central store). The emitter is then
+        asked — exactly like _emit_governance / envelope_govern._govern are —
+        to write to store B, where the dispatch has no report yet. Before this
+        fix this ran completely silently; now it must log the loud,
+        greppable VNX_REPORT_STORE_SPLIT_BRAIN marker.
+        """
+        store_a = tmp_path / "store-a" / ".vnx-data"
+        store_b = tmp_path / "store-b" / ".vnx-data"
+        (store_a / "unified_reports").mkdir(parents=True)
+        store_b.mkdir(parents=True)
+
+        dispatch_id = "20260905-splitbrain-repro"
+        real_report = store_a / "unified_reports" / f"{dispatch_id}.md"
+        real_report.write_text(
+            "# Dispatch " + dispatch_id + "\n\n"
+            "**Dispatch-ID**: " + dispatch_id + "\n\n"
+            "## Summary\n\nThe worker's actual, detailed work — findings, diffs, "
+            "everything a real completion report should contain, well past 50 "
+            "characters.\n\n## Changes\n\nreal changes\n\n## Verification\n\nran "
+            "tests\n\n## Open Items\n\nNone\n"
+        )
+
+        monkeypatch.setattr(data_dir_guard, "_resolve_repo_local_data_dir", lambda: store_a)
+        monkeypatch.setattr(data_dir_guard, "resolve_project_id", lambda: "myproj")
+        monkeypatch.setattr(data_dir_guard, "resolve_central_data_dir", lambda pid: store_a)
+
+        with caplog.at_level(logging.ERROR, logger="governance_emit"):
+            written = governance_emit.emit_unified_report(
+                dispatch_id=dispatch_id,
+                terminal_id="T1",
+                provider="kimi",
+                instruction="do the work",
+                response_text="short narrative completion text",
+                findings=None,
+                duration_seconds=12.3,
+                data_dir=store_b,
+            )
+
+        # The emitter still writes its generic wrapper at the target store —
+        # this dispatch's fix is detection, not a store merge (that migration
+        # is an explicit open item).
+        assert written == store_b / "unified_reports" / f"{dispatch_id}.md"
+        assert written.read_text().count("short narrative completion text") == 1
+
+        split_brain_lines = [
+            r for r in caplog.records if "VNX_REPORT_STORE_SPLIT_BRAIN" in r.getMessage()
+        ]
+        assert len(split_brain_lines) == 1, (
+            f"expected exactly one split-brain ERROR log line, got {len(split_brain_lines)}: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+        assert dispatch_id in split_brain_lines[0].getMessage()
+        assert str(real_report) in split_brain_lines[0].getMessage()
+
+        # The orphaned real report is untouched — still on disk, still rich.
+        assert real_report.exists()
+        assert "findings, diffs" in real_report.read_text()
+
+    def test_no_split_brain_log_when_stores_agree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The common, non-split case: nothing logs when there is no other
+        store to disagree with (the negative control for the test above)."""
+        only = tmp_path / "only" / ".vnx-data"
+        only.mkdir(parents=True)
+
+        monkeypatch.setattr(data_dir_guard, "_resolve_repo_local_data_dir", lambda: only)
+        monkeypatch.setattr(data_dir_guard, "resolve_project_id", lambda: "myproj")
+        monkeypatch.setattr(data_dir_guard, "resolve_central_data_dir", lambda pid: only)
+
+        with caplog.at_level(logging.ERROR, logger="governance_emit"):
+            governance_emit.emit_unified_report(
+                dispatch_id="20260905-no-split",
+                terminal_id="T1",
+                provider="kimi",
+                instruction="do the work",
+                response_text="normal completion",
+                findings=None,
+                duration_seconds=1.0,
+                data_dir=only,
+            )
+
+        assert not any(
+            "VNX_REPORT_STORE_SPLIT_BRAIN" in r.getMessage() for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. The reverse direction OI-1635 explicitly asks for: shorter completion
+#    text must never clobber a longer, already-contract-valid on-disk report.
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentGuardAlreadyProtectsLongerExisting:
+    def test_shorter_completion_text_does_not_overwrite_richer_existing_report(
+        self, tmp_path: Path
+    ) -> None:
+        """Proves the EXISTING idempotent early-return already does the right
+        thing here — no change was needed in this direction, only measured."""
+        data_dir = tmp_path / ".vnx-data"
+        (data_dir / "unified_reports").mkdir(parents=True)
+        dispatch_id = "20260905-idempotent-check"
+        report_path = data_dir / "unified_reports" / f"{dispatch_id}.md"
+        rich_body = (
+            "# Dispatch " + dispatch_id + "\n\n"
+            "**Dispatch-ID**: " + dispatch_id + "\n\n"
+            "## Summary\n\nA long, detailed, contract-valid report the worker "
+            "itself wrote, well past 50 characters of summary content.\n\n"
+            "## Changes\n\nreal changes\n\n## Verification\n\nran tests\n\n"
+            "## Open Items\n\nNone\n"
+        )
+        report_path.write_text(rich_body)
+
+        written = governance_emit.emit_unified_report(
+            dispatch_id=dispatch_id,
+            terminal_id="T1",
+            provider="kimi",
+            instruction="do the work",
+            response_text="x",  # much shorter than rich_body
+            findings=None,
+            duration_seconds=1.0,
+            data_dir=data_dir,
+        )
+
+        assert written == report_path
+        assert report_path.read_text() == rich_body


### PR DESCRIPTION
## Summary

OI-1635's original diagnosis (an unconditional overwrite in `governance_emit.py:798`) was already refuted by T0 on 2026-09-05 — the write there is conditioned on `report_path.exists()`. This PR investigates and fixes the actual defect.

**Root cause, measured (not guessed):** every provider-lane worker (kimi/codex/deepseek-harness/glm-harness/gemini/litellm) is told in its dispatch instructions to write its report to literal `$VNX_DATA_DIR/unified_reports/<id>.md` — but `provider_dispatch.py` never set that env var in the worker's own subprocess. The worker independently re-resolves "VNX_DATA_DIR" and can land somewhere else entirely:

```
$ cd <main checkout> && python3 -c "
import sys; sys.path.insert(0, 'scripts/lib')
import project_root
print(project_root.resolve_data_dir())        # repo-local default
import vnx_paths
print(vnx_paths.resolve_paths()['VNX_DATA_DIR'])  # central
"
/Users/vincentvandeth/Development/vnx-orchestration/.vnx-data      # <- what the worker got
/Users/vincentvandeth/.vnx-data/vnx-dev                            # <- what the envelope/receipt writer uses
```

That first value is byte-for-byte what OI-1635's two audit reports print as their own "VNX_DATA_DIR resolved: …" line. `_emit_governance`/`envelope_govern._govern` resolve the CENTRAL store via `provider_dispatch._resolve_data_dir()`, so the worker's real, rich report and the governance layer's report write silently diverge — the central ledger gets only the generic completion-text wrapper (`response_text` = the raw completion), while the actual work sits in a store nobody in the audit trail ever looks at.

Measured in this repo right now: **293 reports exist only in the repo-local store and never reached the central ledger** (5038 central, 1038 local, 745 shared, 293 local-only).

## Changes

- `scripts/lib/provider_dispatch.py` — `_worker_role_env()` (the single choke point for every provider-lane spawn's `extra_env`, used both by the legacy `_dispatch_*` wrappers and by the door's `envelope_adapters_provider.ProviderAdapter.run`) now also stamps the already-resolved `VNX_DATA_DIR` / `VNX_STATE_DIR` / `VNX_DATA_DIR_EXPLICIT=1` into the worker's env, mirroring the tmux lane's completion-command `env_prefix` (`tmux_interactive_dispatch.py`). Because `VNX_DATA_DIR_EXPLICIT=1` is the highest-precedence branch in both `project_root.resolve_data_dir()` and `vnx_paths.resolve_paths()`, this holds regardless of which resolver the worker's own tooling reaches for, or what its worktree-scoped CWD is — the worker is never asked to re-derive the path itself.
- `scripts/lib/data_dir_guard.py` — new `check_report_store_split_brain()` / `_candidate_report_stores()`: given a target data_dir, checks the OTHER known store (repo-local vs. central) for an existing report under the same dispatch_id.
- `scripts/lib/governance_emit.py` — `emit_unified_report()` calls the guard right before writing the generic wrapper (i.e. only when nothing exists yet at the target path) and logs a loud, greppable `VNX_REPORT_STORE_SPLIT_BRAIN` ERROR when a report is found elsewhere. This is a **safety net**, not a store merge — it does not (and structurally cannot from this call site) migrate the orphaned report.
- Updated `tests/test_provider_lane_role_propagation.py` and `tests/test_envelope_provider_adapter_role_env.py`: their exact-dict-equality assertions on `_worker_role_env`'s output predate this fix and would otherwise false-fail now that the overlay legitimately carries more than the role — changed to membership checks (role key present/absent + VNX_DATA_DIR present), no behavior they were pinning was weakened.

## Verification

- New `tests/test_report_store_split_brain.py` (7 tests): positive/negative detector hits against controlled candidate stores, resolution-error swallowing, an end-to-end RED-then-GREEN reproduction of the split-brain at `emit_unified_report` (worker report in store A, emit asked to write store B — logs exactly one `VNX_REPORT_STORE_SPLIT_BRAIN` line, orphan untouched), a no-log negative control, and the OI-1635-requested reverse check: a short `response_text` never clobbers an existing longer/contract-valid on-disk report (proves the existing idempotent early-return already does this correctly — no change needed there).
- Guard-breaks-red check (not committed): temporarily neutered the new guard call in `governance_emit.py`, re-ran the new test suite — `test_logs_loud_when_writing_wrapper_over_an_orphaned_report` failed (0 log lines instead of 1) as expected, confirming the test actually exercises the guard. Restored and re-verified green.
- "Zero is a measurement error" check: the positive-hit test and the live orphan-count re-measurement (293/1038/5038/745, matching T0's numbers exactly) both confirm the detector fires on a real, existing case, not just the empty case.
- Commands run: `python3 -m pytest tests/test_report_store_split_brain.py tests/test_provider_lane_role_propagation.py tests/test_envelope_provider_adapter_role_env.py tests/test_data_dir_guard.py tests/test_data_dir_resolution.py tests/test_governance_emit.py tests/test_governance_emit_findings_distinction.py tests/test_governance_emit_lane_log_anchor.py tests/test_governance_emit_local_gemma.py tests/test_governance_emit_report_wrapper.py tests/test_governance_emit_schema.py tests/test_kimi_spawn.py tests/test_kimi_spawn_camelcase.py tests/test_kimi_spawn_heartbeat.py tests/test_provider_dispatch_worktree_isolation.py tests/test_kimi_gate_data_dir_guard.py tests/test_glm_gate_data_dir_guard.py tests/test_project_root_resolution.py tests/test_oi897_bare_repo_data_dir.py -q` → **379 passed**.
- Ran in this checkout (not a nested worktree). `git diff HEAD` clean and `git show HEAD:<path>` re-read for all three touched `scripts/lib/*.py` files before pushing.

## Open Items

- **293 orphaned reports** (measured above) never reached the central ledger and predate this fix — this PR does **not** migrate them (would make this an 800-line PR per the dispatch's own scope limit). Proposal: a follow-up PR/script that, for every `dispatch_id` present only in a project's repo-local `.vnx-data/unified_reports/` and absent from `~/.vnx-data/<project_id>/unified_reports/`, copies the richer file across (never overwriting an existing central report) and logs what it moved.
- This PR does **not** touch `report_to_receipt_converter.py` / `append_receipt_internals/**` / `provider_identity.py` per the dispatch's hard file boundary (a parallel dispatch owns the provider-field work there) — so a receipt already emitted against the narrative wrapper for one of the 293 is not retroactively corrected; only new dispatches going forward get the consistent store.
- Does not touch `dispatch_envelope.py` (out of file-scope): the envelope-routed `codex` path (`_dispatch_codex_via_envelope`) builds its `EnvelopeSpec` without any `extra_env`/role overlay at all — a separate, pre-existing gap this PR does not claim to close.

Dispatch-ID: 20260905-golf1b-report-store-split