### PR TITLE
fix(receipt): close the provider vocabulary, fail-loud instead of passthrough (golf1a)

### DIFF
--- a/scripts/lib/provider_identity.py
+++ b/scripts/lib/provider_identity.py
@@ -1,0 +1,221 @@
+"""provider_identity.py — the single closed vocabulary for a receipt's
+``provider`` field (PRD bewijsketen-en-afdwinging, Golf 1a).
+
+Reconciles two vocabularies that disagree today:
+
+  1. ``governance_emit._PROVIDER_RE`` — dispatch-time, fail-loud (raises
+     ValueError on mismatch). Accepts ``claude|codex|gemini|kimi|
+     deepseek-harness|glm-harness|litellm(:sub(:alias)?)?|local-gemma``.
+     Does NOT accept bare ``deepseek`` or ``unknown``.
+  2. ``report_to_receipt_converter._CANONICAL_PROVIDER_LANE`` — receipt-time.
+     Accepts the same set PLUS bare ``deepseek`` as its own canonical value,
+     and falls back to ``return p`` (the raw string, verbatim) for anything
+     it doesn't recognise — a fail-OPEN passthrough. That passthrough is how
+     four free-text fragments — a literal ``` `. ``` and a torn-off
+     instruction sentence among them — reached ``t0_receipts.ndjson``
+     unchanged on 2026-08-09.
+
+This module is the closed, fail-loud replacement for vocabulary #2, wired in
+via ``report_to_receipt_converter._normalise_provider`` ->
+:func:`normalize_provider`. Vocabulary #1 (``governance_emit.py``) is
+untouched here by design — migrating its dispatch-time validation onto this
+same enum is a follow-up PR, not this one.
+
+Where this module DELIBERATELY diverges from ``governance_emit._PROVIDER_RE``
+(and why), see :class:`ProviderIdentity`'s per-member docstring and
+``tests/test_provider_identity.py::TestReconcileWithGovernanceEmit`` — which
+asserts that DEEPSEEK and UNKNOWN are the *only* two divergences and pins the
+reason for each.
+"""
+
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Optional
+
+# Ensure sibling scripts/lib modules resolve even when a caller imports this
+# module by path without scripts/lib already on sys.path (mirrors the same
+# guard in governance_emit.py / report_to_receipt_converter.py).
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from governance_emit import _PROVIDER_RE  # noqa: E402
+
+
+class ProviderIdentity(str, Enum):
+    """CLOSED set — the only legal values for a receipt's ``provider`` field.
+
+    Provenance per member:
+
+    CLAUDE, CODEX, GEMINI, KIMI
+        Native CLI lanes. Members of both ``dispatch_spec.Provider`` and
+        ``governance_emit._PROVIDER_RE``.
+
+    DEEPSEEK_HARNESS = "deepseek-harness"
+        Claude-CLI harness, ``ANTHROPIC_BASE_URL`` redirected to the DeepSeek
+        endpoint, own key + hardening
+        (``provider_spawns/deepseek_harness_spawn.py``;
+        ``~/.claude/rules/provider-constraints.md``'s
+        ``deepseek-harness-subscription-blocked``). Member of both
+        ``dispatch_spec.Provider`` and ``governance_emit._PROVIDER_RE``.
+        The smart-router's route decision for an auto-routed
+        ``deepseek-*`` model resolves via ``smart_router.parse_route_model_id``
+        to ``litellm:deepseek:<model_id>`` — :func:`normalize_provider` folds
+        that (and the bare ``litellm:deepseek`` prefix, and free-text like
+        ``"deepseek (harness, key-auth)"``) back into THIS member, matching
+        the pre-existing, tested lane-identity-resolution contract (OI-1111:
+        ``tests/test_report_to_receipt_converter.py::
+        TestLaneIdentityResolution::test_deepseek_harness_lane_wins``) — not
+        changed by this module.
+
+    DEEPSEEK = "deepseek"
+        A SEPARATE, independently real DeepSeek lane: the cheap key-auth
+        sub-provider under the generic litellm multi-provider dispatcher
+        (``provider_dispatch.py``'s ``sub_provider="deepseek"`` /
+        ``_SUB_PROVIDER_KEY_REQS["deepseek"] = "DEEPSEEK_API_KEY"``).
+        This exact bare spelling is what ``scout_prepass.py``'s sidecar
+        schema, ``gate_request_handler._request_deepseek``'s review-gate
+        payload, and ``vnx_tagger.py``'s ``VNX_TAGGER_PROVIDER`` default
+        ("the cheap key-auth DeepSeek-Flash" lane) all stamp directly — none
+        of them go through a route decision, so their report bodies reach
+        :func:`normalize_provider` via the body-fallback path only.
+        ``governance_emit._PROVIDER_RE`` does NOT accept this literal (only
+        the ``deepseek-harness`` literal, or the compound
+        ``litellm:deepseek(:model)?`` form) — a DELIBERATE divergence, not an
+        oversight: no dispatch ever selects ``--provider deepseek`` (it is
+        absent from ``provider_dispatch._IMPLEMENTED_PROVIDERS`` too), so
+        governance_emit's dispatch-time gate never needed to accept it. The
+        producers above write straight into a report body, a surface
+        governance_emit's regex was never wired to validate. See
+        ``TestReconcileWithGovernanceEmit`` for the pinned assertion.
+
+    GLM_HARNESS = "glm-harness"
+        Claude-CLI harness -> local litellm proxy (:4141) -> OpenRouter/zai.
+        Member of both ``dispatch_spec.Provider`` and
+        ``governance_emit._PROVIDER_RE``. The smart-router's route decision
+        for an auto-routed ``glm-*`` model resolves to the sub-provider key
+        ``litellm:zai`` (its own internal lookup spelling) —
+        :func:`normalize_provider` folds that back into THIS member so the
+        ledger counts one GLM provider, not two (pre-existing, tested:
+        ``test_glm_harness_lane_wins_over_body_sonnet_claude``).
+
+    LOCAL_GEMMA = "local-gemma"
+        Local model runner. Member of both ``dispatch_spec.Provider`` and
+        ``governance_emit._PROVIDER_RE``.
+
+    LITELLM = "litellm"
+        Bare generic litellm dispatch (env-driven sub-provider selection via
+        ``VNX_LITELLM_MODEL``; listed in
+        ``provider_dispatch._IMPLEMENTED_PROVIDERS``) AND the catch-all for
+        any OTHER well-formed ``litellm:<sub>(:<alias>)?`` compound this
+        module has no specific rule for (bedrock, ollama, anthropic, the
+        openrouter-arbitrary lane). Recognised by shape via the SAME
+        ``governance_emit._PROVIDER_RE`` this module reconciles against, so a
+        new litellm sub-provider never needs a matching edit here just to
+        stop raising.
+
+    LITELLM_MOONSHOT = "litellm:moonshot"
+        ``dispatch_spec.Provider.LITELLM_MOONSHOT`` — "BENCHMARK-BASELINE
+        ONLY" per that enum's own comment: the Moonshot-API route
+        ``~/.claude/rules/provider-constraints.md``'s ``kimi-via-cli-only``
+        (blocking) forbids in production ("Kimi K2/K2.6 alleen via kimi CLI
+        OAuth, niet via Moonshot API"). Kept as its OWN member instead of
+        folding into KIMI, which a naive ``"kimi" in value`` substring match
+        would do (a benchmark lane key can legitimately read
+        ``litellm:moonshot:kimi-k2-6``): collapsing it would erase the one
+        signal that lets governance tell a sanctioned CLI-OAuth kimi receipt
+        apart from a forbidden-route attempt.
+
+    UNKNOWN = "unknown"
+        Explicit sentinel: the provider field was genuinely blank/absent.
+        This is NOT a catch-all for unparseable text — see
+        :class:`UnrecognizedProviderError` for that path. 333 live
+        ``task_complete``/non-pytest receipts carry this value (measured
+        2026-09-05); it is the honest admission "no source recorded an
+        identity", not corruption.
+    """
+
+    CLAUDE = "claude"
+    CODEX = "codex"
+    GEMINI = "gemini"
+    KIMI = "kimi"
+    DEEPSEEK_HARNESS = "deepseek-harness"
+    DEEPSEEK = "deepseek"
+    GLM_HARNESS = "glm-harness"
+    LOCAL_GEMMA = "local-gemma"
+    LITELLM = "litellm"
+    LITELLM_MOONSHOT = "litellm:moonshot"
+    UNKNOWN = "unknown"
+
+
+class UnrecognizedProviderError(ValueError):
+    """Raised by :func:`normalize_provider` when *raw* matches no known identity.
+
+    Replaces ``report_to_receipt_converter._normalise_provider``'s old
+    fail-open ``return p`` passthrough. Callers must not swallow this into a
+    silently-invented value of their own — the sanctioned handling (see
+    ``report_to_receipt_converter._build_receipt_from_report_core``) is to
+    book it as an explicit ``"unrecognized_provider"`` contract violation
+    (``event_type="report_contract_invalid"``), which still writes a receipt
+    (so the report is never silently re-processed forever) without ever
+    inventing a provider string that no source actually reported.
+    """
+
+    def __init__(self, raw: str):
+        self.raw = raw
+        super().__init__(f"unrecognized provider value: {raw!r}")
+
+
+_EXACT: Dict[str, "ProviderIdentity"] = {member.value: member for member in ProviderIdentity}
+
+
+def normalize_provider(raw: Optional[str]) -> ProviderIdentity:
+    """Map any known provider spelling to its closed :class:`ProviderIdentity`.
+
+    Fail-loud: raises :class:`UnrecognizedProviderError` on anything this
+    vocabulary cannot place — never a passthrough of the raw string.
+
+    Resolution order (case-insensitive, first match wins):
+      1. Blank/whitespace-only/``None`` -> UNKNOWN.
+      2. Exact match against a closed-set value -> that member.
+      3. Contains "deepseek" (any casing, any surrounding text — covers the
+         ``litellm:deepseek(:model)?`` compound and free-text self-reports
+         like "deepseek (harness, key-auth)") -> DEEPSEEK_HARNESS. Bare
+         "deepseek" never reaches this branch — it is caught by the exact
+         match in step 2.
+      4. Starts with "litellm:moonshot" -> LITELLM_MOONSHOT. Checked BEFORE
+         the "kimi" substring match in step 5 so a benchmark lane key like
+         "litellm:moonshot:kimi-k2-6" is never laundered into looking like
+         the sanctioned kimi lane.
+      5. Contains "kimi" -> KIMI.
+      6. Contains "glm", or starts with "litellm:zai" -> GLM_HARNESS.
+      7. Shape matches ``governance_emit._PROVIDER_RE`` (any well-formed
+         ``litellm:<sub>(:<alias>)?`` this module has no specific rule for)
+         -> LITELLM.
+      8. Otherwise -> raise UnrecognizedProviderError.
+    """
+    if raw is None or not str(raw).strip():
+        return ProviderIdentity.UNKNOWN
+
+    p = str(raw).strip()
+    pl = p.lower()
+
+    exact = _EXACT.get(pl)
+    if exact is not None:
+        return exact
+
+    if "deepseek" in pl:
+        return ProviderIdentity.DEEPSEEK_HARNESS
+    if pl.startswith("litellm:moonshot"):
+        return ProviderIdentity.LITELLM_MOONSHOT
+    if "kimi" in pl:
+        return ProviderIdentity.KIMI
+    if "glm" in pl or pl.startswith("litellm:zai"):
+        return ProviderIdentity.GLM_HARNESS
+    if _PROVIDER_RE.match(pl):
+        return ProviderIdentity.LITELLM
+
+    raise UnrecognizedProviderError(p)

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -50,6 +50,10 @@ from dispatch_identity import _IDENTITY_UNRESOLVED  # single canonical sentinel 
 # no longer carries its own hand-copied terminal-status sets; it resolves every
 # declared status through resolve_status_category() below.
 from event_outcome_semantics import UnknownStatusError, resolve_status_category
+# Closed provider vocabulary (golf1a-provider-enum). _normalise_provider below
+# is a thin wrapper around normalize_provider() — see provider_identity.py for
+# the full reconciliation with governance_emit._PROVIDER_RE.
+from provider_identity import ProviderIdentity, UnrecognizedProviderError, normalize_provider
 
 _LIB_DIR = Path(__file__).resolve().parent
 _SCRIPTS_DIR = _LIB_DIR.parent  # scripts/ — append_receipt.py lives here
@@ -488,25 +492,15 @@ def _resolve_report_role(
 
 
 # ---------------------------------------------------------------------------
-# Provider string normalization (OI-1111)
+# Provider string normalization (OI-1111, golf1a-provider-enum)
 # ---------------------------------------------------------------------------
-
-# Canonical provider names as used by dispatch lanes. Every variant found in
-# the ledger (deepseek-harness, deepseek, litellm:deepseek, kimi-k3, kimi,
-# kimi-code/k3, glm-harness) normalises to one of these.
-_CANONICAL_PROVIDER_LANE = {
-    "deepseek-harness",
-    "deepseek",
-    "kimi",
-    "glm-harness",
-    "claude",
-    "codex",
-    "gemini",
-}
 
 
 def _normalise_provider(provider_raw: str) -> str:
-    """Normalise a provider string to its canonical lane value.
+    """Normalise a provider string to its closed ``ProviderIdentity`` value.
+
+    Thin wrapper around ``provider_identity.normalize_provider`` — see that
+    module for the full closed vocabulary and per-value provenance.
 
     Variants observed in the ledger as of 2026-08-09:
       deepseek-harness (294), deepseek (27), ``deepseek (harness, key-auth)``
@@ -515,32 +509,18 @@ def _normalise_provider(provider_raw: str) -> str:
     Without normalisation every cost aggregation over provider counts these as
     separate providers. The canonical lane values are the short forms the
     dispatch door uses.
+
+    Raises:
+        UnrecognizedProviderError: when *provider_raw* matches nothing in the
+        closed vocabulary. This replaces the old ``return p`` fail-open
+        passthrough (the mechanism by which free-text fragments — a literal
+        `` `. `` and a torn-off instruction sentence among them — reached
+        t0_receipts.ndjson verbatim on 2026-08-09). Callers must not swallow
+        this into an invented value; see
+        ``_build_receipt_from_report_core``'s handling, which books it as an
+        explicit ``"unrecognized_provider"`` contract violation instead.
     """
-    if not provider_raw or not provider_raw.strip():
-        return "unknown"
-    p = provider_raw.strip()
-    pl = p.lower()
-
-    # Already a canonical lane value — pass through.
-    if pl in _CANONICAL_PROVIDER_LANE:
-        return pl
-
-    # DeepSeek variants → deepseek-harness
-    if "deepseek" in pl:
-        return "deepseek-harness"
-
-    # Kimi variants (kimi-k3, kimi-code/k3, kimi) → kimi
-    if "kimi" in pl:
-        return "kimi"
-
-    # GLM variants → glm-harness.  parse_route_model_id maps glm-* model IDs
-    # to litellm:zai (the litellm provider flag for Zhipu AI); normalise that
-    # flag back to the canonical lane name.
-    if "glm" in pl or pl == "litellm:zai":
-        return "glm-harness"
-
-    # Unknown — return as-is rather than invent a value.
-    return p
+    return normalize_provider(provider_raw).value
 
 
 def _resolve_report_provider_model(
@@ -560,6 +540,15 @@ def _resolve_report_provider_model(
          — the lane's own record of which model was selected.
       2. Report body/frontmatter fields — fallback when no route decision
          exists (e.g. plan-gate seats that do not go through the smart router).
+
+    Raises:
+        UnrecognizedProviderError: propagated from the body-fallback call to
+        ``_normalise_provider`` (step 2) when NEITHER the lane nor the body
+        yields a recognisable provider. A lane-side normalisation failure
+        (step 1) is caught here and demoted to a WARNING + fall-through to
+        the body — a stale/malformed route-decision file is an auxiliary
+        hint, not the sole source of truth, so it must not by itself refuse
+        the receipt. Only exhausting BOTH sources raises.
     """
     provider: Optional[str] = None
     model: Optional[str] = None
@@ -569,11 +558,11 @@ def _resolve_report_provider_model(
         route_dec = _load_route_decision(dispatch_id, state_dir)
         if route_dec and route_dec.get("selected_model"):
             model_id = route_dec["selected_model"]
+            lane_provider: Optional[str] = None
+            lane_model: Optional[str] = None
             try:
                 from smart_router import parse_route_model_id  # noqa: PLC0415
                 lane_provider, lane_model = parse_route_model_id(model_id)
-                provider = _normalise_provider(lane_provider)
-                model = lane_model
             except Exception:
                 logger.debug(
                     "report_to_receipt_converter: provider/model lane resolution "
@@ -581,8 +570,21 @@ def _resolve_report_provider_model(
                     dispatch_id, model_id,
                     exc_info=True,
                 )
+            if lane_provider:
+                try:
+                    provider = _normalise_provider(lane_provider)
+                    model = lane_model
+                except UnrecognizedProviderError as exc:
+                    logger.warning(
+                        "report_to_receipt_converter: route decision for "
+                        "dispatch=%s carries unrecognized provider %r (%s) "
+                        "-- falling back to the report body",
+                        dispatch_id, lane_provider, exc,
+                    )
 
-    # Body fallback: only used when lane resolution produced nothing.
+    # Body fallback: only used when lane resolution produced nothing. Left
+    # UNPROTECTED by design — an UnrecognizedProviderError here means both
+    # sources are exhausted and must propagate (see docstring).
     if not provider:
         provider = _normalise_provider(merged.get("provider", "unknown"))
     if not model:
@@ -877,9 +879,27 @@ def _build_receipt_from_report_core(
     # is wrong. The lane's route decision holds the authoritative identity.
     # Provider strings are normalised to canonical lane values so every cost
     # aggregation counts one provider, not four variants of the same lane.
-    _resolved_provider, _resolved_model = _resolve_report_provider_model(
-        dispatch_id, merged, state_dir,
-    )
+    #
+    # golf1a-provider-enum: _resolve_report_provider_model raises
+    # UnrecognizedProviderError when NEITHER the lane nor the body yields a
+    # provider the closed ProviderIdentity vocabulary recognises. This is
+    # booked as an explicit contract violation (event_type=
+    # "report_contract_invalid" below) rather than left to propagate — this
+    # function's contract is "never raises" (see the caller-hardening comment
+    # in _convert_one_detailed), and inventing a provider string no source
+    # ever reported would be exactly the fail-open passthrough this replaces.
+    try:
+        _resolved_provider, _resolved_model = _resolve_report_provider_model(
+            dispatch_id, merged, state_dir,
+        )
+    except UnrecognizedProviderError as exc:
+        logger.warning(
+            "report_to_receipt_converter: unrecognized provider for dispatch=%s: "
+            "%s -- booking as report_contract_invalid instead of inventing a value",
+            dispatch_id, exc,
+        )
+        _resolved_provider, _resolved_model = ProviderIdentity.UNKNOWN.value, ""
+        contract_violations.append("unrecognized_provider")
 
     base: Dict[str, Any] = {
         "dispatch_id": dispatch_id,

--- a/tests/test_provider_identity.py
+++ b/tests/test_provider_identity.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Tests for provider_identity — the closed provider vocabulary
+(PRD bewijsketen-en-afdwinging, Golf 1a).
+
+Covers:
+  1. Every ProviderIdentity member normalises to itself (idempotent).
+  2. The documented variant-cascade (deepseek, kimi, glm, moonshot, generic
+     litellm) resolves as designed.
+  3. Fail-loud: unrecognisable input raises UnrecognizedProviderError, never
+     a passthrough.
+  4. Reconciliation with governance_emit._PROVIDER_RE — pins the exact set
+     of DELIBERATE divergences (DEEPSEEK, UNKNOWN) so a future edit that
+     silently drifts the two vocabularies apart further is caught here.
+  5. Reconciliation with dispatch_spec.Provider — the fleet's closed set for
+     *dispatch-time* provider selection; every member (except the AUTO
+     capability-seam placeholder) must resolve to a consistent
+     ProviderIdentity.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from provider_identity import (
+    ProviderIdentity,
+    UnrecognizedProviderError,
+    normalize_provider,
+)
+
+
+class TestCanonicalPassthrough:
+    """Every closed-set value normalises to itself."""
+
+    @pytest.mark.parametrize("member", list(ProviderIdentity))
+    def test_member_value_is_idempotent(self, member):
+        assert normalize_provider(member.value) is member
+
+    @pytest.mark.parametrize("member", list(ProviderIdentity))
+    def test_member_value_is_case_insensitive(self, member):
+        # Salvage-if-recognisable: "Claude", "CODEX", "Litellm:Zai" etc. must
+        # still resolve, since only governance_emit's dispatch-time gate
+        # requires strict lowercase — the receipt-time vocabulary is more
+        # forgiving by design (it is reading free text, not validating a CLI
+        # argument).
+        assert normalize_provider(member.value.upper()) is member
+
+
+class TestBlankInput:
+    def test_none_is_unknown(self):
+        assert normalize_provider(None) is ProviderIdentity.UNKNOWN
+
+    def test_empty_string_is_unknown(self):
+        assert normalize_provider("") is ProviderIdentity.UNKNOWN
+
+    def test_whitespace_only_is_unknown(self):
+        assert normalize_provider("   ") is ProviderIdentity.UNKNOWN
+
+
+class TestDeepseekVariants:
+    """OI-1111 (test_report_to_receipt_converter.py::TestLaneIdentityResolution
+    ::test_deepseek_harness_lane_wins) already pins litellm:deepseek(:model)?
+    -> deepseek-harness end to end; this class re-covers it at the unit level
+    plus the free-text self-report variant, and the bare-"deepseek" split
+    this module makes explicit for the first time.
+    """
+
+    def test_litellm_deepseek_bare(self):
+        assert normalize_provider("litellm:deepseek") is ProviderIdentity.DEEPSEEK_HARNESS
+
+    def test_litellm_deepseek_with_model_alias(self):
+        assert (
+            normalize_provider("litellm:deepseek:deepseek-v4-pro")
+            is ProviderIdentity.DEEPSEEK_HARNESS
+        )
+
+    def test_self_reported_harness_free_text(self):
+        assert (
+            normalize_provider("deepseek (harness, key-auth)")
+            is ProviderIdentity.DEEPSEEK_HARNESS
+        )
+
+    def test_bare_deepseek_is_its_own_identity_not_harness(self):
+        """The design question golf1a-provider-enum was asked to answer:
+        bare "deepseek" is the cheap key-auth litellm sub-provider lane
+        (scout_prepass.py, gate_request_handler._request_deepseek,
+        vnx_tagger.py's VNX_TAGGER_PROVIDER default) -- a mechanism
+        independently real and distinct from deepseek-harness, not a typo
+        or a variant spelling of it.
+        """
+        assert normalize_provider("deepseek") is ProviderIdentity.DEEPSEEK
+        assert ProviderIdentity.DEEPSEEK is not ProviderIdentity.DEEPSEEK_HARNESS
+
+
+class TestKimiVariants:
+    def test_kimi_k3(self):
+        assert normalize_provider("kimi-k3") is ProviderIdentity.KIMI
+
+    def test_kimi_code_slash_k3(self):
+        assert normalize_provider("kimi-code/k3") is ProviderIdentity.KIMI
+
+    def test_verbose_self_report_salvaged(self):
+        """Recognisable free text is salvaged into the closed identity
+        rather than raising -- this is what actually fixes the "42 distinct
+        provider strings" aggregation problem the fail-open bug caused.
+        Contrast with TestFailLoud below, where NO keyword is present at
+        all and salvage is impossible.
+        """
+        assert normalize_provider("Moonshot AI (Kimi Code CLI)") is ProviderIdentity.KIMI
+
+    def test_moonshot_lane_key_is_not_laundered_into_kimi(self):
+        """kimi-via-cli-only (~/.claude/rules/provider-constraints.md) is a
+        BLOCKING constraint against routing kimi work through the Moonshot
+        API instead of the CLI. A benchmark-baseline litellm:moonshot lane
+        key can legitimately embed a kimi model alias
+        (provider_dispatch._build_lane_key: ("moonshot", "kimi-k2-6") ->
+        "litellm:moonshot:kimi-k2-6") -- collapsing that into plain "kimi"
+        would erase the one signal that lets governance tell a sanctioned
+        CLI-OAuth receipt apart from a forbidden-route attempt.
+        """
+        assert (
+            normalize_provider("litellm:moonshot:kimi-k2-6")
+            is ProviderIdentity.LITELLM_MOONSHOT
+        )
+        assert normalize_provider("litellm:moonshot") is ProviderIdentity.LITELLM_MOONSHOT
+
+
+class TestGlmVariants:
+    def test_glm_harness_exact(self):
+        assert normalize_provider("glm-harness") is ProviderIdentity.GLM_HARNESS
+
+    def test_litellm_zai_lane_key(self):
+        """The smart-router's route decision for an auto-routed glm-* model
+        records lane_provider="litellm:zai" (its own internal sub-provider
+        lookup key, smart_router.parse_route_model_id) -- folded back into
+        GLM_HARNESS so the ledger counts one GLM provider, pre-existing and
+        tested end to end via
+        test_glm_harness_lane_wins_over_body_sonnet_claude.
+        """
+        assert normalize_provider("litellm:zai") is ProviderIdentity.GLM_HARNESS
+
+
+class TestGenericLitellmFallback:
+    def test_bare_litellm(self):
+        assert normalize_provider("litellm") is ProviderIdentity.LITELLM
+
+    def test_unrecognised_but_well_formed_litellm_compound(self):
+        """bedrock/ollama/anthropic/openrouter sub-providers
+        (provider_dispatch._LITELLM_SUB_PROVIDER_DEFAULTS) have no dedicated
+        ProviderIdentity member -- they fall through to the generic LITELLM
+        bucket by SHAPE (governance_emit._PROVIDER_RE), not by an enumerated
+        list, so a new litellm sub-provider never needs a matching edit here
+        just to stop raising.
+        """
+        assert (
+            normalize_provider("litellm:bedrock:claude-sonnet-4-6")
+            is ProviderIdentity.LITELLM
+        )
+        assert (
+            normalize_provider("litellm:openrouter:openai/gpt-4o-mini")
+            is ProviderIdentity.LITELLM
+        )
+
+
+class TestFailLoud:
+    """The defect this module replaces: report_to_receipt_converter's old
+    ``return p`` passthrough let free text with no recognisable provider
+    keyword reach the ledger verbatim. normalize_provider must refuse it.
+    """
+
+    def test_pure_noise_raises(self):
+        with pytest.raises(UnrecognizedProviderError):
+            normalize_provider("`.")
+
+    def test_torn_off_instruction_fragment_raises(self):
+        """Measured 2026-08-09, still reproducible against the unmodified
+        converter as of this PR (see
+        test_report_to_receipt_converter.py::TestNormaliseProvider::
+        test_unrecognised_garbage_is_never_passed_through_raw for the
+        red/green evidence against the actual converter function).
+        """
+        with pytest.raises(UnrecognizedProviderError):
+            normalize_provider(
+                "` regel. Zonder die identiteitsregels landt je receipt niet."
+            )
+
+    def test_never_seen_vendor_name_raises(self):
+        """Break-your-own-guard: a value with no historical precedent at all
+        must still refuse, not silently join the vocabulary.
+        """
+        with pytest.raises(UnrecognizedProviderError):
+            normalize_provider("totally-bogus-vendor-xyz")
+
+    def test_error_carries_the_raw_value(self):
+        with pytest.raises(UnrecognizedProviderError) as exc_info:
+            normalize_provider("`.")
+        assert exc_info.value.raw == "`."
+        assert "`." in str(exc_info.value)
+
+    def test_raise_hits_the_real_call_not_a_stub(self):
+        """Sanity check that this test suite exercises the actual
+        normalize_provider() implementation (imported at module load, not a
+        local reimplementation or a mock) -- a raise on a value the function
+        itself defines as UNRECOGNIZED_PROBE below only proves something if
+        the function under test is the genuine article.
+        """
+        import provider_identity as module
+
+        assert normalize_provider is module.normalize_provider
+        probe = "UNRECOGNIZED_PROBE_never_matches_any_branch"
+        assert probe not in module._EXACT
+        with pytest.raises(UnrecognizedProviderError):
+            normalize_provider(probe)
+
+
+class TestReconcileWithGovernanceEmit:
+    """governance_emit._PROVIDER_RE is the OTHER, dispatch-time vocabulary
+    this module was asked to reconcile with. They agree everywhere except
+    two DELIBERATE divergences (DEEPSEEK, UNKNOWN) -- pinned here so a
+    future change that silently widens that gap is caught.
+
+    HARDE BESTANDSGRENS: governance_emit.py itself is out of scope for this
+    PR (a parallel dispatch owns it) -- imported read-only for comparison.
+    """
+
+    def _provider_re(self):
+        from governance_emit import _PROVIDER_RE
+
+        return _PROVIDER_RE
+
+    @pytest.mark.parametrize(
+        "member",
+        [m for m in ProviderIdentity if m not in (ProviderIdentity.DEEPSEEK, ProviderIdentity.UNKNOWN)],
+    )
+    def test_agreement_members_satisfy_the_regex(self, member):
+        assert self._provider_re().match(member.value), (
+            f"{member} is expected to satisfy governance_emit._PROVIDER_RE "
+            "but does not -- either the regex changed, or this member no "
+            "longer belongs in the agreement set."
+        )
+
+    def test_deepseek_is_the_one_receipt_only_divergence(self):
+        """Bare "deepseek" is accepted by THIS module (see
+        TestDeepseekVariants::test_bare_deepseek_is_its_own_identity_not_harness)
+        but rejected by governance_emit._PROVIDER_RE. This is deliberate, not
+        an oversight: no dispatch ever selects "--provider deepseek" (absent
+        from provider_dispatch._IMPLEMENTED_PROVIDERS too), so the
+        dispatch-time gate never needed to accept it -- the value only ever
+        enters through a report body written by scout_prepass.py,
+        gate_request_handler._request_deepseek, or a vnx_tagger.py-style
+        classifier call, none of which pass through governance_emit at all.
+        """
+        assert not self._provider_re().match(ProviderIdentity.DEEPSEEK.value)
+
+    def test_unknown_is_the_other_receipt_only_divergence(self):
+        """"unknown" is a receipt-layer sentinel for "no source recorded an
+        identity" -- there is no such thing as dispatching to an "unknown"
+        provider, so governance_emit's dispatch-time gate correctly has no
+        concept of it either.
+        """
+        assert not self._provider_re().match(ProviderIdentity.UNKNOWN.value)
+
+    def test_no_further_divergence_exists(self):
+        """Exhaustive check: DEEPSEEK and UNKNOWN are the ONLY two members
+        the regex rejects. If this fails, a member was added or the regex
+        changed without updating the divergence list above.
+        """
+        regex = self._provider_re()
+        rejected = {m for m in ProviderIdentity if not regex.match(m.value)}
+        assert rejected == {ProviderIdentity.DEEPSEEK, ProviderIdentity.UNKNOWN}
+
+
+class TestReconcileWithDispatchSpecProvider:
+    """dispatch_spec.Provider is the fleet's closed set for *dispatch-time*
+    provider selection (docstring: "CLOSED set -- the ONLY legal provider
+    strings"). Every member except AUTO (a capability-seam placeholder that
+    is resolved to a concrete provider before anything is ever dispatched or
+    receipted) must normalise to a consistent, documented ProviderIdentity.
+    """
+
+    def test_every_non_auto_member_normalises_without_raising(self):
+        from dispatch_spec import Provider
+
+        for member in Provider:
+            if member == Provider.AUTO:
+                continue
+            # Must not raise -- every real dispatch-time provider selection
+            # is a receipt-time-recognisable identity by construction.
+            normalize_provider(member.value)
+
+    def test_auto_is_excluded_by_design(self):
+        """AUTO ("auto") is a capability-seam placeholder filled in by the
+        router before planning -- it is never itself a receipt-worthy
+        identity, so it correctly has no ProviderIdentity counterpart and is
+        excluded from the loop above rather than silently swallowed.
+        """
+        from dispatch_spec import Provider
+
+        assert Provider.AUTO.value not in {m.value for m in ProviderIdentity}
+        with pytest.raises(UnrecognizedProviderError):
+            normalize_provider(Provider.AUTO.value)
+
+    def test_harness_lanes_map_to_themselves(self):
+        from dispatch_spec import Provider
+
+        assert normalize_provider(Provider.CLAUDE.value) is ProviderIdentity.CLAUDE
+        assert normalize_provider(Provider.CODEX.value) is ProviderIdentity.CODEX
+        assert normalize_provider(Provider.GEMINI.value) is ProviderIdentity.GEMINI
+        assert normalize_provider(Provider.KIMI.value) is ProviderIdentity.KIMI
+        assert (
+            normalize_provider(Provider.DEEPSEEK_HARNESS.value)
+            is ProviderIdentity.DEEPSEEK_HARNESS
+        )
+        assert (
+            normalize_provider(Provider.GLM_HARNESS.value) is ProviderIdentity.GLM_HARNESS
+        )
+        assert (
+            normalize_provider(Provider.LOCAL_GEMMA.value) is ProviderIdentity.LOCAL_GEMMA
+        )
+
+    def test_benchmark_baseline_litellm_compounds_map_consistently(self):
+        """LITELLM_ZAI and LITELLM_MOONSHOT carry dispatch_spec's own
+        "BENCHMARK-BASELINE ONLY" comment. LITELLM_DEEPSEEK carries no such
+        comment (asymmetric on purpose -- see provider_identity.py's
+        ProviderIdentity.DEEPSEEK docstring): it is a real, independent
+        production lane, not benchmark-only, which is exactly why it does
+        NOT get its own "litellm:deepseek" member here and instead folds
+        into DEEPSEEK_HARNESS (matching the pre-existing OI-1111 lane
+        resolution contract) while LITELLM_ZAI folds into GLM_HARNESS and
+        LITELLM_MOONSHOT is preserved as its own distinct member.
+        """
+        from dispatch_spec import Provider
+
+        assert (
+            normalize_provider(Provider.LITELLM_DEEPSEEK.value)
+            is ProviderIdentity.DEEPSEEK_HARNESS
+        )
+        assert (
+            normalize_provider(Provider.LITELLM_ZAI.value) is ProviderIdentity.GLM_HARNESS
+        )
+        assert (
+            normalize_provider(Provider.LITELLM_MOONSHOT.value)
+            is ProviderIdentity.LITELLM_MOONSHOT
+        )

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -1862,6 +1862,29 @@ class TestNormaliseProvider:
         assert _normalise_provider("") == "unknown"
         assert _normalise_provider("  ") == "unknown"
 
+    def test_unrecognised_garbage_is_never_passed_through_raw(self):
+        """Fail-open regression guard (golf1a-provider-enum).
+
+        Measured 2026-08-09: a torn-off instruction fragment reached
+        t0_receipts.ndjson verbatim via the old ``return p`` passthrough at
+        the end of ``_normalise_provider`` -- still reproducible against an
+        unmodified converter (empirically confirmed before this fix: it
+        returns the string unchanged instead of raising). There is no
+        recognisable provider keyword in it at all, so the fix must REFUSE
+        it, never invent or preserve a free-text value in the closed field.
+
+        NB the OTHER value T0 measured from the same 2026-08-09 window --
+        "Moonshot AI (Kimi Code CLI)" -- does NOT reproduce: it already
+        normalises to "kimi" today (the "kimi" substring rule was added
+        2026-08-10, commit 575019c5, one day after those ledger rows were
+        written). That example predates its own fix and is covered instead
+        by test_kimi_variants_normalised's salvage behaviour.
+        """
+        from report_to_receipt_converter import _normalise_provider
+        garbage = "` regel. Zonder die identiteitsregels landt je receipt niet."
+        with pytest.raises(Exception):
+            _normalise_provider(garbage)
+
 
 class TestLaneIdentityResolution:
     """Provider and model come from the lane (route_decision), not the body.
@@ -2005,6 +2028,54 @@ class TestLaneIdentityResolution:
         )
         assert receipt is not None
         assert receipt["provider"] == "deepseek-harness"
+
+    def test_unrecognized_body_provider_books_contract_invalid_not_a_crash(self, tmp_path):
+        """End-to-end evidence for where the fail-loud raise lands
+        (golf1a-provider-enum). No route decision exists, and the body's
+        provider field is free text with no recognisable keyword at all --
+        _normalise_provider raises UnrecognizedProviderError deep inside
+        _resolve_report_provider_model. build_receipt_from_report must NOT
+        crash (its documented "never raises" contract) and must NOT invent
+        or preserve the garbage string as a provider value -- it books an
+        explicit "unrecognized_provider" contract violation instead.
+
+        No ``status`` field is declared (-> status_category "no_signal", per
+        OI-1408) so this test isolates the ONE violation under test: the
+        unrelated OI-1035 fail-closed checks (schema_version, branch-on-
+        origin) that a terminal-success report would additionally have to
+        satisfy are irrelevant to what this test verifies.
+        """
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        # No route_decision JSON written -- forces the body-fallback path.
+
+        report = tmp_path / "20260601-garbage-provider.md"
+        report.write_text(
+            "---\ndispatch_id: 20260601-garbage-provider\nmodel: sonnet\nterminal: T1\n---\n\n"
+            "## Summary\n\nReport with a corrupted free-text provider field, "
+            "no terminal status declared, real Summary length.\n\n"
+            "## Changes\n\n- scripts/lib/foo.py: edited\n\n"
+            "## Verification\n\npytest tests/ -x: all green\n\n"
+            "## Open Items\n\nNone\n\n"
+            # Bold-field body format (not YAML) so a torn-off instruction
+            # fragment — the actual 2026-08-09 corruption shape — doesn't
+            # trip the YAML parser itself before ever reaching provider
+            # normalisation.
+            "**Provider**: ` regel. Zonder die identiteitsregels landt je receipt niet.\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None, "must never crash, per _build_receipt_from_report_core's contract"
+        assert receipt["event_type"] == "report_contract_invalid"
+        assert "unrecognized_provider" in receipt["contract_violations"]
+        assert receipt["provider"] == "unknown", (
+            "must book the explicit UNKNOWN sentinel, never the raw garbage string"
+        )
 
     def test_kimi_lane_wins_and_normalises(self, tmp_path):
         """Route decision kimi-k3 → provider kimi, model kimi-k3."""


### PR DESCRIPTION
## Summary
- `scripts/lib/provider_identity.py` (new): one closed `ProviderIdentity` enum reconciling `governance_emit._PROVIDER_RE` (dispatch-time, fail-loud) with `report_to_receipt_converter`'s own canonical set (receipt-time, previously fail-open). `normalize_provider()` raises `UnrecognizedProviderError` on anything neither vocabulary can place.
- `report_to_receipt_converter._normalise_provider` is now a thin wrapper around it — the old `return p` fail-open passthrough is gone. That passthrough is how four free-text fragments (a literal `` `. `` and a torn-off instruction sentence among them) reached `t0_receipts.ndjson` verbatim on 2026-08-09.
- The raise is caught once, at the call site in `_build_receipt_from_report_core`, and booked as an explicit `unrecognized_provider` contract violation (`event_type=report_contract_invalid`) — the function's documented "never raises" contract holds, and no source-never-reported provider string is invented.

## Design decisions (measured against the live ledger and the codebase, not assumed)
- **Bare `deepseek` stays its own enum member**, distinct from `deepseek-harness` — `scout_prepass.py`, `gate_request_handler._request_deepseek`, and `vnx_tagger.py`'s `VNX_TAGGER_PROVIDER` default all use the bare litellm/key-auth sub-provider identity independently of the Claude-CLI harness lane. This is a real, designed, distinct mechanism, not a typo.
- **`unknown` stays a legitimate sentinel** for genuinely blank input (333 live receipts, all honest "no source recorded an identity"), never a catch-all for garbage — that's what `UnrecognizedProviderError` is for.
- **`litellm:moonshot` is kept distinct from `kimi`** — a naive substring match would launder a benchmark-baseline Moonshot-API lane key (which can legitimately embed a kimi model alias, e.g. `litellm:moonshot:kimi-k2-6`) into looking like the sanctioned CLI-OAuth kimi lane, erasing the one signal `kimi-via-cli-only` (blocking constraint) needs to audit.
- **Existing OI-1111 lane-identity-resolution behaviour is preserved byte-for-byte**: `litellm:deepseek(:model)?` → `deepseek-harness`, `litellm:zai` → `glm-harness`. All 13 pre-existing provider/lane tests pass unchanged — no test was edited to make this change pass.
- Reconciled against a **third** vocabulary discovered mid-investigation, `dispatch_spec.Provider` (the fleet's closed dispatch-time selection enum) — every non-`AUTO` member normalizes consistently; `AUTO` is excluded by design (capability-seam placeholder, never a receipt-worthy identity).

## Correction to T0's measurement
T0's dispatch cited `"Moonshot AI (Kimi Code CLI)"` as a fail-open passthrough example from 2026-08-09. Empirically this does **not** reproduce against current `main` — it already normalizes to `"kimi"` (the substring rule was added 2026-08-10, commit `575019c5`, one day after those ledger rows were written). The red/green evidence test instead uses the other, still-reproducible example: the torn-off instruction-sentence fragment.

## HARDE BESTANDSGRENS respected
Did not touch `governance_emit.py`, `dispatch_govern.py`, `envelope_govern.py`, `provider_dispatch.py` (parallel dispatch owns them). `governance_emit._PROVIDER_RE` is imported read-only for the shape check and the reconciliation tests.

## Test plan
- [x] RED test written first: `test_unrecognised_garbage_is_never_passed_through_raw` fails against unmodified `_normalise_provider` (`DID NOT RAISE`), passes after the fix — both runs captured in the dispatch report.
- [x] `tests/test_provider_identity.py` (new, 58 tests): canonical passthrough, case-insensitivity, all variant cascades, fail-loud (including a break-your-own-guard never-seen-vendor case and a real-call-not-a-stub sanity check), full reconciliation against `governance_emit._PROVIDER_RE` and `dispatch_spec.Provider`.
- [x] `tests/test_report_to_receipt_converter.py` (170 tests, all pass unchanged +2 new): added the RED/GREEN unit test plus an end-to-end test proving a garbage body provider books `report_contract_invalid` rather than crashing or inventing a value.
- [x] Direct neighbours (`test_report_parser_model_provider.py`, `test_open_items_from_report.py`, `test_worker_heartbeat_silence.py`, `test_dispatch_push_verified.py`, `test_tmux_interactive_dispatch.py`): 558 tests total, all green.
- [x] `ruff check` on both new files: `provider_identity.py` clean; `report_to_receipt_converter.py`'s new import triggers the same pre-existing E402 pattern the file already had before this change (verified via stash comparison against HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)