### PR TITLE
fix(closure-verifier): een poort-uitval is afwezigheid, geen tegenstem (OI-1624)

### DIFF
--- a/docs/governance/decisions/ADR-037-gate-uitval-is-afwezigheid-niet-tegenstem.md
+++ b/docs/governance/decisions/ADR-037-gate-uitval-is-afwezigheid-niet-tegenstem.md
@@ -1,0 +1,66 @@
+# ADR-037 — Een poort-uitval is afwezigheid, geen tegenstem
+
+**Status:** Accepted (dispatch 20260906-oi1624-uitval-is-afwezigheid)
+**Date:** 2026-09-06
+**Decided by:** T0, op basis van een live blokkade op vijf PR's (#1777-#1781) op main `36ee70a3`.
+**Resolves / Cross-refs:** OI-1624. Bouwt voort op OI-1576 (`_find_takeover_successor_results`, ADR nog niet apart vastgelegd) en OI-1469/OI-1470 (de overschrijfwachter in `gate_recorder._check_overwrite_guard`, die dit ADR ongemoeid laat).
+
+## Context
+
+Vijf PR's met CI-conclusie `success` en een volwaardig `glm_gate` PASS-record (nul blocking findings, `commit_sha` gelijk aan de PR-head, `contract_hash` gevuld, rapport op schijf) konden niet mergen. Gemeten op PR #1777 (`~/.vnx-data/vnx-dev/state/review_gates/results/`):
+
+```
+pr-1777-codex_gate.json: status=not_executable, reason=provider_not_installed,
+                          contract_hash="", report_path=""
+pr-1777-glm_gate.json:   status=pass, contract_hash gevuld, report_path bestaat,
+                          commit_sha == head
+pr-1777-kimi_gate.json:  status=unavailable, reason=dispatch_error
+```
+
+De gedeclareerde poort (`gate_obligations.declared_gates_for_pr`) is `codex_gate`. Geen van de drie records draagt een `takeover`/`takeover_path`-annotatie — de drie poorten zijn onafhankelijk van elkaar gedispatcht in dezelfde review-ronde, niet via een sequentiële overname-keten.
+
+`closure_verifier.check_review_gate_for_merge` resolveerde dit als volgt: `codex_gate`'s eigen record heeft geen beslist verdict (`not_executable` zit niet in `_DECIDED_VERDICT_STATES`), dus de functie zoekt een OI-1576-overname-opvolger. Die vindt niets (geen enkel record draagt `takeover_path`). Bij gebrek daaraan viel de functie terug op `_merge_door_record_verdict(result, gate, pr_id)` — **hetzelfde bewijs-invariantenblok dat een ECHTE, beslissen verdict-poging beoordeelt** — toegepast op een record dat nooit een verdict heeft afgeleverd. Dat blok las de lege `contract_hash`/`report_path` als "bewijs onvolledig" en gaf NO-GO, met geen enkele uitweg: de overname-route (OI-1576) vereist een formele `takeover_path`-annotatie die hier nooit is gezet, en de overschrijfwachter (OI-1469/OI-1470) weigert terecht een terminaal record te overschrijven met een niet-terminale herbeoordeling.
+
+**Netto: een provider die niet geïnstalleerd is, produceert een terminaal record dat de merge blokkeert en tegelijk de enige gedocumenteerde uitweg (OI-1576) dichthoudt**, omdat die uitweg een formele koppeling eist die in de praktijk niet altijd ontstaat (meerdere poorten los gedispatcht in één ronde, niet altijd een sequentiële keten-overname).
+
+## Beslissing
+
+**Een poort-status die uitdrukt dat de poort niet gedraaid heeft, is AFWEZIGHEID — nooit een tegenstem — ongeacht of het record terminaal is opgeslagen.**
+
+Dit wordt vastgelegd als een expliciet onderscheid tussen twee onafhankelijke assen, nooit als een uitzondering op een lijstje statusnamen:
+
+- **Terminaal** (`gate_status.is_terminal`): is deze aanvraagpoging afgerond? `not_executable` is terminaal — de poort is definitief geclassificeerd als "kan niet draaien" — ook al is er niets uitgevoerd.
+- **Een uitspraak gedaan** (`_DECIDED_VERDICT_STATES` = pass ∪ fail): is deze poging afgerond MET een oordeel? Terminaal betekent "deze poging is voorbij", nooit "er is geoordeeld". Alleen een pass en een echte afkeuring zijn uitspraken.
+
+Absentie is dus: geen beslist verdict, ÉN (de poging is afgerond zonder oordeel — `is_terminal` — OF het is een expliciete uitval-status — `gate_status.UNAVAILABLE_STATES`, zelf bewust NIET terminaal omdat een herkansing nog kan beslissen). Beide routes lezen af uit `gate_status.py`'s eigen categorieën, nooit uit een tweede, met de hand gekozen lijst in `closure_verifier.py` — een uitvalstatus die morgen aan een van die twee categorieën wordt toegevoegd, valt hier automatisch goed (`closure_verifier._is_absent_without_verdict`).
+
+Bewust UITGESLOTEN van "afwezigheid": `INCOMPLETE_STATES` (pending/running/queued/requested). Die betekenen "dit exemplaar van de poging kan nog steeds tot een oordeel rijpen" — een heel andere bewering dan "deze poging is over en er komt nooit een oordeel". Een in-flight status blijft daarom via het bestaande "niet terminaal"-pad NO-GO, ongewijzigd.
+
+### De voorrangsregel (waarom dit ertoe doet)
+
+Zodra de gedeclareerde poort een bevestigde afwezigheid is (record bestaat, geen uitspraak gedaan) én geen formele OI-1576-overnamesuccessor haar noemt, raadpleegt de merge-poort elke ANDERE bekende poort se eigen, onafhankelijk afgeleverde uitspraak voor exact dezelfde PR/branch/sha (`closure_verifier._find_peer_gate_results`):
+
+1. **Een echte afkeuring blokkeert altijd** — ook naast een pass van een andere poort. Als een peer-poort een beslist `fail` draagt, is het resultaat NO-GO, ongeacht of een andere peer passeert.
+2. **Een volledig bewezen pass van een peer-poort telt als ondertekenaar** — onder DEZELFDE zeven bewijs-invarianten die elke andere verdict-check al afdwingt (record bestaat, terminaal, contract_hash, report_path, rapport bestaat op schijf, verdict spreekt zichzelf niet tegen, sha gelijk aan de head).
+3. **Nul geldige ondertekenaars blijft NO-GO** — geen peer met een bruikbaar oordeel, geen successor, geen eigen uitspraak: de merge wordt geweigerd, nu eerlijk gerapporteerd als afwezigheid ("nul geldige ondertekenaars") in plaats van als "bewijs onvolledig" (een formulering die hoort bij een mislukte poging, niet bij een poort die nooit heeft gesproken).
+
+### Wat dit NIET verandert
+
+- **De OI-1576-overnameroute blijft primair en ongewijzigd.** Een formele `takeover_path`-koppeling wordt, wanneer aanwezig, nog steeds eerst geraadpleegd en beslist zelfstandig — de nieuwe peer-route is uitsluitend het vangnet voor wanneer die koppeling er niet is.
+- **Een gedeclareerde poort zonder ENIG record (`result is None`) krijgt geen peer-fallback.** Dat blijft het bestaande, ongewijzigde contract (`TestUnrelatedRecordsNeverTakeOver`, OI-1576): een poort die nooit is aangevraagd is een onbekende toestand — misschien gewoon nog niet aan de beurt in deze ronde — niet een bevestigde afwezigheid. Een vreemde pass mag daar nooit voor invallen. Alleen een poort die WEL is aangevraagd en terugkwam zonder oordeel (record bestaat) is een bevestigde afwezigheid.
+- **De OI-1469/OI-1470-overschrijfwachter (`gate_recorder._check_overwrite_guard`) is niet aangeraakt.** Die beschermt terecht tegen het overschrijven van een terminaal record met een niet-terminale herbeoordeling. Het probleem zat nooit in die bescherming, maar in de LEESKANT die een niet-gedraaide poort als een beoordeelde-maar-onvolledige uitspraak las.
+
+## Consequenties
+
+- **Positief — de blokkade lost op zonder een invariant te verzwakken.** PR #1777 (en de vier zusters) gaan van NO-GO naar GO zodra minimaal één andere poort in dezelfde ronde een volledig bewezen pass aflevert; een echte afkeuring blijft even hard blokkeren als voorheen.
+- **Eerlijker foutmelding.** Een merge-weigering op een afwezige poort zegt nu letterlijk "afwezig, nul geldige ondertekenaars" in plaats van "bewijs onvolledig" — een operator die het logboek leest, ziet meteen of een provider ontbreekt of een echte review is mislukt.
+- **Nieuw risico — een bredere leesomvang bij afwezigheid.** Waar de merge-poort voorheen alleen de gedeclareerde poort en formele opvolgers las, leest hij nu (uitsluitend bij bevestigde afwezigheid) elke bekende poort in `_KNOWN_GATES` voor dezelfde PR/branch/sha. Dat blijft begrensd: dezelfde scope-matcher (`_record_matches_scope`) en dezelfde zeven bewijs-invarianten gelden onverkort, en `_KNOWN_GATES` is de bestaande, enum-afgeleide verzameling — geen ongebonden scan.
+- **Nog open:** de vraag WAAROM meerdere poorten (codex, kimi, glm) los gedispatcht worden voor dezelfde PR zonder dat een sequentiële overname-keten dat vastlegt, is een aparte kwestie in `gate_request_handler._dispatch_review_seat`/`_stamp_takeover_annotations` — dit ADR verandert daar niets aan en verzwakt de OI-1576-keten niet; het voegt alleen een leeskant-vangnet toe voor het geval die keten (om welke reden dan ook) geen formele koppeling aflevert.
+
+## References
+
+- OI-1624 — dit ADR, `scripts/closure_verifier.py::_is_absent_without_verdict`, `::_find_peer_gate_results`, `::check_review_gate_for_merge`.
+- OI-1576 — `_find_takeover_successor_results`, de primaire overnameroute die dit ADR ongewijzigd laat.
+- OI-1469/OI-1470 — `gate_recorder._check_overwrite_guard`, de schrijfkant-wachter die dit ADR expliciet niet aanraakt.
+- `scripts/lib/gate_status.py` — de canonieke statuscategorieën (`PASS_STATES`, `FAIL_STATES`, `INCOMPLETE_STATES`, `UNAVAILABLE_STATES`, `is_terminal`) waarop dit ADR's "terminaal ≠ uitspraak"-onderscheid leunt.
+- `tests/test_oi1624_gate_absence_vs_rejection.py` — rode-naar-groene regressietests, inclusief een expliciete pin op het ongewijzigde OI-1576-contract (`TestNoRegressionOnZeroRecordAbsence`).

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -29,6 +29,7 @@ from codex_severity_translator import translate_findings as translate_codex_find
 from gate_status import (
     FAIL_STATES as _GATE_FAIL_STATES,
     PASS_STATES as _GATE_PASS_STATES,
+    UNAVAILABLE_STATES as _GATE_UNAVAILABLE_STATES,
     canonical_status as gate_canonical_status,
     has_complete_evidence as gate_has_complete_evidence,
     is_pass as gate_is_pass,
@@ -379,6 +380,48 @@ def _find_gate_result(
 # takeover-provenance route (OI-1576) may speak for it.
 _DECIDED_VERDICT_STATES = _GATE_PASS_STATES | _GATE_FAIL_STATES
 
+
+def _is_absent_without_verdict(result: Dict[str, Any]) -> bool:
+    """OI-1624: does ``result`` represent a gate that will render no verdict
+    for THIS attempt — an ABSENCE, never a rejection?
+
+    This is deliberately built as a distinction between two independent
+    axes, never as a name-list of "known outage statuses" — a status invented
+    tomorrow falls into the right bucket automatically as long as it is
+    classified by ``gate_status.py`` (the module that owns these categories),
+    not by a second hand-picked list living here:
+
+    - **terminal** (``gate_status.is_terminal``) answers "has this attempt
+      concluded" — ``not_executable`` is terminal precisely because the gate
+      was finally classified as unable to run, even though nothing executed.
+    - **verdict rendered** (``_DECIDED_VERDICT_STATES``, pass ∪ fail) answers
+      "did the attempt conclude WITH a decision" — a wholly separate
+      question. Terminal means "this attempt is over", never "a verdict was
+      reached"; only pass and a real rejection are verdicts.
+
+    A status can be terminal without a verdict (``not_executable``) or a
+    verdict without controversy (pass/fail, both terminal). What is
+    deliberately excluded from "absence" is the THIRD combination: a status
+    that is neither terminal nor a verdict AND is not a recognised outage
+    either — the ``INCOMPLETE_STATES`` family (pending/running/queued/
+    requested). Those mean "this same attempt may still mature into a
+    verdict on its own", so treating them as absence and consulting a peer
+    gate while they are still in flight would be premature — the merge door
+    must keep refusing them on "not terminal yet", exactly as it always has
+    (``_merge_door_record_verdict``'s first check, preserved unchanged).
+
+    Absence is therefore: NOT a decided verdict, AND (the attempt concluded
+    without one — ``is_terminal`` — OR it is an explicit outage status —
+    ``gate_status.UNAVAILABLE_STATES``, which is itself deliberately NOT
+    terminal because a rerun can still decide). Both routes read off
+    gate_status.py's own category sets.
+    """
+    status = gate_canonical_status(result)
+    if status in _DECIDED_VERDICT_STATES:
+        return False
+    return gate_is_terminal(result) or status in _GATE_UNAVAILABLE_STATES
+
+
 # Glob metacharacters that would change the meaning of a pr_id-derived glob
 # pattern (e.g. turn it into a wildcard match instead of a literal prefix).
 _GLOB_UNSAFE_CHARS = frozenset("*?[]")
@@ -570,6 +613,62 @@ def _merge_door_record_verdict(
     }
 
 
+def _find_peer_gate_results(
+    gate: str,
+    pr_id: str,
+    results_dir: Path,
+    branch: Optional[str] = None,
+    project_id: Optional[str] = None,
+    head_sha: Optional[str] = None,
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """OI-1624: other KNOWN gates' own rendered verdicts for this exact PR/sha.
+
+    Only reached when the declared gate is an established ABSENCE
+    (:func:`_is_absent_without_verdict`) with no OI-1576 takeover-successor
+    naming it either. Absence is not silence: a review round commonly
+    dispatches several gates for the same PR (measured live: codex_gate,
+    kimi_gate and glm_gate all requested and recorded for the same head),
+    and a gate that never rendered a verdict must not make the OTHER gates'
+    own, independently-reached verdicts invisible to the merge door.
+
+    Deliberately narrower than "any pass anywhere satisfies the obligation":
+
+    - Every candidate is looked up via :func:`_find_gate_result` — the SAME
+      pr_id/branch/project_id/head-sha scope matcher and offline-test-run
+      rejection the declared gate's own lookup already uses, never a second,
+      looser one.
+    - Only records with a RENDERED verdict (``_DECIDED_VERDICT_STATES`` —
+      pass or fail, never another absence status) are returned; an absent
+      peer contributes nothing either way.
+    - The candidate set is bounded to ``_KNOWN_GATES`` (the same enum-derived
+      set the declared-gate lookup trusts), never an unbounded directory
+      scan.
+
+    This does NOT relax ``TestUnrelatedRecordsNeverTakeOver`` (OI-1576): that
+    contract is about a declared gate with NO record at all (never even
+    asked) being handed a stranger's unrelated pass — genuinely unknowable
+    whether the seat is dead or merely not yet scheduled this round. This
+    function is only ever consulted once the declared gate's OWN record
+    already proves it will not render a verdict for this attempt.
+
+    Returns ``[(gate_name, record), ...]``, unordered beyond ``_KNOWN_GATES``
+    iteration order (sorted, for determinism).
+    """
+    peers: List[Tuple[str, Dict[str, Any]]] = []
+    for candidate_gate in sorted(_KNOWN_GATES):
+        if candidate_gate == gate:
+            continue
+        candidate = _find_gate_result(
+            candidate_gate, pr_id, results_dir,
+            branch=branch, project_id=project_id, head_sha=head_sha,
+        )
+        if candidate is None:
+            continue
+        if gate_canonical_status(candidate) in _DECIDED_VERDICT_STATES:
+            peers.append((candidate_gate, candidate))
+    return peers
+
+
 def check_review_gate_for_merge(
     pr_id: str,
     gate: str,
@@ -610,6 +709,24 @@ def check_review_gate_for_merge(
     successor carries about itself; it never walks the chain through other
     records. A decided verdict at the declared gate (pass or fail) always
     stands on its own and is never overridden by a successor.
+
+    OI-1624: a gate-UITVAL is an ABSENCE, never a rejection (see
+    :func:`_is_absent_without_verdict`) — ``not_executable``/``unavailable``
+    mean "this attempt concluded without a verdict", not "this attempt
+    concluded with a NO". When the declared gate is absent AND no formal
+    takeover successor names it either, the declared gate's own absent
+    record is never run back through :func:`_merge_door_record_verdict`
+    (that machinery judges "is this a valid pass", not "did anyone speak at
+    all" — feeding it an absent record used to read as "resultaat mist
+    contract_hash en/of report_path", indistinguishable from a botched
+    attempt). Instead every OTHER known gate's own rendered verdict for the
+    SAME PR/branch/sha is consulted (:func:`_find_peer_gate_results`): a real
+    rejection anywhere in that set still blocks the merge (an echte
+    afkeuring blijft blokkeren, ook naast een pass van een andere poort), a
+    fully-evidenced pass stands in as the signer, and zero rendered peer
+    verdicts is still NO-GO (nul geldige ondertekenaars blijft NO-GO) — now
+    honestly reported as absence rather than "incomplete evidence". See
+    ADR-037.
     """
     result = _find_gate_result(
         gate, pr_id, results_dir, branch=branch, project_id=project_id, head_sha=head_sha
@@ -669,6 +786,76 @@ def check_review_gate_for_merge(
             "override_reason": None,
             "gate": gate,
         }
+    if result is not None and _is_absent_without_verdict(result):
+        # OI-1624: the declared gate spoke (a record exists) and what it said
+        # is that it will render no verdict for this attempt — an ABSENCE,
+        # never a rejection. Unlike a decided fail, absence carries no
+        # information that should block the merge on its own; it just means
+        # this particular seat has nothing to say. Consult every OTHER known
+        # gate's own rendered verdict for the exact same PR/branch/sha before
+        # falling back to "no evidence at all".
+        peers = _find_peer_gate_results(
+            gate, pr_id, results_dir, branch=branch, project_id=project_id, head_sha=head_sha,
+        )
+        peer_fails = [
+            (peer_gate, peer) for peer_gate, peer in peers
+            if gate_canonical_status(peer) in _GATE_FAIL_STATES
+        ]
+        if peer_fails:
+            # A real rejection blocks the merge regardless of what the
+            # absent declared gate has to say about it, and regardless of
+            # any OTHER peer's pass (harde grens: een echte afkeuring
+            # blijft blokkeren, ook naast een pass van een andere poort).
+            culprit_gate, culprit = sorted(peer_fails, key=lambda item: item[0])[0]
+            return {
+                "verdict": "NO-GO",
+                "message": (
+                    f"{gate} is afwezig voor {pr_id} (status={gate_canonical_status(result)!r}: "
+                    f"geen uitspraak gedaan) — {culprit_gate} keurde dezelfde head af "
+                    f"({gate_canonical_status(culprit)!r}): een echte afkeuring blokkeert "
+                    f"de merge, ook naast de afwezigheid van {gate}"
+                ),
+                "overridden": False,
+                "override_reason": None,
+                "gate": gate,
+            }
+        for peer_gate, peer in sorted(peers, key=lambda item: item[0]):
+            if gate_canonical_status(peer) not in _GATE_PASS_STATES:
+                continue
+            peer_verdict = _merge_door_record_verdict(peer, peer_gate, pr_id)
+            if peer_verdict["verdict"] == "GO":
+                return {
+                    "verdict": "GO",
+                    "message": (
+                        f"{gate} is afwezig voor {pr_id} (status={gate_canonical_status(result)!r}: "
+                        f"geen uitspraak gedaan) — {peer_gate} droeg op dezelfde head "
+                        "zelfstandig een geldige, volledig bewezen pass en telt als "
+                        "ondertekenaar bij afwezigheid van de gedeclareerde poort (OI-1624)"
+                    ),
+                    "overridden": False,
+                    "override_reason": None,
+                    "gate": gate,
+                    "evidence_gate": peer_gate,
+                }
+        # Zero valid signers: the declared gate is confirmed absent and no
+        # other known gate on this exact head rendered a usable verdict
+        # either. Still NO-GO (nul geldige ondertekenaars blijft NO-GO), but
+        # honestly reported as absence, never as "bewijs onvolledig" — that
+        # phrasing belongs to a record that attempted a verdict and fell
+        # short, not to one that never tried.
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                f"{gate} is afwezig voor {pr_id} (status={gate_canonical_status(result)!r}: "
+                "geen uitspraak gedaan, geen ondertekening) en geen andere poort op "
+                "deze head leverde een geldige, volledig bewezen uitspraak — nul "
+                "geldige ondertekenaars"
+            ),
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate,
+        }
+
     if result is None:
         return {
             "verdict": "NO-GO",

--- a/scripts/lib/gate_report_generator.py
+++ b/scripts/lib/gate_report_generator.py
@@ -22,6 +22,8 @@ class GateReportGeneratorMixin:
         reason_detail: str,
         contract_hash: str = "",
         dispatch_id: str = "",
+        branch: str = "",
+        commit_sha: str = "",
     ) -> Tuple[Dict[str, Any], bool]:
         """Write a not_executable result record (GATE-4).
 
@@ -35,6 +37,22 @@ class GateReportGeneratorMixin:
         verdict (e.g. a launchd worker missing the gate's CLI on PATH) would
         silently erase that verdict -- measured live against PR #1691's
         codex-gate pass (contract_hash ``466cd2ca75d7a7fb``).
+
+        ``branch``/``commit_sha`` (OI-1624): every caller already resolved
+        both before deciding the gate is unavailable -- the request payload
+        it builds around this call carries them (``_request_codex`` etc.
+        stamp ``branch``/``get_pr_head_sha(pr_number)`` unconditionally,
+        before branching on availability). Without them here, the resulting
+        not_executable record fails ``closure_verifier``'s scope match
+        (ADR-005/OI-1307: a result missing ``branch``/``commit_sha`` is
+        treated as stale evidence, same as a mismatched one) and reads as NO
+        RECORD AT ALL rather than as a confirmed absence -- measured live on
+        PR #1777's ``codex_gate`` not_executable record, which carried
+        neither field and was invisible to the merge door's scope matcher
+        before this fix. Both default to "" (never resolved / not
+        applicable, e.g. the contract-flow callers that pass no PR yet) so
+        every existing caller that does not pass them keeps writing the
+        exact same shape as before.
 
         Returns ``(payload_on_disk, written)``. ``payload_on_disk`` is the
         not_executable payload just built when the write landed, or the
@@ -58,6 +76,8 @@ class GateReportGeneratorMixin:
             "failure_reason": reason_detail,
             "summary": f"{gate} not executable: {reason_detail}",
             "contract_hash": contract_hash,
+            "branch": branch,
+            "commit_sha": commit_sha,
             "report_path": "",
             "blocking_findings": [],
             "advisory_findings": [],

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -1003,6 +1003,15 @@ class GateRequestHandlerMixin:
         happens to the RESULT record below -- a request-time refusal is
         never allowed to go quiet even when the guard blocks the write it
         would otherwise cause (OI-1469/OI-1470/OI-1471).
+
+        OI-1624: ``branch``/``commit_sha`` are read straight off the
+        caller's own ``payload`` -- every real caller (``_request_codex``,
+        ``_request_gemini``, ``_request_kimi``, ``_request_ci_gate``, the
+        contract-flow builders) already stamped both before deciding
+        availability, so this never re-resolves anything; it only stops
+        dropping what the caller already knew on the way into the RESULT
+        record (see ``_write_not_executable_result``'s docstring for why
+        that mattered live on PR #1777).
         """
         reason, detail = self._classify_unavailable(gate)
         payload["reason"] = reason
@@ -1021,6 +1030,8 @@ class GateRequestHandlerMixin:
             reason=reason, reason_detail=detail,
             contract_hash=contract_hash,
             dispatch_id=dispatch_id,
+            branch=payload.get("branch") or "",
+            commit_sha=payload.get("commit_sha") or "",
         )
         if not written:
             # gate_recorder.write_result_guarded already logged the refusal
@@ -1473,6 +1484,8 @@ class GateRequestHandlerMixin:
                 gate="glm_gate", pr_number=pr_number, pr_id="",
                 reason=reason, reason_detail=reason_detail,
                 dispatch_id=dispatch_id,
+                branch=branch,
+                commit_sha=payload.get("commit_sha") or "",
             )
             if not written:
                 logger.warning(
@@ -1535,6 +1548,8 @@ class GateRequestHandlerMixin:
                 gate="deepseek_gate", pr_number=pr_number, pr_id="",
                 reason=reason, reason_detail=reason_detail,
                 dispatch_id=dispatch_id,
+                branch=branch,
+                commit_sha=payload.get("commit_sha") or "",
             )
             self._write_skip_rationale(
                 gate="deepseek_gate", pr_id=str(pr_number),

--- a/tests/test_oi1624_gate_absence_vs_rejection.py
+++ b/tests/test_oi1624_gate_absence_vs_rejection.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""OI-1624: a gate UITVAL (not_executable/unavailable) is an ABSENCE, never a
+rejection — and absence must never silently become "nul geldige
+ondertekenaars" when another gate, dispatched in the SAME review round
+against the SAME commit, already rendered its own valid verdict.
+
+Measured live on PR #1777 (vnx-dev store, 2026-09-05/06): the declared gate
+(``codex_gate``, from the door's obligation) carries a TERMINAL
+``not_executable`` record (``reason=provider_not_installed`` — codex is not
+installed in this environment, a permanent condition, not a transient
+outage). ``glm_gate`` — dispatched in the same review round — independently
+recorded a full, evidenced PASS on the exact same head sha, with NO
+``takeover``/``takeover_path`` annotation linking the two records (the
+OI-1576 chain-walk was never invoked; both gates were requested directly as
+part of the review stack). Before this fix, ``check_review_gate_for_merge``
+fed the absent ``codex_gate`` record straight into
+``_merge_door_record_verdict`` (the machinery that judges "is this a valid
+pass"), which read the missing ``contract_hash``/``report_path`` as
+"bewijs onvolledig" — indistinguishable from a botched review attempt — and
+returned NO-GO with no route out: OI-1576's takeover-successor evidence
+route requires a formal ``takeover_path`` annotation, which this PR's
+records never carried.
+
+The fix distinguishes "terminal" (this attempt concluded) from "a verdict
+was rendered" (pass or fail) as two independent axes
+(``closure_verifier._is_absent_without_verdict``), and — only once the
+declared gate is confirmed absent by that test, with no formal takeover
+successor either — consults every OTHER known gate's own rendered verdict
+for the exact same PR/branch/sha (``closure_verifier._find_peer_gate_results``).
+
+Hard invariants that must survive untouched:
+  - zero valid signers (no peer renders a usable pass either) stays NO-GO.
+  - a real rejection (fail) anywhere in the peer set still blocks the merge,
+    even next to another peer's pass.
+  - the seven evidence invariants (record exists, terminal, contract_hash,
+    report_path, report exists on disk, verdicts do not contradict, sha
+    equals the head) still apply in full to whichever peer ends up signing.
+  - OI-1576's own contract (a declared gate with NO record at all is never
+    handed a stranger's unrelated pass) is untouched — see
+    ``tests/test_oi1576_merge_door_takeover_evidence.py::TestUnrelatedRecordsNeverTakeOver``,
+    which this file does not modify and must keep passing unchanged.
+
+A SECOND, upstream defect surfaced while proving this live against PR #1777:
+its on-disk ``codex_gate`` not_executable record carries neither ``branch``
+nor ``commit_sha`` at all (``gate_request_handler._mark_gate_unavailable`` ->
+``gate_report_generator._write_not_executable_result`` never threaded them
+through, even though every caller — ``_request_codex`` etc. — already
+resolves both before deciding the gate is unavailable). A record missing
+those fields fails ``closure_verifier``'s scope match unconditionally and
+reads as NO RECORD AT ALL, so the absence-vs-rejection fix above never even
+gets to see it. ``TestNotExecutableRecordCarriesScope`` below covers that
+fix end-to-end through the real ``request_reviews`` -> ``_request_codex`` ->
+``_mark_gate_unavailable`` -> ``_write_not_executable_result`` chain.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv
+
+# Mirrored from the live vnx-dev store shape for PR #1777 (2026-09-05/06).
+PR_ID = "1777"
+BRANCH = "dispatch/20260905-golf1b-report-store-split"
+HEAD_SHA = "01f54411d975e39f41cb2b0d005fd8dcd5aad04a"
+OTHER_SHA = "99999999975e39f41cb2b0d005fd8dcd5aad999"
+
+CLEAN_REPORT = "# Gate report\n\nAll findings reviewed, nothing blocking.\n"
+
+
+def _write_result(results_dir: Path, gate: str, data: dict) -> Path:
+    """Write a result record under the writer's real naming (pr-<n>-<gate>.json)."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / f"pr-{PR_ID}-{gate}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _report_file(tmp_path: Path, name: str = "report.md", content: str = CLEAN_REPORT) -> Path:
+    report = tmp_path / name
+    report.write_text(content, encoding="utf-8")
+    return report
+
+
+def _codex_not_executable() -> dict:
+    """pr-1777-codex_gate.json as measured: terminal not_executable, no
+    takeover annotation, no evidence fields — codex is not installed."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": PR_ID,
+        "status": "not_executable",
+        "reason": "provider_not_installed",
+        "reason_detail": "codex binary not found in PATH",
+        "contract_hash": "",
+        "report_path": "",
+        "branch": BRANCH,
+        "commit_sha": HEAD_SHA,
+    }
+
+
+def _glm_pass(report: Path, **overrides) -> dict:
+    """pr-1777-glm_gate.json as measured: a plain, unlinked pass — no
+    takeover claim of any kind."""
+    data = {
+        "gate": "glm_gate",
+        "pr_id": PR_ID,
+        "status": "pass",
+        "blocking_count": 0,
+        "blocking_findings": [],
+        "contract_hash": "549c0288ef98004e",
+        "report_path": str(report),
+        "branch": BRANCH,
+        "commit_sha": HEAD_SHA,
+    }
+    data.update(overrides)
+    return data
+
+
+def _check(results_dir: Path, gate: str = "codex_gate", head_sha: str = HEAD_SHA) -> dict:
+    return cv.check_review_gate_for_merge(
+        PR_ID, gate, results_dir, branch=BRANCH, head_sha=head_sha
+    )
+
+
+class TestAbsentDeclaredGateAcceptsPeerVerdict:
+    """The live #1777 shape: declared codex_gate is a confirmed, terminal
+    absence; glm_gate independently passed the exact same head — no formal
+    takeover linkage between the two records at all."""
+
+    def test_terminal_not_executable_with_peer_pass_is_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable())
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO", verdict["message"]
+        assert verdict["gate"] == "codex_gate"
+        assert verdict["evidence_gate"] == "glm_gate"
+        assert "afwezig" in verdict["message"]
+
+    def test_non_terminal_unavailable_with_peer_pass_is_also_go(self, tmp_path):
+        """OI-1624: absence applies "ongeacht of het record terminaal is
+        opgeslagen" — a non-terminal ``unavailable`` declared-gate record
+        must be treated identically to a terminal ``not_executable`` one."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        codex = _codex_not_executable()
+        codex["status"] = "unavailable"
+        codex["reason"] = "dispatch_error"
+        _write_result(results_dir, "codex_gate", codex)
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO", verdict["message"]
+        assert verdict["evidence_gate"] == "glm_gate"
+
+
+class TestGuardStillHoldsForThePeerRoute:
+    """Breaking the new peer route three separate ways — each must still
+    refuse on its own, exactly like the declared gate's own evidence would."""
+
+    def test_peer_pass_on_a_different_sha_than_head_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable())
+        _write_result(results_dir, "glm_gate", _glm_pass(report, commit_sha=OTHER_SHA))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "nul geldige ondertekenaars" in verdict["message"]
+
+    def test_peer_pass_without_contract_hash_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable())
+        _write_result(results_dir, "glm_gate", _glm_pass(report, contract_hash=""))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "nul geldige ondertekenaars" in verdict["message"]
+
+    def test_peer_pass_with_nonexistent_report_path_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        missing_report = tmp_path / "does-not-exist.md"
+        _write_result(results_dir, "codex_gate", _codex_not_executable())
+        _write_result(results_dir, "glm_gate", _glm_pass(missing_report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "nul geldige ondertekenaars" in verdict["message"]
+
+    def test_real_peer_fail_still_blocks_next_to_another_peers_pass(self, tmp_path):
+        """Harde grens: een echte afkeuring blijft blokkeren, ook naast een
+        pass van een andere poort."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable())
+        _write_result(
+            results_dir, "kimi_gate",
+            {
+                "gate": "kimi_gate", "pr_id": PR_ID, "status": "fail",
+                "blocking_count": 1,
+                "blocking_findings": [{"severity": "blocking", "message": "real defect"}],
+                "contract_hash": "aa11bb22cc33dd44", "report_path": str(report),
+                "branch": BRANCH, "commit_sha": HEAD_SHA,
+            },
+        )
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "kimi_gate" in verdict["message"]
+        assert "afkeuring" in verdict["message"]
+
+
+class TestZeroValidSignersStaysNoGo:
+    def test_absent_declared_gate_with_no_peer_evidence_at_all_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        _write_result(results_dir, "codex_gate", _codex_not_executable())
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "nul geldige ondertekenaars" in verdict["message"]
+        assert "afwezig" in verdict["message"]
+
+    def test_absent_declared_gate_with_only_incomplete_peers_is_no_go(self, tmp_path):
+        """A peer that is itself still in flight (pending) never counts —
+        only a RENDERED verdict (pass/fail) is peer evidence."""
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable())
+        _write_result(
+            results_dir, "kimi_gate",
+            {
+                "gate": "kimi_gate", "pr_id": PR_ID, "status": "pending",
+                "contract_hash": "", "report_path": str(report),
+                "branch": BRANCH, "commit_sha": HEAD_SHA,
+            },
+        )
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "nul geldige ondertekenaars" in verdict["message"]
+
+
+class TestInFlightDeclaredGateIsNotAbsence:
+    """OI-1624 deliberately excludes INCOMPLETE_STATES (pending/running/
+    queued/requested) from "absence": the SAME record may still mature into
+    a verdict, so consulting a peer while it is still in flight would be
+    premature. This must keep going through the ORIGINAL "niet terminaal"
+    path, unchanged (see test_pr_merge_review_gate.py::test_non_terminal_result_is_no_go)."""
+
+    def test_pending_declared_gate_with_peer_pass_stays_not_terminal_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        codex = _codex_not_executable()
+        codex["status"] = "pending"
+        _write_result(results_dir, "codex_gate", codex)
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "niet terminaal" in verdict["message"]
+
+
+class TestNoRegressionOnZeroRecordAbsence:
+    """The pre-existing OI-1576 contract must survive byte-for-byte: a
+    declared gate with NO record at all (never even asked) is never handed a
+    stranger's unrelated pass. This mirrors
+    test_oi1576_merge_door_takeover_evidence.py::TestUnrelatedRecordsNeverTakeOver
+    exactly, as an explicit regression pin for THIS fix."""
+
+    def test_no_record_at_all_with_unrelated_peer_pass_stays_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "geen review-gate resultaat" in verdict["message"]
+
+
+@pytest.fixture
+def manager_env(tmp_path, monkeypatch):
+    """Same isolated-store fixture shape as test_gate_request_handler_w3f.py."""
+    project_root = tmp_path / "project"
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / "unified_reports"
+    for d in (
+        state_dir / "review_gates" / "requests",
+        state_dir / "review_gates" / "results",
+        reports_dir,
+    ):
+        d.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(reports_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    monkeypatch.setenv("VNX_GEMINI_REVIEW_ENABLED", "0")
+    monkeypatch.setenv("VNX_CODEX_HEADLESS_ENABLED", "0")
+    monkeypatch.setenv("VNX_CLAUDE_GITHUB_REVIEW_ENABLED", "0")
+    return {
+        "project_root": project_root,
+        "state_dir": state_dir,
+        "requests_dir": state_dir / "review_gates" / "requests",
+        "results_dir": state_dir / "review_gates" / "results",
+    }
+
+
+class TestNotExecutableRecordCarriesScope:
+    """OI-1624, second defect: a not_executable RESULT record must carry the
+    same ``branch``/``commit_sha`` the caller already resolved for the
+    REQUEST record — measured live on PR #1777's ``codex_gate`` record,
+    which had neither and was therefore invisible to
+    ``closure_verifier``'s scope match (reads as "no record", not as a
+    confirmed absence). Driven through the REAL production chain:
+    ``ReviewGateManager.request_reviews`` -> ``_request_codex`` ->
+    ``_mark_gate_unavailable`` -> ``_write_not_executable_result``.
+    """
+
+    def test_codex_not_executable_result_carries_branch_and_commit_sha(self, manager_env, monkeypatch):
+        monkeypatch.chdir(manager_env["project_root"])
+        import gate_request_handler
+        fake_head_oid = "01f54411d975e39f41cb2b0d005fd8dcd5aad04a"
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: fake_head_oid)
+
+        import review_gate_manager as rgm
+        manager = rgm.ReviewGateManager()
+
+        with patch("governance_receipts.emit_governance_receipt"):
+            manager.request_reviews(
+                pr_number=1777,
+                branch="dispatch/20260905-golf1b-report-store-split",
+                review_stack=["codex_gate"],
+                risk_class="low",
+                changed_files=["scripts/foo.py"],
+                mode="per_pr",
+                dispatch_id="test-oi1624-codex-scope",
+            )
+
+        result_file = manager_env["results_dir"] / "pr-1777-codex_gate.json"
+        assert result_file.exists()
+        record = json.loads(result_file.read_text())
+
+        assert record["status"] == "not_executable"
+        assert record["branch"] == "dispatch/20260905-golf1b-report-store-split"
+        assert record["commit_sha"] == fake_head_oid
+
+        # And the closure_verifier merge door can now find it as a genuine,
+        # scoped absence rather than reading it as "no record at all".
+        found = cv._find_gate_result(
+            "codex_gate", "1777", manager_env["results_dir"],
+            branch="dispatch/20260905-golf1b-report-store-split",
+            head_sha=fake_head_oid,
+        )
+        assert found is not None, "the not_executable record must be scope-matchable, not invisible"
+        assert cv._is_absent_without_verdict(found) is True


### PR DESCRIPTION
## Summary

- `check_review_gate_for_merge` fed a declared gate's own absent record (`not_executable`/`unavailable`, no rendered verdict) straight into the pass/fail evidence-invariant chain (`_merge_door_record_verdict`), which read the empty `contract_hash`/`report_path` as "bewijs onvolledig" and blocked the merge with no route out once no formal OI-1576 `takeover_path` linked another gate's pass to it.
- Live on PR #1777: `codex_gate` is a terminal `not_executable` (provider not installed) next to a fully-evidenced `glm_gate` pass on the same head sha, no takeover annotation between the two.
- Fix distinguishes "terminal" (this attempt concluded) from "a verdict was rendered" (pass or fail) as two independent axes (`_is_absent_without_verdict`), and — only when the declared gate is a confirmed absence with no takeover successor either — consults every other known gate's own rendered verdict for the same PR/branch/sha (`_find_peer_gate_results`). A real rejection anywhere in that set still blocks the merge; zero valid signers still refuses, now honestly reported as absence instead of "bewijs onvolledig".
- OI-1576's own contract (a declared gate with no record at all is never handed a stranger's unrelated pass) and the OI-1469/1470 overwrite guard are untouched.
- Second defect found while proving this live: a `not_executable` RESULT record never carried `branch`/`commit_sha` even though every caller already resolved both for the REQUEST record, making the record invisible to the scope matcher entirely. `_write_not_executable_result`/`_mark_gate_unavailable` now thread them through.
- Decision recorded in ADR-037.

## Test plan

- [x] Red-first: `tests/test_oi1624_gate_absence_vs_rejection.py` — 11 tests, verified red against unmodified `closure_verifier.py`/`gate_report_generator.py`/`gate_request_handler.py`, green after the fix.
- [x] Own-guard breakage (3x, each separately red-then-green): peer pass on a different sha, peer pass without `contract_hash`, peer pass with a nonexistent `report_path` — all still NO-GO.
- [x] Real peer `fail` still blocks next to another peer's pass.
- [x] Zero valid signers still NO-GO (no peer evidence at all; only incomplete/in-flight peers).
- [x] In-flight declared gate (`pending`) is NOT treated as absence — stays on the original "niet terminaal" path unchanged.
- [x] Explicit regression pin: declared gate with no record at all + unrelated peer pass stays NO-GO (OI-1576 contract untouched).
- [x] Full existing suite for closure_verifier/gate_request_handler/gate_recorder/gate_obligation* (46 files, ~940 tests): identical pre-existing failure set (25, unrelated — network/gh/other-module issues) before and after this change.
- [x] `python3 scripts/pr_merge.py --pr 1777 --squash --dry-run`: still NO-GO on the live vnx-dev store, because the on-disk `codex_gate` record predates this fix and lacks `branch`/`commit_sha` (fixed for *future* records by the second defect fix above, but not retroactively — see Open Items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)