### PR TITLE
fix(closure-verifier): peer-route opens on out-of-scope absence too (OI-1642)

### DIFF
--- a/docs/governance/decisions/ADR-037-gate-uitval-is-afwezigheid-niet-tegenstem.md
+++ b/docs/governance/decisions/ADR-037-gate-uitval-is-afwezigheid-niet-tegenstem.md
@@ -64,3 +64,39 @@ Zodra de gedeclareerde poort een bevestigde afwezigheid is (record bestaat, geen
 - OI-1469/OI-1470 — `gate_recorder._check_overwrite_guard`, de schrijfkant-wachter die dit ADR expliciet niet aanraakt.
 - `scripts/lib/gate_status.py` — de canonieke statuscategorieën (`PASS_STATES`, `FAIL_STATES`, `INCOMPLETE_STATES`, `UNAVAILABLE_STATES`, `is_terminal`) waarop dit ADR's "terminaal ≠ uitspraak"-onderscheid leunt.
 - `tests/test_oi1624_gate_absence_vs_rejection.py` — rode-naar-groene regressietests, inclusief een expliciete pin op het ongewijzigde OI-1576-contract (`TestNoRegressionOnZeroRecordAbsence`).
+
+## Addendum (OI-1642, 2026-09-06) — afwezigheid geldt ook buiten scope
+
+Bovenstaand ADR gaat ervan uit dat een bevestigde afwezigheid een IN-SCOPE record is:
+`_find_gate_result` vond het, met matchende `branch`/`project_id`/`commit_sha`. In de
+praktijk bleek dat een te sterke aanname. Zeven PR's (#1777-#1782, #1784) bleven na dit
+ADR alsnog NO-GO: hun `codex_gate`-record dateert van vóór de fix hierboven en draagt
+daarom geen `branch`/`commit_sha` — precies het veld dat `_record_matches_scope`
+onvoorwaardelijk eist. `_find_gate_result` gaf dus `None` terug, niet omdat de poort nooit
+gevraagd was, maar omdat het bestaande record de scope-toets niet haalde. De
+peer-route hierboven wordt alleen bereikt via `result is not None and
+_is_absent_without_verdict(result)` (regel "OI-1624" in
+`check_review_gate_for_merge`), dus bij `None` werd hij nooit geraadpleegd — en omdat
+`gate_recorder`'s overschrijfwachter (OI-1469/OI-1470) een terminaal record nooit
+opnieuw laat schrijven, is dat record blijvend onzichtbaar voor de lezer.
+
+De oplossing (`closure_verifier._find_gate_result_ignoring_scope` +
+`_consult_peers_for_absence`) splitst wat `result is None` voorheen op een hoop gooide,
+in drie gevallen:
+
+- **(a) geen enkel record voor dit gate+pr_id.** Ongewijzigd NO-GO, geen peer-route.
+  Dit blijft exact het contract van `TestUnrelatedRecordsNeverTakeOver`
+  (`tests/test_oi1576_merge_door_takeover_evidence.py`) — gemeten: een peer-route die
+  hier ONVOORWAARDELIJK zou lopen breekt die test twee keer (een losstaande pass en een
+  takeover-claim zonder de gedeclareerde poort in het pad worden dan allebei ten
+  onrechte een geldige ondertekenaar).
+- **(b) een record bestaat, buiten scope, en is zelf een bevestigde afwezigheid**
+  (`_is_absent_without_verdict`). Dezelfde peer-route als hierboven opent, via de
+  gedeelde `_consult_peers_for_absence` — geen tweede, kunnen-uiteenlopen-kopie.
+- **(c) een record bestaat buiten scope MET een uitspraak** (pass/fail op een andere
+  branch/sha). Verouderd bewijs, geen afwezigheid — blijft NO-GO met de bestaande
+  boodschap "geen review-gate resultaat gevonden".
+
+De voorrangsregel en de zeven bewijs-invarianten uit het hoofd-ADR gelden onverkort voor
+de ondertekenende peer in geval (b); er is niets verzwakt, alleen de vraag "bestaat er
+een record" losgekoppeld van "is dat record in scope".

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -328,6 +328,41 @@ def _record_matches_scope(
     return True
 
 
+def _iter_gate_result_candidates(
+    gate: str,
+    pr_id: str,
+    results_dir: Path,
+) -> Iterable[Dict[str, Any]]:
+    """Every on-disk record naming this exact gate+pr_id, contract file first
+    then the legacy glob — the shared path patterns and pr_id/gate matching
+    both ``_find_gate_result`` (scoped) and ``_find_gate_result_ignoring_scope``
+    (OI-1642, unscoped) read, so the two lookups can never grow a second,
+    diverging glob.
+
+    Branch/project_id/head_sha scope is NOT applied here — callers decide.
+    Offline test-run records ARE excluded unconditionally: never valid
+    evidence for a real PR, in or out of scope.
+    """
+    pr_slug = pr_id.lower().replace("-", "")
+    # Contract-based results: {pr_slug}-{gate}-contract.json
+    contract_path = results_dir / f"{pr_slug}-{gate}-contract.json"
+    if contract_path.exists():
+        try:
+            data = json.loads(_read_text(contract_path))
+            if not _is_test_run_record(data):
+                yield data
+        except (json.JSONDecodeError, OSError):
+            pass
+    # Legacy pattern: pr-{number}-{gate}.json — require both pr_id AND gate to match
+    for path in results_dir.glob(f"*-{gate}*.json"):
+        try:
+            data = json.loads(_read_text(path))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("pr_id") == pr_id and data.get("gate") == gate and not _is_test_run_record(data):
+            yield data
+
+
 def _find_gate_result(
     gate: str,
     pr_id: str,
@@ -348,30 +383,63 @@ def _find_gate_result(
     If a result carries a ``report_path``, that file must exist on disk or the
     result is treated as stale and skipped.
     """
-
-    def _accept(data: Dict[str, Any]) -> bool:
-        return _record_matches_scope(data, pr_id, branch, project_id, head_sha)
-
-    pr_slug = pr_id.lower().replace("-", "")
-    # Contract-based results: {pr_slug}-{gate}-contract.json
-    contract_path = results_dir / f"{pr_slug}-{gate}-contract.json"
-    if contract_path.exists():
-        try:
-            data = json.loads(_read_text(contract_path))
-            if _accept(data):
-                return data
-        except (json.JSONDecodeError, OSError):
-            pass
-    # Legacy pattern: pr-{number}-{gate}.json — require both pr_id AND gate to match
-    for path in results_dir.glob(f"*-{gate}*.json"):
-        try:
-            data = json.loads(_read_text(path))
-            if data.get("pr_id") == pr_id and data.get("gate") == gate:
-                if _accept(data):
-                    return data
-        except (json.JSONDecodeError, OSError):
-            continue
+    for data in _iter_gate_result_candidates(gate, pr_id, results_dir):
+        if _record_matches_scope(data, pr_id, branch, project_id, head_sha):
+            return data
     return None
+
+
+def _find_gate_result_ignoring_scope(
+    gate: str,
+    pr_id: str,
+    results_dir: Path,
+) -> Optional[Dict[str, Any]]:
+    """OI-1642: does ANY record exist for this exact gate+pr_id at all,
+    regardless of branch/project_id/head_sha?
+
+    ``_find_gate_result`` returning ``None`` conflates two different facts:
+    the gate was never asked for this PR at all (case a — must stay NO-GO,
+    unchanged, per ``TestUnrelatedRecordsNeverTakeOver``/ADR-037's "geen enig
+    record krijgt geen peer-fallback"), versus a record exists but falls
+    outside the requested scope — e.g. a ``not_executable`` record written
+    before OI-1624 threaded ``branch``/``commit_sha`` through
+    (``gate_request_handler._write_not_executable_result``), which the
+    overwrite guard (OI-1469/OI-1470) then refuses to ever rerun once
+    terminal (measured live: PR #1777's ``codex_gate`` record).
+
+    Only ever consulted by ``check_review_gate_for_merge`` AFTER
+    ``_find_gate_result`` has already returned ``None`` — never a substitute
+    for the scoped lookup, and the caller still re-validates absence
+    (``_is_absent_without_verdict``) before treating this as evidence of
+    anything.
+
+    Same candidate set and read order as ``_find_gate_result``
+    (``_iter_gate_result_candidates``); returns the first candidate, matching
+    ``_find_gate_result``'s own first-match-wins behaviour.
+    """
+    for data in _iter_gate_result_candidates(gate, pr_id, results_dir):
+        return data
+    return None
+
+
+def _describe_scope_mismatch(
+    data: Dict[str, Any],
+    branch: Optional[str],
+    project_id: Optional[str],
+    head_sha: Optional[str],
+) -> str:
+    """Name which scope fields an out-of-scope record failed to satisfy, for
+    the OI-1642 peer-route message — so the operator sees WHY the declared
+    gate's own record could not stand for itself, not just that it could
+    not."""
+    failing: List[str] = []
+    if not _matches_required_field(branch, data.get("branch")):
+        failing.append(f"branch={data.get('branch')!r}")
+    if project_id is not None and not _matches_required_field(project_id, data.get("project_id")):
+        failing.append(f"project_id={data.get('project_id')!r}")
+    if not _matches_required_field(head_sha, data.get("commit_sha")):
+        failing.append(f"commit_sha={data.get('commit_sha')!r}")
+    return ", ".join(failing) if failing else "onbekende scope-afwijking"
 
 
 # A record whose coerced status is in this set reached its own verdict
@@ -669,6 +737,94 @@ def _find_peer_gate_results(
     return peers
 
 
+def _consult_peers_for_absence(
+    gate: str,
+    pr_id: str,
+    results_dir: Path,
+    declared_status: str,
+    *,
+    branch: Optional[str],
+    project_id: Optional[str],
+    head_sha: Optional[str],
+    scope_note: str = "",
+) -> Dict[str, Any]:
+    """OI-1624/OI-1642: the shared peer-consultation verdict for a CONFIRMED
+    absent declared gate — reached either because the declared gate's own,
+    in-scope record is an absence (OI-1624), or because its only on-disk
+    record falls outside the requested branch/project_id/head_sha scope but
+    is itself an absence (OI-1642, e.g. a ``not_executable`` record written
+    before the scope fields were threaded through). Both call sites in
+    ``check_review_gate_for_merge`` route through this ONE function so they
+    can never drift apart on what counts as a valid peer signer.
+
+    ``declared_status`` is the declared gate's own canonical status, used only
+    for the message. ``scope_note``, when given, is folded into every returned
+    message so the operator sees WHY the declared gate's own record could not
+    stand for itself (OI-1642: which scope fields it failed to match).
+    """
+    peers = _find_peer_gate_results(
+        gate, pr_id, results_dir, branch=branch, project_id=project_id, head_sha=head_sha,
+    )
+    peer_fails = [
+        (peer_gate, peer) for peer_gate, peer in peers
+        if gate_canonical_status(peer) in _GATE_FAIL_STATES
+    ]
+    if peer_fails:
+        # A real rejection blocks the merge regardless of what the absent
+        # declared gate has to say about it, and regardless of any OTHER
+        # peer's pass (harde grens: een echte afkeuring blijft blokkeren,
+        # ook naast een pass van een andere poort).
+        culprit_gate, culprit = sorted(peer_fails, key=lambda item: item[0])[0]
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                f"{gate} is afwezig voor {pr_id} (status={declared_status!r}: "
+                f"geen uitspraak gedaan{scope_note}) — {culprit_gate} keurde dezelfde head af "
+                f"({gate_canonical_status(culprit)!r}): een echte afkeuring blokkeert "
+                f"de merge, ook naast de afwezigheid van {gate}"
+            ),
+            "overridden": False,
+            "override_reason": None,
+            "gate": gate,
+        }
+    for peer_gate, peer in sorted(peers, key=lambda item: item[0]):
+        if gate_canonical_status(peer) not in _GATE_PASS_STATES:
+            continue
+        peer_verdict = _merge_door_record_verdict(peer, peer_gate, pr_id)
+        if peer_verdict["verdict"] == "GO":
+            return {
+                "verdict": "GO",
+                "message": (
+                    f"{gate} is afwezig voor {pr_id} (status={declared_status!r}: "
+                    f"geen uitspraak gedaan{scope_note}) — {peer_gate} droeg op dezelfde head "
+                    "zelfstandig een geldige, volledig bewezen pass en telt als "
+                    "ondertekenaar bij afwezigheid van de gedeclareerde poort (OI-1624/OI-1642)"
+                ),
+                "overridden": False,
+                "override_reason": None,
+                "gate": gate,
+                "evidence_gate": peer_gate,
+            }
+    # Zero valid signers: the declared gate is confirmed absent and no other
+    # known gate on this exact head rendered a usable verdict either. Still
+    # NO-GO (nul geldige ondertekenaars blijft NO-GO), but honestly reported
+    # as absence, never as "bewijs onvolledig" — that phrasing belongs to a
+    # record that attempted a verdict and fell short, not to one that never
+    # tried.
+    return {
+        "verdict": "NO-GO",
+        "message": (
+            f"{gate} is afwezig voor {pr_id} (status={declared_status!r}: "
+            f"geen uitspraak gedaan{scope_note}, geen ondertekening) en geen andere poort op "
+            "deze head leverde een geldige, volledig bewezen uitspraak — nul "
+            "geldige ondertekenaars"
+        ),
+        "overridden": False,
+        "override_reason": None,
+        "gate": gate,
+    }
+
+
 def check_review_gate_for_merge(
     pr_id: str,
     gate: str,
@@ -720,13 +876,32 @@ def check_review_gate_for_merge(
     all" — feeding it an absent record used to read as "resultaat mist
     contract_hash en/of report_path", indistinguishable from a botched
     attempt). Instead every OTHER known gate's own rendered verdict for the
-    SAME PR/branch/sha is consulted (:func:`_find_peer_gate_results`): a real
-    rejection anywhere in that set still blocks the merge (an echte
-    afkeuring blijft blokkeren, ook naast een pass van een andere poort), a
-    fully-evidenced pass stands in as the signer, and zero rendered peer
-    verdicts is still NO-GO (nul geldige ondertekenaars blijft NO-GO) — now
-    honestly reported as absence rather than "incomplete evidence". See
-    ADR-037.
+    SAME PR/branch/sha is consulted (:func:`_consult_peers_for_absence` /
+    :func:`_find_peer_gate_results`): a real rejection anywhere in that set
+    still blocks the merge (an echte afkeuring blijft blokkeren, ook naast
+    een pass van een andere poort), a fully-evidenced pass stands in as the
+    signer, and zero rendered peer verdicts is still NO-GO (nul geldige
+    ondertekenaars blijft NO-GO) — now honestly reported as absence rather
+    than "incomplete evidence". See ADR-037.
+
+    OI-1642 (b): the same peer route also opens when the declared gate's OWN
+    record is not even found IN SCOPE (``_find_gate_result`` returned
+    ``None``), but a record for this exact gate+pr_id DOES exist somewhere
+    outside the requested branch/project_id/head_sha scope AND that record is
+    itself a confirmed absence (measured live: PR #1777's ``codex_gate``
+    record predates OI-1624 threading ``branch``/``commit_sha`` through, so it
+    carries neither field at all, and the overwrite guard (OI-1469/OI-1470)
+    permanently refuses to rerun it once terminal). This is NOT the same as
+    "no record at all" (case a, ``TestUnrelatedRecordsNeverTakeOver`` /
+    ADR-037's "geen enig record krijgt geen peer-fallback", which stays
+    unchanged): a gate that was genuinely never asked for this PR gets no
+    peer-fallback, but a gate that WAS asked and answered with an absence —
+    just not scoped the way this call expected — is exactly as confirmed an
+    absence as the in-scope case OI-1624 already handles, and is routed
+    through the identical :func:`_consult_peers_for_absence`. An out-of-scope
+    record that DOES carry a decided verdict (pass/fail on a different
+    branch/sha) is stale evidence, not an absence, and falls through to the
+    unchanged "no evidence found" message instead.
     """
     result = _find_gate_result(
         gate, pr_id, results_dir, branch=branch, project_id=project_id, head_sha=head_sha
@@ -787,76 +962,39 @@ def check_review_gate_for_merge(
             "gate": gate,
         }
     if result is not None and _is_absent_without_verdict(result):
-        # OI-1624: the declared gate spoke (a record exists) and what it said
-        # is that it will render no verdict for this attempt — an ABSENCE,
-        # never a rejection. Unlike a decided fail, absence carries no
-        # information that should block the merge on its own; it just means
-        # this particular seat has nothing to say. Consult every OTHER known
-        # gate's own rendered verdict for the exact same PR/branch/sha before
-        # falling back to "no evidence at all".
-        peers = _find_peer_gate_results(
-            gate, pr_id, results_dir, branch=branch, project_id=project_id, head_sha=head_sha,
+        # OI-1624: the declared gate spoke (a record exists, in scope) and
+        # what it said is that it will render no verdict for this attempt —
+        # an ABSENCE, never a rejection. Consult every OTHER known gate's own
+        # rendered verdict for the exact same PR/branch/sha before falling
+        # back to "no evidence at all".
+        return _consult_peers_for_absence(
+            gate, pr_id, results_dir, gate_canonical_status(result),
+            branch=branch, project_id=project_id, head_sha=head_sha,
         )
-        peer_fails = [
-            (peer_gate, peer) for peer_gate, peer in peers
-            if gate_canonical_status(peer) in _GATE_FAIL_STATES
-        ]
-        if peer_fails:
-            # A real rejection blocks the merge regardless of what the
-            # absent declared gate has to say about it, and regardless of
-            # any OTHER peer's pass (harde grens: een echte afkeuring
-            # blijft blokkeren, ook naast een pass van een andere poort).
-            culprit_gate, culprit = sorted(peer_fails, key=lambda item: item[0])[0]
-            return {
-                "verdict": "NO-GO",
-                "message": (
-                    f"{gate} is afwezig voor {pr_id} (status={gate_canonical_status(result)!r}: "
-                    f"geen uitspraak gedaan) — {culprit_gate} keurde dezelfde head af "
-                    f"({gate_canonical_status(culprit)!r}): een echte afkeuring blokkeert "
-                    f"de merge, ook naast de afwezigheid van {gate}"
-                ),
-                "overridden": False,
-                "override_reason": None,
-                "gate": gate,
-            }
-        for peer_gate, peer in sorted(peers, key=lambda item: item[0]):
-            if gate_canonical_status(peer) not in _GATE_PASS_STATES:
-                continue
-            peer_verdict = _merge_door_record_verdict(peer, peer_gate, pr_id)
-            if peer_verdict["verdict"] == "GO":
-                return {
-                    "verdict": "GO",
-                    "message": (
-                        f"{gate} is afwezig voor {pr_id} (status={gate_canonical_status(result)!r}: "
-                        f"geen uitspraak gedaan) — {peer_gate} droeg op dezelfde head "
-                        "zelfstandig een geldige, volledig bewezen pass en telt als "
-                        "ondertekenaar bij afwezigheid van de gedeclareerde poort (OI-1624)"
-                    ),
-                    "overridden": False,
-                    "override_reason": None,
-                    "gate": gate,
-                    "evidence_gate": peer_gate,
-                }
-        # Zero valid signers: the declared gate is confirmed absent and no
-        # other known gate on this exact head rendered a usable verdict
-        # either. Still NO-GO (nul geldige ondertekenaars blijft NO-GO), but
-        # honestly reported as absence, never as "bewijs onvolledig" — that
-        # phrasing belongs to a record that attempted a verdict and fell
-        # short, not to one that never tried.
-        return {
-            "verdict": "NO-GO",
-            "message": (
-                f"{gate} is afwezig voor {pr_id} (status={gate_canonical_status(result)!r}: "
-                "geen uitspraak gedaan, geen ondertekening) en geen andere poort op "
-                "deze head leverde een geldige, volledig bewezen uitspraak — nul "
-                "geldige ondertekenaars"
-            ),
-            "overridden": False,
-            "override_reason": None,
-            "gate": gate,
-        }
 
     if result is None:
+        # OI-1642: no IN-SCOPE record exists, but a record for this exact
+        # gate+pr_id may still exist OUTSIDE the requested scope — most often
+        # because it predates OI-1624 threading branch/commit_sha through, and
+        # the overwrite guard (OI-1469/OI-1470) now permanently refuses to
+        # rerun it once terminal. That is a DIFFERENT fact than "this gate was
+        # never asked for this PR" (case a — stays NO-GO unchanged, per
+        # TestUnrelatedRecordsNeverTakeOver / ADR-037). Only when the
+        # out-of-scope record is ITSELF a confirmed absence does the same
+        # peer route open; an out-of-scope record carrying a decided verdict
+        # (pass/fail on a stale branch/sha) is stale evidence, not an
+        # absence, and falls through unchanged below.
+        out_of_scope = _find_gate_result_ignoring_scope(gate, pr_id, results_dir)
+        if out_of_scope is not None and _is_absent_without_verdict(out_of_scope):
+            scope_note = (
+                f"; eigen record buiten scope "
+                f"({_describe_scope_mismatch(out_of_scope, branch, project_id, head_sha)})"
+            )
+            return _consult_peers_for_absence(
+                gate, pr_id, results_dir, gate_canonical_status(out_of_scope),
+                branch=branch, project_id=project_id, head_sha=head_sha,
+                scope_note=scope_note,
+            )
         return {
             "verdict": "NO-GO",
             "message": f"geen review-gate resultaat gevonden voor {gate} op {pr_id}: merge niet toetsbaar",

--- a/tests/test_oi1642_peer_route_at_none.py
+++ b/tests/test_oi1642_peer_route_at_none.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""OI-1642: the peer route must also open when the declared gate's OWN record
+is not found IN SCOPE at all (``_find_gate_result`` returns ``None``), as long
+as a record for that exact gate+pr_id exists somewhere OUTSIDE the requested
+branch/project_id/head_sha scope and that out-of-scope record is itself a
+confirmed absence.
+
+Measured live on PR #1777 (vnx-dev store, 2026-09-06, main 7b1fef53 — after
+the OI-1624 fix landed in #1783): ``pr-1777-codex_gate.json`` is a terminal
+``not_executable`` record written 2026-09-05T20:20:41Z, BEFORE #1783 threaded
+``branch``/``commit_sha`` through the writer — it carries neither field.
+``_find_gate_result("codex_gate", ..., branch=..., head_sha=...)`` therefore
+returns ``None`` (``_record_matches_scope`` rejects a record missing a
+required field unconditionally), even though the record obviously exists and
+is a confirmed absence. ``pr-1777-glm_gate.json`` independently carries a full
+PASS on the exact head sha (``gh pr view 1777 --json headRefOid``). Because
+``result is None``, the OI-1624 peer route (guarded by
+``result is not None and _is_absent_without_verdict(result)``) was never
+reached, and ``python3 scripts/pr_merge.py --pr 1777 --squash --dry-run``
+returned NO-GO: "geen review-gate resultaat gevonden voor codex_gate op 1777".
+The record is invisible to the reader (fails scope) and terminal for the
+writer (the overwrite guard, OI-1469/OI-1470, permanently refuses to rerun a
+terminal record with a non-terminal reassessment) — a dead end with no
+upstream fix possible for records already on disk.
+
+The fix (``closure_verifier._find_gate_result_ignoring_scope`` +
+``_consult_peers_for_absence``) distinguishes three cases where
+``_find_gate_result`` returns ``None``:
+
+  (a) NO record at all exists for this gate+pr_id — stays NO-GO, UNCHANGED.
+      This is ``TestUnrelatedRecordsNeverTakeOver``'s contract
+      (test_oi1576_merge_door_takeover_evidence.py) and MUST NOT be touched;
+      pinned again here as a regression guard specific to this fix's own
+      code path.
+  (b) a record exists but falls outside scope AND is itself a confirmed
+      absence (``_is_absent_without_verdict``) — the SAME peer route as
+      OI-1624 opens, via the shared ``_consult_peers_for_absence``.
+  (c) a record exists outside scope but carries a DECIDED verdict (pass/fail
+      on a stale branch/sha) — stale evidence, stays NO-GO with the existing
+      "no evidence found" message, never treated as an absence.
+
+Measured (see this file's own test run in the dispatch report): patching the
+peer route to fire UNCONDITIONALLY whenever ``result is None`` — without the
+(a)/(b)/(c) split — breaks
+``TestUnrelatedRecordsNeverTakeOver::test_plain_pass_for_other_gate_is_no_go``
+and ``::test_takeover_path_without_declared_gate_is_no_go`` (both flip from
+NO-GO to GO on an unrelated stranger's pass). That is exactly the scenario
+case (a) must keep refusing: a gate that was never even asked for this PR
+must never accept a stranger's unrelated pass as a signer.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv
+
+# Mirrored from the live vnx-dev store shape for PR #1777 (2026-09-05/06).
+PR_ID = "1777"
+BRANCH = "dispatch/20260905-golf1b-report-store-split"
+HEAD_SHA = "01f54411d975e39f41cb2b0d005fd8dcd5aad04a"
+OTHER_SHA = "99999999975e39f41cb2b0d005fd8dcd5aad999"
+
+CLEAN_REPORT = "# Gate report\n\nAll findings reviewed, nothing blocking.\n"
+
+
+def _write_result(results_dir: Path, gate: str, data: dict) -> Path:
+    """Write a result record under the writer's real naming (pr-<n>-<gate>.json)."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / f"pr-{PR_ID}-{gate}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _report_file(tmp_path: Path, name: str = "report.md", content: str = CLEAN_REPORT) -> Path:
+    report = tmp_path / name
+    report.write_text(content, encoding="utf-8")
+    return report
+
+
+def _codex_not_executable_out_of_scope() -> dict:
+    """pr-1777-codex_gate.json exactly as measured live: terminal
+    not_executable, but written BEFORE OI-1624 threaded branch/commit_sha
+    through the writer — carries neither field at all."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": PR_ID,
+        "status": "not_executable",
+        "reason": "provider_not_installed",
+        "reason_detail": "codex binary not found in PATH",
+        "contract_hash": "",
+        "report_path": "",
+        # deliberately no "branch", no "commit_sha" — the measured live shape.
+    }
+
+
+def _glm_pass(report: Path, **overrides) -> dict:
+    """pr-1777-glm_gate.json as measured: a plain, unlinked pass on the head."""
+    data = {
+        "gate": "glm_gate",
+        "pr_id": PR_ID,
+        "status": "pass",
+        "blocking_count": 0,
+        "blocking_findings": [],
+        "contract_hash": "549c0288ef98004e",
+        "report_path": str(report),
+        "branch": BRANCH,
+        "commit_sha": HEAD_SHA,
+    }
+    data.update(overrides)
+    return data
+
+
+def _check(results_dir: Path, gate: str = "codex_gate", head_sha: str = HEAD_SHA) -> dict:
+    return cv.check_review_gate_for_merge(
+        PR_ID, gate, results_dir, branch=BRANCH, head_sha=head_sha
+    )
+
+
+class TestOutOfScopeAbsenceAcceptsPeerVerdict:
+    """The live #1777 shape: codex_gate's only on-disk record fails the scope
+    match entirely (no branch/commit_sha field at all), so
+    ``_find_gate_result`` returns None — but the record IS a confirmed
+    absence, and glm_gate independently passed the exact head."""
+
+    def test_1_out_of_scope_absent_declared_gate_with_peer_pass_is_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable_out_of_scope())
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO", verdict["message"]
+        assert verdict["gate"] == "codex_gate"
+        assert verdict["evidence_gate"] == "glm_gate"
+        assert "afwezig" in verdict["message"]
+        assert "buiten scope" in verdict["message"]
+
+    def test_2_out_of_scope_absent_declared_gate_with_peer_fail_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable_out_of_scope())
+        _write_result(
+            results_dir, "glm_gate",
+            _glm_pass(report, status="fail", blocking_count=1,
+                      blocking_findings=[{"severity": "blocking", "message": "real defect"}]),
+        )
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO", verdict["message"]
+
+    def test_3_out_of_scope_absent_declared_gate_with_missing_report_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        missing_report = tmp_path / "does-not-exist.md"
+        _write_result(results_dir, "codex_gate", _codex_not_executable_out_of_scope())
+        _write_result(results_dir, "glm_gate", _glm_pass(missing_report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO", verdict["message"]
+
+    def test_4_out_of_scope_absent_declared_gate_with_peer_on_other_sha_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable_out_of_scope())
+        _write_result(results_dir, "glm_gate", _glm_pass(report, commit_sha=OTHER_SHA))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO", verdict["message"]
+
+
+class TestCaseADistinctFromCaseB:
+    """Case (a) — no record at all for this gate+pr_id — must stay
+    unchanged: no peer fallback, per TestUnrelatedRecordsNeverTakeOver."""
+
+    def test_5_no_codex_record_at_all_with_peer_pass_stays_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "geen review-gate resultaat" in verdict["message"]
+
+
+class TestCaseCStaleVerdictNeverReadAsAbsence:
+    """Case (c) — an out-of-scope record that DID render a verdict (pass on a
+    different sha) is stale evidence, not an absence, and must not unlock the
+    peer route either."""
+
+    def test_6_out_of_scope_codex_pass_on_other_sha_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        codex_pass_stale = {
+            "gate": "codex_gate",
+            "pr_id": PR_ID,
+            "status": "pass",
+            "blocking_count": 0,
+            "blocking_findings": [],
+            "contract_hash": "aaaaaaaaaaaaaaaa",
+            "report_path": str(report),
+            "branch": BRANCH,
+            "commit_sha": OTHER_SHA,
+        }
+        _write_result(results_dir, "codex_gate", codex_pass_stale)
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "geen review-gate resultaat" in verdict["message"]
+
+
+class TestTestRunRecordNeverCountsAsOutOfScopeEvidence:
+    """A test_run: true record for codex_gate must be treated exactly like
+    case (a) — no record at all — never as a confirmed out-of-scope absence."""
+
+    def test_7_out_of_scope_codex_test_run_record_stays_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        codex_test_run = _codex_not_executable_out_of_scope()
+        codex_test_run["test_run"] = True
+        _write_result(results_dir, "codex_gate", codex_test_run)
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO"
+        assert "geen review-gate resultaat" in verdict["message"]
+
+
+class TestRealRejectionStillWinsOverPassThroughTheNewRoute:
+    """Harde grens, replicated for the OI-1642 out-of-scope path: a real peer
+    rejection blocks the merge even next to another peer's pass."""
+
+    def test_8_two_peers_fail_wins_over_pass(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_not_executable_out_of_scope())
+        _write_result(
+            results_dir, "kimi_gate",
+            {
+                "gate": "kimi_gate", "pr_id": PR_ID, "status": "fail",
+                "blocking_count": 1,
+                "blocking_findings": [{"severity": "blocking", "message": "real defect"}],
+                "contract_hash": "aa11bb22cc33dd44", "report_path": str(report),
+                "branch": BRANCH, "commit_sha": HEAD_SHA,
+            },
+        )
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO", verdict["message"]


### PR DESCRIPTION
## Summary

`check_review_gate_for_merge`'s OI-1624 peer-consultation route only fired
when `_find_gate_result` returned an *in-scope* record that was itself a
confirmed absence. Seven PRs (#1777-#1782, #1784) stayed NO-GO because their
`codex_gate` record predates OI-1624 threading `branch`/`commit_sha` through
the writer, so it fails the scope match and `_find_gate_result` returns
`None` — indistinguishable from "this gate was never asked for this PR". The
overwrite guard (OI-1469/OI-1470) permanently refuses to rerun a terminal
record, so these on-disk records can never self-heal.

## Changes

- `scripts/closure_verifier.py`:
  - Extracted `_iter_gate_result_candidates` (shared glob/path logic) out of
    `_find_gate_result` so the scoped and unscoped lookups can never diverge.
  - Added `_find_gate_result_ignoring_scope`: same gate+pr_id lookup, no
    branch/project_id/head_sha filter — used only to tell "no record at all"
    apart from "a record exists but is out of scope".
  - Added `_describe_scope_mismatch` for an operator-readable "which fields
    failed" note in the new NO-GO/GO messages.
  - Extracted `_consult_peers_for_absence` from the OI-1624 in-scope-absence
    branch so the existing peer route and the new out-of-scope route share
    one implementation.
  - `check_review_gate_for_merge`: when `result is None`, now checks whether
    an out-of-scope record exists for this gate+pr_id and is itself a
    confirmed absence (`_is_absent_without_verdict`) — if so, the same peer
    route opens. A genuinely absent record (case a) still gets no
    peer-fallback; an out-of-scope record with a *decided* verdict (case c,
    stale evidence) still falls through unchanged.
  - Docstring of `check_review_gate_for_merge` updated with the OI-1642 case.
- `tests/test_oi1642_peer_route_at_none.py` (new): 8 tests reproducing the
  live #1777 shape plus the (a)/(c)/test_run/multi-peer guard rails.
- `docs/governance/decisions/ADR-037-gate-uitval-is-afwezigheid-niet-tegenstem.md`:
  addendum documenting the out-of-scope-absence case.

## Verification

Measured BEFORE fix (fix reverted via `git checkout HEAD~1 -- scripts/closure_verifier.py`):
```
NO-GO: geen review-gate resultaat gevonden voor codex_gate op 1777: merge niet toetsbaar
NO-GO: geen review-gate resultaat gevonden voor codex_gate op 1778: merge niet toetsbaar
```

Measured AFTER fix, `python3 scripts/pr_merge.py --pr 1777 --squash --dry-run`:
```
Review gate: codex_gate is afwezig voor 1777 (status='not_executable': geen uitspraak
gedaan; eigen record buiten scope (branch=None, commit_sha=None)) — glm_gate droeg op
dezelfde head zelfstandig een geldige, volledig bewezen pass en telt als ondertekenaar
bij afwezigheid van de gedeclareerde poort (OI-1624/OI-1642)
[dry-run] Would merge PR #1777 via squash
OK: PR #1777 (dry-run) via squash
```
Same GO for `--pr 1778`.

Guard-break proof (peer route unconditional at `None`, no a/b/c split):
`tests/test_oi1576_merge_door_takeover_evidence.py::TestUnrelatedRecordsNeverTakeOver`
breaks on BOTH its tests (a stranger's plain pass, and a takeover claim that never
names the declared gate, both wrongly become signers). This is why case (a) — no
record at all — must never reach the peer route.

Guard-break proof (this fix reverted, new test file kept): 1 failed, 7 passed —
only `test_1_out_of_scope_absent_declared_gate_with_peer_pass_is_go` goes red, the
rest (guard-rail tests 2-8) already held under the old fallback message.

Targeted suite:
```
python3 -m pytest tests/test_closure_verifier*.py \
  tests/test_oi1576_merge_door_takeover_evidence.py \
  tests/test_oi1624_gate_absence_vs_rejection.py \
  tests/test_pr_merge_review_gate.py tests/test_pr_merge_ci_gate.py \
  tests/test_oi1642_peer_route_at_none.py -q
133 passed, 9 warnings
```

## Open Items

None

**Dispatch-ID**: 20260906-oi1642-peer-route-bij-none
**Model**: sonnet
**Provider**: claude