### PR TITLE
fix(dispatch): escalation caller drops track_id (OI-1634)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -2612,6 +2612,11 @@ def _maybe_stage_escalation(plan, result, *, vspec, state_dir, data_dir) -> None
             env=dict(os.environ),
             state_dir=state_dir,
             data_dir=data_dir,
+            # OI-1634: an escalation continues the SAME dispatch chain as the
+            # rejected attempt (see stage_escalation_bundle's own comment on
+            # track_id — it never guesses), so it must inherit that attempt's
+            # track from the rejected dispatch's own validated spec.
+            track_id=spec.track_id,
         )
     except ValueError as exc:
         # A decision outcome that refuses to stage: unknown class, auth_rejected,

--- a/tests/test_oi1634_escalation_track_id.py
+++ b/tests/test_oi1634_escalation_track_id.py
@@ -1,0 +1,123 @@
+"""tests/test_oi1634_escalation_track_id.py — OI-1634: the escalation dispatch
+never receives the rejected attempt's track_id.
+
+Root cause, measured 2026-09-05: ``dispatch_bridge.stage_escalation_bundle``
+already HAS a ``track_id`` parameter (OI-1632, PR #1774) with an explicit
+comment that it "never guesses one from rejected_dispatch_id" — the caller
+must supply it. That is designed behavior, not an omission. The defect sits
+one level up: the SOLE production caller, ``dispatch_cli._maybe_stage_escalation``
+(the real call at dispatch_cli.py:2590), never passed ``track_id`` at all. An
+escalation continues the SAME dispatch chain as the rejected attempt, so it
+should carry that attempt's track — instead it silently dropped it on every
+climb.
+
+This test drives the REAL caller (``dispatch_cli._maybe_stage_escalation``),
+never a mock of ``stage_escalation_bundle``, and reads ``track_id`` back from
+the staged ``dispatch-spec.json`` on disk — the same bytes the door -> receipt
+chain copies. It also asserts the staged escalation bundle genuinely exists
+(not an accidental empty-glob false negative) before trusting its contents.
+
+RED on the pre-fix caller: the staged escalation spec's ``track_id`` is None
+even though the rejected dispatch's own spec carried ``"trk-oi1634"``. GREEN
+once the caller forwards ``spec.track_id`` through to ``stage_escalation_bundle``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import dispatch_cli  # noqa: E402
+
+_REJECTED_ID = "20260905-090000-rejected-oi1634"
+_TRACK_ID = "trk-oi1634"
+
+
+def _force_kimi(monkeypatch, present: bool = True):
+    """Deterministic kimi CLI presence (kimi-via-cli-only gate) — mirrors the
+    helper in tests/test_dispatch_bridge_escalation.py so the real
+    ``resolve_tier_route`` walk behaves the same regardless of the machine
+    this test runs on."""
+    import shutil as _shutil
+
+    monkeypatch.setattr(
+        _shutil,
+        "which",
+        (lambda name: "/usr/local/bin/kimi") if present else (lambda name: None),
+    )
+
+
+def _run_maybe_stage_escalation(tmp_path, monkeypatch, *, track_id):
+    _force_kimi(monkeypatch, present=True)
+
+    plan = SimpleNamespace(
+        dispatch_id=_REJECTED_ID,
+        provider="claude",
+        tier_from="tier-low",
+        tier_to=None,
+        task_class=None,
+    )
+    result = SimpleNamespace(
+        status="failure",
+        error="upstream 500 internal error",
+        completion_text="",
+        returncode=1,
+    )
+    spec = SimpleNamespace(
+        role="dev",
+        target_slot="T1",
+        project_id="p1",
+        gate="",
+        deadline_seconds=3600,
+        base_ref="origin/main",
+        track_id=track_id,
+    )
+    vspec = SimpleNamespace(
+        spec=spec,
+        instruction_text="original instruction text for the rejected attempt",
+        normalized_paths=(),
+    )
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path
+
+    dispatch_cli._maybe_stage_escalation(
+        plan, result, vspec=vspec, state_dir=state_dir, data_dir=data_dir,
+    )
+
+    pending = data_dir / "dispatches" / "pending"
+    staged = sorted(pending.glob("*/dispatch-spec.json")) if pending.exists() else []
+
+    # Nul is eerst een meetfout: prove the search itself is sound (a bundle
+    # DOES land under pending/ for this real call) before drawing any
+    # conclusion from its contents. A missing bundle here would mean the
+    # escalation was refused entirely (e.g. classify_failure_safe/escalate_tier
+    # changed under us) — a different bug than a dropped track_id, and this
+    # assertion is what would catch that distinction instead of silently
+    # reading an empty list as "track_id is None".
+    assert len(staged) == 1, (
+        f"expected exactly one staged escalation bundle under {pending}, found "
+        f"{len(staged)}: {staged} — the escalation call itself did not land, "
+        "which is a different failure than a dropped track_id"
+    )
+    return json.loads(staged[0].read_text(encoding="utf-8"))
+
+
+def test_escalation_from_a_tracked_dispatch_keeps_its_track(tmp_path, monkeypatch):
+    """The real call at dispatch_cli.py:2590: a rejected dispatch whose own
+    spec carries track_id="trk-oi1634" must hand that track to its escalation
+    followup — the chain continues, the track does not reset to None."""
+    payload = _run_maybe_stage_escalation(tmp_path, monkeypatch, track_id=_TRACK_ID)
+
+    assert payload["track_id"] == _TRACK_ID
+
+
+def test_escalation_from_an_untracked_dispatch_stays_untracked(tmp_path, monkeypatch):
+    """Companion negative case: a rejected dispatch with no track must not
+    fabricate one on escalation — the absence itself stays a countable,
+    honest None rather than stage_escalation_bundle silently guessing."""
+    payload = _run_maybe_stage_escalation(tmp_path, monkeypatch, track_id=None)
+
+    assert payload["track_id"] is None


### PR DESCRIPTION
## Summary

OI-1634 said `stage_escalation_bundle` didn't get the `track_id` doorgifte from PR #1774 (OI-1632). Measured: the function already has the parameter, with an explicit comment that it never guesses one — the caller must supply it. That's designed behavior, not the defect.

The actual defect sits one level up: the sole production caller, `dispatch_cli._maybe_stage_escalation` (the real call at `dispatch_cli.py:2590`), never passed `track_id` at all. An escalation continues the same dispatch chain as the rejected attempt, so it should inherit that attempt's track — instead it silently dropped it on every climb.

## Changes

- `scripts/lib/dispatch_cli.py`: `_maybe_stage_escalation` now passes `track_id=spec.track_id` (the rejected dispatch's own validated spec) to `stage_escalation_bundle`.
- `tests/test_oi1634_escalation_track_id.py` (new): drives the real caller directly (not a mock of `stage_escalation_bundle`) and reads `track_id` back from the staged `dispatch-spec.json` on disk.

## Test plan

- [x] RED confirmed before the fix: `test_escalation_from_a_tracked_dispatch_keeps_its_track` failed with `assert None == 'trk-oi1634'`.
- [x] GREEN after the fix: both new tests pass.
- [x] Ran `pytest tests/test_oi1634_escalation_track_id.py tests/test_dispatch_bridge_escalation.py tests/test_oi1632_track_overdracht.py tests/test_failure_classification.py` — 71 passed.
- [x] Verified the fix is real (not test-tautology): reverted the one-line change, re-ran the new test, saw it fail again; restored the fix, saw it pass again.
- [x] Ran the broader `tests/test_dispatch_cli.py` suite — 6 pre-existing failures, confirmed present with and without this change (ambient `VNX_OVERRIDE_WORKER_CLAUDE=1` env var + the documented nested-worktree `create_dispatch_worktree` limitation). None touch escalation/track_id.
- [x] `git diff HEAD` clean and `git show HEAD:scripts/lib/dispatch_cli.py` read back to confirm the committed bytes before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)