### PR TITLE
feat(governance): AST-detector voor onbereikbare guards (OI-1632-klasse)

### DIFF
--- a/scripts/guard_reachability_audit.py
+++ b/scripts/guard_reachability_audit.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""guard_reachability_audit.py — CI-runnable wachter for the golf-4 bug class.
+
+golf-4 (2026-09-05): eight independently-discovered defects shared one shape
+— a guard condition that gates a raise/return/skip or a gate decision reads
+a field, column, or spec attribute that in practice is never filled. The
+code looks fully wired. The branch it protects is unreachable. Nothing
+raises, so nothing alerts.
+
+This CLI combines the two halves built for this dispatch:
+  - ``guard_reachability_scanner`` — AST-finds every guard that probes a
+    named field via ``dict.get(str)`` / ``obj[str]`` / a known dataclass
+    attribute.
+  - ``guard_reachability_store`` — measures that field's real fill rate
+    against the store registered for it in ``guard_reachability_registry``.
+
+Subcommands:
+  scan      — list every guarded-field reference found repo-wide (no store
+              measurement; informational, always exits 0).
+  audit     — scan + measure every field that has a FIELD_STORE_MAP entry;
+              exits 1 if any UNSUPPRESSED zero-fill/missing-column finding
+              exists, 0 otherwise. Suppressed findings (ACCEPTED_GAPS) are
+              still printed, with their reason, never silently dropped.
+  selftest  — re-confirm the calibration case(s) in
+              ``guard_reachability_calibration`` against their frozen,
+              real pre-fix source. Exits 1 (loud) if the detector can no
+              longer find a single known-bad case — see that module's
+              docstring for why this exists.
+
+Deliberately NOT wired into CI yet (see the dispatch report's Open Items):
+the first repo-wide `audit` run surfaces genuine, currently-unfixed findings
+(new discoveries, not the calibration case). Wiring this into a blocking CI
+gate today would force either a red pipeline or laundering those findings
+into ACCEPTED_GAPS without real review — precisely the anti-pattern this
+tool exists to catch.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _SCRIPTS_DIR / "lib"
+for _p in (str(_SCRIPTS_DIR), str(_LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import project_root  # noqa: E402
+import vnx_paths  # noqa: E402
+from guard_reachability_calibration import (  # noqa: E402
+    CALIBRATION_CASES,
+    SelfTestFailure,
+    run_selftest,
+)
+from guard_reachability_registry import (  # noqa: E402
+    ACCEPTED_GAPS,
+    FIELD_STORE_MAP,
+    AcceptedGap,
+    StoreTarget,
+    validate_registry,
+)
+from guard_reachability_scanner import GuardedFieldRef, scan_repo_guarded_fields  # noqa: E402
+from guard_reachability_store import (  # noqa: E402
+    FillRate,
+    measure_json_dir_fill_rate,
+    measure_ndjson_fill_rate,
+    measure_sqlite_column_fill_rate,
+)
+
+
+@dataclass(frozen=True)
+class FieldFinding:
+    field: str
+    refs: Tuple[GuardedFieldRef, ...]
+    target: StoreTarget
+    rate: FillRate
+
+    @property
+    def is_defect_shape(self) -> bool:
+        return (not self.rate.exists) or self.rate.is_zero_fill
+
+
+def _measure_target(data_dir: Path, mapping_field: str, target: StoreTarget) -> FillRate:
+    key = target.dict_key or mapping_field
+    if target.kind == "sqlite":
+        return measure_sqlite_column_fill_rate(
+            data_dir / target.db_relpath, target.table, target.column,
+        )
+    if target.kind == "ndjson":
+        paths = [data_dir / rel for rel in target.ndjson_relpaths]
+        return measure_ndjson_fill_rate(paths, field=key)
+    if target.kind == "json_dir":
+        return measure_json_dir_fill_rate(data_dir / target.dir_relpath, target.glob, field=key)
+    raise ValueError(f"unknown StoreTarget.kind={target.kind!r}")  # pragma: no cover - guarded in __post_init__
+
+
+def _matching_gap(field: str, file: str, gaps: Tuple[AcceptedGap, ...]) -> Optional[AcceptedGap]:
+    for gap in gaps:
+        if gap.field != field:
+            continue
+        if gap.file is None or gap.file == file:
+            return gap
+    return None
+
+
+def build_findings(
+    root: Path, data_dir: Path,
+) -> Tuple[List[FieldFinding], List[Tuple[FieldFinding, AcceptedGap]], List[FieldFinding], Dict[str, List[GuardedFieldRef]]]:
+    """Returns (violations, suppressed, ok, unmeasured_by_field).
+
+    ``unmeasured_by_field`` holds every guarded field the scanner found that
+    has no ``FIELD_STORE_MAP`` entry — informational candidates for a human
+    to triage into the registry, never treated as a violation on their own.
+    """
+    validate_registry()
+    refs = scan_repo_guarded_fields(root)
+
+    by_field: Dict[str, List[GuardedFieldRef]] = {}
+    for r in refs:
+        by_field.setdefault(r.field, []).append(r)
+
+    mapping_by_field = {m.field: m for m in FIELD_STORE_MAP}
+
+    violations: List[FieldFinding] = []
+    suppressed: List[Tuple[FieldFinding, AcceptedGap]] = []
+    ok: List[FieldFinding] = []
+    unmeasured: Dict[str, List[GuardedFieldRef]] = {}
+
+    for field, field_refs in sorted(by_field.items()):
+        mapping = mapping_by_field.get(field)
+        if mapping is None:
+            unmeasured[field] = field_refs
+            continue
+        for target in mapping.targets:
+            rate = _measure_target(data_dir, mapping.field, target)
+            finding = FieldFinding(field=field, refs=tuple(field_refs), target=target, rate=rate)
+            if finding.is_defect_shape:
+                gap = None
+                for ref in field_refs:
+                    gap = _matching_gap(field, ref.file, ACCEPTED_GAPS)
+                    if gap is not None:
+                        break
+                if gap is not None:
+                    suppressed.append((finding, gap))
+                else:
+                    violations.append(finding)
+            else:
+                ok.append(finding)
+
+    return violations, suppressed, ok, unmeasured
+
+
+def _print_finding(finding: FieldFinding, *, label: str) -> None:
+    t = finding.target
+    where = (
+        f"{t.table}.{t.column}" if t.kind == "sqlite"
+        else (t.dict_key or finding.field)
+    )
+    store_desc = {
+        "sqlite": f"sqlite:{t.db_relpath}::{where}",
+        "ndjson": f"ndjson:{','.join(t.ndjson_relpaths)}::{where}",
+        "json_dir": f"json_dir:{t.dir_relpath}/{t.glob}::{where}",
+    }[t.kind]
+    exists_desc = "MISSING" if not finding.rate.exists else f"{finding.rate.filled}/{finding.rate.total}"
+    print(f"[{label}] field={finding.field!r} store={store_desc} fill={exists_desc}")
+    for ref in finding.refs[:5]:
+        print(f"    guarded at {ref.file}:{ref.lineno} ({ref.access_kind}) if {ref.test_source}")
+    if len(finding.refs) > 5:
+        print(f"    ... and {len(finding.refs) - 5} more guard site(s)")
+
+
+def cmd_scan(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    refs = scan_repo_guarded_fields(root)
+    by_field: Dict[str, List[GuardedFieldRef]] = {}
+    for r in refs:
+        by_field.setdefault(r.field, []).append(r)
+    print(f"[guard-reachability scan] {len(refs)} guard site(s), {len(by_field)} distinct field(s)\n")
+    for field, field_refs in sorted(by_field.items()):
+        locations = ", ".join(f"{r.file}:{r.lineno}" for r in field_refs[:3])
+        more = f" (+{len(field_refs) - 3} more)" if len(field_refs) > 3 else ""
+        print(f"  {field}: {locations}{more}")
+    return 0
+
+
+def cmd_audit(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    data_dir = Path(args.data_dir).resolve() if args.data_dir else Path(vnx_paths.resolve_paths()["VNX_DATA_DIR"])
+    violations, suppressed, ok, unmeasured = build_findings(root, data_dir)
+
+    print(f"[guard-reachability audit] data_dir={data_dir}\n")
+    for finding in violations:
+        _print_finding(finding, label="VIOLATION")
+    for finding, gap in suppressed:
+        _print_finding(finding, label="SUPPRESSED")
+        print(f"    reason: {gap.reason} (decided_by={gap.decided_by}, decided_on={gap.decided_on})")
+    for finding in ok:
+        _print_finding(finding, label="OK")
+
+    print(
+        f"\n{len(violations)} violation(s), {len(suppressed)} suppressed, "
+        f"{len(ok)} ok, {len(unmeasured)} unmeasured field(s) (no registry mapping)"
+    )
+    if unmeasured and args.show_unmeasured:
+        print("\nUnmeasured fields (candidates to triage into FIELD_STORE_MAP):")
+        for field, refs in sorted(unmeasured.items()):
+            print(f"  {field}: {len(refs)} guard site(s), e.g. {refs[0].file}:{refs[0].lineno}")
+
+    return 1 if violations else 0
+
+
+def cmd_selftest(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    accepted_fields = frozenset(g.field for g in ACCEPTED_GAPS)
+    try:
+        confirmations = run_selftest(root, accepted_fields)
+    except SelfTestFailure as exc:
+        print("[guard-reachability selftest] FAIL")
+        print(str(exc))
+        return 1
+    print(f"[guard-reachability selftest] PASS ({len(CALIBRATION_CASES)} calibration case(s))")
+    for line in confirmations:
+        print(f"  {line}")
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=str(project_root.resolve_project_root(__file__)))
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_scan = sub.add_parser("scan", help="list guarded-field references, no measurement")
+    p_scan.set_defaults(func=cmd_scan)
+
+    p_audit = sub.add_parser("audit", help="scan + measure registered fields")
+    p_audit.add_argument("--data-dir", default=None)
+    p_audit.add_argument("--show-unmeasured", action="store_true")
+    p_audit.set_defaults(func=cmd_audit)
+
+    p_selftest = sub.add_parser("selftest", help="re-confirm calibration cases")
+    p_selftest.set_defaults(func=cmd_selftest)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/guard_reachability_audit.py
+++ b/scripts/guard_reachability_audit.py
@@ -23,9 +23,13 @@ Subcommands:
               still printed, with their reason, never silently dropped.
   selftest  — re-confirm the calibration case(s) in
               ``guard_reachability_calibration`` against their frozen,
-              real pre-fix source. Exits 1 (loud) if the detector can no
-              longer find a single known-bad case — see that module's
-              docstring for why this exists.
+              real pre-fix source, THEN run a live ``audit`` against the
+              real repo/data-dir and require at least one violation
+              (``run_live_violation_selftest``, golf-4 ronde 2). Exits 1
+              (loud) if the detector can no longer find a single known-bad
+              case, frozen OR live — see that module's and
+              ``run_live_violation_selftest``'s docstrings for why both
+              halves exist.
 
 Deliberately NOT wired into CI yet (see the dispatch report's Open Items):
 the first repo-wide `audit` run surfaces genuine, currently-unfixed findings
@@ -58,6 +62,7 @@ from guard_reachability_calibration import (  # noqa: E402
 from guard_reachability_registry import (  # noqa: E402
     ACCEPTED_GAPS,
     FIELD_STORE_MAP,
+    MIN_MAPPED_FIELDS,
     AcceptedGap,
     StoreTarget,
     validate_registry,
@@ -202,7 +207,9 @@ def cmd_audit(args: argparse.Namespace) -> int:
 
     print(
         f"\n{len(violations)} violation(s), {len(suppressed)} suppressed, "
-        f"{len(ok)} ok, {len(unmeasured)} unmeasured field(s) (no registry mapping)"
+        f"{len(ok)} ok, {len(FIELD_STORE_MAP)} field(s) mapped (floor "
+        f"MIN_MAPPED_FIELDS={MIN_MAPPED_FIELDS}), {len(unmeasured)} "
+        "unmeasured field(s) (no registry mapping)"
     )
     if unmeasured and args.show_unmeasured:
         print("\nUnmeasured fields (candidates to triage into FIELD_STORE_MAP):")
@@ -210,6 +217,44 @@ def cmd_audit(args: argparse.Namespace) -> int:
             print(f"  {field}: {len(refs)} guard site(s), e.g. {refs[0].file}:{refs[0].lineno}")
 
     return 1 if violations else 0
+
+
+def run_live_violation_selftest(root: Path, data_dir: Path) -> List[str]:
+    """golf-4 ronde 2 (OI-1640, 2026-09-06) — the live half of the tripwire.
+
+    ``run_selftest`` (above) re-confirms the scanner against a FROZEN
+    historical fixture; it says nothing about whether ``build_findings``
+    run against the ACTUAL live repo right now still surfaces a real
+    problem. That gap is exactly how the original registry shipped: it
+    validated cleanly, ``run_selftest`` passed, and the live ``audit``
+    still reported a false [OK] on ``track_id`` because it was measured
+    against the wrong store (see ``guard_reachability_registry``'s
+    docstring). "0 violations" on a live audit is indistinguishable from
+    "the detector stopped measuring anything" unless something asserts
+    that at least one known-real finding still shows up.
+
+    Raises :class:`SelfTestFailure` when the live repo audit finds ZERO
+    violations — this is a hard stop, not a warning: it means either every
+    known defect this registry maps (OI-1639, OI-1640) has genuinely been
+    fixed (replace this tripwire's expectation with a fresh known-bad case
+    before removing it) or the registry/measurement has been broken or
+    laundered via ``ACCEPTED_GAPS``.
+    """
+    violations, _suppressed, _ok, _unmeasured = build_findings(root, data_dir)
+    if not violations:
+        raise SelfTestFailure(
+            "live audit against the real repo (root="
+            f"{root}, data_dir={data_dir}) found ZERO violations — this is "
+            "indistinguishable from a broken/mis-mapped detector. If every "
+            "known FIELD_STORE_MAP defect (OI-1639, OI-1640) is genuinely "
+            "fixed now, replace this tripwire's known-bad expectation with "
+            "a fresh one before relying on a clean audit again."
+        )
+    fields = sorted({f.field for f in violations})
+    return [
+        f"live audit: {len(violations)} violation(s) found on the real repo "
+        f"({', '.join(fields)}) — detector is live-verified, not just calibrated"
+    ]
 
 
 def cmd_selftest(args: argparse.Namespace) -> int:
@@ -221,6 +266,15 @@ def cmd_selftest(args: argparse.Namespace) -> int:
         print("[guard-reachability selftest] FAIL")
         print(str(exc))
         return 1
+
+    data_dir = Path(args.data_dir).resolve() if args.data_dir else Path(vnx_paths.resolve_paths()["VNX_DATA_DIR"])
+    try:
+        confirmations = confirmations + run_live_violation_selftest(root, data_dir)
+    except SelfTestFailure as exc:
+        print("[guard-reachability selftest] FAIL")
+        print(str(exc))
+        return 1
+
     print(f"[guard-reachability selftest] PASS ({len(CALIBRATION_CASES)} calibration case(s))")
     for line in confirmations:
         print(f"  {line}")
@@ -241,6 +295,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_audit.set_defaults(func=cmd_audit)
 
     p_selftest = sub.add_parser("selftest", help="re-confirm calibration cases")
+    p_selftest.add_argument("--data-dir", default=None)
     p_selftest.set_defaults(func=cmd_selftest)
 
     args = parser.parse_args(argv)

--- a/scripts/lib/guard_reachability_calibration.py
+++ b/scripts/lib/guard_reachability_calibration.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""guard_reachability_calibration.py — the detector's own tripwire.
+
+golf-4's valkuil #4: a detector whose positive signal depends on a field
+that is itself never filled will report a permanently clean "0 findings" and
+nobody will notice it stopped working. The fix is the same shape as the bug
+it hunts: a condition (here, ``run_selftest`` passing) must be shown to
+depend on something that actually varies.
+
+``CALIBRATION_CASES`` freezes ONE real, historical instance of the bug class
+(OI-1632 / #1774, 2026-09-05): before that fix, ``stage_spec_bundle()`` never
+accepted a ``track_id`` parameter, so ``spec.track_id`` was always ``None``
+for every bridge-staged dispatch and the plan-gate enforcement guard in
+``dispatch_cli._check_track_link_verdict`` could never take its blocking
+branch (measured: 0 of 681 non-deliverable dispatch rows had a track). The
+fix landed on main, so the LIVE repo no longer reproduces the bug — which is
+exactly why the self-test cannot just re-run the scanner against the current
+tree. Instead it fetches the real PRE-FIX source straight from git history
+(never retyped, so it cannot silently drift from what the bug actually was)
+and re-runs the scanner against that frozen snapshot.
+
+``run_selftest`` fails loud, not quiet, when:
+  1. the scanner no longer finds a guard on the calibration field in the
+     frozen historical source (a scanner regression), or
+  2. the calibration field has been added to ``ACCEPTED_GAPS`` (a confirmed
+     historical bug can never legitimately become a "designed" gap — if this
+     fires, someone used the escape hatch to launder a real defect).
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+from guard_reachability_scanner import find_guarded_field_refs
+
+# fix(dispatch): stage_spec_bundle draagt geen track_id, dus geen enkele
+# dispatch heeft een track (OI-1632) (#1774) — merged into main 2026-09-05.
+PRE_FIX_COMMIT = "ee818845"
+PRE_FIX_FILE = "scripts/lib/dispatch_cli.py"
+PRE_FIX_FUNCTION = "_check_track_link_verdict"
+
+
+@dataclass(frozen=True)
+class CalibrationCase:
+    name: str
+    field: str
+    pre_fix_commit: str
+    pre_fix_file: str
+    pre_fix_function: str
+    description: str
+
+
+CALIBRATION_CASES: Tuple[CalibrationCase, ...] = (
+    CalibrationCase(
+        name="OI-1632-track_id",
+        field="track_id",
+        pre_fix_commit=PRE_FIX_COMMIT,
+        pre_fix_file=PRE_FIX_FILE,
+        pre_fix_function=PRE_FIX_FUNCTION,
+        description=(
+            "stage_spec_bundle() never accepted track_id, so spec.track_id "
+            "was always None for every bridge-staged dispatch (0 of 681 "
+            "non-deliverable rows had a track); the plan-gate enforcement "
+            "guard in _check_track_link_verdict could never take its "
+            "blocking branch. Fixed in ee818845 (#1774, 2026-09-05)."
+        ),
+    ),
+)
+
+
+class CalibrationFetchError(RuntimeError):
+    pass
+
+
+class SelfTestFailure(RuntimeError):
+    pass
+
+
+def fetch_pre_fix_function_source(root: Path, case: CalibrationCase) -> str:
+    """The REAL historical guard source, read from git — never retyped.
+
+    Fetches the full pre-fix file via ``git show <commit>^:<path>`` (the
+    parent of the fix commit, i.e. the last commit BEFORE the fix) and
+    extracts only ``case.pre_fix_function`` via ``ast`` so the fixture stays
+    small and unambiguously tied to the exact function the bug lived in.
+    """
+    ref = f"{case.pre_fix_commit}^:{case.pre_fix_file}"
+    try:
+        result = subprocess.run(
+            ["git", "show", ref],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise CalibrationFetchError(f"git show {ref} failed to run: {exc}") from exc
+    if result.returncode != 0:
+        raise CalibrationFetchError(
+            f"git show {ref} exited {result.returncode}: {result.stderr.strip()}"
+        )
+    full_source = result.stdout
+    try:
+        tree = ast.parse(full_source, filename=case.pre_fix_file)
+    except SyntaxError as exc:
+        raise CalibrationFetchError(f"pre-fix {case.pre_fix_file} did not parse: {exc}") from exc
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == case.pre_fix_function:
+            segment = ast.get_source_segment(full_source, node)
+            if segment:
+                return segment
+    raise CalibrationFetchError(
+        f"{case.pre_fix_function} not found in pre-fix {case.pre_fix_file} at {ref}"
+    )
+
+
+def run_selftest(root: Path, accepted_gap_fields: frozenset) -> List[str]:
+    """Re-confirm every calibration case; raise :class:`SelfTestFailure` on
+    ANY regression. Returns the list of per-case confirmation strings on
+    success (for a human-readable ``selftest`` CLI report).
+    """
+    confirmations: List[str] = []
+    failures: List[str] = []
+
+    for case in CALIBRATION_CASES:
+        if case.field in accepted_gap_fields:
+            failures.append(
+                f"{case.name}: field {case.field!r} is a CONFIRMED historical "
+                "bug (see description below) but appears in ACCEPTED_GAPS — a "
+                "real defect must never be marked as a deliberate, designed "
+                "gap.\n    " + case.description
+            )
+            continue
+        try:
+            source = fetch_pre_fix_function_source(root, case)
+        except CalibrationFetchError as exc:
+            failures.append(f"{case.name}: could not fetch calibration source: {exc}")
+            continue
+        refs = find_guarded_field_refs(
+            source, case.pre_fix_file, known_attr_fields={case.field},
+        )
+        matches = [r for r in refs if r.field == case.field]
+        if not matches:
+            failures.append(
+                f"{case.name}: scanner found ZERO guards on field "
+                f"{case.field!r} in the known-broken historical source "
+                f"({case.pre_fix_commit}^:{case.pre_fix_file}:{case.pre_fix_function}) "
+                "— this is a detector regression. Do not trust a clean audit "
+                "report until this is fixed."
+            )
+            continue
+        confirmations.append(
+            f"{case.name}: found {len(matches)} guard(s) on field "
+            f"{case.field!r} in the frozen pre-fix source — OK"
+        )
+
+    if not confirmations and not failures:
+        # Cannot happen while CALIBRATION_CASES is non-empty, but an empty
+        # CALIBRATION_CASES tuple must never read as "self-test passed" —
+        # zero known cases confirmed is itself the failure this guards
+        # against (valkuil #4).
+        failures.append("CALIBRATION_CASES is empty — self-test cannot confirm anything")
+
+    if failures:
+        raise SelfTestFailure("\n".join(failures))
+    return confirmations

--- a/scripts/lib/guard_reachability_registry.py
+++ b/scripts/lib/guard_reachability_registry.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""guard_reachability_registry.py — the ONE place a guarded field is mapped
+to a real store, and the ONE place a zero-fill/missing-column finding may be
+marked as a deliberate, reviewed design choice instead of a defect.
+
+Why this file exists instead of a comment at the call site: golf-4
+(2026-09-05) found that three of the eight discovered defects were already
+written down — as a "Caveat" in ``docs/core/DISPATCH_RULES.md`` or as "an
+accepted, intentional no-op" in a module docstring — and that is exactly what
+kept them invisible. A prose note near the code is not consulted by the
+detector and carries no reviewer signal that it was a DECISION rather than an
+unnoticed gap. Every entry below is the opposite: machine-read by
+``guard_reachability_audit.py``, and ``validate_registry()`` refuses to load
+an ``ACCEPTED_GAPS`` entry that has no reason.
+
+Two registries:
+
+- ``FIELD_STORE_MAP`` — which real store backs a field the scanner found in a
+  guard. A field the scanner finds with NO entry here is reported separately
+  as "unmeasured" (informational, not a violation) — most guard fields in
+  this repo are unrelated to this bug class (feature flags, env toggles,
+  ordinary optional config), and only a curated subset is worth measuring
+  against a store at all.
+- ``ACCEPTED_GAPS`` — a field (optionally scoped to one file) whose
+  zero-fill or missing-column finding is a REVIEWED, DELIBERATE design
+  choice, not a defect. Every entry requires a non-empty ``reason``,
+  ``decided_by``, and ``decided_on``.
+
+A calibration case (``guard_reachability_calibration.py``) must NEVER appear
+in ``ACCEPTED_GAPS`` — that module's self-test enforces this directly: a
+confirmed historical bug that gets "explained away" here is the exact
+Caveat-pattern this detector was built to stop laundering.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class StoreTarget:
+    """One real store to measure a field's fill rate against."""
+
+    kind: str  # "sqlite" | "ndjson" | "json_dir"
+    note: str
+    # sqlite
+    db_relpath: Optional[str] = None
+    table: Optional[str] = None
+    column: Optional[str] = None
+    # ndjson (relative to the data root; multiple ledgers may share a field)
+    ndjson_relpaths: Tuple[str, ...] = ()
+    # json_dir (a directory of one-JSON-document-per-file records)
+    dir_relpath: Optional[str] = None
+    glob: str = "*.json"
+    # dict key to probe for ndjson/json_dir stores, when it differs from the
+    # FieldMapping's own field name (mirrors sqlite's separate `column`).
+    # None means "use the mapping's field name unchanged".
+    dict_key: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.kind == "sqlite":
+            if not (self.db_relpath and self.table and self.column):
+                raise ValueError(f"sqlite StoreTarget missing db_relpath/table/column: {self!r}")
+        elif self.kind == "ndjson":
+            if not self.ndjson_relpaths:
+                raise ValueError(f"ndjson StoreTarget has no ndjson_relpaths: {self!r}")
+        elif self.kind == "json_dir":
+            if not self.dir_relpath:
+                raise ValueError(f"json_dir StoreTarget missing dir_relpath: {self!r}")
+        else:
+            raise ValueError(f"unknown StoreTarget.kind={self.kind!r}")
+
+
+@dataclass(frozen=True)
+class FieldMapping:
+    field: str
+    targets: Tuple[StoreTarget, ...]
+    note: str
+
+
+# Curated, reviewed mappings from a field the scanner can find in a guard to
+# the real store that would prove whether it is ever filled. Extending this
+# list is the expected way to bring a new guarded field under measurement —
+# NOT adding a comment near the guard.
+FIELD_STORE_MAP: Tuple[FieldMapping, ...] = (
+    FieldMapping(
+        field="track_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite",
+                db_relpath="state/runtime_coordination.db",
+                table="dispatches",
+                column="track",
+                note=(
+                    "OI-1632 (#1774, 2026-09-05): registration writes "
+                    "dispatches.track; a nonexistent dispatches.track_id "
+                    "column was the pre-fix bug. Reads THIS column, not "
+                    "track_id, on purpose — see dispatch_cli.py:_persist_track_id."
+                ),
+            ),
+        ),
+        note=(
+            "spec.track_id (DispatchSpec) gates the plan-first-gate "
+            "enforcement branch in dispatch_cli._check_track_link_verdict. "
+            "VNX_REQUIRE_DISPATCH_TRACK defaults OFF, so a nonzero-but-partial "
+            "fill rate is the designed advisory state, not a defect — only "
+            "an EXACT zero (the pre-#1774 state) is flagged."
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class AcceptedGap:
+    """A reviewed, deliberate exception to a zero-fill/missing-column finding.
+
+    ``file`` scopes the exception to one guard site (repo-relative path);
+    ``None`` accepts the field's finding wherever it is found. Every field
+    here MUST also still resolve through ``FIELD_STORE_MAP`` — an accepted
+    gap does not remove the measurement, it only changes how the audit
+    reports it (SUPPRESSED with the reason shown, never silently dropped).
+    """
+
+    field: str
+    reason: str
+    decided_by: str
+    decided_on: str
+    file: Optional[str] = None
+
+
+# Empty by design: golf-4's finding was that EVERY zero-fill guard found so
+# far turned out to be a genuine defect, not a deliberate choice. An entry
+# only belongs here after a human has reviewed a specific zero-fill finding
+# and decided it is intentional — never added pre-emptively to keep an audit
+# run green.
+ACCEPTED_GAPS: Tuple[AcceptedGap, ...] = ()
+
+
+def validate_registry() -> None:
+    """Fail loud on a malformed registry — called before every audit run.
+
+    A ``StoreTarget`` already validates its own shape in ``__post_init__``;
+    this validates the registry-level invariants: no duplicate field
+    mappings, and no ``ACCEPTED_GAPS`` entry with an empty/whitespace reason
+    (the whole point of this module is that a reason is mandatory and
+    reviewable — an empty string is the same failure mode as a doc-comment
+    nobody reads).
+    """
+    seen_fields = set()
+    for mapping in FIELD_STORE_MAP:
+        if not mapping.field or not mapping.field.strip():
+            raise ValueError("FIELD_STORE_MAP entry with empty field name")
+        if mapping.field in seen_fields:
+            raise ValueError(f"duplicate FIELD_STORE_MAP entry for field={mapping.field!r}")
+        seen_fields.add(mapping.field)
+        if not mapping.targets:
+            raise ValueError(f"FIELD_STORE_MAP entry for field={mapping.field!r} has no targets")
+
+    for gap in ACCEPTED_GAPS:
+        if not gap.field or not gap.field.strip():
+            raise ValueError("ACCEPTED_GAPS entry with empty field name")
+        if not gap.reason or not gap.reason.strip():
+            raise ValueError(
+                f"ACCEPTED_GAPS entry for field={gap.field!r} has an empty reason — "
+                "every accepted gap MUST carry a machine-readable reason; a "
+                "docstring 'Caveat' or 'accepted, intentional no-op' elsewhere "
+                "does not count (2026-09-05 golf-4 finding)"
+            )
+        if not gap.decided_by or not gap.decided_by.strip():
+            raise ValueError(f"ACCEPTED_GAPS entry for field={gap.field!r} missing decided_by")
+        if not gap.decided_on or not gap.decided_on.strip():
+            raise ValueError(f"ACCEPTED_GAPS entry for field={gap.field!r} missing decided_on")

--- a/scripts/lib/guard_reachability_registry.py
+++ b/scripts/lib/guard_reachability_registry.py
@@ -82,32 +82,112 @@ class FieldMapping:
 # the real store that would prove whether it is ever filled. Extending this
 # list is the expected way to bring a new guarded field under measurement —
 # NOT adding a comment near the guard.
+#
+# EXPLICIT RULE (golf-4 ronde 2 / OI-1640, 2026-09-06): a field may carry
+# MORE THAN ONE StoreTarget, and each is measured and reported
+# INDEPENDENTLY (see ``build_findings`` — one ``FieldFinding`` per target).
+# When a field has several targets, the one the GUARD ITSELF READS is
+# authoritative for "is this guard reachable" and MUST be a target here —
+# a downstream store that something else WRITES after the guard already
+# ran (a persisted column, a derived ledger) may also be listed, but its
+# note must say so explicitly, and a healthy fill rate on it is NOT
+# evidence the guard is reachable. golf-4r2's own finding was the registry
+# doing exactly that: mapping ``track_id`` ONLY against the sqlite column
+# ``_persist_track_id`` writes downstream, never against the staged
+# ``dispatch-spec.json`` both ``_check_track_link_verdict`` (the door's
+# guard, dispatch_cli.py:1030) and ``_persist_track_id`` itself
+# (dispatch_cli.py:1423) actually read — a partially-filled downstream
+# column reported a clean [OK] on the exact case this detector exists to
+# catch (0 of 1115 staged specs had a track_id, measured 2026-09-06).
 FIELD_STORE_MAP: Tuple[FieldMapping, ...] = (
     FieldMapping(
         field="track_id",
         targets=(
+            StoreTarget(
+                kind="json_dir",
+                dir_relpath="dispatches",
+                glob="dispatch-spec.json",
+                note=(
+                    "AUTHORITATIVE for guard reachability: this is what both "
+                    "guard sites actually read — dispatch_cli.py:1030 "
+                    "(_check_track_link_verdict, 'if track_id:' on the local "
+                    "assigned from spec.track_id) and dispatch_cli.py:1423 "
+                    "(_persist_track_id, 'if not track_id: return'). Measured "
+                    "2026-09-06: 0 of 1115 staged dispatch-spec.json bundles "
+                    "had a track_id — OI-1640."
+                ),
+            ),
             StoreTarget(
                 kind="sqlite",
                 db_relpath="state/runtime_coordination.db",
                 table="dispatches",
                 column="track",
                 note=(
-                    "OI-1632 (#1774, 2026-09-05): registration writes "
-                    "dispatches.track; a nonexistent dispatches.track_id "
-                    "column was the pre-fix bug. Reads THIS column, not "
-                    "track_id, on purpose — see dispatch_cli.py:_persist_track_id."
+                    "DOWNSTREAM PERSISTENCE ONLY, not guard reachability: "
+                    "OI-1632 (#1774, 2026-09-05) fixed registration to write "
+                    "dispatches.track; _persist_track_id (dispatch_cli.py) "
+                    "UPDATEs this SAME column after the door's guard has "
+                    "already run. A nonzero fill rate here only proves "
+                    "_persist_track_id executed on a row that already had a "
+                    "track_id — it says nothing about whether the guard's "
+                    "OWN read of spec.track_id (the json_dir target above) "
+                    "is ever reachable. golf-4r2 (OI-1640, 2026-09-06): this "
+                    "column alone being partially filled (122/815) is what "
+                    "let a genuine zero-fill guard-source (0/1115, above) "
+                    "report a false [OK] — never read this target's rate as "
+                    "an answer to 'can the guard fire'."
                 ),
             ),
         ),
         note=(
             "spec.track_id (DispatchSpec) gates the plan-first-gate "
-            "enforcement branch in dispatch_cli._check_track_link_verdict. "
+            "enforcement branch in dispatch_cli._check_track_link_verdict, "
+            "and the persistence early-return in _persist_track_id. "
             "VNX_REQUIRE_DISPATCH_TRACK defaults OFF, so a nonzero-but-partial "
-            "fill rate is the designed advisory state, not a defect — only "
-            "an EXACT zero (the pre-#1774 state) is flagged."
+            "fill rate on the json_dir target is the designed advisory "
+            "state, not a defect — only an EXACT zero is flagged. The "
+            "sqlite target is informational only (see its own note)."
+        ),
+    ),
+    FieldMapping(
+        field="post_merge_verification",
+        targets=(
+            StoreTarget(
+                kind="json_dir",
+                dir_relpath="dispatches",
+                glob="dispatch-spec.json",
+                note=(
+                    "AUTHORITATIVE for guard reachability: dispatch_cli.py:2209 "
+                    "reads spec.post_merge_verification directly ('and "
+                    "spec.post_merge_verification:'), no local-var indirection. "
+                    "Measured 2026-09-06: every staged spec that carries this "
+                    "key (365 of 1116) carries it as the literal value False — "
+                    "OI-1639, a second, independent instance of the golf-4 "
+                    "unreachable-guard shape, found in the same ronde as "
+                    "OI-1640 above and deliberately NOT fixed by this dispatch "
+                    "(see the dispatch report's Open Items)."
+                ),
+            ),
+        ),
+        note=(
+            "spec.post_merge_verification (DispatchSpec) gates the "
+            "checkout-lag verification-reminder verdict in "
+            "run_dispatch (dispatch_cli.py:2209) — a truthy bool test, no "
+            "indirection. No caller in the repo sets it True on a staged "
+            "bundle (grep dispatch_bridge.py / the stage_spec_bundle CLI), "
+            "so that branch is currently unreachable in practice (OI-1639, "
+            "tracked separately from this dispatch's OI-1640 fix)."
         ),
     ),
 )
+
+# golf-4r2 (2026-09-06): "1364 unmeasured fields" is not itself a defect —
+# most guard fields in this repo are unrelated to this bug class — but it
+# must never SILENTLY become "0 mapped fields" (a registry that lost every
+# entry would report a permanently clean audit and nobody would notice,
+# the exact valkuil this whole detector exists to close). Bump this only
+# after actually adding a reviewed entry above, never to make room for one.
+MIN_MAPPED_FIELDS = 2
 
 
 @dataclass(frozen=True)
@@ -141,11 +221,21 @@ def validate_registry() -> None:
 
     A ``StoreTarget`` already validates its own shape in ``__post_init__``;
     this validates the registry-level invariants: no duplicate field
-    mappings, and no ``ACCEPTED_GAPS`` entry with an empty/whitespace reason
+    mappings, no ``ACCEPTED_GAPS`` entry with an empty/whitespace reason
     (the whole point of this module is that a reason is mandatory and
     reviewable — an empty string is the same failure mode as a doc-comment
-    nobody reads).
+    nobody reads), and the mapped-field count never silently drops below
+    ``MIN_MAPPED_FIELDS`` (golf-4r2: a registry that lost every entry would
+    report a permanently clean audit and look identical to "nothing to fix").
     """
+    if len(FIELD_STORE_MAP) < MIN_MAPPED_FIELDS:
+        raise ValueError(
+            f"FIELD_STORE_MAP has {len(FIELD_STORE_MAP)} entr(y/ies), below "
+            f"MIN_MAPPED_FIELDS={MIN_MAPPED_FIELDS} — a mapped-field count "
+            "silently dropping is indistinguishable from the registry "
+            "losing coverage, not from there being nothing left to map "
+            "(golf-4r2, 2026-09-06)"
+        )
     seen_fields = set()
     for mapping in FIELD_STORE_MAP:
         if not mapping.field or not mapping.field.strip():

--- a/scripts/lib/guard_reachability_scanner.py
+++ b/scripts/lib/guard_reachability_scanner.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""guard_reachability_scanner.py — AST scanner for field-presence guards.
+
+Golf-4 (2026-09-05) surfaced eight unrelated defects sharing one shape: a
+guard condition (an ``if`` that gates a raise/return/skip or a gate decision)
+reads a field, column, or spec attribute that in practice is never filled.
+The code is correct. The branch it protects is unreachable. Nothing fails, so
+nothing alerts — three of the eight cases were already written down as a
+"Caveat" or "accepted, intentional no-op" and that is exactly what kept them
+invisible: a documented limitation reads as an accepted boundary, not as a
+defect with a measurable consequence.
+
+This module is the STATIC half of the detector: given Python source, find
+every ``if`` whose test expression probes a named field via ``dict.get(str)``,
+``obj[str]``, or ``obj.attr`` (attribute access is only counted when the
+attribute name is a field of some ``@dataclass`` discovered in the scanned
+tree(s) — see :func:`collect_dataclass_fields` — otherwise every ``self.foo``
+in the repo would match). The MEASURE half
+(``guard_reachability_store.py``) answers whether that field is ever actually
+filled in a real store; only the combination tells you whether a guard is
+reachable in practice — this module alone only tells you a guard EXISTS.
+
+Deliberately out of scope (documented, not silently dropped): SQL literals
+passed to ``cursor.execute()`` that reference a column only inside the query
+string are not parsed here. A generic SQL-column extractor was drafted during
+golf-4 and cut for precision: this codebase's own ``_has_col(conn, table,
+col)`` helper (12 call sites) already guards most such reads defensively, and
+conflating a defensive existence-check with the unreachable-guard bug class
+it was written to prevent produces exactly the false-positive noise this
+detector must not add. Tracked as follow-up scope, not fixed here.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+DEFAULT_SCAN_DIRS: Tuple[str, ...] = ("scripts/lib", "scripts")
+
+
+@dataclass(frozen=True)
+class GuardedFieldRef:
+    """One field-presence probe found inside an ``if`` test expression."""
+
+    file: str
+    lineno: int
+    field: str
+    access_kind: str  # "dict_get" | "subscript" | "attribute"
+    container: str
+    enclosing_function: Optional[str]
+    test_source: str
+
+
+def _has_dataclass_decorator(node: ast.ClassDef) -> bool:
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(target, ast.Name) and target.id == "dataclass":
+            return True
+        if isinstance(target, ast.Attribute) and target.attr == "dataclass":
+            return True
+    return False
+
+
+def collect_dataclass_fields(tree: ast.AST) -> Set[str]:
+    """Field names of every ``@dataclass``-decorated class in ``tree``.
+
+    Used to qualify ``obj.attr`` guard probes: a bare attribute name is far
+    too noisy to treat as a "field" on its own (every ``self.foo`` and
+    ``logger.info`` reference is an ``ast.Attribute``), but a name that is
+    also a declared dataclass field — the exact shape ``DispatchSpec.track_id``
+    took in the OI-1632 case — is a genuine candidate.
+    """
+    fields: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or not _has_dataclass_decorator(node):
+            continue
+        for stmt in node.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                fields.add(stmt.target.id)
+    return fields
+
+
+def _slice_value(node: ast.Subscript) -> Optional[ast.AST]:
+    sl = node.slice
+    # Python <3.9 wrapped simple subscripts in ast.Index; 3.9+ (this repo
+    # targets 3.12) exposes the expression directly. Handle both defensively.
+    if sl.__class__.__name__ == "Index":  # pragma: no cover - py<3.9 shape
+        return getattr(sl, "value", None)
+    return sl
+
+
+def _is_string_constant(node: Optional[ast.AST]) -> bool:
+    return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+
+def _safe_unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return "<unparseable>"
+
+
+def _iter_field_probes(
+    test: ast.AST, known_attr_fields: Set[str],
+) -> Iterator[Tuple[ast.AST, str, str, str]]:
+    """Yield (probe_node, field_name, access_kind, container_repr) for every
+    field-presence probe anywhere inside ``test`` (``ast.walk`` already
+    descends through ``not``/``and``/``or``/comparison wrappers, so
+    ``if not spec.get("x"):`` and ``if spec.get("x") is None:`` both match
+    without extra handling).
+    """
+    for node in ast.walk(test):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and _is_string_constant(node.args[0])
+        ):
+            yield node, node.args[0].value, "dict_get", _safe_unparse(node.func.value)
+            continue
+        if isinstance(node, ast.Subscript):
+            sv = _slice_value(node)
+            if _is_string_constant(sv):
+                yield node, sv.value, "subscript", _safe_unparse(node.value)
+            continue
+        if isinstance(node, ast.Attribute) and node.attr in known_attr_fields:
+            yield node, node.attr, "attribute", _safe_unparse(node.value)
+
+
+_SCOPE_BOUNDARY_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+
+
+def _direct_statements(node: ast.AST) -> Iterator[ast.stmt]:
+    """Statements reachable by normal control flow inside ONE function scope.
+
+    Descends into ``if``/``for``/``while``/``try``/``with`` bodies (an
+    assignment made in a sibling branch is still visible later in the same
+    function) but never into a nested function/class/lambda — those open
+    their own local scope, and a same-named local there must not be confused
+    with the enclosing function's variable.
+    """
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+        stmts: List[ast.stmt] = list(node.body)
+    elif isinstance(node, (ast.If, ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith)):
+        stmts = list(node.body) + list(getattr(node, "orelse", []))
+    elif isinstance(node, ast.Try):
+        stmts = list(node.body) + list(node.orelse) + list(node.finalbody)
+        for handler in node.handlers:
+            stmts += list(handler.body)
+    else:
+        stmts = []
+    for stmt in stmts:
+        yield stmt
+        if not isinstance(stmt, _SCOPE_BOUNDARY_TYPES):
+            yield from _direct_statements(stmt)
+
+
+def _local_field_assignments(
+    func_node: ast.AST, known_attr_fields: Set[str],
+) -> Dict[str, List[Tuple[str, str, str]]]:
+    """Map ``var_name -> [(field, kind, container), ...]`` for every simple
+    local assignment in ``func_node`` whose right-hand side contains a field
+    probe — the ``track_id = (spec.track_id or "").strip()`` shape from the
+    OI-1632 calibration case, where the guard later tests the bare local
+    name (``if track_id:``), not the attribute access itself.
+    """
+    mapping: Dict[str, List[Tuple[str, str, str]]] = {}
+    for stmt in _direct_statements(func_node):
+        target: Optional[str] = None
+        value: Optional[ast.AST] = None
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+            target, value = stmt.targets[0].id, stmt.value
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name) and stmt.value is not None:
+            target, value = stmt.target.id, stmt.value
+        if target is None or value is None:
+            continue
+        for _node, field, kind, container in _iter_field_probes(value, known_attr_fields):
+            mapping.setdefault(target, []).append((field, kind, container))
+    return mapping
+
+
+def find_guarded_field_refs(
+    source: str,
+    filename: str,
+    known_attr_fields: Set[str] = frozenset(),
+) -> List[GuardedFieldRef]:
+    """Every field-presence guard in ``source``, keyed by (line, field, kind).
+
+    Matches two shapes:
+      1. the field probe sits directly in the ``if`` test
+         (``if spec.get("track_id"):``);
+      2. the probe sits in an assignment, and the ``if`` test later gates on
+         the bare local name (``track_id = (spec.track_id or "").strip()``
+         ... ``if track_id:``) — the ACTUAL shape of the OI-1632 calibration
+         case. Resolved per-function via :func:`_local_field_assignments`,
+         never across function boundaries.
+
+    Scoped to the guarding ``if`` itself, not what its branches do — the
+    condition is the guard; what the branches do with it varies too much
+    across the eight known cases to use as a reliable shape signal (requiring
+    e.g. a ``raise``/``return`` in the body false-negatives on the
+    calibration case: ``_check_track_link_verdict`` returns a Verdict on
+    every branch, guarded or not).
+    """
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return []
+
+    refs: List[GuardedFieldRef] = []
+    seen: Set[Tuple[int, str, str]] = set()
+    func_stack: List[str] = []
+    scope_stack: List[Dict[str, List[Tuple[str, str, str]]]] = []
+
+    def _emit(lineno: int, field: str, kind: str, container: str, test_source: str) -> None:
+        key = (lineno, field, kind)
+        if key in seen:
+            return
+        seen.add(key)
+        refs.append(
+            GuardedFieldRef(
+                file=filename,
+                lineno=lineno,
+                field=field,
+                access_kind=kind,
+                container=container,
+                enclosing_function=func_stack[-1] if func_stack else None,
+                test_source=test_source,
+            )
+        )
+
+    class _Visitor(ast.NodeVisitor):
+        def _enter_function(self, node: ast.AST) -> None:
+            func_stack.append(getattr(node, "name", "<lambda>"))
+            scope_stack.append(_local_field_assignments(node, known_attr_fields))
+            self.generic_visit(node)
+            scope_stack.pop()
+            func_stack.pop()
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+            self._enter_function(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+            self._enter_function(node)
+
+        def visit_If(self, node: ast.If) -> None:  # noqa: N802
+            test_source = _safe_unparse(node.test)
+            for probe_node, field, kind, container in _iter_field_probes(
+                node.test, known_attr_fields,
+            ):
+                _emit(getattr(probe_node, "lineno", node.lineno), field, kind, container, test_source)
+
+            scope = scope_stack[-1] if scope_stack else {}
+            resolved_names: Set[str] = set()
+            for name_node in ast.walk(node.test):
+                if not isinstance(name_node, ast.Name) or name_node.id not in scope:
+                    continue
+                if name_node.id in resolved_names:
+                    continue
+                resolved_names.add(name_node.id)
+                for field, kind, container in scope[name_node.id]:
+                    _emit(
+                        name_node.lineno, field, kind,
+                        f"{container} (via local {name_node.id!r})", test_source,
+                    )
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return refs
+
+
+def iter_scan_files(root: Path, scan_dirs: Tuple[str, ...] = DEFAULT_SCAN_DIRS) -> List[Path]:
+    files: List[Path] = []
+    for d in scan_dirs:
+        base = root / d
+        if not base.is_dir():
+            continue
+        # "scripts" itself is scanned shallow (top-level entry points only);
+        # "scripts/lib" is scanned recursively (it has its own subpackages,
+        # e.g. scripts/lib/append_receipt_internals/, scripts/lib/providers/).
+        candidates = base.rglob("*.py") if d.endswith("lib") else base.glob("*.py")
+        files.extend(sorted(candidates))
+    return files
+
+
+def scan_repo_guarded_fields(
+    root: Path, scan_dirs: Tuple[str, ...] = DEFAULT_SCAN_DIRS,
+) -> List[GuardedFieldRef]:
+    """Two-pass repo scan: collect dataclass fields fleet-wide first (a field
+    like ``DispatchSpec.track_id`` is declared in ``dispatch_spec.py`` but
+    read as a guard in ``dispatch_cli.py`` — a single-file pass would miss
+    the attribute-guard shape entirely), then scan every file for guards
+    qualified against that merged field set.
+    """
+    files = iter_scan_files(root, scan_dirs)
+    sources: Dict[Path, str] = {}
+    known_fields: Set[str] = set()
+    for f in files:
+        try:
+            src = f.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        sources[f] = src
+        try:
+            tree = ast.parse(src, filename=str(f))
+        except SyntaxError:
+            continue
+        known_fields |= collect_dataclass_fields(tree)
+
+    refs: List[GuardedFieldRef] = []
+    for f, src in sources.items():
+        rel = f.relative_to(root).as_posix()
+        refs.extend(find_guarded_field_refs(src, rel, known_fields))
+    return refs

--- a/scripts/lib/guard_reachability_store.py
+++ b/scripts/lib/guard_reachability_store.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""guard_reachability_store.py — fill-rate measurement against a real store.
+
+The MEASURE half of the golf-4 unreachable-guard detector
+(``guard_reachability_scanner.py`` is the static half). A guard that reads a
+field is only a defect if that field is, in practice, never filled — this
+module answers that question against three store shapes actually used in
+this repo: an NDJSON ledger (the receipt grootboek), a SQLite table+column
+(``runtime_coordination.db``), or a directory of per-dispatch JSON documents
+(staged ``dispatch-spec.json`` bundles).
+
+A missing SQLite column is reported as its own state (``exists=False``), not
+folded into "zero filled" — the PRD is explicit that these are the two
+distinct, separately-reportable strengths of evidence: a column that never
+existed is the stronger case.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class FillRate:
+    """One field's measured presence in a real store.
+
+    ``exists=False`` means the backing column/table was not found at all
+    (the strongest defect signal). ``exists=True, total=0`` means the store
+    was reachable but had no rows to measure (inconclusive, not a violation —
+    an empty ledger is not evidence of an unreachable guard).
+    """
+
+    exists: bool
+    total: int
+    filled: int
+
+    @property
+    def fill_pct(self) -> float:
+        if self.total == 0:
+            return 0.0
+        return 100.0 * self.filled / self.total
+
+    @property
+    def is_zero_fill(self) -> bool:
+        """True only when the store was measurable and EVERY row was empty.
+
+        Deliberately excludes ``total == 0`` (nothing to measure is not the
+        same claim as "measured N rows, all empty") and deliberately excludes
+        any nonzero fill, however small — a 2% fill rate is a design/adoption
+        question, not the "structurally cannot fire" defect this detector
+        targets (see percentage-over-een-gemengde-populatie-meet-de-mengverhouding:
+        a nonzero rate can still be the wrong number for other reasons, but
+        it is not this bug class).
+        """
+        return self.exists and self.total > 0 and self.filled == 0
+
+
+def _is_filled(value: object) -> bool:
+    return value not in (None, "", [], {})
+
+
+def measure_ndjson_fill_rate(paths: Sequence[Path], field: str) -> FillRate:
+    total = 0
+    filled = 0
+    for p in paths:
+        if not p.exists():
+            continue
+        with p.open("r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                total += 1
+                if field in rec and _is_filled(rec[field]):
+                    filled += 1
+    return FillRate(exists=True, total=total, filled=filled)
+
+
+def measure_json_dir_fill_rate(dirpath: Path, glob: str, field: str) -> FillRate:
+    total = 0
+    filled = 0
+    if dirpath.is_dir():
+        for p in sorted(dirpath.rglob(glob)):
+            try:
+                rec = json.loads(p.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(rec, dict):
+                continue
+            total += 1
+            if field in rec and _is_filled(rec[field]):
+                filled += 1
+    return FillRate(exists=True, total=total, filled=filled)
+
+
+def measure_sqlite_column_fill_rate(db_path: Path, table: str, column: str) -> FillRate:
+    if not (_IDENTIFIER_RE.match(table) and _IDENTIFIER_RE.match(column)):
+        raise ValueError(f"unsafe identifier: table={table!r} column={column!r}")
+    if not db_path.exists():
+        return FillRate(exists=False, total=0, filled=0)
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
+    except sqlite3.Error:
+        return FillRate(exists=False, total=0, filled=0)
+    try:
+        cols = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        if column not in cols:
+            return FillRate(exists=False, total=0, filled=0)
+        total, filled = conn.execute(
+            f"SELECT COUNT(*), COUNT({column}) FROM {table}"
+        ).fetchone()
+        return FillRate(exists=True, total=int(total), filled=int(filled))
+    finally:
+        conn.close()

--- a/scripts/lib/guard_reachability_store.py
+++ b/scripts/lib/guard_reachability_store.py
@@ -62,7 +62,23 @@ class FillRate:
 
 
 def _is_filled(value: object) -> bool:
-    return value not in (None, "", [], {})
+    """True when a guard's truthy test on this value would actually pass.
+
+    golf-4r2 (2026-09-06): the previous check (``value not in (None, "", [],
+    {})``) treated ``False`` and ``0`` as "filled" — they are not in that
+    tuple, since ``False == 0`` and neither equals ``None``/``""``/``[]``/
+    ``{}``. Every one of the real repo's staged specs carries
+    ``post_merge_verification: False`` (measured 2026-09-06, 365 of 365);
+    the guard at ``dispatch_cli.py:2209`` is a plain truthy test
+    (``and spec.post_merge_verification:``), so a stored ``False`` means
+    that guard can never fire — exactly the unreachable-guard shape this
+    detector exists to catch. The old check would have reported all 365 as
+    "filled" and printed a false [OK], the same laundering this ronde
+    exists to close on ``track_id``. Plain ``bool()`` already treats
+    ``""``/``[]``/``{}``/``None`` as falsy, so this is a strict fix, not a
+    behavior change for the string/collection fields already mapped.
+    """
+    return bool(value)
 
 
 def measure_ndjson_fill_rate(paths: Sequence[Path], field: str) -> FillRate:

--- a/tests/test_guard_reachability_audit.py
+++ b/tests/test_guard_reachability_audit.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Tests for scripts/guard_reachability_audit.py — the CLI that combines the
+scanner + store measurement + registry into an actual audit run.
+
+These are integration tests against a SYNTHETIC repo layout (tmp_path), not
+the real one — the real repo's own audit output is exercised manually (see
+the dispatch report's Verification section for the actual run), because the
+real repo currently surfaces genuine unresolved findings (open items, not
+bugs in this detector) that would make a hardcoded pytest assertion either
+brittle or dishonestly permissive.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+for p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import guard_reachability_audit as audit_cli  # noqa: E402
+import guard_reachability_registry as registry  # noqa: E402
+from guard_reachability_registry import AcceptedGap, FieldMapping, StoreTarget  # noqa: E402
+
+
+def _make_synthetic_repo(tmp_path: Path) -> Path:
+    """A tiny repo with ONE guard shape mirroring OI-1632: a dataclass field
+    read via a local-var indirection, gated in an ``if``."""
+    lib = tmp_path / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "fake_dispatch_cli.py").write_text(
+        "from dataclasses import dataclass\n"
+        "\n"
+        "@dataclass\n"
+        "class FakeSpec:\n"
+        "    dispatch_id: str\n"
+        "    widget_id: str | None = None\n"
+        "\n"
+        "def check_widget_link(spec: FakeSpec):\n"
+        "    widget_id = (spec.widget_id or '').strip()\n"
+        "    if widget_id:\n"
+        "        return 'checked'\n"
+        "    return 'advisory-skip'\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _make_zero_fill_db(tmp_path: Path, *, n: int, filled: int) -> Path:
+    db_path = tmp_path / "state" / "runtime_coordination.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE widgets (widget_id TEXT, linked TEXT)")
+    rows = [(f"w{i}", "X" if i < filled else None) for i in range(n)]
+    conn.executemany("INSERT INTO widgets (widget_id, linked) VALUES (?, ?)", rows)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_build_findings_flags_zero_fill_as_violation(tmp_path, monkeypatch):
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_zero_fill_db(data_dir, n=25, filled=0)
+
+    mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    monkeypatch.setattr(registry, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(registry, "ACCEPTED_GAPS", ())
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", ())
+
+    violations, suppressed, ok, unmeasured = audit_cli.build_findings(root, data_dir)
+    assert len(violations) == 1
+    assert violations[0].field == "widget_id"
+    assert suppressed == []
+    assert ok == []
+
+
+def test_build_findings_reports_ok_when_fill_rate_nonzero(tmp_path, monkeypatch):
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_zero_fill_db(data_dir, n=25, filled=5)
+
+    mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", ())
+
+    violations, suppressed, ok, unmeasured = audit_cli.build_findings(root, data_dir)
+    assert violations == []
+    assert len(ok) == 1
+
+
+def test_build_findings_reports_missing_column_as_violation(tmp_path, monkeypatch):
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_zero_fill_db(data_dir, n=10, filled=10)  # column exists, but wrong name below
+
+    mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="this_column_does_not_exist", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", ())
+
+    violations, suppressed, ok, unmeasured = audit_cli.build_findings(root, data_dir)
+    assert len(violations) == 1
+    assert violations[0].rate.exists is False
+
+
+def test_build_findings_suppresses_with_accepted_gap_but_still_lists_reason(tmp_path, monkeypatch):
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_zero_fill_db(data_dir, n=25, filled=0)
+
+    mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    gap = AcceptedGap(
+        field="widget_id", reason="genuinely optional in this synthetic fixture",
+        decided_by="test", decided_on="2026-09-05",
+    )
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", (gap,))
+
+    violations, suppressed, ok, unmeasured = audit_cli.build_findings(root, data_dir)
+    assert violations == []
+    assert len(suppressed) == 1
+    finding, matched_gap = suppressed[0]
+    assert matched_gap.reason == "genuinely optional in this synthetic fixture"
+
+
+def test_build_findings_puts_unmapped_fields_in_unmeasured_bucket(tmp_path, monkeypatch):
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", ())
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", ())
+
+    violations, suppressed, ok, unmeasured = audit_cli.build_findings(root, data_dir)
+    assert violations == []
+    assert "widget_id" in unmeasured
+
+
+def test_cli_audit_exits_nonzero_on_unsuppressed_violation(tmp_path, monkeypatch, capsys):
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_zero_fill_db(data_dir, n=25, filled=0)
+
+    mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", ())
+
+    rc = audit_cli.main(["--root", str(root), "audit", "--data-dir", str(data_dir)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "VIOLATION" in out
+    assert "widget_id" in out
+
+
+def test_cli_scan_always_exits_zero(tmp_path, capsys):
+    root = _make_synthetic_repo(tmp_path)
+    rc = audit_cli.main(["--root", str(root), "scan"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "widget_id" in out
+
+
+def test_cli_selftest_passes_on_real_repo(capsys):
+    rc = audit_cli.main(["--root", str(VNX_ROOT), "selftest"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "PASS" in out

--- a/tests/test_guard_reachability_audit.py
+++ b/tests/test_guard_reachability_audit.py
@@ -16,6 +16,8 @@ import sqlite3
 import sys
 from pathlib import Path
 
+import pytest
+
 VNX_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = VNX_ROOT / "scripts"
 LIB_DIR = SCRIPTS_DIR / "lib"
@@ -63,6 +65,61 @@ def _make_zero_fill_db(tmp_path: Path, *, n: int, filled: int) -> Path:
     return db_path
 
 
+def test_track_id_violation_surfaces_from_the_staged_spec_not_the_persisted_column(tmp_path):
+    """OI-1640 (golf4 ronde 2), the bug this dispatch fixes.
+
+    Uses the REAL registry (unmonkeypatched) and the REAL scanner against
+    the REAL repo (``VNX_ROOT``) — only the DATA is synthetic, shaped to
+    reproduce the measured split T0 found on 2026-09-06: the persisted
+    ``dispatches.track`` sqlite column partially filled (mirrors the live
+    122/815), the staged ``dispatch-spec.json`` bundles the door's guard
+    (``_check_track_link_verdict`` and ``_persist_track_id``) ACTUALLY read
+    at exact zero (mirrors the live 0/1115).
+
+    Before this dispatch's fix, ``FIELD_STORE_MAP`` mapped ``track_id``
+    ONLY against the sqlite column — a nonzero-but-partial persisted column
+    read as [OK], laundering the real zero-fill guard-source into a clean
+    report. This test fails red against that pre-fix registry (the sqlite
+    target alone is "ok", no violation) and passes once the registry also
+    measures the staged-spec store the guard actually reads.
+    """
+    data_dir = tmp_path / "data"
+    db_path = data_dir / "state" / "runtime_coordination.db"
+    db_path.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE dispatches (dispatch_id TEXT, track TEXT)")
+    conn.executemany(
+        "INSERT INTO dispatches (dispatch_id, track) VALUES (?, ?)",
+        [(f"d{i}", "T1" if i < 3 else None) for i in range(20)],
+    )
+    conn.commit()
+    conn.close()
+
+    specs_dir = data_dir / "dispatches" / "pending"
+    specs_dir.mkdir(parents=True)
+    for i in range(20):
+        one = specs_dir / f"s{i}"
+        one.mkdir()
+        (one / "dispatch-spec.json").write_text(
+            json.dumps({"dispatch_id": f"s{i}"}),  # no track_id key at all — 0 of 20
+            encoding="utf-8",
+        )
+
+    violations, suppressed, ok, unmeasured = audit_cli.build_findings(VNX_ROOT, data_dir)
+
+    track_id_violations = [f for f in violations if f.field == "track_id"]
+    assert track_id_violations, (
+        "track_id must surface as a violation from the staged-spec store "
+        "even though the persisted sqlite column is partially filled — a "
+        "nonzero downstream column does not prove the door's guard is "
+        "reachable, it only proves _persist_track_id ran"
+    )
+    assert any(f.target.kind == "json_dir" for f in track_id_violations)
+    # the sqlite target's own partial fill must still read as ok, not dropped
+    track_id_ok = [f for f in ok if f.field == "track_id"]
+    assert any(f.target.kind == "sqlite" for f in track_id_ok)
+
+
 def test_build_findings_flags_zero_fill_as_violation(tmp_path, monkeypatch):
     root = _make_synthetic_repo(tmp_path)
     data_dir = tmp_path / "data"
@@ -80,6 +137,7 @@ def test_build_findings_flags_zero_fill_as_violation(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(registry, "FIELD_STORE_MAP", (mapping,))
     monkeypatch.setattr(registry, "ACCEPTED_GAPS", ())
+    monkeypatch.setattr(registry, "MIN_MAPPED_FIELDS", 1)
     monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
     monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", ())
 
@@ -214,3 +272,143 @@ def test_cli_selftest_passes_on_real_repo(capsys):
     out = capsys.readouterr().out
     assert rc == 0
     assert "PASS" in out
+
+
+def _make_synthetic_repo_two_fields(tmp_path: Path) -> Path:
+    """Two independent guarded fields, each its own zero-fill-shaped guard —
+    needed to prove one field's ACCEPTED_GAPS suppression does not silently
+    launder the other's violation away (golf4r2 bewijs #3)."""
+    lib = tmp_path / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "fake_dispatch_cli.py").write_text(
+        "from dataclasses import dataclass\n"
+        "\n"
+        "@dataclass\n"
+        "class FakeSpec:\n"
+        "    dispatch_id: str\n"
+        "    widget_id: str | None = None\n"
+        "    gizmo_id: str | None = None\n"
+        "\n"
+        "def check_widget_link(spec: FakeSpec):\n"
+        "    widget_id = (spec.widget_id or '').strip()\n"
+        "    if widget_id:\n"
+        "        return 'checked'\n"
+        "    return 'advisory-skip'\n"
+        "\n"
+        "def check_gizmo_link(spec: FakeSpec):\n"
+        "    gizmo_id = (spec.gizmo_id or '').strip()\n"
+        "    if gizmo_id:\n"
+        "        return 'checked'\n"
+        "    return 'advisory-skip'\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _make_two_zero_fill_tables(tmp_path: Path, *, n: int) -> Path:
+    db_path = tmp_path / "state" / "runtime_coordination.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE widgets (widget_id TEXT, linked TEXT)")
+    conn.execute("CREATE TABLE gizmos (gizmo_id TEXT, linked TEXT)")
+    conn.executemany(
+        "INSERT INTO widgets (widget_id, linked) VALUES (?, NULL)", [(f"w{i}",) for i in range(n)],
+    )
+    conn.executemany(
+        "INSERT INTO gizmos (gizmo_id, linked) VALUES (?, NULL)", [(f"g{i}",) for i in range(n)],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_run_live_violation_selftest_passes_when_a_real_violation_exists(tmp_path, monkeypatch):
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_zero_fill_db(data_dir, n=25, filled=0)
+
+    mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", ())
+
+    lines = audit_cli.run_live_violation_selftest(root, data_dir)
+    assert any("widget_id" in line for line in lines)
+
+
+def test_run_live_violation_selftest_survives_partial_suppression(tmp_path, monkeypatch):
+    """bewijs #3: gapping ONE of two known-bad fields must not launder the
+    whole live-assertion green — the other stays a live violation."""
+    root = _make_synthetic_repo_two_fields(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_two_zero_fill_tables(data_dir, n=25)
+
+    widget_mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    gizmo_mapping = FieldMapping(
+        field="gizmo_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="gizmos", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    gap = AcceptedGap(
+        field="widget_id", reason="suppress only ONE of the two for this test",
+        decided_by="test", decided_on="2026-09-06",
+    )
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (widget_mapping, gizmo_mapping))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", (gap,))
+
+    lines = audit_cli.run_live_violation_selftest(root, data_dir)
+    assert any("gizmo_id" in line for line in lines)
+    assert not any("widget_id" in line for line in lines)
+
+    rc = audit_cli.main(["--root", str(root), "audit", "--data-dir", str(data_dir)])
+    assert rc == 1  # gizmo_id alone keeps the overall audit red
+
+
+def test_run_live_violation_selftest_fails_loud_when_all_known_violations_suppressed(tmp_path, monkeypatch):
+    """'Maak je eigen wachter kapot': suppressing EVERY known violation must
+    make the live-assertion itself fail loud, not report a clean audit."""
+    root = _make_synthetic_repo(tmp_path)
+    data_dir = tmp_path / "data"
+    _make_zero_fill_db(data_dir, n=25, filled=0)
+
+    mapping = FieldMapping(
+        field="widget_id",
+        targets=(
+            StoreTarget(
+                kind="sqlite", db_relpath="state/runtime_coordination.db",
+                table="widgets", column="linked", note="test",
+            ),
+        ),
+        note="test mapping",
+    )
+    gap = AcceptedGap(
+        field="widget_id", reason="suppress the only known violation",
+        decided_by="test", decided_on="2026-09-06",
+    )
+    monkeypatch.setattr(audit_cli, "FIELD_STORE_MAP", (mapping,))
+    monkeypatch.setattr(audit_cli, "ACCEPTED_GAPS", (gap,))
+
+    with pytest.raises(audit_cli.SelfTestFailure, match="ZERO violations"):
+        audit_cli.run_live_violation_selftest(root, data_dir)

--- a/tests/test_guard_reachability_calibration.py
+++ b/tests/test_guard_reachability_calibration.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/guard_reachability_calibration.py — the detector's
+own tripwire (golf-4 valkuil #4: "je detector mag zelf niet in deze klasse
+vallen").
+
+Three things are proven here, matching the dispatch's "bewijs" requirements:
+  1. the self-test PASSES today, against the real repo + the real registry
+     (``test_selftest_passes_on_real_repo``);
+  2. "maak je eigen wachter kapot": adding the calibration field to
+     ACCEPTED_GAPS must make the self-test FAIL loud
+     (``test_selftest_fails_when_calibration_case_is_suppressed``) — this is
+     the literal "onderdruk het bekende geval" instruction;
+  3. a scanner regression (the detector silently losing the ability to find
+     the known-bad guard) must also fail loud, independent of the
+     ACCEPTED_GAPS check (``test_selftest_fails_on_scanner_regression``).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = VNX_ROOT / "scripts" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import guard_reachability_calibration as calibration  # noqa: E402
+from guard_reachability_calibration import (  # noqa: E402
+    CALIBRATION_CASES,
+    CalibrationFetchError,
+    SelfTestFailure,
+    fetch_pre_fix_function_source,
+    run_selftest,
+)
+
+
+def test_fetch_pre_fix_function_source_gets_real_historical_code():
+    """Not retyped: pulled straight from git history. Sanity-check the exact
+    shape the OI-1632 bug had (a local-var assignment, then a bare-name
+    guard) is really there."""
+    case = CALIBRATION_CASES[0]
+    source = fetch_pre_fix_function_source(VNX_ROOT, case)
+    assert "track_id = (spec.track_id or" in source
+    assert "if track_id:" in source
+
+
+def test_fetch_unknown_function_raises_fetch_error():
+    from dataclasses import replace
+
+    bogus = replace(CALIBRATION_CASES[0], pre_fix_function="_this_function_never_existed")
+    with pytest.raises(CalibrationFetchError):
+        fetch_pre_fix_function_source(VNX_ROOT, bogus)
+
+
+def test_selftest_passes_on_real_repo():
+    confirmations = run_selftest(VNX_ROOT, accepted_gap_fields=frozenset())
+    assert len(confirmations) == len(CALIBRATION_CASES)
+    assert all("OK" in c for c in confirmations)
+
+
+def test_selftest_fails_when_calibration_case_is_suppressed():
+    """bewijs #2: 'Maak je eigen wachter kapot' — mark the KNOWN-BUG field as
+    an accepted gap and show the self-test refuses to pass. A confirmed
+    historical defect must never be laundered into "designed", even with a
+    reason attached — that is precisely how three of the eight golf-4 cases
+    stayed hidden."""
+    calibration_field = CALIBRATION_CASES[0].field
+    with pytest.raises(SelfTestFailure, match="CONFIRMED historical"):
+        run_selftest(VNX_ROOT, accepted_gap_fields=frozenset({calibration_field}))
+
+
+def test_selftest_fails_on_scanner_regression(monkeypatch):
+    """A scanner that can no longer find ANY guard must fail the self-test,
+    independent of the ACCEPTED_GAPS check — this is the other half of
+    valkuil #4 (a broken detector, not a laundered finding)."""
+
+    def _finds_nothing(source, filename, known_attr_fields=frozenset()):
+        return []
+
+    monkeypatch.setattr(calibration, "find_guarded_field_refs", _finds_nothing)
+    with pytest.raises(SelfTestFailure, match="detector regression"):
+        run_selftest(VNX_ROOT, accepted_gap_fields=frozenset())
+
+
+def test_selftest_fails_loud_on_empty_calibration_cases(monkeypatch):
+    monkeypatch.setattr(calibration, "CALIBRATION_CASES", ())
+    with pytest.raises(SelfTestFailure, match="empty"):
+        run_selftest(VNX_ROOT, accepted_gap_fields=frozenset())

--- a/tests/test_guard_reachability_registry.py
+++ b/tests/test_guard_reachability_registry.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/guard_reachability_registry.py.
+
+golf-4's core finding: three of the eight defects were already "explained"
+in prose (a "Caveat" in a doc, "an accepted, intentional no-op" in a
+docstring) and that is exactly what kept them invisible — a doc-comment is
+not consulted by anything. ``ACCEPTED_GAPS`` is the registry's answer: a
+machine-read escape hatch that REFUSES to load without a reason. These tests
+prove the refusal actually fires, and that the real (in-repo) registry is
+itself valid.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = VNX_ROOT / "scripts" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import guard_reachability_registry as registry  # noqa: E402
+from guard_reachability_registry import (  # noqa: E402
+    AcceptedGap,
+    FieldMapping,
+    StoreTarget,
+    validate_registry,
+)
+
+
+def test_real_registry_validates_clean():
+    validate_registry()  # must not raise
+
+
+def test_accepted_gap_with_empty_reason_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        registry, "ACCEPTED_GAPS",
+        (AcceptedGap(field="x", reason="   ", decided_by="vincent", decided_on="2026-09-05"),),
+    )
+    with pytest.raises(ValueError, match="empty reason"):
+        validate_registry()
+
+
+def test_accepted_gap_missing_decided_by_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        registry, "ACCEPTED_GAPS",
+        (AcceptedGap(field="x", reason="genuinely optional", decided_by="", decided_on="2026-09-05"),),
+    )
+    with pytest.raises(ValueError, match="decided_by"):
+        validate_registry()
+
+
+def test_accepted_gap_with_real_reason_passes(monkeypatch):
+    monkeypatch.setattr(
+        registry, "ACCEPTED_GAPS",
+        (AcceptedGap(field="x", reason="genuinely optional field, reviewed", decided_by="vincent", decided_on="2026-09-05"),),
+    )
+    validate_registry()  # must not raise
+
+
+def test_duplicate_field_mapping_is_rejected(monkeypatch):
+    dup = FieldMapping(
+        field="dup",
+        targets=(StoreTarget(kind="ndjson", ndjson_relpaths=("x.ndjson",), note="t"),),
+        note="n",
+    )
+    monkeypatch.setattr(registry, "FIELD_STORE_MAP", (dup, dup))
+    with pytest.raises(ValueError, match="duplicate"):
+        validate_registry()
+
+
+def test_store_target_requires_kind_specific_fields():
+    with pytest.raises(ValueError):
+        StoreTarget(kind="sqlite", note="missing table/column")
+    with pytest.raises(ValueError):
+        StoreTarget(kind="ndjson", note="missing paths")
+    with pytest.raises(ValueError):
+        StoreTarget(kind="json_dir", note="missing dir")
+    with pytest.raises(ValueError):
+        StoreTarget(kind="not-a-real-kind", note="bogus")
+
+
+def test_calibration_field_is_not_in_accepted_gaps():
+    """OI-1632's track_id is a CONFIRMED historical bug, never a deliberate
+    gap — belt-and-suspenders alongside the calibration self-test's own
+    check of this same invariant."""
+    accepted_fields = {g.field for g in registry.ACCEPTED_GAPS}
+    assert "track_id" not in accepted_fields

--- a/tests/test_guard_reachability_registry.py
+++ b/tests/test_guard_reachability_registry.py
@@ -88,3 +88,35 @@ def test_calibration_field_is_not_in_accepted_gaps():
     check of this same invariant."""
     accepted_fields = {g.field for g in registry.ACCEPTED_GAPS}
     assert "track_id" not in accepted_fields
+
+
+def test_min_mapped_fields_floor_is_enforced(monkeypatch):
+    """golf4r2 (2026-09-06): 1364 unmeasured fields is not itself a defect,
+    but the MAPPED count must never silently drop below the floor — a
+    registry that lost every entry would report a permanently clean audit
+    and look identical to 'nothing left to fix'."""
+    monkeypatch.setattr(registry, "FIELD_STORE_MAP", ())
+    with pytest.raises(ValueError, match="MIN_MAPPED_FIELDS"):
+        validate_registry()
+
+
+def test_real_registry_meets_its_own_min_mapped_fields_floor():
+    assert len(registry.FIELD_STORE_MAP) >= registry.MIN_MAPPED_FIELDS
+
+
+def test_track_id_and_post_merge_verification_are_both_mapped():
+    """The two known golf-4 ronde 2 findings (OI-1640 fixed by this
+    dispatch, OI-1639 deliberately left open) must both be in the registry
+    — see the dispatch report's Open Items for why OI-1639 stays unfixed."""
+    fields = {m.field for m in registry.FIELD_STORE_MAP}
+    assert "track_id" in fields
+    assert "post_merge_verification" in fields
+
+
+def test_track_id_mapping_has_a_json_dir_target_authoritative_for_the_guard():
+    """The guard (dispatch_cli.py:1030 / :1423) reads spec.track_id from the
+    staged spec — NOT the persisted sqlite column _persist_track_id writes
+    downstream. Regressing to sqlite-only silently reintroduces OI-1640."""
+    mapping = next(m for m in registry.FIELD_STORE_MAP if m.field == "track_id")
+    kinds = {t.kind for t in mapping.targets}
+    assert "json_dir" in kinds

--- a/tests/test_guard_reachability_scanner.py
+++ b/tests/test_guard_reachability_scanner.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/guard_reachability_scanner.py — the golf-4 (2026-09-05)
+unreachable-guard detector's STATIC half.
+
+The calibration test (``test_finds_historical_oi1632_track_id_guard``) is the
+"RODE TEST EERST" required by the dispatch: it runs the scanner against the
+REAL pre-fix source of ``_check_track_link_verdict`` (fetched via
+``git show ee818845^:...``, never retyped) and asserts the guard is found.
+Before ``_local_field_assignments``/name-resolution existed, this test failed
+(the scanner only looked at the ``if`` test expression directly, and the
+real guard is ``if track_id:`` where ``track_id`` is a local assigned from
+``spec.track_id`` a few lines earlier) — see the dispatch report's
+Verification section for both the RED and GREEN pytest runs.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from guard_reachability_scanner import (  # noqa: E402
+    collect_dataclass_fields,
+    find_guarded_field_refs,
+)
+
+
+def _fetch_pre_fix_check_track_link_verdict() -> str:
+    """The real pre-OI-1632 source, extracted the same way the calibration
+    module does — duplicated here (not imported) so this test file exercises
+    the scanner in complete isolation from ``guard_reachability_calibration``.
+    """
+    import ast
+
+    result = subprocess.run(
+        ["git", "show", "ee818845^:scripts/lib/dispatch_cli.py"],
+        cwd=VNX_ROOT, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    tree = ast.parse(result.stdout)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_check_track_link_verdict":
+            seg = ast.get_source_segment(result.stdout, node)
+            assert seg
+            return seg
+    raise AssertionError("_check_track_link_verdict not found in pre-fix dispatch_cli.py")
+
+
+def test_finds_historical_oi1632_track_id_guard():
+    """Calibration case: the REAL, historical, structurally-unreachable guard.
+
+    Pre-#1774, ``spec.track_id`` was always ``None`` for bridge-staged
+    dispatches (0 of 681 rows had a track), so ``if track_id:`` here never
+    took its blocking branch. The scanner must find this guard.
+    """
+    source = _fetch_pre_fix_check_track_link_verdict()
+    refs = find_guarded_field_refs(source, "dispatch_cli.py", known_attr_fields={"track_id"})
+    matches = [r for r in refs if r.field == "track_id"]
+    assert matches, (
+        "scanner found no guard on 'track_id' in the real pre-fix "
+        "_check_track_link_verdict source — this is the calibration case "
+        "from OI-1632 (#1774); see the module docstring"
+    )
+    assert matches[0].access_kind == "attribute"
+    assert matches[0].enclosing_function == "_check_track_link_verdict"
+
+
+def test_direct_dict_get_guard_is_found():
+    source = (
+        "def handler(payload):\n"
+        "    if payload.get('pr_link'):\n"
+        "        return 'linked'\n"
+        "    return 'unlinked'\n"
+    )
+    refs = find_guarded_field_refs(source, "x.py")
+    assert len(refs) == 1
+    ref = refs[0]
+    assert ref.field == "pr_link"
+    assert ref.access_kind == "dict_get"
+    assert ref.container == "payload"
+    assert ref.enclosing_function == "handler"
+
+
+def test_direct_subscript_guard_is_found():
+    source = (
+        "def handler(row):\n"
+        "    if row['track']:\n"
+        "        return True\n"
+        "    return False\n"
+    )
+    refs = find_guarded_field_refs(source, "x.py")
+    assert len(refs) == 1
+    assert refs[0].field == "track"
+    assert refs[0].access_kind == "subscript"
+
+
+def test_negated_and_is_none_forms_are_found():
+    source = (
+        "def handler(payload):\n"
+        "    if not payload.get('x'):\n"
+        "        return None\n"
+        "    if payload.get('y') is None:\n"
+        "        return None\n"
+        "    return True\n"
+    )
+    refs = find_guarded_field_refs(source, "x.py")
+    fields = {r.field for r in refs}
+    assert fields == {"x", "y"}
+
+
+def test_attribute_guard_requires_known_dataclass_field():
+    """An arbitrary attribute access must not be treated as a field probe —
+    only names cross-referenced against a real @dataclass field (otherwise
+    every ``logger.info`` / ``self.foo`` in the repo would match)."""
+    source = (
+        "def handler(spec):\n"
+        "    if spec.track_id:\n"
+        "        return True\n"
+        "    return False\n"
+    )
+    refs_unqualified = find_guarded_field_refs(source, "x.py", known_attr_fields=set())
+    assert refs_unqualified == []
+
+    refs_qualified = find_guarded_field_refs(source, "x.py", known_attr_fields={"track_id"})
+    assert len(refs_qualified) == 1
+    assert refs_qualified[0].field == "track_id"
+    assert refs_qualified[0].access_kind == "attribute"
+
+
+def test_local_variable_indirection_is_resolved():
+    """The exact OI-1632 shape: the probe is in an ASSIGNMENT, the guard
+    tests the bare local name."""
+    source = (
+        "def handler(spec):\n"
+        "    track_id = (spec.track_id or '').strip()\n"
+        "    if track_id:\n"
+        "        return 'checked'\n"
+        "    return 'advisory'\n"
+    )
+    refs = find_guarded_field_refs(source, "x.py", known_attr_fields={"track_id"})
+    assert len(refs) == 1
+    assert refs[0].field == "track_id"
+    assert refs[0].access_kind == "attribute"
+    assert "via local 'track_id'" in refs[0].container
+
+
+def test_local_variable_indirection_scoped_per_function():
+    """The same local name in an UNRELATED function must not cross-pollute:
+    only a name assigned from a field probe resolves."""
+    source = (
+        "def other(spec):\n"
+        "    track_id = 'unrelated-literal'\n"
+        "    if track_id:\n"
+        "        return True\n"
+        "\n"
+        "def handler(spec):\n"
+        "    track_id = spec.track_id\n"
+        "    if track_id:\n"
+        "        return True\n"
+    )
+    refs = find_guarded_field_refs(source, "x.py", known_attr_fields={"track_id"})
+    assert len(refs) == 1
+    assert refs[0].enclosing_function == "handler"
+
+
+def test_unrelated_condition_is_not_flagged():
+    source = (
+        "def handler(x):\n"
+        "    if x > 5:\n"
+        "        return True\n"
+        "    return False\n"
+    )
+    assert find_guarded_field_refs(source, "x.py") == []
+
+
+def test_syntax_error_returns_empty_not_raise():
+    assert find_guarded_field_refs("def broken(:\n", "x.py") == []
+
+
+def test_collect_dataclass_fields_finds_annotated_class_fields():
+    source = (
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class DispatchSpec:\n"
+        "    dispatch_id: str\n"
+        "    track_id: str | None = None\n"
+        "class NotADataclass:\n"
+        "    other_field: str\n"
+    )
+    import ast
+
+    fields = collect_dataclass_fields(ast.parse(source))
+    assert fields == {"dispatch_id", "track_id"}
+
+
+def test_docstring_mentioning_a_guard_is_not_matched():
+    """bewijs #4: the scanner must hit the REAL call, not prose about one.
+    A docstring that describes ``if payload.get("ghost_field"):`` in English
+    must not register 'ghost_field' as a finding — no such code runs."""
+    source = (
+        "def handler(payload):\n"
+        "    '''Note: earlier drafts used if payload.get(\"ghost_field\"): here.'''\n"
+        "    # if payload.get(\"also_ghost\"): -- old approach, removed\n"
+        "    if payload.get('real_field'):\n"
+        "        return True\n"
+        "    return False\n"
+    )
+    refs = find_guarded_field_refs(source, "x.py")
+    fields = {r.field for r in refs}
+    assert fields == {"real_field"}
+
+
+def test_repo_scan_still_finds_live_track_id_guard():
+    """Sanity check against the CURRENT (fixed) tree: the guard shape still
+    exists post-#1774 (VNX_REQUIRE_DISPATCH_TRACK stays advisory-only), it
+    is simply no longer ALWAYS empty. The scan half must still find it —
+    only the measure half (guard_reachability_store) can tell fixed from
+    broken.
+    """
+    from guard_reachability_scanner import scan_repo_guarded_fields
+
+    refs = scan_repo_guarded_fields(VNX_ROOT)
+    track_refs = [r for r in refs if r.field == "track_id"]
+    assert track_refs, "expected at least one live 'track_id' guard in dispatch_cli.py post-fix"

--- a/tests/test_guard_reachability_store.py
+++ b/tests/test_guard_reachability_store.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/guard_reachability_store.py — the golf-4 detector's
+MEASURE half: fill-rate against a real NDJSON ledger, SQLite column, or
+directory of staged JSON specs.
+
+``test_sqlite_zero_fill_reconstructs_oi1632_ratio`` reconstructs the OI-1632
+measured ratio (0 of 681 dispatches rows had a track) at test scale — the
+real historical DB no longer exists in that state (the fix landed on main),
+so a fixture is the only way to exercise "confirmed zero across many rows"
+deterministically and offline.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = VNX_ROOT / "scripts" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from guard_reachability_store import (  # noqa: E402
+    measure_json_dir_fill_rate,
+    measure_ndjson_fill_rate,
+    measure_sqlite_column_fill_rate,
+)
+
+
+def test_ndjson_fill_rate_counts_present_nonempty_values(tmp_path):
+    ledger = tmp_path / "t0_receipts.ndjson"
+    ledger.write_text(
+        "\n".join([
+            json.dumps({"dispatch_id": "a", "pr_link": "linked"}),
+            json.dumps({"dispatch_id": "b"}),  # key absent
+            json.dumps({"dispatch_id": "c", "pr_link": None}),  # present but null
+            json.dumps({"dispatch_id": "d", "pr_link": ""}),  # present but empty
+            "",  # blank line, must be skipped
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    rate = measure_ndjson_fill_rate([ledger], field="pr_link")
+    assert rate.exists is True
+    assert rate.total == 4
+    assert rate.filled == 1
+
+
+def test_ndjson_missing_file_is_zero_total_not_error(tmp_path):
+    rate = measure_ndjson_fill_rate([tmp_path / "does-not-exist.ndjson"], field="x")
+    assert rate.exists is True
+    assert rate.total == 0
+    assert rate.filled == 0
+    assert rate.is_zero_fill is False  # total==0 is inconclusive, not a violation
+
+
+def test_ndjson_malformed_lines_are_skipped(tmp_path):
+    ledger = tmp_path / "t0_receipts.ndjson"
+    ledger.write_text("not json\n" + json.dumps({"pr_link": "linked"}) + "\n", encoding="utf-8")
+    rate = measure_ndjson_fill_rate([ledger], field="pr_link")
+    assert rate.total == 1
+    assert rate.filled == 1
+
+
+def test_json_dir_fill_rate_counts_per_file_documents(tmp_path):
+    specs = tmp_path / "pending"
+    specs.mkdir()
+    (specs / "a.json").write_text(json.dumps({"dispatch_id": "a", "track_id": "T1"}), encoding="utf-8")
+    (specs / "b.json").write_text(json.dumps({"dispatch_id": "b"}), encoding="utf-8")
+    (specs / "c.json").write_text("not json", encoding="utf-8")
+    rate = measure_json_dir_fill_rate(specs, "*.json", field="track_id")
+    assert rate.total == 2  # c.json is skipped (unreadable)
+    assert rate.filled == 1
+
+
+def test_sqlite_missing_db_reports_not_exists(tmp_path):
+    rate = measure_sqlite_column_fill_rate(tmp_path / "nope.db", "dispatches", "track")
+    assert rate.exists is False
+    assert rate.is_zero_fill is False  # missing is its own state, not "zero fill"
+
+
+def test_sqlite_missing_column_reports_not_exists(tmp_path):
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE dispatches (dispatch_id TEXT)")
+    conn.execute("INSERT INTO dispatches VALUES ('a')")
+    conn.commit()
+    conn.close()
+
+    rate = measure_sqlite_column_fill_rate(db_path, "dispatches", "track_id")
+    assert rate.exists is False
+    assert rate.total == 0
+
+
+def test_sqlite_zero_fill_reconstructs_oi1632_ratio(tmp_path):
+    """Reconstructs the OI-1632 measurement (0 of 681 dispatches rows had a
+    track) at N=20 test scale: a real column, real rows, every value NULL.
+    """
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE dispatches (dispatch_id TEXT, track TEXT)")
+    conn.executemany(
+        "INSERT INTO dispatches (dispatch_id, track) VALUES (?, NULL)",
+        [(f"d{i}",) for i in range(20)],
+    )
+    conn.commit()
+    conn.close()
+
+    rate = measure_sqlite_column_fill_rate(db_path, "dispatches", "track")
+    assert rate.exists is True
+    assert rate.total == 20
+    assert rate.filled == 0
+    assert rate.is_zero_fill is True
+
+
+def test_sqlite_partial_fill_is_not_zero_fill(tmp_path):
+    """122 of 814 dispatches carry a track on the LIVE post-fix DB (measured
+    2026-09-05) — nonzero, so it must not be flagged as the "structurally
+    cannot fire" defect this detector targets."""
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE dispatches (dispatch_id TEXT, track TEXT)")
+    conn.executemany(
+        "INSERT INTO dispatches (dispatch_id, track) VALUES (?, ?)",
+        [(f"d{i}", "T1" if i < 3 else None) for i in range(20)],
+    )
+    conn.commit()
+    conn.close()
+
+    rate = measure_sqlite_column_fill_rate(db_path, "dispatches", "track")
+    assert rate.total == 20
+    assert rate.filled == 3
+    assert rate.is_zero_fill is False
+
+
+def test_sqlite_rejects_unsafe_identifiers(tmp_path):
+    import pytest
+
+    db_path = tmp_path / "x.db"
+    sqlite3.connect(db_path).close()
+    with pytest.raises(ValueError):
+        measure_sqlite_column_fill_rate(db_path, "dispatches; DROP TABLE x", "track")

--- a/tests/test_guard_reachability_store.py
+++ b/tests/test_guard_reachability_store.py
@@ -73,6 +73,58 @@ def test_json_dir_fill_rate_counts_per_file_documents(tmp_path):
     assert rate.filled == 1
 
 
+def test_json_dir_fill_rate_treats_stored_false_as_not_filled(tmp_path):
+    """golf4r2 (OI-1640): spec.post_merge_verification is a plain bool guard
+    (``and spec.post_merge_verification:`` at dispatch_cli.py:2209). Every
+    staged spec in the real repo carries this key with the literal value
+    ``False`` (measured 2026-09-06: 365 of 365) — the guard's truthy test
+    can never pass. The old presence-based ``_is_filled`` counted ``False``
+    as "filled" (it is not in ``(None, "", [], {})``), which would have
+    printed a false [OK] on exactly this field.
+    """
+    specs = tmp_path / "pending"
+    specs.mkdir()
+    for i in range(5):
+        (specs / f"s{i}.json").write_text(
+            json.dumps({"dispatch_id": f"s{i}", "post_merge_verification": False}),
+            encoding="utf-8",
+        )
+    rate = measure_json_dir_fill_rate(specs, "*.json", field="post_merge_verification")
+    assert rate.total == 5
+    assert rate.filled == 0
+    assert rate.is_zero_fill is True
+
+
+def test_json_dir_fill_rate_counts_stored_true_as_filled(tmp_path):
+    """Nul is eerst een meetfout: the fix above must not also report a
+    real ``True`` as unfilled — test against a case that DOES exist."""
+    specs = tmp_path / "pending"
+    specs.mkdir()
+    (specs / "a.json").write_text(
+        json.dumps({"dispatch_id": "a", "post_merge_verification": True}), encoding="utf-8",
+    )
+    (specs / "b.json").write_text(
+        json.dumps({"dispatch_id": "b", "post_merge_verification": False}), encoding="utf-8",
+    )
+    rate = measure_json_dir_fill_rate(specs, "*.json", field="post_merge_verification")
+    assert rate.total == 2
+    assert rate.filled == 1
+    assert rate.is_zero_fill is False
+
+
+def test_ndjson_fill_rate_treats_numeric_zero_as_not_filled(tmp_path):
+    """Same _is_filled fix, other store shape: a stored ``0`` is not in
+    ``(None, "", [], {})`` either, so the old check counted it as filled."""
+    ledger = tmp_path / "t0_receipts.ndjson"
+    ledger.write_text(
+        "\n".join([json.dumps({"count": 0}), json.dumps({"count": 3})]) + "\n",
+        encoding="utf-8",
+    )
+    rate = measure_ndjson_fill_rate([ledger], field="count")
+    assert rate.total == 2
+    assert rate.filled == 1
+
+
 def test_sqlite_missing_db_reports_not_exists(tmp_path):
     rate = measure_sqlite_column_fill_rate(tmp_path / "nope.db", "dispatches", "track")
     assert rate.exists is False


### PR DESCRIPTION
## Summary

Golf-4 (2026-09-05) vond acht losstaande defecten met dezelfde vorm: een guard die een handeling afschermt op een veld/kolom die in de praktijk nooit gevuld is. Drie ervan stonden al opgeschreven als "Caveat" of "accepted, intentional no-op" — precies wat ze onzichtbaar hield.

- `scripts/lib/guard_reachability_scanner.py` — AST-scanner die zulke guards vindt: `dict.get(str)`, `obj[str]`, `obj.attr` (attribuut alleen bij een bekend `@dataclass`-veld), inclusief lokale-variabele-indirectie (`track_id = (spec.track_id or "").strip(); if track_id:` — de ECHTE vorm van het OI-1632-defect).
- `scripts/lib/guard_reachability_store.py` — meet de echte vulgraad: SQLite-kolom (onderscheidt "bestaat niet" van "bestaat, is leeg"), NDJSON-ledger, of JSON-spec-map.
- `scripts/lib/guard_reachability_registry.py` — koppelt een gevonden veld aan een echte store, en scheidt ONTWORPEN van KAPOT via een machineleesbare `ACCEPTED_GAPS` met verplichte `reason`/`decided_by`/`decided_on` — leeg vandaag, want elk tot nu toe gevonden nul-vulgraad-geval bleek een echt defect.
- `scripts/lib/guard_reachability_calibration.py` — zelftoets-tripwire: haalt de ECHTE pre-fix broncode op via `git show ee818845^:scripts/lib/dispatch_cli.py` en faalt hard als het bekende geval wordt weggemoffeld of de scanner regresseert.
- `scripts/guard_reachability_audit.py` — CLI (`scan`/`audit`/`selftest`).

## Test plan

- [x] RODE test eerst (naïeve scanner faalt op het echte historische OI-1632-geval), GROENE test na implementatie — beide runs in het dispatch-rapport.
- [x] Zelftoets kapotgemaakt: bekend geval in `ACCEPTED_GAPS` gezet → self-test weigert; scanner gemonkeypatcht naar "vindt niets" → self-test weigert onafhankelijk.
- [x] Repo-wide `audit`-run tegen de echte centrale store (`~/.vnx-data/vnx-dev`): `track_id` correct als OK (122/814, fixed door #1774), 0 violations, 1.375 unmeasured velden gerapporteerd als open item.
- [x] 42 tests groen (`pytest tests/test_guard_reachability_*.py -v`).
- [x] `git diff HEAD` leeg, `git show HEAD:<pad>` teruggelezen voor beide entry-modules.

Volledig bewijs (beide TDD-runs, self-test-break-demo, repo-wide auditoutput, open items): dispatch-rapport `20260905-golf4-klasse-wachter.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)