### PR TITLE
fix(hooks): PreToolUse deny form + subagent operator-override (OI-1643)

### DIFF
--- a/scripts/hooks/pretooluse_block_raw_claude_spawn.sh
+++ b/scripts/hooks/pretooluse_block_raw_claude_spawn.sh
@@ -6,10 +6,18 @@
 #          subprocess_dispatch.py or provider_dispatch.py, which spawn CLIs via
 #          Popen and always emit a receipt.
 #
-# Claude Code hook contract (2.1+):
+# Claude Code hook contract (2.1+), PreToolUse:
 #   stdin  : JSON {tool_name, tool_input, session_id, cwd, transcript_path}
-#   stdout : {"decision":"block","reason":"..."} to block, empty to allow
+#   stdout : {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#             "permissionDecision":"deny","permissionDecisionReason":"..."}}
+#            to deny, empty to allow
 #   exit   : 0 always — decision is communicated via JSON output
+#
+# OI-1643: this hook used to emit the deprecated flat
+# {"decision":"block","reason":"..."} form, which is the PostToolUse/Stop/
+# UserPromptSubmit contract, not PreToolUse. Claude Code's PreToolUse event
+# reads hookSpecificOutput.permissionDecision instead, so blocked commands
+# were silently allowed through. Fixed to the hookSpecificOutput wrapper.
 #
 # Detection is delegated to pretooluse_spawn_detector.py (same directory)
 # for reliable cross-platform regex without bash heredoc/quoting issues.
@@ -61,7 +69,7 @@ DECISION="$(echo "$INPUT" | python3 "$DETECTOR")"
 
 # ── Emit JSON decision ────────────────────────────────────────────────────────
 if [[ "$DECISION" == "block" ]]; then
-  printf '{"decision":"block","reason":"Worker-dispatch moet via scripts/lib/subprocess_dispatch.py of provider_dispatch.py (governed, emit receipt). Rauwe claude -p/--dangerously-skip-permissions, kimi --print/-p, en codex exec bypassen de governance receipt-trail. Gebruik: python3 scripts/lib/provider_dispatch.py --provider <claude|kimi|codex> <dispatch_id>"}\n'
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Worker-dispatch moet via scripts/lib/subprocess_dispatch.py of provider_dispatch.py (governed, emit receipt). Rauwe claude -p/--dangerously-skip-permissions, kimi --print/-p, en codex exec bypassen de governance receipt-trail. Gebruik: python3 scripts/lib/provider_dispatch.py --provider <claude|kimi|codex> <dispatch_id>"}}\n'
 fi
 
 # ── Tool-call signal aggregation (receipt-quality PR-B2, additive) ───────────

--- a/scripts/hooks/pretooluse_block_subagent.sh
+++ b/scripts/hooks/pretooluse_block_subagent.sh
@@ -78,7 +78,7 @@ fi
 if [[ -n "${VNX_TMUX_SIGNAL_DIR:-}" ]]; then
   _BLOCKED=0
   case "$OUTPUT" in
-    *'"permissionDecision":"deny"'*) _BLOCKED=1 ;;
+    *'"permissionDecision": "deny"'*) _BLOCKED=1 ;;
   esac
   printf '%s' "$INPUT" | python3 "${HOOK_DIR}/../lib/toolcall_signals.py" \
     --signal-dir "$VNX_TMUX_SIGNAL_DIR" --blocked "$_BLOCKED" >/dev/null 2>&1 || true

--- a/scripts/hooks/pretooluse_block_subagent.sh
+++ b/scripts/hooks/pretooluse_block_subagent.sh
@@ -1,50 +1,88 @@
 #!/usr/bin/env bash
-# PreToolUse Hook: Block subagents (Task tool)
+# PreToolUse Hook: Block subagents (Task tool), with an operator override.
 #
 # Purpose: Enforce T0 governance rule — all work must route through governed
 #          VNX lanes (tmux-spawn / provider_dispatch), never via subagents.
 #          Subagents bypass the governance receipt trail; governed lanes
 #          always emit a receipt.
 #
-# Claude Code hook contract (2.1+):
+# OI-1643: this hook used to emit the deprecated flat
+# {"decision":"block","reason":"..."} form, which is the PostToolUse/Stop/
+# UserPromptSubmit contract, not PreToolUse. Claude Code's PreToolUse event
+# reads hookSpecificOutput.permissionDecision instead, so that output was
+# silently ignored and every Task call was allowed through — the rule
+# existed on paper only. Fixed by delegating the whole decision (including
+# the operator-override marker + audit trail) to pretooluse_subagent_guard.py.
+#
+# Claude Code hook contract (2.1+), PreToolUse:
 #   stdin  : JSON {tool_name, tool_input, session_id, cwd, transcript_path}
-#   stdout : {"decision":"block","reason":"..."} to block, empty to allow
+#   stdout : {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#             "permissionDecision":"deny","permissionDecisionReason":"..."}}
+#            to deny; "allow" to allow; empty stdout for non-Task tools.
 #   exit   : 0 always — decision is communicated via JSON output
 #
-# Token budget: ~40 tokens/call — fast-path exits for non-Task tools
+# Default is deny: no marker, an unreadable marker, an expired marker, or a
+# marker without a reason all deny. A crash of the Python core also denies
+# (fail-closed) — a broken enforcement mechanism must never silently degrade
+# to "allow everything", which is the exact defect this hook replaces.
+#
+# Token budget: ~40 tokens/call for non-Task tools (fast-path exit below);
+# a Task call spawns python3 once to consult the marker/audit state.
 
-set -euo pipefail
+set -uo pipefail
 
-# Resolve hook directory for the tool-call signal recorder (scripts/lib/).
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CORE="${HOOK_DIR}/pretooluse_subagent_guard.py"
 
 # ── Read hook payload ─────────────────────────────────────────────────────────
 INPUT="$(cat)"
 
-# ── Extract tool name ─────────────────────────────────────────────────────────
+# ── Fast path: only inspect Task tool calls ───────────────────────────────────
+# settings.json matcher="Task" already filters, but defense-in-depth here
+# avoids spawning python3 for other tools if this hook is ever wired broader.
 TOOL_NAME=""
 if command -v jq >/dev/null 2>&1; then
-  TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")"
+  TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")"
 fi
 
-# ── Only block the Task (subagent) tool ──────────────────────────────────────
-if [[ "$TOOL_NAME" != "Task" ]]; then
+if [[ -n "$TOOL_NAME" && "$TOOL_NAME" != "Task" ]]; then
   exit 0
 fi
 
-# ── Emit block decision ──────────────────────────────────────────────────────
-printf '{"decision":"block","reason":"Subagents (Task tool) are disabled in this project. Route work through governed VNX lanes: tmux-spawn (scripts/lib/tmux_interactive_dispatch.py) or provider_dispatch.py — these emit receipts. See T0 CLAUDE.md worker-dispatch policy."}\n'
-
-# ── Tool-call signal aggregation (receipt-quality PR-B2, additive) ───────────
-# Every Task call reaching this point was just blocked above. Best-effort
-# record for later receipt-time aggregation (scripts/lib/toolcall_signals.py).
-# No-op unless this is a dispatch that exports VNX_TMUX_SIGNAL_DIR (same
-# scoping as tmux_signal_stop_receipt.sh). Writes to /dev/null so nothing
-# leaks into stdout (Claude Code treats hook stdout as the decision payload).
-if [[ -n "${VNX_TMUX_SIGNAL_DIR:-}" ]]; then
-  printf '%s' "$INPUT" | python3 "${HOOK_DIR}/../lib/toolcall_signals.py" \
-    --signal-dir "$VNX_TMUX_SIGNAL_DIR" --blocked 1 >/dev/null 2>&1 || true
+# ── Guard: core script must exist — fail CLOSED (deny), not open ────────────
+if [[ ! -f "$CORE" ]]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Subagent guard core ontbreekt (%s) — standaard geblokkeerd (fail-closed)."}}\n' "$CORE"
+  exit 0
 fi
 
-# Exit 0 always — block/allow is communicated via JSON stdout, not exit code
+# ── Delegate the full decision to the Python core ────────────────────────────
+OUTPUT="$(printf '%s' "$INPUT" | python3 "$CORE" 2>/dev/null)"
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Subagent guard core faalde (exit %s) — standaard geblokkeerd (fail-closed). Zie scripts/subagents_allow.py."}}\n' "$RC"
+  exit 0
+fi
+
+# Empty output means the core decided "not a Task call" (allow silently).
+if [[ -n "$OUTPUT" ]]; then
+  printf '%s\n' "$OUTPUT"
+fi
+
+# ── Tool-call signal aggregation (receipt-quality PR-B2, additive) ───────────
+# Best-effort record for later receipt-time aggregation
+# (scripts/lib/toolcall_signals.py). No-op unless this is a dispatch that
+# exports VNX_TMUX_SIGNAL_DIR (same scoping as tmux_signal_stop_receipt.sh).
+# Writes to /dev/null so nothing leaks into stdout (Claude Code treats hook
+# stdout as the decision payload).
+if [[ -n "${VNX_TMUX_SIGNAL_DIR:-}" ]]; then
+  _BLOCKED=0
+  case "$OUTPUT" in
+    *'"permissionDecision":"deny"'*) _BLOCKED=1 ;;
+  esac
+  printf '%s' "$INPUT" | python3 "${HOOK_DIR}/../lib/toolcall_signals.py" \
+    --signal-dir "$VNX_TMUX_SIGNAL_DIR" --blocked "$_BLOCKED" >/dev/null 2>&1 || true
+fi
+
+# Exit 0 always — allow/deny is communicated via JSON stdout, not exit code
 exit 0

--- a/scripts/hooks/pretooluse_subagent_guard.py
+++ b/scripts/hooks/pretooluse_subagent_guard.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""pretooluse_subagent_guard.py — PreToolUse hook core: subagent (Task tool) gate.
+
+OI-1643: the previous bash-only hook (pretooluse_block_subagent.sh) emitted
+the deprecated flat ``{"decision":"block",...}`` form. Claude Code's
+PreToolUse event reads ``hookSpecificOutput.permissionDecision`` instead, so
+that output was silently ignored and every Task call was allowed through —
+the rule existed on paper only. This module is the corrected core:
+
+  - No marker, an unreadable/malformed marker, an expired marker, or a marker
+    with an empty ``reason`` all deny. Deny is the only default.
+  - A present, unexpired marker with a non-empty ``reason`` allows the call
+    AND appends one line to ``<state_dir>/subagent_use.ndjson`` so an allowed
+    subagent still leaves a governance trail. If the audit write itself fails
+    the decision flips back to deny (fail-closed) — an "allow" that leaves no
+    trace is exactly the bypass this hook exists to close.
+
+Marker file: ``<state_dir>/subagents_allowed.json``, written by
+``scripts/subagents_allow.py`` (reason, granted_at, expires_at, granted_by).
+State dir is resolved via ``vnx_paths.resolve_paths()['VNX_STATE_DIR']`` —
+same central-store resolution every other hook in this repo uses (see
+``path_parity_check.sh``), not a hardcoded ``.vnx-data/`` literal.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+_HOOK_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _HOOK_DIR.parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from vnx_paths import resolve_paths  # noqa: E402
+from atomic_io import audit_event_append  # noqa: E402
+
+MARKER_FILENAME = "subagents_allowed.json"
+AUDIT_EVENT_TYPE = "subagent_use"
+PROMPT_EXCERPT_LEN = 200
+
+_ALLOW_CLI_HINT = 'python3 scripts/subagents_allow.py --reason "..." --hours N'
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(ts: Any) -> Optional[datetime]:
+    if not isinstance(ts, str) or not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def resolve_state_dir() -> Path:
+    """Central per-project state dir. Honors VNX_STATE_DIR (tests override this)."""
+    paths = resolve_paths()
+    return Path(paths["VNX_STATE_DIR"])
+
+
+def _load_marker(state_dir: Path) -> Tuple[Optional[dict], Optional[str]]:
+    """Return (marker, load_error). marker is None when absent or unreadable."""
+    marker_path = state_dir / MARKER_FILENAME
+    if not marker_path.is_file():
+        return None, None
+    try:
+        raw = marker_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"onleesbaar ({exc})"
+    if not isinstance(data, dict):
+        return None, "onleesbaar (geen JSON-object)"
+    return data, None
+
+
+def evaluate(marker: Optional[dict], load_error: Optional[str]) -> Tuple[bool, str, Optional[str]]:
+    """Return (allowed, reason, marker_reason). marker_reason is set only when
+    the marker was structurally valid enough to carry a reason string."""
+    if load_error:
+        return (
+            False,
+            f"Subagent-marker {load_error}; behandeld als geblokkeerd. Zet een nieuwe met: {_ALLOW_CLI_HINT}",
+            None,
+        )
+
+    if marker is None:
+        return (
+            False,
+            "Subagents (Task tool) zijn standaard geblokkeerd — Task-aanroepen laten geen "
+            f"governance-receipt achter. Sta tijdelijk toe met: {_ALLOW_CLI_HINT}",
+            None,
+        )
+
+    reason = str(marker.get("reason") or "").strip()
+    if not reason:
+        return (
+            False,
+            "Subagent-marker ongeldig: 'reason' ontbreekt of is leeg. "
+            f"Zet een reden met: {_ALLOW_CLI_HINT}",
+            None,
+        )
+
+    expires_raw = marker.get("expires_at")
+    expiry_dt = _parse_iso(expires_raw)
+    if expiry_dt is None:
+        return (
+            False,
+            f"Subagent-marker ongeldig: 'expires_at' ({expires_raw!r}) is geen geldige ISO-8601 datum. "
+            f"Zet een nieuwe met: {_ALLOW_CLI_HINT}",
+            reason,
+        )
+
+    if _utc_now() >= expiry_dt:
+        return (
+            False,
+            f"Subagent-marker verlopen op {expires_raw} (reden was: {reason}). "
+            f"Vernieuw met: {_ALLOW_CLI_HINT}",
+            reason,
+        )
+
+    return (
+        True,
+        f"Subagents tijdelijk toegestaan tot {expires_raw} (reden: {reason}). "
+        "Gebruik wordt gelogd in state/subagent_use.ndjson.",
+        reason,
+    )
+
+
+def _append_audit(state_dir: Path, session_id: str, prompt: str, marker_reason: str) -> None:
+    audit_event_append(
+        state_dir,
+        AUDIT_EVENT_TYPE,
+        {
+            "session_id": session_id,
+            "prompt_excerpt": prompt[:PROMPT_EXCERPT_LEN],
+            "reason": marker_reason,
+        },
+    )
+
+
+def build_decision(payload: dict) -> dict:
+    state_dir = resolve_state_dir()
+    marker, load_error = _load_marker(state_dir)
+    allowed, reason, marker_reason = evaluate(marker, load_error)
+
+    if allowed:
+        session_id = str(payload.get("session_id") or "")
+        tool_input = payload.get("tool_input")
+        prompt = ""
+        if isinstance(tool_input, dict):
+            prompt = str(tool_input.get("prompt") or "")
+        try:
+            _append_audit(state_dir, session_id, prompt, marker_reason or "")
+        except OSError as exc:
+            allowed = False
+            reason = (
+                f"Subagent-marker geldig maar audit-log kon niet geschreven worden ({exc}); "
+                "geweigerd (fail-closed) — een subagent zonder spoor is exact wat dit "
+                "mechanisme voorkomt."
+            )
+
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow" if allowed else "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {}
+
+    if not isinstance(payload, dict) or payload.get("tool_name") != "Task":
+        return 0  # Not our concern — allow silently, no stdout.
+
+    decision = build_decision(payload)
+    sys.stdout.write(json.dumps(decision) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/subagents_allow.py
+++ b/scripts/subagents_allow.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""subagents_allow.py — grant/revoke/inspect the OI-1643 subagent override marker.
+
+Claude Code subagents (the Task tool) bypass the governance receipt trail, so
+``scripts/hooks/pretooluse_block_subagent.sh`` denies every Task call by
+default. This CLI is the operator's deliberate, time-boxed override: it
+writes/removes ``<state_dir>/subagents_allowed.json``, the marker the hook
+reads. Every subagent call made while a marker is active is still appended to
+``<state_dir>/subagent_use.ndjson`` by the hook — this CLI only controls
+whether calls are allowed, not whether they are logged.
+
+Usage:
+    python3 scripts/subagents_allow.py --reason "..." --hours 24
+    python3 scripts/subagents_allow.py --status
+    python3 scripts/subagents_allow.py --revoke
+
+Stdlib-only. State dir resolution matches every other hook in this repo
+(vnx_paths.resolve_paths()['VNX_STATE_DIR']) — never a hardcoded
+``.vnx-data/`` literal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from vnx_paths import resolve_paths  # noqa: E402
+from atomic_io import atomic_write_json  # noqa: E402
+
+MARKER_FILENAME = "subagents_allowed.json"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(ts: str):
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _state_dir() -> Path:
+    return Path(resolve_paths()["VNX_STATE_DIR"])
+
+
+def _marker_path() -> Path:
+    return _state_dir() / MARKER_FILENAME
+
+
+def _granted_by() -> str:
+    return (
+        os.environ.get("VNX_ACTOR")
+        or os.environ.get("USER")
+        or os.environ.get("LOGNAME")
+        or "unknown"
+    )
+
+
+def cmd_grant(reason: str, hours: float) -> int:
+    reason = reason.strip()
+    if not reason:
+        print("Weiger: --reason mag niet leeg zijn.", file=sys.stderr)
+        return 2
+    if hours is None or hours <= 0:
+        print("Weiger: --hours is verplicht en moet > 0 zijn.", file=sys.stderr)
+        return 2
+
+    granted_at = _utc_now()
+    expires_at = granted_at + timedelta(hours=hours)
+    marker = {
+        "reason": reason,
+        "granted_at": _iso(granted_at),
+        "expires_at": _iso(expires_at),
+        "granted_by": _granted_by(),
+    }
+    atomic_write_json(_marker_path(), marker)
+    print(
+        f"Subagents toegestaan tot {marker['expires_at']} UTC "
+        f"(reden: {reason}, granted_by: {marker['granted_by']})."
+    )
+    return 0
+
+
+def cmd_status() -> int:
+    marker_path = _marker_path()
+    if not marker_path.is_file():
+        print("Subagents niet toegestaan (geen marker aanwezig).")
+        return 1
+
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"Subagents niet toegestaan (marker onleesbaar: {exc}).")
+        return 1
+
+    reason = str(marker.get("reason") or "").strip()
+    if not reason:
+        print("Subagents niet toegestaan (marker ongeldig: reason ontbreekt).")
+        return 1
+
+    expiry_dt = _parse_iso(marker.get("expires_at", ""))
+    if expiry_dt is None:
+        print("Subagents niet toegestaan (marker ongeldig: expires_at is geen geldige datum).")
+        return 1
+
+    if _utc_now() >= expiry_dt:
+        print(f"Subagents niet toegestaan (marker verlopen op {marker['expires_at']}).")
+        return 1
+
+    print(
+        f"Subagents toegestaan tot {marker['expires_at']} UTC "
+        f"(reden: {reason}, granted_by: {marker.get('granted_by', 'onbekend')})."
+    )
+    return 0
+
+
+def cmd_revoke() -> int:
+    marker_path = _marker_path()
+    if marker_path.is_file():
+        marker_path.unlink()
+        print("Subagent-marker ingetrokken.")
+    else:
+        print("Geen actieve subagent-marker om in te trekken.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Grant, revoke, or inspect the OI-1643 subagent (Task tool) override marker."
+    )
+    parser.add_argument("--reason", type=str, default=None, help="Reden voor het toestaan (verplicht bij grant).")
+    parser.add_argument("--hours", type=float, default=None, help="Aantal uren tot de marker verloopt.")
+    parser.add_argument("--status", action="store_true", help="Toon de huidige marker-status.")
+    parser.add_argument("--revoke", action="store_true", help="Trek een actieve marker in.")
+    args = parser.parse_args(argv)
+
+    if args.status:
+        return cmd_status()
+    if args.revoke:
+        return cmd_revoke()
+    if args.reason is not None or args.hours is not None:
+        if args.reason is None:
+            print("Weiger: --reason is verplicht (samen met --hours) om subagents toe te staan.", file=sys.stderr)
+            return 2
+        return cmd_grant(args.reason, args.hours)
+
+    parser.error("Geef --reason (met --hours), --status, of --revoke.")
+    return 2  # pragma: no cover — parser.error() exits before this
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pretooluse_block_raw_claude_spawn.py
+++ b/tests/test_pretooluse_block_raw_claude_spawn.py
@@ -22,7 +22,14 @@ Covers:
 
   general:
   - ALLOW: non-Bash tool calls (Write, Read, etc.)
-  - JSON output contract: decision + reason on block, empty on allow
+  - JSON output contract (OI-1643): PreToolUse deny is
+    {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+    "permissionDecision":"deny","permissionDecisionReason":"..."}}, empty on
+    allow. The deprecated flat {"decision":"block","reason":"..."} form is a
+    PostToolUse/Stop/UserPromptSubmit contract that Claude Code silently
+    ignores for PreToolUse — assert_blocked() below unwraps the envelope and
+    still returns {"decision": "block", "reason": ...} so existing assertions
+    read unchanged.
   - Exit code always 0
 """
 
@@ -74,15 +81,22 @@ def run_hook(tool_name: str, command: str | None = None) -> tuple[int, str]:
 
 
 def assert_blocked(tool_name: str, command: str) -> dict:
-    """Run hook; assert block decision. Returns parsed JSON."""
+    """Run hook; assert deny decision (PreToolUse hookSpecificOutput contract).
+    Returns the parsed hookSpecificOutput dict (not the outer envelope) so
+    existing callers keep reading .get("reason") unchanged.
+    """
     rc, out = run_hook(tool_name, command)
-    assert rc == 0, f"Hook must exit 0 even on block; got {rc}"
+    assert rc == 0, f"Hook must exit 0 even on deny; got {rc}"
     assert out.strip(), f"Blocked command produced no output: {command!r}"
     data = json.loads(out)
-    assert data.get("decision") == "block", (
-        f"Expected block for {command!r}, got {data.get('decision')!r}"
+    hso = data.get("hookSpecificOutput", {})
+    assert hso.get("hookEventName") == "PreToolUse", (
+        f"Expected PreToolUse hookSpecificOutput for {command!r}, got {data!r}"
     )
-    return data
+    assert hso.get("permissionDecision") == "deny", (
+        f"Expected deny for {command!r}, got {hso.get('permissionDecision')!r}"
+    )
+    return {"decision": "block", "reason": hso.get("permissionDecisionReason")}
 
 
 def assert_allowed(tool_name: str, command: str | None = None) -> None:
@@ -406,6 +420,20 @@ class TestHookOutputContract:
         _, out = run_hook("Bash", 'claude -p "test"')
         data = json.loads(out)
         assert isinstance(data, dict)
+
+    def test_block_uses_hookspecificoutput_envelope(self):
+        """OI-1643 regression guard: PreToolUse must use hookSpecificOutput.
+        permissionDecision, not the deprecated flat {"decision":"block"} form
+        (that form is the PostToolUse/Stop/UserPromptSubmit contract and is
+        silently ignored for PreToolUse — the bug this fix closes).
+        """
+        _, out = run_hook("Bash", 'claude -p "test"')
+        data = json.loads(out)
+        assert "decision" not in data, "deprecated flat form must not reappear"
+        hso = data["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert hso["permissionDecisionReason"]
 
     def test_block_has_decision_block(self):
         data = assert_blocked("Bash", 'claude -p "test"')

--- a/tests/test_pretooluse_block_subagent.py
+++ b/tests/test_pretooluse_block_subagent.py
@@ -1,0 +1,289 @@
+"""Tests for pretooluse_block_subagent.sh, pretooluse_subagent_guard.py and
+scripts/subagents_allow.py.
+
+OI-1643: the hook used to emit the deprecated flat ``{"decision":"block",...}``
+form. Claude Code's PreToolUse event reads
+``hookSpecificOutput.permissionDecision`` (``allow``/``deny``/``ask``) instead,
+so the old form was silently ignored and subagents were never actually
+blocked. This suite locks in the corrected contract plus the operator
+override mechanism (marker file + audit trail + CLI).
+
+Covers:
+  - No marker: deny, valid hookSpecificOutput JSON.
+  - Valid marker: allow, exactly one new line appended to the audit NDJSON.
+  - Expired marker: deny, reason mentions the marker is expired.
+  - Marker with an empty/missing reason: deny (never a bare "allow").
+  - Non-Task tool calls: allowed silently (empty stdout) — unaffected by the
+    marker/guard logic (defense-in-depth fast path).
+  - CLI (scripts/subagents_allow.py): --status without a marker (exit 1,
+    "niet toegestaan"); --reason + --hours grants (exit 0); --status after
+    grant (exit 0); --revoke removes the marker; no --reason refuses.
+  - Static: bash -n / py_compile on every touched file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "pretooluse_block_subagent.sh"
+GUARD_CORE = REPO_ROOT / "scripts" / "hooks" / "pretooluse_subagent_guard.py"
+CLI_SCRIPT = REPO_ROOT / "scripts" / "subagents_allow.py"
+
+MARKER_FILENAME = "subagents_allowed.json"
+AUDIT_FILENAME = "subagent_use.ndjson"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def iso_now() -> str:
+    return _iso(datetime.now(timezone.utc))
+
+
+def iso_in(hours: float) -> str:
+    return _iso(datetime.now(timezone.utc) + timedelta(hours=hours))
+
+
+def make_task_payload(session_id: str = "test-session", prompt: str = "Do a subtask") -> str:
+    payload = {
+        "tool_name": "Task",
+        "tool_input": {
+            "description": "test subagent",
+            "prompt": prompt,
+            "subagent_type": "general-purpose",
+        },
+        "session_id": session_id,
+        "cwd": "/tmp/test-project",
+        "transcript_path": "/tmp/test.jsonl",
+    }
+    return json.dumps(payload)
+
+
+def run_hook(payload: str, state_dir: Path) -> tuple[int, str]:
+    env = dict(os.environ, VNX_STATE_DIR=str(state_dir))
+    result = subprocess.run(
+        ["bash", str(HOOK_SCRIPT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    return result.returncode, result.stdout
+
+
+def run_cli(args: list[str], state_dir: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ, VNX_STATE_DIR=str(state_dir))
+    return subprocess.run(
+        [sys.executable, str(CLI_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+
+def write_marker(state_dir: Path, **fields) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    marker = {
+        "reason": "operator toegestaan (test)",
+        "granted_at": iso_now(),
+        "expires_at": iso_in(1),
+        "granted_by": "test-user",
+    }
+    marker.update(fields)
+    (state_dir / MARKER_FILENAME).write_text(json.dumps(marker), encoding="utf-8")
+
+
+# ── 1. No marker: deny ─────────────────────────────────────────────────────────
+
+class TestNoMarker:
+    def test_no_marker_denies(self, tmp_path):
+        rc, out = run_hook(make_task_payload(), tmp_path)
+        assert rc == 0, "hook must always exit 0; decision travels via stdout JSON"
+        assert out.strip(), "a deny decision must produce JSON stdout"
+        data = json.loads(out)
+        hso = data["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert hso["permissionDecisionReason"]
+
+    def test_no_marker_produces_no_audit_file(self, tmp_path):
+        run_hook(make_task_payload(), tmp_path)
+        assert not (tmp_path / AUDIT_FILENAME).exists()
+
+
+# ── 2. Valid marker: allow + audit line ────────────────────────────────────────
+
+class TestValidMarker:
+    def test_valid_marker_allows(self, tmp_path):
+        write_marker(tmp_path)
+        rc, out = run_hook(make_task_payload(), tmp_path)
+        assert rc == 0
+        data = json.loads(out)
+        hso = data["hookSpecificOutput"]
+        assert hso["permissionDecision"] == "allow"
+        assert hso["hookEventName"] == "PreToolUse"
+
+    def test_valid_marker_writes_exactly_one_audit_line(self, tmp_path):
+        write_marker(tmp_path, reason="ronde-2 handtest")
+        run_hook(make_task_payload(session_id="sess-abc", prompt="X" * 300), tmp_path)
+        audit_path = tmp_path / AUDIT_FILENAME
+        assert audit_path.is_file(), "an allowed subagent call must leave an audit trail"
+        lines = [ln for ln in audit_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["reason"] == "ronde-2 handtest"
+        assert entry["session_id"] == "sess-abc"
+        assert len(entry["prompt_excerpt"]) <= 200
+
+    def test_two_allowed_calls_append_two_lines(self, tmp_path):
+        write_marker(tmp_path)
+        run_hook(make_task_payload(), tmp_path)
+        run_hook(make_task_payload(), tmp_path)
+        lines = [
+            ln for ln in (tmp_path / AUDIT_FILENAME).read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+        assert len(lines) == 2
+
+
+# ── 3. Expired marker: deny, reason mentions expiry ────────────────────────────
+
+class TestExpiredMarker:
+    def test_expired_marker_denies(self, tmp_path):
+        write_marker(tmp_path, granted_at=iso_in(-3), expires_at=iso_in(-1))
+        rc, out = run_hook(make_task_payload(), tmp_path)
+        assert rc == 0
+        data = json.loads(out)
+        hso = data["hookSpecificOutput"]
+        assert hso["permissionDecision"] == "deny"
+        assert "verlopen" in hso["permissionDecisionReason"].lower()
+
+    def test_expired_marker_produces_no_audit_file(self, tmp_path):
+        write_marker(tmp_path, granted_at=iso_in(-3), expires_at=iso_in(-1))
+        run_hook(make_task_payload(), tmp_path)
+        assert not (tmp_path / AUDIT_FILENAME).exists()
+
+
+# ── 4. Marker without a reason: deny ───────────────────────────────────────────
+
+class TestMarkerWithoutReason:
+    def test_empty_reason_denies(self, tmp_path):
+        write_marker(tmp_path, reason="")
+        rc, out = run_hook(make_task_payload(), tmp_path)
+        assert rc == 0
+        data = json.loads(out)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_missing_reason_key_denies(self, tmp_path):
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        marker = {"granted_at": iso_now(), "expires_at": iso_in(1), "granted_by": "x"}
+        (tmp_path / MARKER_FILENAME).write_text(json.dumps(marker), encoding="utf-8")
+        rc, out = run_hook(make_task_payload(), tmp_path)
+        data = json.loads(out)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+# ── Defense-in-depth: non-Task tools are unaffected ────────────────────────────
+
+class TestNonTaskTool:
+    def test_non_task_tool_allows_silently(self, tmp_path):
+        env = dict(os.environ, VNX_STATE_DIR=str(tmp_path))
+        payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}, "session_id": "x"})
+        result = subprocess.run(
+            ["bash", str(HOOK_SCRIPT)], input=payload, capture_output=True, text=True, env=env, timeout=15
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+# ── 5. CLI: scripts/subagents_allow.py ─────────────────────────────────────────
+
+class TestCLI:
+    def test_status_without_marker_exits_1(self, tmp_path):
+        result = run_cli(["--status"], tmp_path)
+        assert result.returncode == 1
+        assert "niet toegestaan" in (result.stdout + result.stderr).lower()
+
+    def test_grant_requires_reason(self, tmp_path):
+        result = run_cli(["--hours", "1"], tmp_path)
+        assert result.returncode != 0
+
+    def test_grant_requires_nonempty_reason(self, tmp_path):
+        result = run_cli(["--reason", "   ", "--hours", "1"], tmp_path)
+        assert result.returncode != 0
+        assert not (tmp_path / MARKER_FILENAME).exists()
+
+    def test_grant_writes_marker(self, tmp_path):
+        result = run_cli(["--reason", "sessie-test", "--hours", "2"], tmp_path)
+        assert result.returncode == 0
+        marker_path = tmp_path / MARKER_FILENAME
+        assert marker_path.is_file()
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        assert marker["reason"] == "sessie-test"
+        assert marker["granted_at"]
+        assert marker["expires_at"]
+        assert marker["granted_by"]
+
+    def test_status_after_grant_exits_0(self, tmp_path):
+        run_cli(["--reason", "sessie-test", "--hours", "1"], tmp_path)
+        result = run_cli(["--status"], tmp_path)
+        assert result.returncode == 0
+
+    def test_revoke_removes_marker(self, tmp_path):
+        run_cli(["--reason", "sessie-test", "--hours", "1"], tmp_path)
+        assert (tmp_path / MARKER_FILENAME).exists()
+        result = run_cli(["--revoke"], tmp_path)
+        assert result.returncode == 0
+        assert not (tmp_path / MARKER_FILENAME).exists()
+
+    def test_revoke_is_idempotent_without_marker(self, tmp_path):
+        result = run_cli(["--revoke"], tmp_path)
+        assert result.returncode == 0
+
+    def test_cli_grant_then_hook_allows(self, tmp_path):
+        """End-to-end: CLI grant is readable by the hook (same state dir, same schema)."""
+        grant = run_cli(["--reason", "end-to-end", "--hours", "1"], tmp_path)
+        assert grant.returncode == 0
+        rc, out = run_hook(make_task_payload(), tmp_path)
+        data = json.loads(out)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+# ── Static checks ───────────────────────────────────────────────────────────────
+
+class TestStatic:
+    def test_hook_script_exists(self):
+        assert HOOK_SCRIPT.exists()
+
+    def test_guard_core_exists(self):
+        assert GUARD_CORE.exists()
+
+    def test_cli_script_exists(self):
+        assert CLI_SCRIPT.exists()
+
+    def test_hook_script_bash_syntax(self):
+        result = subprocess.run(["bash", "-n", str(HOOK_SCRIPT)], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+    def test_guard_core_python_syntax(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "py_compile", str(GUARD_CORE)], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_cli_python_syntax(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "py_compile", str(CLI_SCRIPT)], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_pretooluse_block_subagent.py
+++ b/tests/test_pretooluse_block_subagent.py
@@ -68,8 +68,10 @@ def make_task_payload(session_id: str = "test-session", prompt: str = "Do a subt
     return json.dumps(payload)
 
 
-def run_hook(payload: str, state_dir: Path) -> tuple[int, str]:
+def run_hook(payload: str, state_dir: Path, signal_dir: Path | None = None) -> tuple[int, str]:
     env = dict(os.environ, VNX_STATE_DIR=str(state_dir))
+    if signal_dir is not None:
+        env["VNX_TMUX_SIGNAL_DIR"] = str(signal_dir)
     result = subprocess.run(
         ["bash", str(HOOK_SCRIPT)],
         input=payload,
@@ -258,6 +260,42 @@ class TestCLI:
         rc, out = run_hook(make_task_payload(), tmp_path)
         data = json.loads(out)
         assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+# ── 6. Toolcall signal aggregation: a deny must be recorded as blocked ─────────
+# OI-1643 restpunt: the case pattern matched the JSON key/value with no space
+# (`"permissionDecision":"deny"`), but json.dumps' default separators put a
+# space after the colon (`"permissionDecision": "deny"`), so the pattern never
+# matched and every denied Task call was logged with blocked=false — the
+# tool_call_failures receipt field silently undercounted every block.
+
+class TestToolcallSignalAggregation:
+    def test_deny_is_recorded_as_blocked(self, tmp_path):
+        state_dir = tmp_path / "state"
+        signal_dir = tmp_path / "signal"
+        rc, out = run_hook(make_task_payload(), state_dir, signal_dir=signal_dir)
+        assert rc == 0
+        data = json.loads(out)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+        signal_path = signal_dir / "toolcalls.ndjson"
+        assert signal_path.is_file(), "a Task call must always produce a toolcall signal line"
+        lines = [ln for ln in signal_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["blocked"] is True, f"denied Task call must be blocked=true, got {entry!r}"
+
+    def test_allow_is_recorded_as_not_blocked(self, tmp_path):
+        state_dir = tmp_path / "state"
+        signal_dir = tmp_path / "signal"
+        write_marker(state_dir)
+        rc, out = run_hook(make_task_payload(), state_dir, signal_dir=signal_dir)
+        assert rc == 0
+        data = json.loads(out)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "allow"
+        entry = json.loads(
+            (signal_dir / "toolcalls.ndjson").read_text(encoding="utf-8").strip().splitlines()[0]
+        )
+        assert entry["blocked"] is False
 
 
 # ── Static checks ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `pretooluse_block_subagent.sh` and `pretooluse_block_raw_claude_spawn.sh` both emitted the deprecated flat `{"decision":"block",...}` form. That's the PostToolUse/Stop/UserPromptSubmit contract; PreToolUse reads `hookSpecificOutput.permissionDecision` (`allow`/`deny`/`ask`). Claude Code silently ignored the old output, so subagents and raw provider spawns were never actually blocked — the rule existed on paper only.
- Both hooks now emit the correct `hookSpecificOutput` envelope, default deny.
- Added a deliberate, auditable operator override for subagents: `scripts/subagents_allow.py --reason "..." --hours N` (+ `--status`/`--revoke`) writes a time-boxed marker; the new guard core (`scripts/hooks/pretooluse_subagent_guard.py`) checks it before allowing a Task call and logs every allowed call to `state/subagent_use.ndjson`. A crash of the guard core, or a failed audit write, fails **closed** (deny) — an allow with no trace is exactly the bypass this hook exists to prevent.

## Changes
- `scripts/hooks/pretooluse_block_subagent.sh` — rewritten to delegate the full decision to the new Python core; fail-closed on core-missing/core-crash.
- `scripts/hooks/pretooluse_subagent_guard.py` (new) — marker validation (missing/unreadable/expired/reason-less all deny), audit-trail append via `atomic_io.audit_event_append`, state dir via `vnx_paths.resolve_paths()`.
- `scripts/subagents_allow.py` (new) — stdlib-only CLI: grant/status/revoke, atomic marker write via `atomic_io.atomic_write_json`.
- `scripts/hooks/pretooluse_block_raw_claude_spawn.sh` — same deprecated→`hookSpecificOutput` fix, output format only (detection logic unchanged).
- `tests/test_pretooluse_block_subagent.py` (new) — red-first suite: 24 tests covering no-marker/valid/expired/reason-less marker, non-Task passthrough, full CLI lifecycle, and static syntax checks.
- `tests/test_pretooluse_block_raw_claude_spawn.py` — updated `assert_blocked()` + `TestHookOutputContract` to the corrected envelope (the old assertions tested the exact deprecated form this PR removes); added an explicit `test_block_uses_hookspecificoutput_envelope` regression guard.

## Verification
See the dispatch report for full RED/GREEN transcripts: `python3 -m pytest tests/test_pretooluse_block_subagent.py tests/test_pretooluse_block_raw_claude_spawn.py -q` → 124 passed. Also ran the direct neighbours (`test_atomic_io.py`, `test_vnx_paths_*.py`, `test_toolcall_signals*.py`, `test_pretooluse_spawn_detector.py`, `test_pretooluse_headless_hook.py`) — 462 passed total, no regressions. `bash -n` and `py_compile` clean on every touched/new file.

## Open items
- Could not update `.claude/terminals/T0/role-orchestrator.md` (line 84) or `.claude/skills/fabric-reference/SKILL.md` (line 40) — both are outside this headless worker's file-write scope (`scripts/**`, `tests/**`, `dashboard/**`) and Claude Code flags `.claude/` as sensitive. Exact replacement text is in the dispatch report for a human or differently-scoped worker to apply.
- `scripts/hooks/pretooluse_worker_scope_enforce.sh`/`.py` also emit the same deprecated flat form, but that hook is not wired in this repo's `.claude/settings.json` (dormant, gated off by `VNX_ENFORCE_WORKER_PERMISSIONS`) and wasn't in this dispatch's scope — flagged, not fixed.

Dispatch-ID: 20260906-oi1643-subagent-hook-r2