### PR TITLE
fix(receipt): monitor-loop converter stderr no longer discarded, rejections traceable (OI-1631)

### DIFF
--- a/scripts/lib/receipt_conversion_rejection_beacon.py
+++ b/scripts/lib/receipt_conversion_rejection_beacon.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""receipt_conversion_rejection_beacon.py — per-rejection detail for the
+``report_to_receipt_converter.py`` scan (golf3b / F1-2).
+
+Bug this closes: ``report_to_receipt_converter``'s OWN health beacon
+(``health/report_to_receipt_converter.json``, owned by that module — not
+touched here) already carries a ``rejected_count`` integer, but no per-report
+detail. A count of 27 with no names is not actionable: nobody can tell WHICH
+report was refused or WHY without re-running the converter by hand and
+watching stderr, and that stderr is exactly what
+``scripts/receipt_processor.sh`` used to throw away with ``2>/dev/null``
+(both the polling-loop call and, before OI-1753, the catchup call too).
+
+This module is the Bash caller's own health writer, not a change to the
+converter: ``receipt_processor.sh`` now captures the converter's stderr (see
+``_run_receipt_converter_scan``), and pipes the raw text here on stdin. Every
+line matching the converter's own fail-closed log format —
+
+    "REJECTED (fail-closed) dispatch=<id> file=<name> reason=<msg>"
+
+(``report_to_receipt_converter.py``'s ``_convert_one_detailed``, logged via
+``logger.warning`` on ``AppendReceiptError.code == "missing_model"``) — is
+parsed into a ``{dispatch_id, file, reason}`` record and written as this
+scan's beacon detail. Any other line (INFO chatter, the per-scan summary
+line, a different WARNING) is ignored: it is not this beacon's job to
+duplicate the processing log, only to make the REJECTED reason traceable.
+
+Snapshot semantics, matching ``report_to_receipt_converter._write_scan_heartbeat``'s
+own convention: each heartbeat reflects ONLY the rejections seen in the scan
+that just ran, not an ever-growing history — a report rejected every cycle
+until its cause is fixed would otherwise make ``details.rejections`` grow
+without bound. History lives in the processing log (now that it is no longer
+discarded); this beacon answers "what is wrong RIGHT NOW", the question a
+human or ``vnx doctor`` actually asks.
+
+Component name is a module-level string constant so
+``scripts/lib/beacon_register.py``'s AST scan discovers it as an EXPECTED
+writer (mirrors every other ``HealthBeacon(...)`` call site in this repo) —
+if this beacon ever stops being written, ``all_beacons(expected=...)`` marks
+it ``absent`` (not silently missing), the same "absence-is-loud" contract
+every other component here already has.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from health_beacon import HealthBeacon  # noqa: E402
+
+_COMPONENT = "receipt_conversion_rejections"
+_EXPECTED_INTERVAL_SECONDS = 3600
+
+# Mirrors report_to_receipt_converter.py's own log line exactly:
+#   "report_to_receipt_converter: REJECTED (fail-closed) dispatch=%s file=%s reason=%s"
+_REJECTED_PATTERN = re.compile(
+    r"REJECTED \(fail-closed\) dispatch=(\S+) file=(\S+) reason=(.*)$"
+)
+
+
+def parse_rejections(raw_stderr: str) -> List[Dict[str, str]]:
+    """Extract ``{dispatch_id, file, reason}`` records from raw stderr text.
+
+    Never raises on malformed input — a line that doesn't match the pattern
+    is simply not a rejection line and is skipped, not an error.
+    """
+    rejections: List[Dict[str, str]] = []
+    for line in raw_stderr.splitlines():
+        match = _REJECTED_PATTERN.search(line)
+        if not match:
+            continue
+        dispatch_id, file_name, reason = match.groups()
+        rejections.append({
+            "dispatch_id": dispatch_id,
+            "file": file_name,
+            "reason": reason.strip(),
+        })
+    return rejections
+
+
+def record_rejections(state_dir: Path, rejections: List[Dict[str, str]]) -> None:
+    """Write this scan's rejections as a heartbeat under ``<data_dir>/health/``.
+
+    ``state_dir`` is ``$VNX_STATE_DIR`` (``<data_root>/state``) — the same
+    convention ``report_to_receipt_converter._write_scan_heartbeat`` documents
+    for its own beacon. ``status`` is ``fail`` when this scan saw at least one
+    rejection, ``ok`` otherwise (an empty scan, or a scan with only
+    new/duplicate outcomes, is healthy — the same "attempted with zero
+    success" distinction the converter's own beacon makes, narrowed to just
+    the rejected outcome since that's the one this beacon exists to detail).
+    """
+    data_dir = state_dir.parent
+    beacon = HealthBeacon(data_dir, _COMPONENT, expected_interval_seconds=_EXPECTED_INTERVAL_SECONDS)
+    status = "fail" if rejections else "ok"
+    details: Dict[str, Any] = {
+        "count": len(rejections),
+        "rejections": rejections,
+    }
+    beacon.heartbeat(status=status, details=details)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--state-dir", required=True,
+        help="$VNX_STATE_DIR (<data_root>/state) — the beacon lands at its parent's health/ dir",
+    )
+    args = parser.parse_args(argv)
+
+    raw_stderr = sys.stdin.read()
+    rejections = parse_rejections(raw_stderr)
+    record_rejections(Path(args.state_dir), rejections)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -335,6 +335,57 @@ _ppr_collect_pending() {
     log_too_old_cycle_summary
 }
 
+# Run the Python report_to_receipt_converter.py scan once, capturing stderr
+# so a fail-closed REJECTED warning (or any other converter log line) is
+# never silently discarded — every line is routed through log() instead of
+# being piped to /dev/null. Shared by both call sites that invoke the
+# converter (_ppr_process_rate_limited's catchup/manual sweep and
+# _poll_new_reports_cycle's periodic monitor-mode sweep) so a stderr-capture
+# fix here can never be applied to one call site and missed on the other —
+# exactly what happened before: OI-1753 (Cluster D) fixed the catchup call's
+# `2>/dev/null` but the monitor-loop's OWN separate `2>/dev/null` a few lines
+# below survived untouched, so the actual 24/7 polling path (the one that
+# runs in production) kept discarding the reason (golf3b / F1-2).
+#
+# D3: the converter fail-closed-refuses a report with no valid Model field
+# (scripts/lib/append_receipt_internals/validation.py::
+# _validate_model_present) and logs that refusal as a WARNING on its own
+# logger — which writes to stderr. main() always returns 0 even when it
+# rejected reports this scan (a rejection is not a crash), so an
+# exit-code-only fallback never fires for a REJECTED. Capture stderr
+# explicitly (independent of exit code, since exit code is not a reliable
+# signal here) and route every line through log() so a REJECTED is visible;
+# the non-fatal design itself is unchanged.
+#
+# golf3b: a raw count in report_to_receipt_converter's OWN beacon
+# (rejected_count) is not actionable on its own — it says HOW MANY, not
+# WHICH report or WHY. The captured stderr is additionally piped into
+# receipt_conversion_rejection_beacon.py, which parses each REJECTED line
+# into a {dispatch_id, file, reason} record and writes it as its own
+# heartbeat under health/ — the same already-wired reading paths
+# (hooks/sessionstart.sh's beacon digest, scripts/health_check.py, vnx
+# doctor, the dashboard) surface it without a new consumer needing to be
+# built. Best-effort: a beacon-write failure never aborts the scan.
+_run_receipt_converter_scan() {
+    local _converter_stderr _converter_rc
+    _converter_stderr="$(python3 "$SCRIPTS_DIR/lib/report_to_receipt_converter.py" \
+        --state-dir "$STATE_DIR" \
+        "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" 2>&1 >/dev/null)"
+    _converter_rc=$?
+    if [ -n "$_converter_stderr" ]; then
+        while IFS= read -r _converter_line; do
+            [ -n "$_converter_line" ] && log "WARNING" "report_to_receipt_converter: $_converter_line"
+        done <<< "$_converter_stderr"
+    fi
+    if [ "$_converter_rc" -ne 0 ]; then
+        log "ERROR" "report_to_receipt_converter scan FAILED non-fatal, processor continues (exit $_converter_rc)"
+    fi
+    printf '%s' "$_converter_stderr" | python3 "$SCRIPTS_DIR/lib/receipt_conversion_rejection_beacon.py" \
+        --state-dir "$STATE_DIR" 2>>"$PROCESSING_LOG" \
+        || log "WARN" "Failed to record receipt-conversion-rejection beacon (non-fatal)"
+    return 0
+}
+
 # Process reports (passed as "$@") with rate limiting and watermark update.
 _ppr_process_rate_limited() {
     local processed_count=0
@@ -360,32 +411,9 @@ _ppr_process_rate_limited() {
     # Run Python converter after the Bash scan so YAML-frontmatter reports
     # not handled by report_parser.py also get receipts.  Non-fatal: a
     # crash here must never abort the processor loop (kept, unchanged).
-    #
-    # D3: the converter fail-closed-refuses a report with no valid Model
-    # field (scripts/lib/append_receipt_internals/validation.py::
-    # _validate_model_present) and logs that refusal as a WARNING on its
-    # own logger — which writes to stderr. main() always returns 0 even
-    # when it rejected reports this scan (a rejection is not a crash), so
-    # the old `|| log ERROR ... (exit $?)` fallback below never fired for
-    # a REJECTED — and the plain `2>/dev/null` threw the WARNING away
-    # regardless of exit code. Net effect: a refused report vanished from
-    # the audit trail with zero trace in this log. Capture stderr
-    # explicitly (independent of exit code, since exit code is not a
-    # reliable signal here) and route every line through log() so a
-    # REJECTED is visible; the non-fatal design itself is unchanged.
-    local _converter_stderr _converter_rc
-    _converter_stderr="$(python3 "$SCRIPTS_DIR/lib/report_to_receipt_converter.py" \
-        --state-dir "$STATE_DIR" \
-        "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" 2>&1 >/dev/null)"
-    _converter_rc=$?
-    if [ -n "$_converter_stderr" ]; then
-        while IFS= read -r _converter_line; do
-            [ -n "$_converter_line" ] && log "WARNING" "report_to_receipt_converter: $_converter_line"
-        done <<< "$_converter_stderr"
-    fi
-    if [ "$_converter_rc" -ne 0 ]; then
-        log "ERROR" "report_to_receipt_converter catchup scan FAILED non-fatal, processor continues (exit $_converter_rc)"
-    fi
+    # See _run_receipt_converter_scan for why stderr is captured instead of
+    # discarded.
+    _run_receipt_converter_scan
 }
 
 # Process all pending reports with flood protection and rate limiting.
@@ -412,43 +440,52 @@ process_pending_reports() {
 # caused orphan fswatches, duplicate watchers, and fseventsd memory bloat
 # (5+ GB observed). Polling at 5s is effectively free (<1ms per cycle) and
 # eliminates the entire class of process-lifecycle bugs.
+# Run one polling cycle's body — extracted from _poll_new_reports (which is
+# an unconditional `while true` loop) so it is directly callable from tests
+# without needing to break out of an infinite loop. $1 is the 1-based cycle
+# number, $2 is the retry-cycles interval computed by the caller.
+_poll_new_reports_cycle() {
+    local _cycle="$1"
+    local _retry_cycles="$2"
+    local _poll_max_mtime=0
+    for report in "$UNIFIED_REPORTS"/*.md "$HEADLESS_REPORTS"/*.md; do
+        [ -f "$report" ] || continue
+        if should_process_report "$report" && process_single_report "$report"; then
+            local _mtime
+            _mtime=$(stat -c %Y "$report" 2>/dev/null || stat -f %m "$report" 2>/dev/null)
+            if [ -n "$_mtime" ] && [ "$_mtime" -gt "$_poll_max_mtime" ]; then
+                _poll_max_mtime=$_mtime
+            fi
+        fi
+    done
+    log_too_old_cycle_summary
+    # Update watermark once after the full sweep with the maximum mtime seen.
+    if [ "$_poll_max_mtime" -gt 0 ]; then
+        echo "$_poll_max_mtime" > "$WATERMARK_FILE"
+    fi
+    # Generic YAML-frontmatter converter: runs every ~30 s (every 6 cycles).
+    # Handles reports written with --- YAML frontmatter that report_parser.py
+    # does not parse.  Owns its own dedup store
+    # (report_to_receipt_processed.txt) — does NOT read the Bash watermark
+    # to avoid format-conflation risk.  Non-fatal. See _run_receipt_converter_scan
+    # for why stderr is captured instead of discarded (golf3b / F1-2: this was
+    # the one call site OI-1753/Cluster D did NOT fix).
+    if [ $(( _cycle % 6 )) -eq 0 ]; then
+        _run_receipt_converter_scan
+    fi
+    if [ $(( _cycle % _retry_cycles )) -eq 0 ]; then
+        _retry_pending_receipts
+    fi
+}
+
 _poll_new_reports() {
     log "INFO" "Using polling mode (${POLL_INTERVAL}s intervals, receipt retry every ${RECEIPT_RETRY_INTERVAL}s)"
     local _retry_cycles=$(( RECEIPT_RETRY_INTERVAL / POLL_INTERVAL ))
     [ "$_retry_cycles" -lt 1 ] && _retry_cycles=1
     local _cycle=0
     while true; do
-        local _poll_max_mtime=0
-        for report in "$UNIFIED_REPORTS"/*.md "$HEADLESS_REPORTS"/*.md; do
-            [ -f "$report" ] || continue
-            if should_process_report "$report" && process_single_report "$report"; then
-                local _mtime
-                _mtime=$(stat -c %Y "$report" 2>/dev/null || stat -f %m "$report" 2>/dev/null)
-                if [ -n "$_mtime" ] && [ "$_mtime" -gt "$_poll_max_mtime" ]; then
-                    _poll_max_mtime=$_mtime
-                fi
-            fi
-        done
-        log_too_old_cycle_summary
-        # Update watermark once after the full sweep with the maximum mtime seen.
-        if [ "$_poll_max_mtime" -gt 0 ]; then
-            echo "$_poll_max_mtime" > "$WATERMARK_FILE"
-        fi
-        # Generic YAML-frontmatter converter: runs every ~30 s (every 6 cycles).
-        # Handles reports written with --- YAML frontmatter that report_parser.py
-        # does not parse.  Owns its own dedup store
-        # (report_to_receipt_processed.txt) — does NOT read the Bash watermark
-        # to avoid format-conflation risk.  Non-fatal.
         _cycle=$(( _cycle + 1 ))
-        if [ $(( _cycle % 6 )) -eq 0 ]; then
-            python3 "$SCRIPTS_DIR/lib/report_to_receipt_converter.py" \
-                --state-dir "$STATE_DIR" \
-                "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" 2>/dev/null \
-                || log "ERROR" "report_to_receipt_converter scan FAILED non-fatal, processor continues (exit $?)"
-        fi
-        if [ $(( _cycle % _retry_cycles )) -eq 0 ]; then
-            _retry_pending_receipts
-        fi
+        _poll_new_reports_cycle "$_cycle" "$_retry_cycles"
         sleep "$POLL_INTERVAL"
     done
 }

--- a/tests/test_beacon_register.py
+++ b/tests/test_beacon_register.py
@@ -156,10 +156,21 @@ def test_expected_component_names_is_just_the_names(fixture_scripts: Path) -> No
 
 
 def test_real_scripts_tree_gives_the_nine_measured_writers() -> None:
-    """Sanity check against the actual repo (measured 2026-08-30): 9
-    statically-resolvable HealthBeacon(...) call sites. subsystem_health.py
-    is the 10th HealthBeacon(...)-mentioning file but its call site is a
-    loop variable, so it is correctly excluded (see the fixture test above)."""
+    """Sanity check against the actual repo (measured 2026-09-05, was 9 on
+    2026-08-30): 10 statically-resolvable HealthBeacon(...) call sites.
+    subsystem_health.py is an 11th HealthBeacon(...)-mentioning file but its
+    call site is a loop variable, so it is correctly excluded (see the
+    fixture test above).
+
+    golf3b / F1-2 legitimately adds the 10th: receipt_processor.sh's own
+    stderr-capture fix pipes the converter's captured stderr into
+    scripts/lib/receipt_conversion_rejection_beacon.py, a NEW beacon writer
+    (component "receipt_conversion_rejections") that records per-report
+    dispatch_id/file/reason detail the converter's own beacon (counts only)
+    does not carry. This is the same category of deliberate addition the
+    D3a/D3b fix-forwards already bumped this measurement for — not a name
+    accidentally picked up by the scan.
+    """
     reg = br.read_beacon_register()
     names = {s.name for s in reg}
     assert names == {
@@ -172,4 +183,5 @@ def test_real_scripts_tree_gives_the_nine_measured_writers() -> None:
         "cleanup_worker_exit",
         "producer_freshness_monitor",
         "report_to_receipt_converter",
+        "receipt_conversion_rejections",
     }

--- a/tests/test_receipt_conversion_rejection_beacon.py
+++ b/tests/test_receipt_conversion_rejection_beacon.py
@@ -1,0 +1,181 @@
+"""Tests for scripts/lib/receipt_conversion_rejection_beacon.py (golf3b / F1-2).
+
+report_to_receipt_converter.py's own beacon (health/report_to_receipt_converter.json,
+out of scope for this dispatch — a different agent owns that file) already
+carries a rejected_count integer, measured live at 27 on 2026-09-05 with zero
+detail about WHICH report or WHY. This module is the Bash caller's
+(receipt_processor.sh) own health writer: it parses the converter's captured
+stderr for "REJECTED (fail-closed) dispatch=... file=... reason=..." lines and
+writes each one as a {dispatch_id, file, reason} record into its own beacon,
+reusing the exact same health_beacon.py mechanism/consumers (health_check.py,
+hooks/sessionstart.sh's digest, vnx doctor, the dashboard) already used for
+every other component under health/.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_LIB))
+
+from health_beacon import all_beacons  # noqa: E402
+import receipt_conversion_rejection_beacon as beacon_mod  # noqa: E402
+
+_REAL_REJECTED_LINE = (
+    "WARNING report_to_receipt_converter: report_to_receipt_converter: "
+    "REJECTED (fail-closed) dispatch=DISP-20260905-golf3b file="
+    "20260905-golf3b-receipt-refusals-visible.md reason=missing model"
+)
+
+
+class TestParseRejections:
+    def test_extracts_dispatch_file_and_reason_from_a_real_shaped_line(self) -> None:
+        rejections = beacon_mod.parse_rejections(_REAL_REJECTED_LINE)
+        assert rejections == [{
+            "dispatch_id": "DISP-20260905-golf3b",
+            "file": "20260905-golf3b-receipt-refusals-visible.md",
+            "reason": "missing model",
+        }]
+
+    def test_multiple_rejections_in_one_scan_are_all_captured(self) -> None:
+        raw = "\n".join([
+            "WARNING report_to_receipt_converter: REJECTED (fail-closed) dispatch=A file=a.md reason=missing model",
+            "INFO report_to_receipt_converter: 2 new receipt(s) emitted",
+            "WARNING report_to_receipt_converter: REJECTED (fail-closed) dispatch=B file=b.md reason=missing model",
+        ])
+        rejections = beacon_mod.parse_rejections(raw)
+        assert [r["dispatch_id"] for r in rejections] == ["A", "B"]
+
+    def test_non_rejection_lines_are_ignored(self) -> None:
+        raw = "\n".join([
+            "INFO report_to_receipt_converter: 3 new receipt(s) emitted",
+            "WARNING report_to_receipt_converter: append failed for x.md: boom",
+            "WARNING report_to_receipt_converter: 1 rejected, 0 malformed, 0 error(s) this scan",
+        ])
+        assert beacon_mod.parse_rejections(raw) == []
+
+    def test_empty_stderr_yields_no_rejections(self) -> None:
+        assert beacon_mod.parse_rejections("") == []
+
+    def test_malformed_garbage_never_raises(self) -> None:
+        # Nul-is-eerst-een-meetfout: prove the parser tolerates arbitrary
+        # noise rather than crashing the caller's non-fatal scan.
+        garbage = "\x00\xff not even close to the pattern REJECTED (fail-closed"
+        assert beacon_mod.parse_rejections(garbage) == []
+
+
+class TestRecordRejections:
+    def test_writes_fail_status_with_detail_when_rejections_present(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        rejections = [{"dispatch_id": "A", "file": "a.md", "reason": "missing model"}]
+
+        beacon_mod.record_rejections(state_dir, rejections)
+
+        beacon_path = tmp_path / "health" / "receipt_conversion_rejections.json"
+        assert beacon_path.is_file(), "beacon must land at <state_dir.parent>/health/"
+        payload = json.loads(beacon_path.read_text(encoding="utf-8"))
+        assert payload["status"] == "fail"
+        assert payload["details"]["count"] == 1
+        assert payload["details"]["rejections"] == rejections
+        assert payload["expected_interval_seconds"] == beacon_mod._EXPECTED_INTERVAL_SECONDS
+
+    def test_writes_ok_status_when_no_rejections(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        beacon_mod.record_rejections(state_dir, [])
+
+        beacon_path = tmp_path / "health" / "receipt_conversion_rejections.json"
+        payload = json.loads(beacon_path.read_text(encoding="utf-8"))
+        assert payload["status"] == "ok"
+        assert payload["details"]["count"] == 0
+
+    def test_is_a_snapshot_not_an_accumulator(self, tmp_path: Path) -> None:
+        """A report that gets re-rejected every cycle until fixed must not
+        make details.rejections grow without bound — each heartbeat reflects
+        only the scan that just ran."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        beacon_mod.record_rejections(state_dir, [{"dispatch_id": "A", "file": "a.md", "reason": "x"}] * 5)
+        beacon_mod.record_rejections(state_dir, [{"dispatch_id": "A", "file": "a.md", "reason": "x"}])
+
+        beacon_path = tmp_path / "health" / "receipt_conversion_rejections.json"
+        payload = json.loads(beacon_path.read_text(encoding="utf-8"))
+        assert payload["details"]["count"] == 1
+
+    def test_beacon_is_discoverable_by_beacon_register(self) -> None:
+        """The component name is a module-level string constant so
+        beacon_register.py's AST scan resolves it as an expected writer —
+        the same 'absence-is-loud' contract every other beacon here has."""
+        import beacon_register
+
+        reg = beacon_register.read_beacon_register(SCRIPTS_LIB)
+        names = {spec.name for spec in reg}
+        assert beacon_mod._COMPONENT in names
+
+
+class TestMainCli:
+    def test_stdin_to_beacon_end_to_end(self, tmp_path: Path, capsys) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        monkeypatch_stdin = _REAL_REJECTED_LINE
+
+        import io
+        old_stdin = sys.stdin
+        try:
+            sys.stdin = io.StringIO(monkeypatch_stdin)
+            rc = beacon_mod.main(["--state-dir", str(state_dir)])
+        finally:
+            sys.stdin = old_stdin
+
+        assert rc == 0
+        beacon_path = tmp_path / "health" / "receipt_conversion_rejections.json"
+        payload = json.loads(beacon_path.read_text(encoding="utf-8"))
+        assert payload["details"]["rejections"][0]["dispatch_id"] == "DISP-20260905-golf3b"
+
+
+class TestStalenessWatchdogFires:
+    """golf3b requirement #3: prove the staleness watchdog that already
+    exists (health_beacon.all_beacons()) actually classifies THIS
+    component's beacon as stale once it stops running — not just some
+    other component's beacon. Kapot-maken: manufacture a beacon older than
+    its own expected_interval_seconds and confirm all_beacons() flags it,
+    regardless of the status it self-reported at write time."""
+
+    def test_beacon_older_than_its_own_interval_is_stale_even_if_self_reported_ok(
+        self, tmp_path: Path,
+    ) -> None:
+        health_dir = tmp_path / "health"
+        health_dir.mkdir()
+        now = time.time()
+        stale_ts = now - (beacon_mod._EXPECTED_INTERVAL_SECONDS * 3)
+        payload = {
+            "component": beacon_mod._COMPONENT,
+            "last_run_ts": int(stale_ts),
+            "last_run_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(stale_ts)),
+            "status": "ok",
+            "details": {"count": 0, "rejections": []},
+            "expected_interval_seconds": beacon_mod._EXPECTED_INTERVAL_SECONDS,
+        }
+        (health_dir / f"{beacon_mod._COMPONENT}.json").write_text(
+            json.dumps(payload), encoding="utf-8",
+        )
+
+        beacons = all_beacons(tmp_path)
+        assert beacons[beacon_mod._COMPONENT]["health"] == "stale"
+
+    def test_fresh_ok_beacon_is_not_flagged(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        beacon_mod.record_rejections(state_dir, [])
+
+        beacons = all_beacons(tmp_path)
+        assert beacons[beacon_mod._COMPONENT]["health"] == "ok"

--- a/tests/test_receipt_processor_poll_converter_rejection_visible.py
+++ b/tests/test_receipt_processor_poll_converter_rejection_visible.py
@@ -1,0 +1,219 @@
+"""golf3b / F1-2: the MONITOR-mode polling cycle must not silently discard
+the converter's REJECTED reason either.
+
+tests/test_receipt_processor_converter_rejection_visible.py (PR #1753 /
+Cluster D) already fixed and covers _ppr_process_rate_limited — the
+catchup/manual-mode call site. But scripts/receipt_processor.sh's actual
+24/7 production path is _poll_new_reports (MODE=monitor, the default), which
+had its OWN separate `2>/dev/null` on the converter invocation
+(receipt_processor.sh:444-447 as measured 2026-09-05) that PR #1753 never
+touched — confirmed live: health/report_to_receipt_converter.json shows
+rejected_count=27 with last_run_iso 2026-09-03T05:35:06Z, two days stale at
+the time of measurement, while the processing log carries zero trace of any
+REJECTED line.
+
+Both call sites now share one helper, _run_receipt_converter_scan (see
+receipt_processor.sh) — this test exercises that helper via the polling
+loop's own per-cycle function, _poll_new_reports_cycle (extracted from the
+`while true` loop specifically so a single cycle is callable in isolation
+without needing to break out of an infinite loop).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+RP_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "receipt_processor.sh"
+
+ENV_PREAMBLE = """
+set -u
+export _RP_LIB_MODE=1
+export VNX_DATA_DIR="{data_dir}"
+export VNX_STATE_DIR="{state}"
+export VNX_PIDS_DIR="{pids}"
+export VNX_LOCKS_DIR="{locks}"
+export VNX_REPORTS_DIR="{unified}"
+export VNX_HEADLESS_REPORTS_DIR="{headless}"
+source "{rp_script}" || {{ echo "FATAL: source failed" >&2; exit 1; }}
+"""
+
+_REJECTED_LINE = (
+    "WARNING report_to_receipt_converter: report_to_receipt_converter: "
+    "REJECTED (fail-closed) dispatch=DISP-POLL-STUB file=poll-stub.md reason=missing model"
+)
+_SUMMARY_LINE = (
+    "WARNING report_to_receipt_converter: report_to_receipt_converter: "
+    "1 rejected, 0 malformed, 0 error(s) this scan"
+)
+
+
+def _make_dirs(tmp: Path) -> dict:
+    data_dir = tmp / "data"
+    dirs = {
+        "unified": tmp / "unified",
+        "headless": tmp / "headless",
+        "state": data_dir / "state",
+        "pids": tmp / "pids",
+        "locks": tmp / "locks",
+        "data_dir": data_dir,
+    }
+    for d in dirs.values():
+        d.mkdir(parents=True, exist_ok=True)
+    return dirs
+
+
+def _make_stub_converter(tmp: Path, *, exit_code: int = 0) -> Path:
+    """A stub lib/report_to_receipt_converter.py reproducing the real
+    converter's fail-closed REJECTED warning-to-stderr, exit-0 behavior."""
+    stub_scripts = tmp / "stub_scripts"
+    stub_lib = stub_scripts / "lib"
+    stub_lib.mkdir(parents=True, exist_ok=True)
+    converter = stub_lib / "report_to_receipt_converter.py"
+    converter.write_text(
+        textwrap.dedent(f"""\
+            #!/usr/bin/env python3
+            import sys
+            print({_REJECTED_LINE!r}, file=sys.stderr)
+            print({_SUMMARY_LINE!r}, file=sys.stderr)
+            sys.exit({exit_code})
+            """),
+        encoding="utf-8",
+    )
+    converter.chmod(0o755)
+    # The real beacon writer lives alongside the converter under lib/ — copy
+    # it into the stub tree so _run_receipt_converter_scan's second stage
+    # (piping stderr into receipt_conversion_rejection_beacon.py) resolves
+    # against the SAME "$SCRIPTS_DIR/lib/..." path the production script
+    # uses, exactly like the real deployment layout.
+    real_beacon_writer = (
+        Path(__file__).resolve().parent.parent
+        / "scripts" / "lib" / "receipt_conversion_rejection_beacon.py"
+    )
+    (stub_lib / "receipt_conversion_rejection_beacon.py").write_text(
+        real_beacon_writer.read_text(encoding="utf-8"), encoding="utf-8",
+    )
+    real_health_beacon = (
+        Path(__file__).resolve().parent.parent / "scripts" / "lib" / "health_beacon.py"
+    )
+    (stub_lib / "health_beacon.py").write_text(
+        real_health_beacon.read_text(encoding="utf-8"), encoding="utf-8",
+    )
+    return stub_scripts
+
+
+def _run_bash(dirs: dict, body: str) -> subprocess.CompletedProcess:
+    cmd = ENV_PREAMBLE.format(rp_script=RP_SCRIPT, **dirs) + body
+    return subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
+
+
+def test_poll_cycle_rejected_warning_reaches_the_processing_log(tmp_path: Path) -> None:
+    """The real defect: does a REJECTED warning surfaced during the MONITOR
+    polling loop's periodic converter sweep (every 6th cycle) land in
+    $PROCESSING_LOG, or does it vanish behind the loop's own `2>/dev/null`?"""
+    dirs = _make_dirs(tmp_path)
+    stub_scripts = _make_stub_converter(tmp_path)
+
+    body = f"""
+SCRIPTS_DIR="{stub_scripts}"
+# cycle=6 is divisible by 6 -> triggers the converter sweep.
+# retry_cycles=7 -> 6 % 7 != 0 -> _retry_pending_receipts is skipped.
+_poll_new_reports_cycle 6 7
+"""
+    result = _run_bash(dirs, body)
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+
+    processing_log = dirs["state"] / "receipt_processing.log"
+    assert processing_log.is_file(), "receipt_processing.log was never created"
+    log_contents = processing_log.read_text(encoding="utf-8")
+
+    assert "REJECTED (fail-closed)" in log_contents, (
+        "converter's REJECTED warning never reached the processing log during "
+        f"the polling cycle (stderr was thrown away). log contents:\n{log_contents}"
+    )
+    assert "1 rejected, 0 malformed, 0 error(s) this scan" in log_contents
+
+
+def test_poll_cycle_skips_converter_on_non_sixth_cycle(tmp_path: Path) -> None:
+    """Unchanged cadence: the converter must only run every 6th cycle, exactly
+    as before this fix — a cycle count that is NOT a multiple of 6 must not
+    invoke it at all."""
+    dirs = _make_dirs(tmp_path)
+    stub_scripts = _make_stub_converter(tmp_path)
+
+    body = f"""
+SCRIPTS_DIR="{stub_scripts}"
+_poll_new_reports_cycle 5 100
+"""
+    result = _run_bash(dirs, body)
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+
+    processing_log = dirs["state"] / "receipt_processing.log"
+    log_contents = processing_log.read_text(encoding="utf-8") if processing_log.is_file() else ""
+    assert "REJECTED (fail-closed)" not in log_contents
+
+
+def test_poll_cycle_rejection_lands_in_its_own_health_beacon(tmp_path: Path) -> None:
+    """golf3b requirement #2: the reason must be traceable to WHICH report
+    and WHY, not just a bare count. Confirms the per-cycle converter sweep
+    writes dispatch_id/file/reason into
+    health/receipt_conversion_rejections.json — the same already-wired
+    reading path (hooks/sessionstart.sh's digest, health_check.py, vnx
+    doctor, the dashboard) every other component's beacon uses."""
+    dirs = _make_dirs(tmp_path)
+    stub_scripts = _make_stub_converter(tmp_path)
+
+    body = f"""
+SCRIPTS_DIR="{stub_scripts}"
+_poll_new_reports_cycle 6 7
+"""
+    result = _run_bash(dirs, body)
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+
+    beacon_path = dirs["data_dir"] / "health" / "receipt_conversion_rejections.json"
+    assert beacon_path.is_file(), "receipt_conversion_rejections.json beacon was never written"
+    payload = json.loads(beacon_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "fail"
+    assert payload["details"]["rejections"] == [{
+        "dispatch_id": "DISP-POLL-STUB",
+        "file": "poll-stub.md",
+        "reason": "missing model",
+    }]
+
+
+def test_poll_cycle_non_fatal_design_preserved_on_a_real_crash(tmp_path: Path) -> None:
+    """Sanity: a genuine converter crash (nonzero exit) during the polling
+    cycle must still be logged as a non-fatal ERROR and must NOT abort the
+    processor's per-cycle function."""
+    dirs = _make_dirs(tmp_path)
+    stub_scripts = _make_stub_converter(tmp_path, exit_code=1)
+
+    body = f"""
+SCRIPTS_DIR="{stub_scripts}"
+_poll_new_reports_cycle 6 7
+echo "REACHED_END=yes"
+"""
+    result = _run_bash(dirs, body)
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+    assert "REACHED_END=yes" in result.stdout, "the cycle function must return, not abort, on a converter crash"
+
+    processing_log = (dirs["state"] / "receipt_processing.log").read_text(encoding="utf-8")
+    assert "FAILED non-fatal" in processing_log
+    assert "exit 1" in processing_log
+
+
+def test_no_raw_devnull_remains_on_the_converter_invocation() -> None:
+    """Regression guard: the exact class of bug this dispatch closes (a
+    converter call whose stderr is piped straight to /dev/null) must not
+    reappear on either call site. Both now route through
+    _run_receipt_converter_scan, which captures stderr with `2>&1 >/dev/null`
+    (redirect-then-log) rather than discarding it — this asserts no sibling
+    line still throws it away directly."""
+    text = RP_SCRIPT.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        if "report_to_receipt_converter.py" in line and "2>/dev/null" in line:
+            raise AssertionError(
+                f"found a converter invocation still discarding stderr: {line!r}"
+            )


### PR DESCRIPTION
## Summary

`scripts/receipt_processor.sh:444-447`'s periodic converter call — inside `_poll_new_reports`, the MODE=monitor polling loop that is the actual 24/7 production path — piped the `report_to_receipt_converter.py` scan's stderr straight to `/dev/null`. PR #1753 (Cluster D / OI-1753) fixed the *other* call site (`_ppr_process_rate_limited`, used at catchup startup and in manual mode) but never touched this one, so a fail-closed `REJECTED` refusal kept vanishing with zero trace anywhere a human reads. Measured live on 2026-09-05: `health/report_to_receipt_converter.json` shows `rejected_count: 27`, `status: "fail"`, `last_run_iso: 2026-09-03T05:35:06Z` — two days stale, with no names or reasons attached to the count.

## Changes

- `scripts/receipt_processor.sh`
  - New shared helper `_run_receipt_converter_scan()`: captures the converter's stderr, routes every line through `log()` (instead of discarding it), logs a non-fatal `ERROR` on a nonzero exit, and pipes the raw stderr into the new beacon writer below.
  - `_ppr_process_rate_limited()` now calls the shared helper instead of its own inline block (behavior-preserving refactor — the fix already merged here is unchanged).
  - `_poll_new_reports` split into `_poll_new_reports_cycle()` (one cycle's body, now directly callable/testable) + a thin `while true` wrapper — this is the call site that was still broken, and it now calls the same shared helper.
- `scripts/lib/receipt_conversion_rejection_beacon.py` (new): parses `REJECTED (fail-closed) dispatch=... file=... reason=...` lines out of the captured stderr and writes each scan's rejections as `{dispatch_id, file, reason}` records to `health/receipt_conversion_rejections.json` via the existing `health_beacon.py` mechanism — snapshot semantics (this cycle's rejections, not an ever-growing history), `status="fail"` when non-empty else `"ok"`, `expected_interval_seconds=3600` so the existing staleness watchdog (`health_beacon.all_beacons()`) applies to it the same as every other component. This reuses the already-wired reading paths (`hooks/sessionstart.sh`'s beacon digest, `scripts/health_check.py`, `vnx doctor`, the dashboard) instead of inventing a new unread channel — the alternative (writing only to the processing log) reproduces the exact "nobody reads it" defect this dispatch closes.
  - `report_to_receipt_converter.py` itself was **not touched** (hard file boundary — a parallel dispatch owns it). Its own beacon (`rejected_count`) still only carries an aggregate; this is the Bash caller's own companion beacon for per-report detail.
- `tests/test_beacon_register.py`: bumped the measured "real scripts tree" baseline from 9 to 10 `HealthBeacon(...)` call sites — the new writer is a legitimate addition, same category as the D3a/D3b fix-forwards already visible in that test's history.

## Verification

- `bash -n scripts/receipt_processor.sh` — OK
- `python3 -m pytest tests/test_receipt_conversion_rejection_beacon.py tests/test_receipt_processor_poll_converter_rejection_visible.py tests/test_receipt_processor_converter_rejection_visible.py tests/test_beacon_register.py tests/test_sessionstart_hook_beacon_health.py tests/smoke/smoke_health_beacons_fresh.py -q` → 47 passed, 1 skipped
- Broader regression sweep: `python3 -m pytest tests/ -k "receipt_processor or beacon or health_check or receipt_conversion" -q` → 167 passed, 1 skipped (one unrelated pre-existing failure in `tests/test_future_state_reconciliation.py::TestWriteFailureReflectedBeforePersist::test_health_beacon_receives_fail_when_writes_fail` deselected — confirmed via `git stash`/reapply that it fails identically on unmodified `main`; it's a `build_t0_state.py`/test signature mismatch unrelated to this change and outside this dispatch's file scope)
- Also ran the receipt_processor shellcheck-emulation guards (`test_receipt_processor_sc2181.py`, `sc1091`, `sc2155`) — all pass, no new violations introduced
- Red-before-fix, self-witnessed: reproduced the exact pre-fix inline block (`... 2>/dev/null || log ERROR ...`) standalone against a stub converter emitting a REJECTED line — confirmed 0 occurrences of "REJECTED" reached the log. Then confirmed green against the actual fixed code path (both direct pytest runs and a manual `_poll_new_reports_cycle` invocation).
- "Kapot maken" of the new watcher: temporarily replaced the beacon writer's regex with a non-matching pattern, reran `tests/test_receipt_conversion_rejection_beacon.py`, watched 3 tests go red (parser tests + end-to-end CLI test), then restored the original and reconfirmed green (12/12).
- `git diff HEAD` empty and `git show HEAD:scripts/receipt_processor.sh` / `git show HEAD:scripts/lib/receipt_conversion_rejection_beacon.py` read back correctly before push.
- `report_to_receipt_converter.py` confirmed untouched (`git diff HEAD -- scripts/lib/report_to_receipt_converter.py` → 0 lines).

## Open Items

None.