### PR TITLE
fix(overlap-scan): squash-aware merge detection + bounded bulk scan (OI-1641)

### DIFF
--- a/scripts/lib/file_scope_overlap.py
+++ b/scripts/lib/file_scope_overlap.py
@@ -15,18 +15,61 @@ Shape of the check:
 
 Everything is best-effort: any git/network failure degrades to "no overlaps found" and a debug
 log line, never an exception that blocks the merge.
+
+OI-1641: on the live remote (370 dispatch branches) the original implementation did ~715 serial
+`git fetch` calls (one per branch, twice for the merging branch's counterparts) at ~0.59s each —
+~7 minutes of silence on every merge, with zero progress output. It also treated
+``git merge-base --is-ancestor`` as the only "is this merged" signal, but VNX squashes every PR,
+so a squash-merged branch's tip is never main's ancestor and stayed "open" forever (345/370
+measured as open, only 25 recognized). Three fixes:
+  1. ``_is_merged`` adds two more layers after the cheap ancestry check: membership in a bulk
+     ``gh pr list --state merged`` lookup (strongest evidence for a squash-merge), then a
+     patch-equivalence fallback (the branch's files now diff empty against main) for when gh is
+     unavailable or found no PR.
+  2. One bulk ``git fetch`` for all ``dispatch/*`` refs replaces the per-branch fetches, and one
+     bulk ``gh pr list`` replaces what would otherwise be a per-branch gh query — a per-branch
+     ``gh pr list --head <branch>`` is itself a serial network call and measured 2026-09-06 at
+     ~0.4s/branch, i.e. almost the exact stall the bulk git fetch was meant to eliminate.
+  3. ``_run`` takes a timeout, and the branch scan itself is bounded by both a branch-count
+     ceiling and a wall-clock ceiling — exceeding either aborts the scan and returns ``[]`` with
+     a stderr warning, per the "never blocks a merge" contract above.
 """
 from __future__ import annotations
 
+import json
 import logging
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any, Optional
 
 _LOG = logging.getLogger(__name__)
 
 DEFAULT_BASE_REF = "origin/main"
+
+# Per-command timeout (seconds). No single git/gh invocation in this module may hang past this.
+DEFAULT_RUN_TIMEOUT = 30.0
+
+# Scan ceilings: exceeding either aborts the whole scan and returns [] (best-effort, never
+# blocks a merge). max_branches is checked BEFORE any git call so a runaway branch count costs
+# zero network round-trips; max_scan_seconds is checked as the per-branch merge-status loop runs.
+# max_branches is a sanity ceiling against a runaway branch count, not the normal operating
+# limit: measured 2026-09-06 the live remote already carries 358 dispatch branches (cleanup
+# lags creation) and the bulk-fetch+bulk-gh scan covers all of them in ~17s, so a low ceiling
+# here would dead-zone the whole feature on every merge until cleanup catches up — the wall-clock
+# ceiling below is the real circuit breaker.
+DEFAULT_MAX_BRANCHES = 1000
+DEFAULT_MAX_SCAN_SECONDS = 60.0
+
+# Progress line cadence on stderr during the merge-status scan.
+_PROGRESS_EVERY_N_BRANCHES = 25
+_PROGRESS_EVERY_SECONDS = 5.0
+
+# Ceiling for the bulk `gh pr list --state merged` lookup. A growing repo needs headroom;
+# gate_obligation_retire_backlog.py measured 1537 merged PRs on this repo 2026-08-23, so 5000
+# leaves ample margin without needing pagination.
+_GH_LIST_LIMIT = 5000
 
 # A dispatch branch is a remote ref under refs/heads/dispatch/. A fix-forward branch keeps the
 # same shape (it is the parent's dispatch/<id> branch), so the dispatch-id is the last path
@@ -51,29 +94,45 @@ def dispatch_id_from_branch(branch: str) -> Optional[str]:
     return rest or None
 
 
-def _run(cmd: list[str], *, repo: Optional[Path], check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        cmd,
-        cwd=str(repo) if repo else None,
-        capture_output=True,
-        text=True,
-        check=check,
-    )
+def _run(
+    cmd: list[str],
+    *,
+    repo: Optional[Path],
+    check: bool = True,
+    timeout: float = DEFAULT_RUN_TIMEOUT,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd``, never letting it hang past ``timeout``.
+
+    A timeout degrades to a failed-but-benign CompletedProcess (returncode 124, like the shell
+    convention for a timed-out command) instead of raising — every caller in this module already
+    treats a non-zero returncode as "no signal, move on", so a slow git/gh call now costs at most
+    ``timeout`` seconds instead of hanging the merge indefinitely.
+    """
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=str(repo) if repo else None,
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        _LOG.warning("file_scope_overlap: command timed out after %ss: %s", timeout, " ".join(cmd))
+        return subprocess.CompletedProcess(cmd, returncode=124, stdout="", stderr="timeout")
 
 
-def _list_remote_dispatch_branches(repo: Optional[Path]) -> list[str]:
+def _list_remote_dispatch_branches(
+    repo: Optional[Path], *, run_timeout: float = DEFAULT_RUN_TIMEOUT
+) -> list[str]:
     """Return remote ``dispatch/*`` branch names (bare, no origin/ prefix) from the remote.
 
     Uses ``git ls-remote --heads origin`` so the result reflects what is actually pushed, not a
     possibly-stale local remote-tracking view.
     """
-    proc = subprocess.run(
+    proc = _run(
         ["git", "ls-remote", "--heads", "origin", "refs/heads/dispatch/*"],
-        cwd=str(repo) if repo else None,
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
+        repo=repo, check=False, timeout=run_timeout,
     )
     if proc.returncode != 0:
         return []
@@ -89,48 +148,187 @@ def _list_remote_dispatch_branches(repo: Optional[Path]) -> list[str]:
     return branches
 
 
-def changed_files(branch: str, *, base_ref: str = DEFAULT_BASE_REF, repo: Optional[Path] = None) -> set[str]:
+def _fetch_all_dispatch_branches(repo: Optional[Path], *, timeout: float = DEFAULT_RUN_TIMEOUT) -> None:
+    """One fetch for every remote ``dispatch/*`` branch — replaces N per-branch fetches.
+
+    Best-effort: on failure, callers proceed with whatever remote-tracking refs already exist
+    locally (same degrade-to-no-signal behavior as every other call in this module).
+    """
+    _run(
+        ["git", "fetch", "origin", "--prune", "+refs/heads/dispatch/*:refs/remotes/origin/dispatch/*"],
+        repo=repo, check=False, timeout=timeout,
+    )
+
+
+def changed_files(
+    branch: str,
+    *,
+    base_ref: str = DEFAULT_BASE_REF,
+    repo: Optional[Path] = None,
+    fetch: bool = True,
+    run_timeout: float = DEFAULT_RUN_TIMEOUT,
+) -> set[str]:
     """Return the files ``branch`` changed relative to ``base_ref`` (``git diff --name-only``).
 
-    Fetches the branch first so the comparison is against the PUSHED tip, not a stale local
-    ref. Empty set on any failure (a missing branch, a bad ref, no network).
+    Fetches the branch first (unless ``fetch=False``, for a caller that already did a bulk fetch
+    covering this ref) so the comparison is against the PUSHED tip, not a stale local ref. Empty
+    set on any failure (a missing branch, a bad ref, no network).
     """
-    _run(["git", "fetch", "origin", branch], repo=repo, check=False)
+    if fetch:
+        _run(["git", "fetch", "origin", branch], repo=repo, check=False, timeout=run_timeout)
     merge_base = _run(
-        ["git", "merge-base", base_ref, f"origin/{branch}"], repo=repo, check=False,
+        ["git", "merge-base", base_ref, f"origin/{branch}"], repo=repo, check=False, timeout=run_timeout,
     ).stdout.strip()
     if not merge_base:
         return set()
     diff = _run(
-        ["git", "diff", "--name-only", f"{merge_base}..origin/{branch}"], repo=repo, check=False,
+        ["git", "diff", "--name-only", f"{merge_base}..origin/{branch}"], repo=repo, check=False, timeout=run_timeout,
     ).stdout
     return {line for line in diff.splitlines() if line.strip()}
 
 
-def _is_merged(branch: str, *, base_ref: str = DEFAULT_BASE_REF, repo: Optional[Path] = None) -> bool:
-    """True when the branch's tip is already an ancestor of base_ref (i.e. fully merged)."""
+def _fetch_merged_pr_branches(repo: Optional[Path], *, run_timeout: float = DEFAULT_RUN_TIMEOUT) -> set[str]:
+    """Bulk ``gh pr list --state merged``, once, keyed by head branch name.
+
+    One gh call instead of one per branch: a `gh pr list --head <branch>` query is itself a
+    serial network round-trip, and a per-branch version of this check measured 2026-09-06 at
+    ~0.4s/branch on the live remote — reintroducing almost the exact stall the bulk git fetch
+    above was meant to eliminate. Same bulk-list-then-lookup shape as
+    ``gate_obligation_retire_backlog.py::fetch_prs``. Empty set on any failure (gh missing, not
+    authenticated, bad JSON, timeout) — every caller here treats "branch not in the set" as
+    inconclusive and falls through to patch-equivalence, so a total gh failure degrades exactly
+    like "gh found no merged PR for any branch", never a false negative.
+    """
+    try:
+        proc = _run(
+            ["gh", "pr", "list", "--state", "merged", "--json", "headRefName", "--limit", str(_GH_LIST_LIMIT)],
+            repo=repo, check=False, timeout=run_timeout,
+        )
+    except OSError:
+        return set()
+    if proc.returncode != 0:
+        return set()
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except ValueError:
+        return set()
+    if not isinstance(data, list):
+        return set()
+    return {item["headRefName"] for item in data if isinstance(item, dict) and item.get("headRefName")}
+
+
+def _patch_equivalent(
+    branch: str, *, base_ref: str = DEFAULT_BASE_REF, repo: Optional[Path], run_timeout: float = DEFAULT_RUN_TIMEOUT,
+) -> bool:
+    """True when the files ``branch`` touched now diff empty against ``base_ref``.
+
+    This is the squash-merge signature: a squash commit on main applies the same net change to
+    the same files, so after the squash the branch tip and main agree on those files' content
+    even though the branch tip is not an ancestor of main. An empty-diff branch (no files) is NOT
+    treated as equivalent here — ``_is_merged``'s ancestry check already covers that case, and a
+    branch with zero changed files but a divergent tip is ambiguous, not evidence of a merge.
+    """
+    files = changed_files(branch, base_ref=base_ref, repo=repo, fetch=False, run_timeout=run_timeout)
+    if not files:
+        return False
+    diff = _run(
+        ["git", "diff", f"origin/{branch}", base_ref, "--", *sorted(files)],
+        repo=repo, check=False, timeout=run_timeout,
+    ).stdout
+    return diff.strip() == ""
+
+
+def _is_merged(
+    branch: str,
+    *,
+    base_ref: str = DEFAULT_BASE_REF,
+    repo: Optional[Path] = None,
+    run_timeout: float = DEFAULT_RUN_TIMEOUT,
+    merged_pr_branches: Optional[set[str]] = None,
+) -> bool:
+    """True when ``branch`` is already reflected in ``base_ref``, squash-merges included.
+
+    Three layers, cheapest and most certain first:
+      1. Ancestry (``merge-base --is-ancestor``) — a real fast-forward/merge-commit history.
+      2. Membership in ``merged_pr_branches`` — the strongest evidence for a squash-merge.
+      3. Patch-equivalence — no PR evidence, but the branch's files already diff empty against
+         base_ref (the squash landed the same content another way).
+
+    ``merged_pr_branches`` is the result of :func:`_fetch_merged_pr_branches`. A caller scanning
+    many branches (``open_dispatch_branches``) fetches it ONCE and passes it in here to avoid a
+    gh call per branch; a caller checking a single branch (tests, ad-hoc CLI use) can omit it and
+    this function fetches it itself.
+    """
     proc = _run(
         ["git", "merge-base", "--is-ancestor", f"origin/{branch}", base_ref],
-        repo=repo, check=False,
+        repo=repo, check=False, timeout=run_timeout,
     )
-    return proc.returncode == 0
+    if proc.returncode == 0:
+        return True
+    if merged_pr_branches is None:
+        merged_pr_branches = _fetch_merged_pr_branches(repo, run_timeout=run_timeout)
+    if branch in merged_pr_branches:
+        return True
+    return _patch_equivalent(branch, base_ref=base_ref, repo=repo, run_timeout=run_timeout)
 
 
 def open_dispatch_branches(
-    *, base_ref: str = DEFAULT_BASE_REF, repo: Optional[Path] = None
+    *,
+    base_ref: str = DEFAULT_BASE_REF,
+    repo: Optional[Path] = None,
+    max_branches: int = DEFAULT_MAX_BRANCHES,
+    max_scan_seconds: float = DEFAULT_MAX_SCAN_SECONDS,
+    run_timeout: float = DEFAULT_RUN_TIMEOUT,
+    stream: Optional[Any] = None,
 ) -> list[str]:
     """Remote ``dispatch/*`` branches that are not yet merged into ``base_ref``.
 
     An already-merged branch (merged but its remote ref not deleted) is excluded: its files are
     already on the base, so it cannot collide with a new merge.
+
+    Bounded on both axes so this can never turn back into the OI-1641 7-minute stall: a branch
+    count above ``max_branches`` skips the scan entirely (zero git calls), and a scan running
+    past ``max_scan_seconds`` aborts mid-loop. Either case returns ``[]`` with a stderr warning —
+    "no overlaps found" is the documented best-effort degrade, never a block.
     """
+    out = sys.stderr if stream is None else stream
+    branches = _list_remote_dispatch_branches(repo, run_timeout=run_timeout)
+    total = len(branches)
+    if total > max_branches:
+        message = (
+            f"WARN: file-scope overlap scan skipped — {total} remote dispatch branches exceeds "
+            f"the {max_branches}-branch limit; returning no overlaps (best-effort, never blocks a merge)"
+        )
+        print(message, file=out)
+        _LOG.warning("file_scope_overlap: %s", message)
+        return []
+
+    _fetch_all_dispatch_branches(repo, timeout=run_timeout)
+    merged_pr_branches = _fetch_merged_pr_branches(repo, run_timeout=run_timeout)
+
+    start = time.monotonic()
+    last_progress = start
     open_branches: list[str] = []
-    for branch in _list_remote_dispatch_branches(repo):
-        # _is_merged needs origin/<branch> present; changed_files fetches it, so reuse that
-        # side effect only when the branch is otherwise a candidate.
-        _run(["git", "fetch", "origin", branch], repo=repo, check=False)
-        if not _is_merged(branch, base_ref=base_ref, repo=repo):
+    for i, branch in enumerate(branches, start=1):
+        elapsed = time.monotonic() - start
+        if elapsed > max_scan_seconds:
+            message = (
+                f"WARN: file-scope overlap scan aborted after {elapsed:.1f}s (limit "
+                f"{max_scan_seconds}s) at {i - 1}/{total} branches; returning no overlaps "
+                f"(best-effort, never blocks a merge)"
+            )
+            print(message, file=out)
+            _LOG.warning("file_scope_overlap: %s", message)
+            return []
+        if not _is_merged(
+            branch, base_ref=base_ref, repo=repo, run_timeout=run_timeout,
+            merged_pr_branches=merged_pr_branches,
+        ):
             open_branches.append(branch)
+        now = time.monotonic()
+        if i % _PROGRESS_EVERY_N_BRANCHES == 0 or (now - last_progress) >= _PROGRESS_EVERY_SECONDS:
+            print(f"[overlap] {i}/{total} branches, {now - start:.1f}s", file=out)
+            last_progress = now
     return open_branches
 
 
@@ -139,6 +337,10 @@ def find_overlaps(
     *,
     base_ref: str = DEFAULT_BASE_REF,
     repo: Optional[Path] = None,
+    max_branches: int = DEFAULT_MAX_BRANCHES,
+    max_scan_seconds: float = DEFAULT_MAX_SCAN_SECONDS,
+    run_timeout: float = DEFAULT_RUN_TIMEOUT,
+    stream: Optional[Any] = None,
 ) -> list[tuple[str, list[str]]]:
     """Return [(other_dispatch_id, [overlapping files])] for the branch being merged.
 
@@ -147,17 +349,22 @@ def find_overlaps(
     Best-effort: on any failure returns [].
     """
     try:
-        mine = changed_files(merging_branch, base_ref=base_ref, repo=repo)
+        mine = changed_files(merging_branch, base_ref=base_ref, repo=repo, run_timeout=run_timeout)
         if not mine:
             return []
         overlaps: list[tuple[str, list[str]]] = []
-        for other in open_dispatch_branches(base_ref=base_ref, repo=repo):
+        others = open_dispatch_branches(
+            base_ref=base_ref, repo=repo, max_branches=max_branches,
+            max_scan_seconds=max_scan_seconds, run_timeout=run_timeout, stream=stream,
+        )
+        for other in others:
             if other == merging_branch:
                 continue
             other_id = dispatch_id_from_branch(other)
             if not other_id:
                 continue
-            theirs = changed_files(other, base_ref=base_ref, repo=repo)
+            # open_dispatch_branches already did the bulk fetch — no per-branch fetch here.
+            theirs = changed_files(other, base_ref=base_ref, repo=repo, fetch=False, run_timeout=run_timeout)
             shared = sorted(mine & theirs)
             if shared:
                 overlaps.append((other_id, shared))
@@ -173,6 +380,9 @@ def warn_overlaps(
     base_ref: str = DEFAULT_BASE_REF,
     repo: Optional[Path] = None,
     stream: Optional[Any] = None,
+    max_branches: int = DEFAULT_MAX_BRANCHES,
+    max_scan_seconds: float = DEFAULT_MAX_SCAN_SECONDS,
+    run_timeout: float = DEFAULT_RUN_TIMEOUT,
 ) -> list[tuple[str, list[str]]]:
     """Compute overlaps for ``merging_branch`` and emit a WARN line per colliding dispatch.
 
@@ -180,7 +390,10 @@ def warn_overlaps(
     names the other dispatch AND lists the shared files (OI-1091's contract). Emits to ``stream``
     (default stderr) and the logger; never raises.
     """
-    overlaps = find_overlaps(merging_branch, base_ref=base_ref, repo=repo)
+    overlaps = find_overlaps(
+        merging_branch, base_ref=base_ref, repo=repo, max_branches=max_branches,
+        max_scan_seconds=max_scan_seconds, run_timeout=run_timeout, stream=stream,
+    )
     if not overlaps:
         return overlaps
     out = sys.stderr if stream is None else stream

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -558,6 +558,9 @@ def merge_pr(
 
     # OI-1091: warn (never block) when another OPEN dispatch branch touches the same files as
     # the branch being merged. Best-effort; a git/network failure degrades to no warning.
+    # OI-1641: the scan itself is now bounded (one bulk fetch + one bulk gh lookup instead of a
+    # fetch/gh-call per branch, plus a per-command timeout and a wall-clock scan ceiling) so it
+    # can no longer turn into minutes of serial network round-trips on every merge.
     if result["branch"]:
         try:
             from file_scope_overlap import warn_overlaps  # noqa: PLC0415

--- a/tests/test_file_scope_overlap_squash.py
+++ b/tests/test_file_scope_overlap_squash.py
@@ -1,0 +1,173 @@
+"""test_file_scope_overlap_squash.py — OI-1641: squash-aware merge detection + bounded scan.
+
+warn_overlaps() used to `git fetch origin <branch>` once per remote dispatch/* branch just to
+learn whether it was merged, then fetch AGAIN per "open" branch to diff it. On the live remote
+(370 branches) that was ~715 serial fetches at ~0.59s each — ~7 minutes of silence on every
+merge. Worse: `_is_merged` used only `git merge-base --is-ancestor`, and VNX squashes every PR,
+so a squash-merged branch's tip is never main's ancestor and stayed "open" forever (345/370
+measured as open, only 25 recognized via ancestry).
+
+This file covers the three fixes: (1) `_is_merged` recognizes a squash-merged branch via a
+gh-PR-status check with a patch-equivalence fallback, (2) a single bulk fetch replaces the
+per-branch fetches, (3) a hard timeout on `_run` plus a scan ceiling so the "an overlap check
+must never block a merge" contract in pr_merge.py is actually true under load.
+
+Companion to tests/test_file_scope_overlap.py (ancestry-only path + pr_merge.py wiring), which
+this file does not duplicate.
+"""
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import file_scope_overlap as fso
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True,
+    )
+
+
+@pytest.fixture()
+def git_fixture(tmp_path: Path):
+    bare = tmp_path / "origin.git"
+    work = tmp_path / "work"
+    bare.mkdir()
+    _run_git(bare, "init", "--bare", "-b", "main")
+
+    work.mkdir()
+    _run_git(work, "init", "-b", "main")
+    _run_git(work, "config", "user.email", "test@example.com")
+    _run_git(work, "config", "user.name", "Test")
+    (work / "README.md").write_text("base\n", encoding="utf-8")
+    _run_git(work, "add", "README.md")
+    _run_git(work, "commit", "-m", "base commit")
+    _run_git(work, "remote", "add", "origin", str(bare))
+    _run_git(work, "push", "origin", "main")
+    return work
+
+
+def _push_branch(work: Path, branch: str, filename: str, content: str) -> None:
+    """Push a branch off main carrying one new file, then drop the local branch ref."""
+    _run_git(work, "checkout", "-b", branch, "main")
+    (work / filename).write_text(content, encoding="utf-8")
+    _run_git(work, "add", filename)
+    _run_git(work, "commit", "-m", f"add {filename}")
+    _run_git(work, "push", "origin", branch)
+    _run_git(work, "checkout", "main")
+    _run_git(work, "branch", "-D", branch)
+
+
+def _squash_merge_into_main(work: Path, filename: str, content: str) -> None:
+    """Simulate a GitHub squash-merge: land the branch's file change on main as a brand-new
+    commit with no ancestry link back to the branch tip, then push main. The branch ref itself
+    is left in place on the remote (VNX's normal state before dispatch-reap deletes it) — the
+    exact shape that defeats `merge-base --is-ancestor`.
+    """
+    _run_git(work, "checkout", "main")
+    (work / filename).write_text(content, encoding="utf-8")
+    _run_git(work, "add", filename)
+    _run_git(work, "commit", "-m", f"squash: add {filename} (#1)")
+    _run_git(work, "push", "origin", "main")
+
+
+# ---------------------------------------------------------------------------
+# 1. _is_merged must recognize a squash-merged branch (the ROOD case pre-fix)
+# ---------------------------------------------------------------------------
+
+
+def test_is_merged_true_for_squash_merged_branch(git_fixture):
+    _push_branch(git_fixture, "dispatch/squash-me", "squash.txt", "squashed content\n")
+    _squash_merge_into_main(git_fixture, "squash.txt", "squashed content\n")
+    _run_git(git_fixture, "fetch", "origin")
+    # sanity: ancestry alone must NOT see this as merged — otherwise the test proves nothing.
+    assert fso._run(
+        ["git", "merge-base", "--is-ancestor", "origin/dispatch/squash-me", "origin/main"],
+        repo=git_fixture, check=False,
+    ).returncode != 0
+    assert fso._is_merged(
+        "dispatch/squash-me", base_ref="origin/main", repo=git_fixture, run_timeout=5,
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. _is_merged stays False for a branch with genuinely unique, unmerged work
+# ---------------------------------------------------------------------------
+
+
+def test_is_merged_false_for_unmerged_branch(git_fixture):
+    _push_branch(git_fixture, "dispatch/unmerged", "unmerged.txt", "still open\n")
+    _run_git(git_fixture, "fetch", "origin")
+    assert fso._is_merged(
+        "dispatch/unmerged", base_ref="origin/main", repo=git_fixture, run_timeout=5,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. _run() honors a timeout instead of hanging or raising
+# ---------------------------------------------------------------------------
+
+
+def test_run_honors_timeout_without_raising():
+    start = time.perf_counter()
+    result = fso._run(["sleep", "5"], repo=None, check=False, timeout=1)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 4
+    assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# 4. A branch count above the ceiling short-circuits to [] with zero git calls
+# ---------------------------------------------------------------------------
+
+
+def test_open_dispatch_branches_bails_above_max_branches(monkeypatch):
+    fake_branches = [f"dispatch/fake-{i}" for i in range(500)]
+    monkeypatch.setattr(fso, "_list_remote_dispatch_branches", lambda repo, **kw: fake_branches)
+
+    def _no_run_expected(cmd, **kw):
+        raise AssertionError(f"no _run call expected once the branch-count ceiling is hit: {cmd}")
+
+    monkeypatch.setattr(fso, "_run", _no_run_expected)
+
+    capture = io.StringIO()
+    result = fso.open_dispatch_branches(repo=None, max_branches=10, stream=capture)
+    assert result == []
+    emitted = capture.getvalue()
+    assert "500" in emitted
+    assert "10" in emitted
+
+
+# ---------------------------------------------------------------------------
+# 5. Exactly one `git fetch` regardless of branch count
+# ---------------------------------------------------------------------------
+
+
+def test_open_dispatch_branches_does_a_single_bulk_fetch(monkeypatch):
+    fake_branches = [f"dispatch/fake-{i}" for i in range(12)]
+    monkeypatch.setattr(fso, "_list_remote_dispatch_branches", lambda repo, **kw: fake_branches)
+    monkeypatch.setattr(fso, "_is_merged", lambda branch, **kw: False)
+
+    fetch_calls = []
+
+    def _counting_run(cmd, **kw):
+        if cmd[:2] == ["git", "fetch"]:
+            fetch_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(fso, "_run", _counting_run)
+
+    result = fso.open_dispatch_branches(repo=None, max_branches=100)
+    assert len(fetch_calls) == 1
+    assert result == fake_branches


### PR DESCRIPTION
## Summary
- `warn_overlaps()` did a serial `git fetch origin <branch>` per remote `dispatch/*` branch to learn its merge status, then fetched again per open branch to diff it. Measured on the live remote (T0, 06-09): ~715 serial fetches, ~7 minutes of silence, on 370 branches.
- `_is_merged` only checked `git merge-base --is-ancestor`. VNX squashes every PR, so a squash-merged branch's tip is never an ancestor of `main` and stayed "open" forever (345/370 measured as open).
- `_is_merged` now layers: (1) ancestry (cheap, unchanged), (2) a **bulk** `gh pr list --state merged` lookup, (3) patch-equivalence fallback (branch's touched files diff empty against main) — recognizes a squash-merge via two independent signals.
- One bulk `git fetch origin --prune '+refs/heads/dispatch/*:refs/remotes/origin/dispatch/*'` replaces the per-branch fetches. One bulk `gh pr list --state merged --json headRefName --limit 5000` replaces what would otherwise be a per-branch `gh` call — a naive per-branch `gh pr list --head <branch>` reintroduces almost the same stall (measured ~0.4s/branch) before this was caught and fixed in the same PR.
- `_run()` takes a `timeout` (default 30s) and degrades to a benign `CompletedProcess` instead of hanging. The scan is bounded by a branch-count ceiling (checked **before** any git/gh call, so a runaway count costs zero network round-trips) and a wall-clock ceiling (default 60s), aborting mid-scan with a stderr warning if exceeded — matches the module's existing "never blocks a merge" contract.
- Progress line on stderr every 25 branches or 5s: `[overlap] n/N branches, x s`.

## Changes
- `scripts/lib/file_scope_overlap.py`: `_run()` gains a `timeout` param; new `_fetch_all_dispatch_branches()` (single bulk fetch); new `_fetch_merged_pr_branches()` (single bulk `gh pr list`); `_patch_equivalent()` added; `_is_merged()` now takes an optional `merged_pr_branches` set and layers ancestry → PR-status → patch-equivalence; `changed_files()` gains a `fetch: bool` param so batch callers skip the redundant per-branch fetch after the bulk one; `open_dispatch_branches()` gains `max_branches`/`max_scan_seconds`/`run_timeout` bounds, does the two bulk calls once, and emits progress/warning lines; `find_overlaps()`/`warn_overlaps()` thread the new params through.
- `scripts/pr_merge.py`: comment-only addition above the existing `warn_overlaps()` call site noting the OI-1641 bound (no logic change).
- `tests/test_file_scope_overlap_squash.py` (new): squash-merge detection (real tmp-repo squash simulation, was RED before the fix), unmerged-branch negative case, `_run()` timeout behavior, branch-count ceiling with zero git calls, and single-bulk-fetch assertion.

## Verification
Red run (before the fix, on the pre-existing module):
```
$ python3 -m pytest tests/test_file_scope_overlap_squash.py -v
...
FAILED tests/test_file_scope_overlap_squash.py::test_is_merged_true_for_squash_merged_branch
FAILED tests/test_file_scope_overlap_squash.py::test_is_merged_false_for_unmerged_branch
FAILED tests/test_file_scope_overlap_squash.py::test_run_honors_timeout_without_raising
FAILED tests/test_file_scope_overlap_squash.py::test_open_dispatch_branches_bails_above_max_branches
FAILED tests/test_file_scope_overlap_squash.py::test_open_dispatch_branches_does_a_single_bulk_fetch
============================== 5 failed in 1.10s ===============================
```

Green run (after the fix), plus the pre-existing suite and pr_merge.py's direct neighbours:
```
$ python3 -m pytest tests/test_file_scope_overlap_squash.py tests/test_file_scope_overlap.py -v
============================== 25 passed in 5.28s ===============================

$ python3 -m pytest tests/test_pr_merge_match_head.py tests/test_pr_merge_dual_scheme.py \
    tests/test_pr_merge_ci_gate.py tests/test_pr_merge_receipt.py \
    tests/test_pr_merge_review_gate.py tests/test_pr_merge_outcome_exitcode.py -q
86 passed in 10.09s
```

Live-remote timing (read-only, no merge executed — direct `open_dispatch_branches()`/`warn_overlaps()` calls against `origin`, 358 remote `dispatch/*` branches at measurement time, down from T0's 370 due to a concurrent branch-cleanup effort):
- OLD code, `open_dispatch_branches()` alone (ancestry-only, per-branch fetch): **162.43s**, 333/358 branches counted "open" (squash-merged branches misclassified as open).
- NEW code, `open_dispatch_branches()` with the branch-count ceiling raised to see the real scan cost: **16.59s**, 138/358 branches correctly "open" (squash-merged branches now recognized).
- NEW code, full `warn_overlaps()` (bulk fetch + bulk gh + scan + overlap diff) against a real branch with actual overlaps: **19.57s**, correctly surfacing 6 genuine file-scope overlaps.

Note on defaults: the live remote currently carries 358 dispatch branches (cleanup lags creation). `DEFAULT_MAX_BRANCHES` is set to 1000, not a lower "safe-looking" number — a low ceiling would immediately dead-zone the whole overlap check on every merge until cleanup catches up, given the branch-count check fires before any network call. The wall-clock ceiling (60s) is the real circuit breaker against runaway growth.

## Open Items
None.