### PR TITLE
fix(receipt): thread the resolved PR number onto the envelope receipt (F1-1)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -40,6 +40,7 @@ import hashlib
 import logging
 import subprocess
 import sys
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Optional
@@ -238,6 +239,12 @@ def _enforce_push_pr(
             "envelope: PR-enforcement OK dispatch=%s state=%s pr=%s created=%s",
             dispatch_id, state, pr_result.pr_number, pr_result.created,
         )
+        # F1-1: thread the resolved PR number onto the adapter result so
+        # _govern can stamp it on the receipt — previously dropped here,
+        # the reason a successfully auto-PR'd dispatch's receipt still
+        # carried no PR number at all.
+        if pr_result.pr_number is not None:
+            return replace(result, pr_number=pr_result.pr_number)
         return result
 
     logger.warning(

--- a/scripts/lib/envelope_govern.py
+++ b/scripts/lib/envelope_govern.py
@@ -405,7 +405,25 @@ def _govern(
                     terminal_id=spec.terminal_id,
                     provider=spec.provider,
                     model=_cost_model,
-                    pr_id=spec.pr_id,
+                    # F1-1 (PRD bewijsketen): spec.pr_id is a pre-known
+                    # fix-forward target (set at dispatch-creation time) and
+                    # always wins when present. Otherwise fall back to the PR
+                    # dispatch_envelope._enforce_push_pr resolved THIS run
+                    # (found or auto-created) — previously discarded, the
+                    # reason a freshly-created PR never reached the receipt.
+                    # The two never race: skip_pr (fix-forward's own branch
+                    # already has a PR) always leaves pr_number None on the
+                    # adapter result for exactly the dispatches that carry a
+                    # spec.pr_id.
+                    pr_id=(
+                        spec.pr_id
+                        if spec.pr_id
+                        else (
+                            str(adapter_result.pr_number)
+                            if adapter_result.pr_number is not None
+                            else None
+                        )
+                    ),
                     status=_effective_status,
                     completion_pct=100 if _effective_status == "success" else 0,
                     risk=0.0,

--- a/scripts/lib/envelope_types.py
+++ b/scripts/lib/envelope_types.py
@@ -96,3 +96,15 @@ class _AdapterResult:
     # actually ran, not a placeholder from the dispatch spec. None when the
     # adapter did not resolve a distinct model (caller falls back to spec.model).
     model: Optional[str] = None
+    # PRD bewijsketen F1-1: the PR number pr_enforcement.enforce_pr_exists
+    # resolved (found or created) when dispatch_envelope._enforce_push_pr ran
+    # the rij-7 push+PR obligation on this dispatch's own worktree/branch.
+    # None when enforcement was not applicable (clean worktree), was skipped
+    # (fix-forward onto an existing dispatch branch — see skip_pr), or has not
+    # run yet (adapter result fresh off EXECUTE, before _enforce_push_pr).
+    # _govern threads this into the receipt's pr_id field ONLY when
+    # spec.pr_id (a pre-known fix-forward target) is absent, so the two
+    # sources — pre-known target vs. resolved-this-run — never race: a
+    # fix-forward dispatch's spec.pr_id always wins, matching skip_pr always
+    # leaving this field None for that same dispatch.
+    pr_number: Optional[int] = None

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -16,14 +16,14 @@
     },
     {
       "file": "tests/test_dispatch_door_row.py",
-      "line": 569,
+      "line": 574,
       "mechanism": "direct-call",
       "module_target": "envelope_types",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_door_row.py",
-      "line": 574,
+      "line": 579,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
@@ -1105,6 +1105,41 @@
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_pr_number_receipt_wiring.py",
+      "line": 44,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_pr_number_receipt_wiring.py",
+      "line": 44,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_pr_number_receipt_wiring.py",
+      "line": 45,
+      "mechanism": "direct-call",
+      "module_target": "envelope_govern",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_pr_number_receipt_wiring.py",
+      "line": 100,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_enforce_push_pr"
+    },
+    {
+      "file": "tests/test_pr_number_receipt_wiring.py",
+      "line": 131,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_enforce_push_pr"
     },
     {
       "file": "tests/test_provider_deadline_passthrough.py",

--- a/tests/test_pr_number_receipt_wiring.py
+++ b/tests/test_pr_number_receipt_wiring.py
@@ -1,0 +1,198 @@
+"""test_pr_number_receipt_wiring.py — PRD bewijsketen fase 1, F1-1: the PR
+number a dispatch's own push+PR enforcement resolves must survive into the
+receipt written to the ledger.
+
+T0 measured (2026-09-05, 5,926 LIVE task_complete/non-pytest receipts):
+pr_number 0.0%, pr_link 0.0%, pr_id 1.4%. Two independent defects mask each
+other:
+
+  1. ``envelope_types._AdapterResult`` (the value dispatch_envelope.
+     _enforce_push_pr and envelope_govern._govern pass between EXECUTE and
+     GOVERN) had no field to carry a PR number resolved DURING this
+     dispatch's own run — only ``EnvelopeSpec.pr_id``, a pre-known
+     fix-forward target set at dispatch-creation time, ever reached the
+     receipt (the source of the measured 1.4%).
+  2. ``dispatch_envelope._enforce_push_pr`` discarded
+     ``pr_enforcement.PrEnforcementResult.pr_number`` on the success path —
+     even once the schema HAD a field for it, nothing fed it.
+
+This file proves both are fixed: ``_enforce_push_pr`` threads the resolved
+number onto the ``_AdapterResult`` it returns, and ``_govern`` stamps it onto
+the receipt's ``pr_id`` field (reused — see envelope_types.py's
+``_AdapterResult.pr_number`` docstring for why reuse over a new field) when
+no pre-known ``spec.pr_id`` already claims that slot.
+
+Mirrors tests/test_lane_matrix_row7_push_pr.py's and
+tests/test_receipt_v2_pr4_wiring.py's fixture patterns (this file does not
+import from either — it isolates ``_enforce_push_pr``/``_govern`` directly
+rather than driving the full run_envelope_headless_plan worktree scaffolding,
+since the discarded-value bug lives entirely inside those two functions).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import dispatch_envelope  # noqa: E402
+from envelope_types import EnvelopeSpec, _AdapterResult  # noqa: E402
+from envelope_govern import _govern  # noqa: E402
+from pr_enforcement import PrEnforcementResult  # noqa: E402
+
+
+def _read_lines(receipts_path: Path) -> list:
+    if not receipts_path.exists():
+        return []
+    return [json.loads(l) for l in receipts_path.read_text().splitlines() if l.strip()]
+
+
+def _spec(tmp_path: Path, *, pr_id=None, dispatch_id: str) -> EnvelopeSpec:
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "unified_reports").mkdir(parents=True, exist_ok=True)
+    return EnvelopeSpec(
+        dispatch_id=dispatch_id,
+        terminal_id="T1",
+        provider="claude",
+        model="claude-sonnet-5",
+        instruction="do the work",
+        role=None,
+        pr_id=pr_id,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+
+def _success_result(**overrides) -> _AdapterResult:
+    base = dict(returncode=0, completion_text="done", status="success")
+    base.update(overrides)
+    return _AdapterResult(**base)
+
+
+# ---------------------------------------------------------------------------
+# Unit: _enforce_push_pr threads the resolved PR number onto the result
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_push_pr_threads_resolved_pr_number_onto_result(tmp_path):
+    """Before the fix, a successful enforce_pr_exists() call's pr_number was
+    logged and then discarded — the returned _AdapterResult was untouched.
+    """
+    result_in = _success_result()
+
+    fake_pr_result = PrEnforcementResult(
+        applicable=True, ok=True, pushed=True, pr_number=4242, created=True,
+    )
+
+    with patch("dispatch_worktree_isolation.read_worktree_base_sha",
+               return_value=("d" * 40, None)), \
+         patch("tmux_worktree.resolve_effective_branch",
+               side_effect=lambda *, wt, expected_branch, dispatch_id: expected_branch), \
+         patch("tmux_worktree.classify_path", return_value="pushed"), \
+         patch("pr_enforcement.enforce_pr_exists", return_value=fake_pr_result):
+        result_out = dispatch_envelope._enforce_push_pr(
+            dispatch_id="pr-number-unit-test",
+            branch="dispatch/pr-number-unit-test",
+            wt_path=tmp_path / "wt",
+            repo_root=tmp_path,
+            receipts_file=tmp_path / "t0_receipts.ndjson",
+            result=result_in,
+        )
+
+    assert result_out.pr_number == 4242, (
+        f"_enforce_push_pr must thread the resolved PR number onto the "
+        f"_AdapterResult it returns; got pr_number={result_out.pr_number!r}"
+    )
+    # Unrelated fields must pass through untouched.
+    assert result_out.status == "success"
+    assert result_out.completion_text == "done"
+
+
+def test_enforce_push_pr_leaves_result_unchanged_when_not_applicable(tmp_path):
+    """clean worktree: enforce_pr_exists returns applicable=False — nothing
+    to thread, the result must be returned untouched (not even a no-op copy
+    that could mask a future field getting dropped)."""
+    result_in = _success_result()
+    fake_pr_result = PrEnforcementResult(applicable=False, ok=True, reason="clean")
+
+    with patch("dispatch_worktree_isolation.read_worktree_base_sha",
+               return_value=("d" * 40, None)), \
+         patch("tmux_worktree.resolve_effective_branch",
+               side_effect=lambda *, wt, expected_branch, dispatch_id: expected_branch), \
+         patch("tmux_worktree.classify_path", return_value="clean"), \
+         patch("pr_enforcement.enforce_pr_exists", return_value=fake_pr_result):
+        result_out = dispatch_envelope._enforce_push_pr(
+            dispatch_id="pr-number-unit-test-clean",
+            branch="dispatch/pr-number-unit-test-clean",
+            wt_path=tmp_path / "wt",
+            repo_root=tmp_path,
+            receipts_file=tmp_path / "t0_receipts.ndjson",
+            result=result_in,
+        )
+
+    assert result_out is result_in
+    assert result_out.pr_number is None
+
+
+# ---------------------------------------------------------------------------
+# Behavior: _govern stamps pr_id from the resolved pr_number — the RED test.
+#
+# Before the fix, _AdapterResult had no pr_number field at all: constructing
+# `_success_result(pr_number=4242)` below raised
+# `TypeError: __init__() got an unexpected keyword argument 'pr_number'` —
+# the field did not survive the schema step because the schema (the
+# dataclass _govern reads from) did not carry it, by construction.
+# ---------------------------------------------------------------------------
+
+
+def test_govern_stamps_pr_id_from_resolved_pr_number_when_spec_pr_id_absent(tmp_path):
+    spec = _spec(tmp_path, pr_id=None, dispatch_id="pr-number-govern-test")
+    adapter_result = _success_result(pr_number=4242)
+    now = datetime.now(timezone.utc)
+
+    report_path, receipt_path = _govern(spec, adapter_result, now, now)
+
+    assert receipt_path is not None, "GOVERN must have written a receipt"
+    lines = _read_lines(spec.state_dir / "t0_receipts.ndjson")
+    assert lines, "no receipt line was written"
+    assert lines[-1]["pr_id"] == "4242", (
+        f"the PR number resolved by push+PR enforcement this run must survive "
+        f"into the receipt's pr_id field; got {lines[-1].get('pr_id')!r} in "
+        f"{lines[-1]!r}"
+    )
+
+
+def test_govern_prefers_spec_pr_id_over_resolved_pr_number(tmp_path):
+    """A pre-known fix-forward target (spec.pr_id) always wins — the two
+    sources are not expected to disagree in practice (skip_pr leaves
+    pr_number None for exactly the dispatches that carry a spec.pr_id), but
+    the precedence must be deterministic and must never let a resolved
+    number silently overwrite an explicit target."""
+    spec = _spec(tmp_path, pr_id="1000", dispatch_id="pr-number-govern-precedence")
+    adapter_result = _success_result(pr_number=4242)
+    now = datetime.now(timezone.utc)
+
+    _report_path, receipt_path = _govern(spec, adapter_result, now, now)
+
+    assert receipt_path is not None
+    lines = _read_lines(spec.state_dir / "t0_receipts.ndjson")
+    assert lines[-1]["pr_id"] == "1000"
+
+
+def test_govern_leaves_pr_id_none_when_neither_source_present(tmp_path):
+    spec = _spec(tmp_path, pr_id=None, dispatch_id="pr-number-govern-absent")
+    adapter_result = _success_result()  # pr_number defaults to None
+    now = datetime.now(timezone.utc)
+
+    _report_path, receipt_path = _govern(spec, adapter_result, now, now)
+
+    assert receipt_path is not None
+    lines = _read_lines(spec.state_dir / "t0_receipts.ndjson")
+    assert lines[-1]["pr_id"] is None


### PR DESCRIPTION
## Summary

T0 measured 2026-09-05 on 5,926 LIVE task_complete receipts: `pr_number` 0.0%, `pr_link` 0.0%, `pr_id` 1.4%. Two independent defects mask each other:

1. `envelope_types._AdapterResult` (the value passed from EXECUTE to GOVERN on the envelope lanes) had no field to carry a PR number resolved *during* the dispatch's own run — only `EnvelopeSpec.pr_id`, a pre-known fix-forward target set at dispatch-creation time, ever reached the receipt (the source of the measured 1.4%).
2. `dispatch_envelope._enforce_push_pr` discarded `pr_enforcement.PrEnforcementResult.pr_number` on the success path — it was logged and the adapter result returned unchanged.

## Changes

- `scripts/lib/envelope_types.py`: adds `_AdapterResult.pr_number: Optional[int]`.
- `scripts/lib/dispatch_envelope.py`: `_enforce_push_pr` now threads `pr_result.pr_number` onto the returned `_AdapterResult` via `dataclasses.replace` when enforcement succeeded.
- `scripts/lib/envelope_govern.py`: `_govern` stamps `pr_id` from `spec.pr_id` when present (pre-known fix-forward target, unchanged precedence), else falls back to `str(adapter_result.pr_number)`. Reuses `pr_id` rather than adding a new schema field — the two sources are mutually exclusive by construction (`skip_pr` always leaves `pr_number=None` for exactly the dispatches that carry a `spec.pr_id`).
- `tests/test_pr_number_receipt_wiring.py` (new): 5 tests proving the wiring, including the RED-test-first case.
- `tests/data/dispatch_envelope_census.json`: regenerated (the new test file's direct calls into the envelope family are now tracked by the existing characterization-census guard).

**Scoped to the envelope lane** per dispatch instruction (this is the dominant receipt-writing path since the A2 headless-default cutover). The tmux lane has the identical gap (`autopr_result.pr_number` discarded before `_govern_report` in `tmux_interactive_dispatch.py` ~line 3727) — left as an open item below, not fixed here, to keep this PR scoped to F1-1.

**No reprocessing of existing receipts** — ADR-005:76 and PRD-deliverable F1-4 own that (need one outcome identity + durable idempotency first).

## Verification

RED test first, on behavior (confirmed by temporarily stashing the fix and re-running):
```
$ git stash push -u -- scripts/lib/envelope_types.py scripts/lib/dispatch_envelope.py scripts/lib/envelope_govern.py
$ python3 -m pytest tests/test_pr_number_receipt_wiring.py -v
...
FAILED test_enforce_push_pr_threads_resolved_pr_number_onto_result
FAILED test_enforce_push_pr_leaves_result_unchanged_when_not_applicable
FAILED test_govern_stamps_pr_id_from_resolved_pr_number_when_spec_pr_id_absent  (TypeError: unexpected keyword argument 'pr_number' — the field literally did not survive the schema)
FAILED test_govern_prefers_spec_pr_id_over_resolved_pr_number  (same TypeError)
4 failed, 1 passed in 0.30s
$ git stash pop
```

GREEN after restoring the fix:
```
$ python3 -m pytest tests/test_pr_number_receipt_wiring.py -v
5 passed in 0.33s
```

Own-guard-breaks-red proof (unprompted): adding the new test file tripped the existing `tests/test_dispatch_envelope_characterization.py::TestLayer2Census::test_census_matches_fixture` guard (it censuses every direct call into the envelope module family). Regenerated via `python3 tests/dispatch_envelope_census_scanner.py` — now green.

Own-measurement-methodology sanity check (bewijs: "nul is eerst een meetfout" — verify the query against a case that DOES exist before trusting a 0%): ran my own script against the live ledger (`~/.vnx-data/vnx-dev/state/t0_receipts.ndjson`, read-only, 29,064 lines) mirroring T0's filter (`event_type=task_complete`, `source != pytest`):
```
task_complete_nonpytest 5938
pr_id_truthy       85  (1.43%)  <- matches T0's 85/1.4%, confirms my query methodology is sound
pr_link_truthy      1  (0.02%)
pr_number_truthy    0  (0.00%)
```

Broader regression sweep (envelope, receipt schema, governance emit, PR enforcement, lane matrix):
```
$ python3 -m pytest tests/test_lane_matrix_row7_push_pr.py tests/test_receipt_v2_pr5_schema_cutover.py \
    tests/test_receipt_v2_pr_b2_wiring.py tests/test_receipt_schema.py tests/test_governance_emit.py \
    tests/test_governance_emit_schema.py tests/test_dispatch_envelope.py \
    tests/test_dispatch_envelope_characterization.py tests/test_dispatch_envelope_field_propagation.py \
    tests/test_dispatch_envelope_plan.py tests/test_envelope_govern_contract_enforce.py \
    tests/test_pr_enforcement.py tests/test_pr_number_receipt_wiring.py -q
321 passed in 8.31s
```

One pre-existing, unrelated failure was found and confirmed NOT caused by this change (`tests/test_receipt_v2_pr4_wiring.py::test_t24_envelope_subpath_verification_from_report` — fails identically with the fix stashed out, on a report-body-contract assertion unrelated to pr_id/pr_number). Not touched by this PR.

## Open Items

- **Tmux lane has the identical gap.** `tmux_interactive_dispatch.py`'s `_enforce_pr_exists` call (~line 3727) also discards a successful `autopr_result.pr_number` before `_govern_report` builds the receipt. Same fix shape (thread the resolved number into the receipt dict before `_govern_report`), different code shape (dict-based receipt, not `_AdapterResult`). Not fixed here — flagging for a follow-up dispatch since this PR is scoped to the envelope lane per instruction.
- **Backfill scope estimate for a future F1-4 reprocessing pass** (not attempted in this PR, per ADR-005:76 / idempotency prerequisite): of 5,938 live non-pytest `task_complete` receipts, 1,215 (20.46%) are `status=success` with no `pr_id` — the rough ceiling of what a future backfill could recover. Breakdown by provider: deepseek-harness 415, glm-harness 206, kimi 152, codex 111, unknown 108, codex_cli 87, claude 77, others ~35.
- **Converter path (`report_to_receipt_converter.py`'s `pr_link` status field)** is untouched — separate mechanism (a linked/unreported/refused status on the *gate obligation*, not a PR number on the receipt itself) and separately near-dead (`report_to_receipt_converter.json` health status `fail`, 2 days stale as of T0's 2026-09-05 measurement). Out of scope for F1-1.

Dispatch-ID: 20260906-golf3a-pr-nummer-op-receipt