### PR TITLE
fix(closure-verifier): only review gates may sign as a merge peer (OI-1645)

### DIFF
--- a/docs/governance/decisions/ADR-037-gate-uitval-is-afwezigheid-niet-tegenstem.md
+++ b/docs/governance/decisions/ADR-037-gate-uitval-is-afwezigheid-niet-tegenstem.md
@@ -100,3 +100,54 @@ in drie gevallen:
 De voorrangsregel en de zeven bewijs-invarianten uit het hoofd-ADR gelden onverkort voor
 de ondertekenende peer in geval (b); er is niets verzwakt, alleen de vraag "bestaat er
 een record" losgekoppeld van "is dat record in scope".
+
+## Addendum (OI-1645, 2026-09-06) — een peer is een review-poort; CI is een tweede, onafhankelijke eis, geen ondertekenaar
+
+Bij de merge van PR #1781 zei de deur letterlijk: "ci_gate droeg op dezelfde head
+zelfstandig een geldige, volledig bewezen pass en telt als ondertekenaar bij afwezigheid
+van de gedeclareerde poort". Een droge simulatie tegen een tmp results-dir met UITSLUITEND
+`pr-1781-codex_gate.json` (status `unavailable`) en `pr-1781-ci_gate.json` (status `pass`,
+alle zeven bewijs-invarianten aanwezig) bevestigde dit: GO, `evidence_gate="ci_gate"`, geen
+enkele review-poort aanwezig.
+
+`_find_peer_gate_results` (het hoofd-ADR hierboven) en `_find_takeover_successor_results`
+(OI-1576) begrensden de kandidatenverzameling allebei tot `_KNOWN_GATES` — de
+enum-afgeleide verzameling van poorten die de closure-verifier kan INTERPRETEREN. Dat is
+een andere bewering dan "dit is een review": `ci_gate` toetst CI-checks (tests, lint,
+build), nooit de codewijziging zelf, maar levert wel een volledig bewezen pass/fail-record
+op dat elke bewijs-invariant haalt die `_merge_door_record_verdict` toetst. Niets in de
+bewijsketen ving dit — de ketting was sterk, maar aan het verkeerde ding vastgemaakt.
+
+**Beslissing:** interpreteerbaar zijn en een review zijn zijn twee aparte beweringen.
+`closure_verifier._REVIEW_PEER_GATES` is een nieuwe, striktere verzameling — ook afgeleid
+van de `Gate`-enum met een uitsluitingslijst met reden per poort
+(`_NON_REVIEW_SIGNER_REASONS`), dezelfde discipline als `_GATES_NOT_IMPLEMENTED_BY_CLOSURE`
+— die BEIDE routes nu delen:
+
+- `ci_gate` uitgesloten: toetst CI-checks, geen code-review. Uitgesloten in BEIDE
+  richtingen — kan geen pass ondertekenen, en (nieuw) een `ci_gate`-record met een
+  `takeover_path` die een andere poort noemt telt ook niet als opvolger op de OI-1576-route.
+  Symmetrisch ook geen "echte afkeuring": een `ci_gate`-FAIL in de resultaatstore blokkeert
+  de peer-route niet langer. Dat is geen verzwakking — `pr_merge.main` roept
+  `_run_ci_gate` (een LIVE `gh`-statusCheckRollup-toets) vóór de review-poort aan en geeft
+  `EXIT_ERROR` bij een niet-groene CI-conclusie, dus een echte CI-afkeuring blokkeert de
+  merge al via die aparte, onafhankelijke weg. Een verouderd `ci_gate`-resultaatbestand ook
+  hier laten blokkeren zou dezelfde afkeuring dubbel tellen, geen extra veiligheid
+  toevoegen.
+- `wiring_gate` uitgesloten: staat al buiten `_KNOWN_GATES` (geen interpreteerbaar
+  bewijs), dus a fortiori geen ondertekenaar.
+- `claude_github_optional` blijft WEL een geldige peer. Het is optioneel — mag nooit
+  draaien — maar wanneer `state="completed"` bereikt wordt, is `result_status` een echte
+  Claude-code-review van de diff, geen CI-signaal (`claude_github_receipt.EVIDENCE_STATES`).
+  Optioneel-maar-echt telt; alleen niet-review-bewijs is uitgesloten. De eigen
+  afwezigheidstoestanden (`not_configured`, `configured_dry_run`) coderen sowieso nooit
+  naar een beslist verdict, dus een niet-gedraaide instantie draagt toch al niets bij.
+
+Een nieuwe enum-waarde die morgen wordt toegevoegd is automatisch ONGECLASSIFICEERD tot
+iemand hem in een van beide verzamelingen zet — vastgepind door de drift-test in
+`tests/test_oi1645_peer_is_review_gate.py`, naast de bestaande
+`test_closure_verifier_gate_enum_drift.py`.
+
+**Wat dit niet verandert:** de voorrangsregel en de zeven bewijs-invarianten uit het
+hoofd-ADR blijven ongewijzigd voor elke poort die WEL in `_REVIEW_PEER_GATES` zit. Alleen
+de kandidatenverzameling is versmald van "interpreteerbaar" naar "een review".

--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -72,6 +72,56 @@ _KNOWN_GATES = frozenset(
 )
 
 
+# OI-1645: which gates may stand in as a PEER SIGNER when the declared gate is
+# a confirmed absence (_consult_peers_for_absence) or an OI-1576 takeover
+# successor (_find_takeover_successor_results). Being in _KNOWN_GATES only
+# means the closure verifier can INTERPRET a gate's result record — it says
+# nothing about whether that record represents a code review. Signing power
+# is a strictly narrower claim.
+#
+# Measured live 2026-09-06 (PR #1781, main c41c7f36): with codex_gate
+# unavailable and only ci_gate carrying a full, all-seven-invariant-passing
+# PASS on the head, ``check_review_gate_for_merge`` returned GO with
+# ``evidence_gate="ci_gate"`` — zero review gates had spoken. ci_gate renders
+# a genuine, fully-evidenced pass/fail (it satisfies every invariant
+# ``_merge_door_record_verdict`` checks), so nothing in the evidence-quality
+# chain catches this; it verifies CI checks (tests, lint, build), never the
+# code change itself. ADR-037's addendum below names the distinction: a peer
+# is a review gate, CI is a second, independent merge requirement, never a
+# signer.
+#
+# Derived from the Gate enum with a reason per exclusion — the same
+# discipline _GATES_NOT_IMPLEMENTED_BY_CLOSURE already uses — so a gate added
+# to the enum tomorrow is UNCLASSIFIED (caught by the drift test in
+# tests/test_oi1645_peer_is_review_gate.py) instead of silently inheriting
+# peer-signing rights.
+#
+# claude_github_optional is deliberately NOT excluded: reading
+# claude_github_receipt.EVIDENCE_STATES / INTENTIONALLY_ABSENT_STATES and
+# gate_request_handler's ``completed`` branch, its terminal outcome
+# (``state="completed"`` + ``result_status="pass"|"fail"``) is a genuine
+# Claude code review of the diff, not a CI signal — it being optional
+# (may never run) only means its own absence states (not_configured,
+# configured_dry_run) never coerce to a decided status, so an unrun instance
+# contributes nothing to the peer route either way. Optional-but-real review
+# evidence still counts when it exists; only non-review evidence is excluded.
+_NON_REVIEW_SIGNER_REASONS: Dict[str, str] = {
+    "wiring_gate": (
+        "not implemented by the closure verifier at all — carries no "
+        "interpretable verdict to sign with (see _GATES_NOT_IMPLEMENTED_BY_CLOSURE)"
+    ),
+    "ci_gate": (
+        "verifies CI checks (tests, lint, build), not a code review of the "
+        "change — ADR-037 addendum (OI-1645): CI is a second, independent "
+        "merge requirement (enforced separately in pr_merge._run_ci_gate), "
+        "never a review peer signer"
+    ),
+}
+_REVIEW_PEER_GATES = frozenset(
+    g.value for g in Gate if g.value not in _NON_REVIEW_SIGNER_REASONS
+)
+
+
 def _run(cmd: Sequence[str], *, cwd: Optional[Path] = None, timeout: int = 20) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         list(cmd),
@@ -581,6 +631,14 @@ def _find_takeover_successor_results(
         # this route only ever looks at OTHER gates' records.
         if not record_gate or record_gate == gate:
             continue
+        # OI-1645: a successor must itself be a review gate. A ci_gate (or
+        # any other _NON_REVIEW_SIGNER_REASONS gate) that annotates a
+        # takeover_path naming the declared gate has still never reviewed the
+        # code — the same reason it cannot sign via _find_peer_gate_results
+        # applies here, so both routes share _REVIEW_PEER_GATES rather than
+        # risking a second, diverging notion of "who may sign".
+        if record_gate not in _REVIEW_PEER_GATES:
+            continue
         if data.get("takeover") is not True:
             continue
         if not _record_matches_scope(data, pr_id, branch, project_id, head_sha):
@@ -708,9 +766,12 @@ def _find_peer_gate_results(
     - Only records with a RENDERED verdict (``_DECIDED_VERDICT_STATES`` —
       pass or fail, never another absence status) are returned; an absent
       peer contributes nothing either way.
-    - The candidate set is bounded to ``_KNOWN_GATES`` (the same enum-derived
-      set the declared-gate lookup trusts), never an unbounded directory
-      scan.
+    - The candidate set is bounded to ``_REVIEW_PEER_GATES`` (OI-1645) —
+      NOT ``_KNOWN_GATES``. ``_KNOWN_GATES`` only says the verifier can
+      interpret a gate's record; ``_REVIEW_PEER_GATES`` additionally
+      excludes gates whose record is not a code review at all (``ci_gate``:
+      CI checks, not review — see ``_NON_REVIEW_SIGNER_REASONS``). Never an
+      unbounded directory scan either way.
 
     This does NOT relax ``TestUnrelatedRecordsNeverTakeOver`` (OI-1576): that
     contract is about a declared gate with NO record at all (never even
@@ -719,11 +780,11 @@ def _find_peer_gate_results(
     function is only ever consulted once the declared gate's OWN record
     already proves it will not render a verdict for this attempt.
 
-    Returns ``[(gate_name, record), ...]``, unordered beyond ``_KNOWN_GATES``
-    iteration order (sorted, for determinism).
+    Returns ``[(gate_name, record), ...]``, unordered beyond
+    ``_REVIEW_PEER_GATES`` iteration order (sorted, for determinism).
     """
     peers: List[Tuple[str, Dict[str, Any]]] = []
-    for candidate_gate in sorted(_KNOWN_GATES):
+    for candidate_gate in sorted(_REVIEW_PEER_GATES):
         if candidate_gate == gate:
             continue
         candidate = _find_gate_result(

--- a/tests/test_oi1645_peer_is_review_gate.py
+++ b/tests/test_oi1645_peer_is_review_gate.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""OI-1645: only REVIEW gates may stand in as a peer signer — ci_gate is a CI
+check, never a code review.
+
+Measured live 2026-09-06 on the vnx-dev store, at the merge of PR #1781 (main
+c41c7f36): the door said, literally, "ci_gate droeg op dezelfde head
+zelfstandig een geldige, volledig bewezen pass en telt als ondertekenaar bij
+afwezigheid van de gedeclareerde poort". A dry-run simulation against a tmp
+results-dir carrying only ``pr-1781-codex_gate.json`` (status=unavailable, the
+real recorded reason) and ``pr-1781-ci_gate.json`` (status=pass, the real
+recorded contract_hash/report_path/commit_sha) confirmed:
+``check_review_gate_for_merge(pr_id="1781", gate="codex_gate", ...)`` returned
+GO with ``evidence_gate="ci_gate"`` — zero review gates had spoken for this
+head. Not exploited live: every one of the eight merges around this date also
+carried an independent glm_gate PASS on the same head (verified against
+t0_receipts.ndjson pr_merged events since 2026-09-06T10:00Z and the merge
+logs), so this dispatch's own report carries that verification, not this test
+file.
+
+Root cause: ``closure_verifier._find_peer_gate_results`` (OI-1624/OI-1642)
+iterated ``_KNOWN_GATES`` — the enum-derived set of gates the closure verifier
+can INTERPRET a result record for. ``ci_gate`` is in that set (the verifier
+does know how to read a ci_gate record) but it is not a review: it reports on
+CI checks (tests, lint, build), never on the code change itself. Being
+interpretable and being a review are two different claims that
+``_find_peer_gate_results`` conflated into one.
+
+The fix (``_NON_REVIEW_SIGNER_REASONS`` / ``_REVIEW_PEER_GATES``, both derived
+from the ``Gate`` enum with a reason per exclusion, same discipline as
+``_GATES_NOT_IMPLEMENTED_BY_CLOSURE``) narrows both the OI-1624/OI-1642 peer
+route (``_find_peer_gate_results``) AND the OI-1576 takeover-successor route
+(``_find_takeover_successor_results``) to gates that are actual reviews.
+``ci_gate`` and ``wiring_gate`` are excluded by name with a reason;
+``claude_github_optional`` is deliberately kept IN the peer set — its
+``completed`` state is a genuine Claude code review of the diff, not a CI
+signal, so it counts when it exists (see the reason comment on
+``_NON_REVIEW_SIGNER_REASONS`` in ``closure_verifier.py``).
+
+Scenario 3 below also pins a related design decision: a ci_gate FAIL is no
+longer read as a "real rejection" in the peer route either (symmetry — a gate
+that cannot sign a PASS should not silently block via a FAIL in the same
+route). This is not a safety regression: ``pr_merge.main`` calls
+``_run_ci_gate`` (a LIVE ``gh`` statusCheckRollup check via
+``merge_preflight_ci_check.check_ci_run_for_head``) BEFORE the review gate
+and returns EXIT_ERROR immediately on a non-green CI conclusion — a real CI
+failure already blocks the merge through that separate, independent check,
+so the review-gate peer route reading a stale ci_gate result-file FAIL as a
+second rejection would be double-counting, not added safety.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv
+from dispatch_spec import Gate
+
+# Mirrored from the live vnx-dev store shape for PR #1781 (2026-09-06).
+PR_ID = "1781"
+BRANCH = "dispatch/20260905-golf4-klasse-wachter"
+HEAD_SHA = "ea42e9221ecb51c2290440b76e9d4c90a3c9a72b"
+
+CLEAN_REPORT = "# Gate report\n\nAll findings reviewed, nothing blocking.\n"
+
+
+def _write_result(results_dir: Path, gate: str, data: dict) -> Path:
+    """Write a result record under the writer's real naming (pr-<n>-<gate>.json)."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / f"pr-{PR_ID}-{gate}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _report_file(tmp_path: Path, name: str = "report.md", content: str = CLEAN_REPORT) -> Path:
+    report = tmp_path / name
+    report.write_text(content, encoding="utf-8")
+    return report
+
+
+def _codex_unavailable() -> dict:
+    """pr-1781-codex_gate.json as measured live: terminal-absence via
+    UNAVAILABLE_STATES, in scope (carries the real branch/commit_sha)."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": PR_ID,
+        "status": "unavailable",
+        "reason": "exit_nonzero",
+        "contract_hash": "",
+        "report_path": "",
+        "branch": BRANCH,
+        "commit_sha": HEAD_SHA,
+    }
+
+
+def _ci_gate_pass(report: Path, **overrides) -> dict:
+    """pr-1781-ci_gate.json as measured live: a full, all-invariants-passing
+    PASS record — status/contract_hash/report_path/commit_sha all populated,
+    same shape a genuine review gate would carry."""
+    data = {
+        "gate": "ci_gate",
+        "pr_id": PR_ID,
+        "status": "pass",
+        "blocking_findings": [],
+        "advisory_findings": [],
+        "blocking_count": 0,
+        "advisory_count": 0,
+        "contract_hash": "2245497555d37997",
+        "report_path": str(report),
+        "branch": BRANCH,
+        "commit_sha": HEAD_SHA,
+    }
+    data.update(overrides)
+    return data
+
+
+def _glm_pass(report: Path, **overrides) -> dict:
+    data = {
+        "gate": "glm_gate",
+        "pr_id": PR_ID,
+        "status": "pass",
+        "blocking_count": 0,
+        "blocking_findings": [],
+        "contract_hash": "48ac3a901eb93175",
+        "report_path": str(report),
+        "branch": BRANCH,
+        "commit_sha": HEAD_SHA,
+    }
+    data.update(overrides)
+    return data
+
+
+def _check(results_dir: Path, gate: str = "codex_gate") -> dict:
+    return cv.check_review_gate_for_merge(
+        PR_ID, gate, results_dir, branch=BRANCH, head_sha=HEAD_SHA
+    )
+
+
+class TestCiGateAloneNeverSigns:
+    """Scenario 1 (dispatch): codex absent, only ci_gate PASS on the head.
+    Before the fix this returned GO with evidence_gate=ci_gate (measured live
+    on PR #1781) — RED against pre-fix code. After the fix: zero review gates
+    have spoken, so this stays NO-GO, honestly reported as absence."""
+
+    def test_ci_gate_only_pass_is_no_go_zero_signers(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_unavailable())
+        _write_result(results_dir, "ci_gate", _ci_gate_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO", verdict["message"]
+        assert "nul geldige ondertekenaars" in verdict["message"]
+        assert verdict.get("evidence_gate") != "ci_gate"
+
+
+class TestGenuineReviewPeerStillSigns:
+    """Scenario 2 (dispatch): codex absent, ci_gate PASS AND glm_gate PASS on
+    the same head. glm_gate must be the signer — never ci_gate, even though
+    'ci_gate' sorts alphabetically before 'glm_gate' (pre-fix, the peer loop's
+    sorted-first-match-wins order made ci_gate win the race; that ordering
+    bug is now moot because ci_gate is not a candidate at all)."""
+
+    def test_glm_pass_signs_ci_gate_pass_does_not(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_unavailable())
+        _write_result(results_dir, "ci_gate", _ci_gate_pass(report))
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO", verdict["message"]
+        assert verdict["evidence_gate"] == "glm_gate"
+
+
+class TestCiGateFailureDoesNotDoubleBlockThePeerRoute:
+    """Scenario 3 (dispatch): codex absent, ci_gate FAIL, glm_gate PASS.
+
+    Design decision (documented in closure_verifier._NON_REVIEW_SIGNER_REASONS):
+    ci_gate is excluded from the peer route SYMMETRICALLY — it can neither
+    sign a pass nor block via a fail there. A real CI failure on the head
+    already blocks the merge through the separate, independent
+    ``pr_merge._run_ci_gate`` check (a live gh statusCheckRollup query) before
+    the review gate is ever reached; letting a stale ci_gate result-file FAIL
+    also reject here would be double-counting the same fact, not added
+    safety. This test pins that choice: the genuine review peer (glm_gate)
+    still signs.
+    """
+
+    def test_ci_gate_fail_does_not_block_when_a_review_peer_passes(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_unavailable())
+        _write_result(
+            results_dir, "ci_gate",
+            _ci_gate_pass(report, status="fail", blocking_count=1,
+                          blocking_findings=[{"severity": "blocking", "message": "CI red"}]),
+        )
+        _write_result(results_dir, "glm_gate", _glm_pass(report))
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "GO", verdict["message"]
+        assert verdict["evidence_gate"] == "glm_gate"
+
+
+class TestTakeoverSuccessorMustAlsoBeAReviewGate:
+    """Scenario 4 (dispatch): the OI-1576 takeover-successor route must apply
+    the same review-only boundary. A ci_gate record that annotates a
+    takeover_path naming codex_gate has still never reviewed the code — it
+    must not be accepted as codex_gate's successor evidence."""
+
+    def test_ci_gate_takeover_annotation_naming_codex_is_no_go(self, tmp_path):
+        results_dir = tmp_path / "results"
+        report = _report_file(tmp_path)
+        _write_result(results_dir, "codex_gate", _codex_unavailable())
+        _write_result(
+            results_dir, "ci_gate",
+            _ci_gate_pass(
+                report,
+                takeover=True,
+                takeover_from="codex_gate",
+                takeover_path=[{"gate": "codex_gate", "status": "unavailable"}],
+            ),
+        )
+
+        verdict = _check(results_dir)
+
+        assert verdict["verdict"] == "NO-GO", verdict["message"]
+        assert verdict.get("evidence_gate") != "ci_gate"
+
+
+class TestReviewPeerGatesDerivedFromEnumNeverUnclassified:
+    """Scenario 5 (dispatch): drift pin alongside
+    test_closure_verifier_gate_enum_drift.py — every Gate enum member is
+    EITHER a review peer OR carries an explicit exclusion reason. A gate
+    added to the enum tomorrow with no disposition here would silently
+    inherit (or silently lose) peer-signing rights; this test fails loud
+    instead."""
+
+    def test_every_enum_member_is_either_a_peer_or_excluded_with_reason(self):
+        enum_values = {g.value for g in Gate}
+        accounted = cv._REVIEW_PEER_GATES | set(cv._NON_REVIEW_SIGNER_REASONS)
+        missing = enum_values - accounted
+        assert not missing, (
+            f"Gate enum members with no peer-signer disposition: {sorted(missing)}. "
+            f"Add them to _REVIEW_PEER_GATES (if a real review) or to "
+            f"_NON_REVIEW_SIGNER_REASONS (with a reason)."
+        )
+
+    def test_peer_gates_and_exclusions_are_disjoint(self):
+        overlap = cv._REVIEW_PEER_GATES & set(cv._NON_REVIEW_SIGNER_REASONS)
+        assert not overlap, (
+            f"gates in both _REVIEW_PEER_GATES and _NON_REVIEW_SIGNER_REASONS: "
+            f"{sorted(overlap)}"
+        )
+
+    def test_exclusions_are_a_subset_of_known_gates(self):
+        """A gate excluded from peer-signing must still be a real enum
+        member the closure verifier knows about (or wiring_gate, the one
+        enum member _KNOWN_GATES itself excludes)."""
+        enum_values = {g.value for g in Gate}
+        assert set(cv._NON_REVIEW_SIGNER_REASONS).issubset(enum_values), (
+            f"_NON_REVIEW_SIGNER_REASONS has values not in the Gate enum: "
+            f"{sorted(set(cv._NON_REVIEW_SIGNER_REASONS) - enum_values)}"
+        )
+
+    def test_ci_gate_and_wiring_gate_are_excluded_with_reasons(self):
+        assert "ci_gate" in cv._NON_REVIEW_SIGNER_REASONS
+        assert cv._NON_REVIEW_SIGNER_REASONS["ci_gate"]
+        assert "wiring_gate" in cv._NON_REVIEW_SIGNER_REASONS
+        assert cv._NON_REVIEW_SIGNER_REASONS["wiring_gate"]
+        assert "ci_gate" not in cv._REVIEW_PEER_GATES
+        assert "wiring_gate" not in cv._REVIEW_PEER_GATES
+
+    def test_claude_github_optional_remains_a_review_peer(self):
+        """It IS optional (may never run), but when it renders a decided
+        verdict that verdict is a genuine Claude code review, not a CI
+        signal — it must stay a valid peer signer."""
+        assert "claude_github_optional" in cv._REVIEW_PEER_GATES
+        assert "claude_github_optional" not in cv._NON_REVIEW_SIGNER_REASONS


### PR DESCRIPTION
## Summary
- `ci_gate` rendered a fully-evidenced pass/fail record that satisfied every peer-consultation invariant, so it could sign a merge, block via a stale FAIL, or take over via a `takeover_path` annotation — despite verifying CI checks, never the code change.
- Measured live on PR #1781: `codex_gate` unavailable + only `ci_gate` passing produced GO with `evidence_gate=ci_gate`, zero review gates having spoken.
- Adds `_REVIEW_PEER_GATES` (Gate enum minus `_NON_REVIEW_SIGNER_REASONS`, same derivation discipline as `_GATES_NOT_IMPLEMENTED_BY_CLOSURE`) and routes both `_find_peer_gate_results` (OI-1624/OI-1642) and `_find_takeover_successor_results` (OI-1576) through it.
- `ci_gate` and `wiring_gate` excluded with reasons; `claude_github_optional` stays a valid peer since its `completed` state is a genuine Claude code review, not a CI signal.
- ADR-037 addendum documents the decision, including the symmetric choice that a `ci_gate` FAIL no longer blocks the peer route either — not a safety regression, since `pr_merge.main` already hard-blocks on a live, independent `gh` CI check before the review gate runs.

## Test plan
- [x] Red run against pre-fix code reproduced the exact live bug (`tests/test_oi1645_peer_is_review_gate.py`, 9 failures, both AttributeError and behavioral GO/NO-GO inversions)
- [x] Green run after the fix: 9/9 passed
- [x] Full regression sweep: `test_closure_verifier_gate_enum_drift.py`, `test_oi1576_merge_door_takeover_evidence.py`, `test_oi1624_gate_absence_vs_rejection.py`, `test_oi1642_peer_route_at_none.py`, `test_pr_merge_review_gate.py`, `test_dlv45_gate_recognition.py`, `test_gate_required_gates.py`, `test_roadmap_manager.py` — 122/122 passed, zero existing tests modified
- [x] Measured live results store: no `ci_gate` record currently carries a `takeover` annotation (preventive guard, not fixing an already-exploited path)
- [x] Measured `t0_receipts.ndjson` `pr_merged` events since 2026-09-06T10:00Z: 11 merges (not 8 as assumed), 10/11 independently carry a `glm_gate` pass; PR #1783 has zero review-gate evidence at all under its pr_id — flagged as an out-of-scope open item, not a `ci_gate` exploitation

🤖 Generated with [Claude Code](https://claude.com/claude-code)