### PR TITLE
fix(receipt): outcome identity across booking routes, durable idempotency (ADR-038)

### DIFF
--- a/docs/governance/decisions/ADR-038-receipt-outcome-identity.md
+++ b/docs/governance/decisions/ADR-038-receipt-outcome-identity.md
@@ -1,0 +1,89 @@
+# ADR-038 — Een uitkomstidentiteit voor beide boekingsroutes
+
+**Status:** Accepted (dispatch 20260906-f14-uitkomstidentiteit)
+**Date:** 2026-09-06
+**Decided by:** T0, op basis van een meting op het centrale grootboek (`~/.vnx-data/vnx-dev/state/t0_receipts.ndjson`).
+**Resolves / Cross-refs:** OI-1639-klasse dubbele boekingen (twee routes, één uitkomst). Bouwt voort op ADR-005 (NDJSON-grootboek is canoniek, correcties zijn nieuwe regels) en de `commit_sha`/`status`-uitbreiding van `IDEMPOTENCY_FIELDS` (`idempotency.py:24-57`, agent-dispatch 2026-09-04, OI tegen PR #1762's glm_gate/kimi_gate-boekingsvolgorde).
+
+## Context
+
+Twee boekingsroutes leveren completion-receipts voor dezelfde dispatch-uitkomst: de lane zelf (`governance_emit` / `envelope_govern` / `dispatch_govern` / `provider_dispatch`) direct na afloop, en `report_to_receipt_converter` wanneer die later een rapport in `unified_reports/` alsnog omzet. Beide roepen `append_receipt_payload` aan, en dus dezelfde idempotentie-laag (`append_receipt_internals/idempotency.py`).
+
+De bestaande idempotentiesleutel (`IDEMPOTENCY_FIELDS`) bevat naast identiteitsvelden ook route-velden: `source`, `report_path`, `file`, `trigger`, `section`, `terminal`. Die velden verschillen tussen de twee routes VOOR DEZELFDE uitkomst per constructie — de lane stempelt `source="governance_emit"` met een leeg `report_path`, de converter stempelt `source="report_to_receipt_converter"` met het pad naar het rapport. Twee routes, identieke uitkomst, twee verschillende sleutels, twee regels in het grootboek.
+
+De dedup zelf is bovendien een tijdvenster (`cache_window_seconds`, default 300s, `idempotency.py:216-246`): zelfs bij een toevallig gelijke sleutel ziet een herverwerking na een uur niets van een eerdere boeking.
+
+**Meting vooraf (06-09, op het huidige grootboek):** groepering van completion-receipts op `(dispatch_id, status)` gaf 106 groepen met meer dan één distincte `source`, waarvan 104 een boeking `source=None` naast `source=subprocess` combineren. Deze meting was een proxy: hij telt alleen kruis-route-duplicaten op een grovere sleutel dan de uiteindelijke oplossing gebruikt.
+
+**Meting na de fix (droog, tegen dezelfde ledger, zonder te schrijven — `--rebuild-outcome-index --dry-run`):** van 29166 regels dragen 27023 een `dispatch_id`. Daarvan zou de uitkomst-index **13547 regels** als duplicaat hebben geweigerd en **173** als correctie hebben geboekt. Opsplitsing van die 13547: 7696 zijn `source=pytest` (bekende testlek in het centrale grootboek, gedocumenteerd bij `payload.resolve_central_data_dir` — "the test suite's pinned appends leaked 684+ lines into the real central ledger"), 3349 zijn overige ontwikkel-/smoke-fixtures (niet-datum-voorvoegsel `dispatch_id`, bv. `DISP-PANES-CODEX-001` tientallen keren herhaald), en **2502 regels over 86 distincte, echte (datum-voorvoegsel) productie-dispatch_id's** zijn de daadwerkelijke dubbele productieboekingen die dit ADR voorkomt. De 106/104-vooraf-meting was dus een sterke onderschatting van het werkelijke aantal dubbele regels in het grootboek — hij mat alleen het geval waarin de twee kopieën een verschillende `source` droegen, niet het bredere geval van een identieke uitkomst die twee keer (ongeacht bron) geboekt is.
+
+## Beslissing
+
+**Elke receipt krijgt een `outcome_id`: een deterministische hash over precies de velden die de UITKOMST identificeren, nooit de velden die de boekings-ROUTE identificeren.** Een index op die identiteit dekt het hele grootboek, niet een tijdvenster.
+
+### De twee identiteiten, expliciet gescheiden
+
+- **`outcome_id`** — hash over `dispatch_id, event_type, status, commit_sha, gate, pr_number`. Dit IS de uitkomst: welke dispatch, welke gebeurtenis, welk resultaat, op welke commit, voor welke poort/PR.
+- **correctie-sleutel** — dezelfde velden MINUS `status`: de familie van uitkomsten voor één dispatch/event/gate/pr/commit. Een nieuwe `status` binnen dezelfde familie is een correctie (ADR-005: correcties zijn nieuwe regels die de gecorrigeerde gebeurtenis bij ID noemen, nooit een in-place edit), geen duplicaat.
+
+Bewust NIET in `outcome_id`: `source`, `report_path`, `file`, `trigger`, `section`, `timestamp`, `terminal`, `task_id`. Dat zijn precies de velden die tussen de twee boekingsroutes verschillen voor dezelfde uitkomst — ze in de identiteit opnemen zou het probleem dat dit ADR oplost reproduceren.
+
+### Scope: alleen receipts met een echte `dispatch_id`
+
+De index handhaaft alleen wanneer `dispatch_id` aanwezig is. Zonder die beperking zou een receipt zonder `dispatch_id` (sommige `state_mutation`/test-events) samenvallen met ELKE andere `dispatch_id`-loze receipt — alle zes velden leeg geeft dezelfde hash — en zo losstaande, legitieme gebeurtenissen stil laten verdwijnen. `outcome_id` wordt wél op elke receipt gestempeld (vereiste 1); alleen de handhaving (duplicaat/correctie-detectie) is tot dispatch-uitkomsten beperkt.
+
+### Twee lagen, snel-naar-langzaam
+
+1. **Het bestaande tijdvenster** (`recent_keys`, `IDEMPOTENCY_FIELDS`-sleutel) blijft de eerste, goedkope voorfilter — ongewijzigd.
+2. **De duurzame index** (`state/receipt_outcome_index.json`, sibling van het grootboekbestand) is de tweede laag: hij dekt de volledige geschiedenis, niet vijf minuten. Alleen geraadpleegd wanneer de eerste laag GEEN duplicaat meldt (anders is de dure laag overbodig) én de receipt een `dispatch_id` draagt.
+
+Structuur van de index:
+
+```json
+{
+  "version": 1,
+  "outcomes": {"<outcome_id>": <epoch-seconde-van-boeking>, ...},
+  "correction_index": {"<correctie_sleutel>": "<laatst-geboekte-outcome_id>", ...}
+}
+```
+
+`correction_index` bewaart alleen de LAATST geboekte `outcome_id` per familie — voldoende om een `supersedes`-pointer te zetten; de volledige keten van correcties is af te leiden uit het grootboek zelf (elke regel draagt zijn eigen `outcome_id` en, indien van toepassing, zijn eigen `supersedes`).
+
+### Correcties blijven zichtbaar, nooit stil vervangen
+
+Een receipt met dezelfde correctie-sleutel maar een andere `outcome_id` (want andere `status`) wordt **geboekt**, met een `supersedes: <vorige outcome_id>`-veld. Dit is de directe voortzetting van de OI-1639/2026-09-04-fix (status in `IDEMPOTENCY_FIELDS`): een `unavailable`-boeking mag nooit een latere echte `pass`/`fail` blokkeren. `outcome_id` maakt dat onderscheid nu ook op de lange termijn (buiten het tijdvenster) waterdicht, in plaats van alleen binnen 300 seconden.
+
+### Rebuildbaar uit het grootboek (ADR-005)
+
+`rebuild_outcome_index(receipts_path, write=...)` (`append_receipt_internals/outcome_identity.py`) speelt het grootboek in volgorde af en herleidt de index helemaal opnieuw — een projectie, nooit een tweede bron van waarheid, conform ADR-005's regel dat een SQLite/JSON-projectie altijd uit het grootboek herbouwbaar moet zijn. Aangeroepen via `scripts/append_receipt.py --rebuild-outcome-index` (optioneel `--dry-run`: rapporteert tellingen zonder de indexfile te schrijven — dit is ook het gereedschap waarmee de "meting na de fix"-cijfers hierboven zijn genomen, droog tegen het echte grootboek).
+
+### Fail-open, nooit fail-closed, op de index zelf
+
+Een onleesbare of onschrijfbare index-file blokkeert de receipt-schrijving nooit. Zowel de lees- als de schrijf-kant van de index volgen dezelfde postuur als de bestaande idempotentie-cache (`_write_cache`'s bestaande "Audit #3"-commentaar): de receipt is op het moment van de indexcheck al duurzaam weggeschreven of staat op het punt dat te worden; in het slechtste geval ontstaat een zeldzame toekomstige duplicaat, nooit een verloren receipt. Een kapotte index is bovendien altijd herstelbaar via `--rebuild-outcome-index`.
+
+### Hash-chain blijft orthogonaal
+
+`VNX_CHAIN_RECEIPTS` blijft default uit. Met de vlag uit is het appendpad byte-gelijk aan vóór dit ADR, BEHALVE het nieuwe `outcome_id`-veld (en, waar van toepassing, `supersedes`) — die twee velden zijn de enige bewust toegevoegde velden, ongeacht de vlagstand. `compute_entry_hash` sluit alleen `prev_hash` uit van zijn hash-berekening (`ndjson_hash_chain.canonical_json`), dus de toevoeging van `outcome_id`/`supersedes` aan een regel is voor de keten-verificatie transparant: elke regel hasht over zijn eigen, volledige inhoud zoals geschreven.
+
+## Consequenties
+
+### Geaccepteerd
+
+- Elke receipt draagt voortaan `outcome_id`. Dit is een additief, nooit een verwijderd of hernoemd veld (in lijn met ADR-035 §9's additive-only-discipline voor de v2-vormgeving).
+- `state/receipt_outcome_index.json` is runtime state (net als `t0_receipts.ndjson` zelf) — niet gecommit, wél onderdeel van het herstel-verhaal (`--rebuild-outcome-index` na een corruptie of migratie).
+- De 2502-regel/86-dispatch_id meting hierboven is de daadwerkelijke productie-impact; de 7696+3349 overige gevallen zijn test-/fixture-ruis die apart moet worden opgeschoond (zie Open Items in het dispatchrapport) — dit ADR lost de identiteits- en dedup-mechaniek op, niet de historische ledger-vervuiling.
+
+### Afgewezen
+
+- **`outcome_id` zonder de `dispatch_id`-scope-beperking** — afgewezen: zou `state_mutation`/test-events zonder `dispatch_id` op elkaar laten samenvallen en legitieme herhalingen stil laten verdwijnen.
+- **Alleen het tijdvenster vergroten** (bv. naar 24 uur) — afgewezen: lost het kruis-route-probleem niet op (de sleutel zelf verschilt nog steeds tussen routes) en verschuift het "te laat"-probleem alleen in de tijd.
+- **In-place corrigeren van de eerdere regel bij een status-wijziging** — afgewezen: in strijd met ADR-005's append-only-regel. Een correctie is een nieuwe regel met `supersedes`, nooit een edit.
+- **SQLite-index in plaats van JSON** — afgewezen voor deze iteratie: het append-pad heeft nog geen SQLite-afhankelijkheid voor dit doel; JSON met atomic tmp+`os.replace` (zelfde patroon als de bestaande idempotentie-cache) is voldoende en voegt geen nieuwe storage-laag toe. Een migratie naar SQLite bij significante schaalgroei is een latere, aparte beslissing.
+
+## See also
+
+- ADR-005 — NDJSON-grootboek is canoniek; correcties zijn nieuwe regels, projecties zijn herbouwbaar
+- ADR-023 / `VNX_CHAIN_RECEIPTS` — hash-chain, orthogonaal aan dit ADR
+- `scripts/lib/append_receipt_internals/idempotency.py` — het bestaande tijdvenster (laag 1) en `IDEMPOTENCY_FIELDS`
+- `scripts/lib/append_receipt_internals/outcome_identity.py` — implementatie van `outcome_id`, de correctie-sleutel, de index en `rebuild_outcome_index`
+- `scripts/append_receipt.py --rebuild-outcome-index [--dry-run]` — CLI voor herbouw en droge meting

--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -43,6 +43,10 @@ from append_receipt_internals.common import (
 )
 from append_receipt_internals.idempotency import (
     _compute_idempotency_key,
+    _resolve_receipts_file,
+)
+from append_receipt_internals.outcome_identity import (
+    rebuild_outcome_index,
 )
 from append_receipt_internals.validation import (
     _is_completion_event,
@@ -97,6 +101,7 @@ __all__ = [
     "_parse_input",
     "_register_quality_open_items",
     "_resolve_model_provider",
+    "_resolve_receipts_file",
     "_resolve_session_id",
     "_rsi_check_env_session",
     "_rsi_check_provider_files",
@@ -114,6 +119,7 @@ __all__ = [
     "get_changed_files",
     "is_headless_t0",
     "main",
+    "rebuild_outcome_index",
     "register_facade",
     "resolve_state_dir",
     "should_route_to_gate_stream",
@@ -160,7 +166,36 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--receipts-file", help="Override canonical receipts file path", default=None)
     parser.add_argument("--cache-window-seconds", type=int, default=300, help="Recent idempotency window in seconds")
     parser.add_argument("--skip-enrichment", action="store_true", default=False, help="Skip quality advisory and provenance enrichment (for state-mutation events)")
+    parser.add_argument(
+        "--rebuild-outcome-index",
+        action="store_true",
+        default=False,
+        help="Rebuild receipt_outcome_index.json from the ledger (ADR-038) and exit; takes no receipt input",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="With --rebuild-outcome-index: report counts without writing the index file",
+    )
     args = parser.parse_args(argv)
+
+    if args.rebuild_outcome_index:
+        receipts_path = _resolve_receipts_file(args.receipts_file).expanduser().resolve()
+        stats = rebuild_outcome_index(receipts_path, write=not args.dry_run)
+        _emit(
+            "INFO",
+            "outcome_index_rebuilt",
+            receipts_file=str(receipts_path),
+            written=not args.dry_run,
+            total_lines=stats.total_lines,
+            malformed_lines=stats.malformed_lines,
+            considered=stats.considered,
+            booked=stats.booked,
+            duplicates=stats.duplicates,
+            corrections=stats.corrections,
+        )
+        return EXIT_OK
 
     try:
         receipt = _parse_input(args.receipt, args.receipt_file)

--- a/scripts/lib/append_receipt_internals/idempotency.py
+++ b/scripts/lib/append_receipt_internals/idempotency.py
@@ -18,6 +18,15 @@ from .common import (
     EXIT_LOCK_ERROR,
     facade,
 )
+from .outcome_identity import (
+    compute_outcome_id,
+    has_outcome_identity,
+    load_outcome_index,
+    record_outcome,
+    resolve_outcome_booking,
+    write_outcome_index,
+    _outcome_index_path_for,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -251,6 +260,48 @@ def _write_receipt_under_lock(
                     idempotency_key=idempotency_key,
                 )
 
+            # ADR-038: outcome identity + durable cross-window idempotency.
+            # The check above is a fast, short-window (cache_window_seconds)
+            # pre-filter keyed on IDEMPOTENCY_FIELDS — which includes route
+            # fields (source, report_path, ...) that legitimately differ
+            # between the two receipt-booking routes (the lane itself vs
+            # report_to_receipt_converter) for the SAME outcome. This second
+            # check is the durable backstop: it hashes ONLY the fields that
+            # identify the outcome (dispatch_id, event_type, status,
+            # commit_sha, gate, pr_number) against an on-disk index that
+            # spans the whole ledger, not a 5-minute window. Every receipt
+            # gets `outcome_id` stamped unconditionally (byte-identical
+            # append path otherwise, per ADR-038); the durable dedup/
+            # correction check itself only runs for receipts that carry a
+            # real dispatch_id (has_outcome_identity) — see that function's
+            # docstring for why a dispatch_id-less receipt is excluded from
+            # enforcement rather than risk collapsing distinct events onto
+            # one all-empty-fields outcome_id.
+            receipt["outcome_id"] = compute_outcome_id(receipt)
+            outcome_index_data: Optional[Dict[str, Any]] = None
+            outcome_booking = None
+            if has_outcome_identity(receipt):
+                outcome_index_path = _outcome_index_path_for(receipt_path)
+                try:
+                    outcome_index_data = load_outcome_index(outcome_index_path)
+                except Exception as exc:
+                    # Fail-open, matching the cache-write posture below: a
+                    # broken projection index must never block the durable
+                    # receipt write. Worst case a rare future duplicate that
+                    # this backstop would have caught, never a lost receipt.
+                    _log.warning("outcome index read failed (dedup skipped, fail-open): %s", exc)
+                    outcome_index_data = None
+                if outcome_index_data is not None:
+                    outcome_booking = resolve_outcome_booking(receipt, outcome_index_data)
+                    if outcome_booking.is_duplicate:
+                        return AppendResult(
+                            status="duplicate",
+                            receipts_file=receipt_path,
+                            idempotency_key=idempotency_key,
+                        )
+                    if outcome_booking.supersedes:
+                        receipt["supersedes"] = outcome_booking.supersedes
+
             if pre_write_hook is not None:
                 pre_write_hook(receipt)
 
@@ -275,6 +326,20 @@ def _write_receipt_under_lock(
                     )
             except OSError as exc:
                 raise AppendReceiptError("receipt_write_failed", EXIT_IO_ERROR, f"Failed to append receipt: {exc}") from exc
+
+            if outcome_index_data is not None and outcome_booking is not None:
+                record_outcome(receipt, outcome_index_data, outcome_booking)
+                try:
+                    write_outcome_index(outcome_index_path, outcome_index_data)
+                except Exception as exc:
+                    # Same fail-open posture as the idempotency cache write below:
+                    # the receipt is already durable. Worst case a rebuild is
+                    # needed later (--rebuild replays the ledger and re-derives
+                    # this index from scratch, ADR-005) — never a lost receipt.
+                    _log.warning(
+                        "outcome index write failed after receipt append (outcome_id=%s): %s",
+                        outcome_booking.outcome_id, exc,
+                    )
 
             cache_entries.append({"ts": time.time(), "key": idempotency_key})
             try:

--- a/scripts/lib/append_receipt_internals/outcome_identity.py
+++ b/scripts/lib/append_receipt_internals/outcome_identity.py
@@ -1,0 +1,242 @@
+"""Outcome identity: a durable identity for WHAT happened, independent of
+HOW or via which route it was booked (ADR-038).
+
+Two booking routes write completion receipts for the same dispatch outcome:
+the lane itself (``governance_emit`` / ``envelope_govern`` / ``dispatch_govern``
+/ ``provider_dispatch``) right after the work finishes, and
+``report_to_receipt_converter`` when it later turns a report in
+``unified_reports/`` into a receipt. Both call ``append_receipt_payload``.
+The existing idempotency key (``idempotency.IDEMPOTENCY_FIELDS``) includes
+route-identifying fields — ``source``, ``report_path``, ``file``, ``trigger``,
+``section`` — that legitimately differ between the two routes for the exact
+same outcome, so the same outcome gets two different keys and lands as two
+ledger lines. The existing dedup cache is also only a
+``cache_window_seconds`` (default 300s) window, so a re-booking after a
+longer gap (a backfill, a re-processed report) is invisible to it regardless
+of key.
+
+This module defines the identity of the OUTCOME itself — dispatch_id,
+event_type, status, commit_sha, gate, pr_number — deliberately excluding
+every route-identifying field, and a durable on-disk index
+(``receipt_outcome_index.json``, sibling to the ledger file) so the dedup
+check spans the whole ledger rather than a short cache window. See
+``docs/governance/decisions/ADR-038-receipt-outcome-identity.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+log = logging.getLogger(__name__)
+
+# Fields that identify the OUTCOME. Deliberately NOT source/report_path/
+# file/trigger/section/timestamp — those identify the booking ROUTE, not the
+# outcome, and are exactly the fields that differ between the two routes for
+# one real-world event (see module docstring).
+OUTCOME_ID_FIELDS = ("dispatch_id", "event_type", "status", "commit_sha", "gate", "pr_number")
+
+# Same identity, minus status: the "family" of outcomes for one
+# dispatch/event/gate/pr/commit. A new status within the same family is a
+# correction (ADR-005 — corrections are new lines that reference the
+# corrected event by ID, never an in-place edit), not a duplicate.
+CORRECTION_KEY_FIELDS = ("dispatch_id", "event_type", "commit_sha", "gate", "pr_number")
+
+OUTCOME_INDEX_FILENAME = "receipt_outcome_index.json"
+OUTCOME_INDEX_VERSION = 1
+
+
+def _normalize_field(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _resolve_event_name(receipt: Dict[str, Any]) -> str:
+    """``event_type`` with the legacy ``event`` alias as fallback.
+
+    Independent re-derivation (not a call into ``validation._resolve_event_name``)
+    so this module has no dependency on the schema-version-aware resolver —
+    by the time a receipt reaches the append lock it already carries whichever
+    of the two keys its schema version uses; either is a stable identity input.
+    """
+    return _normalize_field(receipt.get("event_type") or receipt.get("event"))
+
+
+def _canonical_payload(receipt: Dict[str, Any], fields: tuple) -> str:
+    values: Dict[str, str] = {}
+    for field_name in fields:
+        if field_name == "event_type":
+            values[field_name] = _resolve_event_name(receipt)
+        else:
+            values[field_name] = _normalize_field(receipt.get(field_name))
+    return json.dumps(values, sort_keys=True, separators=(",", ":"))
+
+
+def compute_outcome_id(receipt: Dict[str, Any]) -> str:
+    """Deterministic identity hash over ``OUTCOME_ID_FIELDS``.
+
+    Two receipts for the same outcome booked via different routes (different
+    source/report_path/terminal/task_id) collapse to the same outcome_id.
+    """
+    payload = _canonical_payload(receipt, OUTCOME_ID_FIELDS)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def compute_correction_key(receipt: Dict[str, Any]) -> str:
+    """Deterministic hash over ``CORRECTION_KEY_FIELDS`` (outcome identity
+    minus status) — the family a correction is scoped to."""
+    payload = _canonical_payload(receipt, CORRECTION_KEY_FIELDS)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def has_outcome_identity(receipt: Dict[str, Any]) -> bool:
+    """True when the receipt carries a real ``dispatch_id``.
+
+    Durable cross-window dedup is scoped to dispatch outcomes — the concrete
+    two-route double-booking problem this module exists to fix. A receipt
+    with no dispatch_id (e.g. some state_mutation/test events) would collapse
+    onto the SAME outcome_id as every other dispatch_id-less receipt (all six
+    fields empty) and silently swallow genuinely distinct events; excluding
+    them from enforcement is deliberate, not an oversight.  ``outcome_id`` is
+    still computed and stamped on such a receipt (every receipt gets one) —
+    only the durable-index duplicate/correction check is skipped.
+    """
+    return bool(_normalize_field(receipt.get("dispatch_id")))
+
+
+def _outcome_index_path_for(receipts_path: Path) -> Path:
+    return receipts_path.parent / OUTCOME_INDEX_FILENAME
+
+
+def _empty_index() -> Dict[str, Any]:
+    return {"version": OUTCOME_INDEX_VERSION, "outcomes": {}, "correction_index": {}}
+
+
+def load_outcome_index(index_path: Path) -> Dict[str, Any]:
+    """Load the durable outcome index, or an empty one if absent/corrupt.
+
+    A corrupt/unreadable index fails open (returns empty) rather than
+    raising — callers must not let a projection-index problem block the
+    durable receipt write, matching this append path's existing posture
+    toward the short-window idempotency cache (``idempotency._load_cache``).
+    """
+    if not index_path.exists():
+        return _empty_index()
+    try:
+        with index_path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("outcome index unreadable, treating as empty (fail-open): %s", exc)
+        return _empty_index()
+    if not isinstance(data, dict):
+        return _empty_index()
+    data.setdefault("version", OUTCOME_INDEX_VERSION)
+    data.setdefault("outcomes", {})
+    data.setdefault("correction_index", {})
+    return data
+
+
+def write_outcome_index(index_path: Path, data: Dict[str, Any]) -> None:
+    """Durable atomic write (tmp file + os.replace), mirroring
+    ``idempotency._write_cache``'s convention."""
+    tmp_path = index_path.with_name(f"{index_path.name}.{os.getpid()}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, sort_keys=True, separators=(",", ":"))
+        os.replace(tmp_path, index_path)
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+
+
+@dataclass(frozen=True)
+class OutcomeBooking:
+    outcome_id: str
+    supersedes: Optional[str]
+    is_duplicate: bool
+
+
+def resolve_outcome_booking(receipt: Dict[str, Any], index_data: Dict[str, Any]) -> OutcomeBooking:
+    """Pure decision: given a receipt and the CURRENT index state, decide
+    duplicate / correction / fresh outcome. Never mutates ``index_data`` —
+    the caller commits via ``record_outcome`` only after the receipt has
+    actually been written (mirrors the append-then-commit ordering the
+    idempotency cache and receipt_finalize's pre_write_hook already use)."""
+    outcome_id = compute_outcome_id(receipt)
+    if outcome_id in index_data["outcomes"]:
+        return OutcomeBooking(outcome_id=outcome_id, supersedes=None, is_duplicate=True)
+
+    correction_key = compute_correction_key(receipt)
+    prior_outcome_id = index_data["correction_index"].get(correction_key)
+    supersedes = prior_outcome_id if prior_outcome_id and prior_outcome_id != outcome_id else None
+    return OutcomeBooking(outcome_id=outcome_id, supersedes=supersedes, is_duplicate=False)
+
+
+def record_outcome(receipt: Dict[str, Any], index_data: Dict[str, Any], booking: OutcomeBooking) -> None:
+    """Mutate ``index_data`` in place to record a booked (non-duplicate) outcome."""
+    correction_key = compute_correction_key(receipt)
+    index_data["outcomes"][booking.outcome_id] = int(time.time())
+    index_data["correction_index"][correction_key] = booking.outcome_id
+
+
+@dataclass
+class RebuildStats:
+    total_lines: int = 0
+    malformed_lines: int = 0
+    considered: int = 0
+    booked: int = 0
+    duplicates: int = 0
+    corrections: int = 0
+
+
+def rebuild_outcome_index(receipts_path: Path, *, write: bool = True) -> RebuildStats:
+    """Replay ``receipts_path`` from scratch and (re)derive the outcome index.
+
+    ADR-005: the index is a projection over the ledger and MUST be
+    rebuildable from it. Also serves as the dry-run measurement tool: with
+    ``write=False`` this never touches disk (no index file is created or
+    updated) and simply reports what the index WOULD have caught, which is
+    exactly the "how many double-bookings does this catch" measurement this
+    dispatch is required to take before and after the change.
+    """
+    stats = RebuildStats()
+    index_data = _empty_index()
+
+    if receipts_path.exists():
+        with receipts_path.open("r", encoding="utf-8") as fh:
+            for raw_line in fh:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                stats.total_lines += 1
+                try:
+                    receipt = json.loads(line)
+                except json.JSONDecodeError:
+                    stats.malformed_lines += 1
+                    continue
+                if not isinstance(receipt, dict) or not has_outcome_identity(receipt):
+                    continue
+                stats.considered += 1
+                booking = resolve_outcome_booking(receipt, index_data)
+                if booking.is_duplicate:
+                    stats.duplicates += 1
+                    continue
+                if booking.supersedes:
+                    stats.corrections += 1
+                record_outcome(receipt, index_data, booking)
+                stats.booked += 1
+
+    if write:
+        write_outcome_index(_outcome_index_path_for(receipts_path), index_data)
+
+    return stats

--- a/tests/test_receipt_outcome_identity.py
+++ b/tests/test_receipt_outcome_identity.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""ADR-038 — outcome identity + durable cross-window idempotency.
+
+Dispatch-ID: 20260906-f14-uitkomstidentiteit
+
+Two booking routes (the lane itself, and the report_to_receipt_converter
+processing the same report later) both call ``append_receipt_payload`` for
+the SAME dispatch outcome. The existing idempotency key
+(``IDEMPOTENCY_FIELDS`` in idempotency.py) includes ``source``/``report_path``
+— fields that differ BETWEEN the two routes by construction — so the same
+outcome gets two different keys and lands as two ledger lines. The existing
+dedup cache is also only a 300s window (``cache_window_seconds``), so even a
+matching key would not catch a re-booking after a longer gap (a
+re-processing run, hours later).
+
+This module tests the fix: ``compute_outcome_id`` hashes ONLY the fields that
+identify the OUTCOME (dispatch_id, event_type, status, commit_sha, gate,
+pr_number) — never the booking-route fields — and a durable on-disk index
+(``receipt_outcome_index.json``, sibling to the ledger) makes the dedup check
+span the whole ledger, not a 5-minute cache window. A later receipt for the
+same dispatch/event/gate/pr/commit but a DIFFERENT status is a correction
+(ADR-005: corrections are new lines referencing the corrected event), not a
+duplicate — it is booked with a ``supersedes`` pointer to the prior
+outcome_id, not silently dropped and not silently merged.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_LIB = VNX_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from append_receipt_internals.idempotency import (  # noqa: E402
+    _cache_file_for,
+    _compute_idempotency_key,
+    _write_receipt_under_lock,
+)
+from append_receipt_internals.outcome_identity import (  # noqa: E402
+    OUTCOME_INDEX_FILENAME,
+    compute_outcome_id,
+    rebuild_outcome_index,
+)
+
+
+def _read_lines(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _append(receipt_path: Path, receipt: dict, *, window: int = 300):
+    cache_path = _cache_file_for(receipt_path)
+    key = _compute_idempotency_key(receipt, receipt.get("event_type", "task_complete"))
+    return _write_receipt_under_lock(receipt, receipt_path, cache_path, key, window)
+
+
+def _outcome_receipt(*, dispatch_id: str, status: str, source: str, report_path: str) -> dict:
+    """Same OUTCOME, deliberately different booking-route fields (source,
+    report_path) — the shape the two real booking routes actually produce
+    for one dispatch completion."""
+    return {
+        "event_type": "task_complete",
+        "dispatch_id": dispatch_id,
+        "status": status,
+        "terminal": "T1",
+        "source": source,
+        "report_path": report_path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Same outcome via two routes -> second append is 'duplicate', one line.
+# ---------------------------------------------------------------------------
+
+
+def test_same_outcome_via_two_routes_is_duplicate(tmp_path):
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+
+    r_lane = _outcome_receipt(
+        dispatch_id="disp-two-routes-A", status="success",
+        source="governance_emit", report_path="",
+    )
+    r_converter = _outcome_receipt(
+        dispatch_id="disp-two-routes-A", status="success",
+        source="report_to_receipt_converter", report_path="/reports/disp-two-routes-A.md",
+    )
+
+    # Pre-condition: the two routes really do produce different SHORT-WINDOW
+    # idempotency keys today (source/report_path differ) -- if this fails the
+    # rest of the test is not exercising the bug it claims to fix.
+    k_lane = _compute_idempotency_key(r_lane, "task_complete")
+    k_converter = _compute_idempotency_key(r_converter, "task_complete")
+    assert k_lane != k_converter, "pre-condition: routes must differ on the short-window key"
+
+    res1 = _append(receipt_path, r_lane)
+    res2 = _append(receipt_path, r_converter)
+
+    assert res1.status == "appended"
+    assert res2.status == "duplicate", (
+        f"second route's booking of the SAME outcome was {res2.status!r}, expected 'duplicate'"
+    )
+
+    lines = _read_lines(receipt_path)
+    assert len(lines) == 1, f"expected exactly one ledger line for one outcome, got {len(lines)}"
+    assert lines[0]["outcome_id"] == compute_outcome_id(r_lane)
+
+
+# ---------------------------------------------------------------------------
+# 2. Durable across a cache_window expiry (not just a 300s coincidence).
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_survives_cache_window_expiry(tmp_path):
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    r1 = _outcome_receipt(
+        dispatch_id="disp-window-expiry", status="success",
+        source="governance_emit", report_path="",
+    )
+    r2 = _outcome_receipt(
+        dispatch_id="disp-window-expiry", status="success",
+        source="report_to_receipt_converter", report_path="/reports/disp-window-expiry.md",
+    )
+
+    res1 = _append(receipt_path, r1, window=1)
+    assert res1.status == "appended"
+
+    time.sleep(2)  # the 1-second short-window cache has now expired
+
+    res2 = _append(receipt_path, r2, window=1)
+    assert res2.status == "duplicate", (
+        "outcome-identity dedup must be durable — it must not depend on the "
+        "short cache_window_seconds still covering the first booking"
+    )
+    assert len(_read_lines(receipt_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Different status for the same dispatch -> booked as a correction.
+# ---------------------------------------------------------------------------
+
+
+def test_different_status_is_booked_as_correction(tmp_path):
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    r_unavailable = _outcome_receipt(
+        dispatch_id="disp-correction", status="unavailable",
+        source="governance_emit", report_path="",
+    )
+    r_pass = _outcome_receipt(
+        dispatch_id="disp-correction", status="success",
+        source="report_to_receipt_converter", report_path="/reports/disp-correction.md",
+    )
+
+    res1 = _append(receipt_path, r_unavailable)
+    res2 = _append(receipt_path, r_pass)
+
+    assert res1.status == "appended"
+    assert res2.status == "appended", (
+        "a genuinely different outcome (different status) for the same "
+        "dispatch must be booked, never dropped as a duplicate (this is the "
+        "OI-1639/2026-09-04 regression: an unavailable booking must never "
+        "block a later real verdict)"
+    )
+
+    lines = _read_lines(receipt_path)
+    assert len(lines) == 2
+    first_outcome_id = compute_outcome_id(r_unavailable)
+    second_outcome_id = compute_outcome_id(r_pass)
+    assert lines[0]["outcome_id"] == first_outcome_id
+    assert lines[1]["outcome_id"] == second_outcome_id
+    assert lines[1].get("supersedes") == first_outcome_id, (
+        "the second (differently-statused) booking for the same dispatch must "
+        "reference the outcome it corrects, per ADR-005 (corrections are new "
+        "lines that reference the corrected event by ID, never in-place edits)"
+    )
+    assert "supersedes" not in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# 4. Two different gates on the same PR/dispatch -> two distinct outcome_ids,
+#    both booked (no cross-gate collision).
+# ---------------------------------------------------------------------------
+
+
+def test_two_gates_on_same_pr_both_booked(tmp_path):
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    r_codex = {
+        "event_type": "review_gate_result",
+        "dispatch_id": "disp-two-gates",
+        "status": "pass",
+        "gate": "codex_gate",
+        "pr_number": 1900,
+        "source": "gate_result_parser",
+    }
+    r_kimi = {
+        "event_type": "review_gate_result",
+        "dispatch_id": "disp-two-gates",
+        "status": "pass",
+        "gate": "kimi_gate",
+        "pr_number": 1900,
+        "source": "gate_result_parser",
+    }
+
+    res1 = _append(receipt_path, r_codex)
+    res2 = _append(receipt_path, r_kimi)
+
+    assert res1.status == "appended"
+    assert res2.status == "appended"
+
+    lines = _read_lines(receipt_path)
+    assert len(lines) == 2
+    ids = {l["outcome_id"] for l in lines}
+    assert len(ids) == 2, "two different gates on the same PR must get distinct outcome_ids"
+
+
+# ---------------------------------------------------------------------------
+# 5. --rebuild equivalent: rebuilding the index from a 3-line ledger yields 3
+#    booked outcome ids.
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_from_ledger_yields_three_ids(tmp_path):
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    receipts = [
+        {"event_type": "task_complete", "dispatch_id": "disp-r1", "status": "success"},
+        {"event_type": "task_complete", "dispatch_id": "disp-r2", "status": "success"},
+        {"event_type": "task_complete", "dispatch_id": "disp-r3", "status": "failure"},
+    ]
+    with receipt_path.open("w", encoding="utf-8") as fh:
+        for r in receipts:
+            fh.write(json.dumps(r) + "\n")
+
+    stats = rebuild_outcome_index(receipt_path, write=True)
+
+    assert stats.booked == 3
+    assert stats.duplicates == 0
+    assert stats.corrections == 0
+
+    index_path = receipt_path.parent / OUTCOME_INDEX_FILENAME
+    assert index_path.exists()
+    index_data = json.loads(index_path.read_text(encoding="utf-8"))
+    assert len(index_data["outcomes"]) == 3
+    expected_ids = {compute_outcome_id(r) for r in receipts}
+    assert set(index_data["outcomes"].keys()) == expected_ids
+
+
+def test_rebuild_dry_run_does_not_write_index(tmp_path):
+    """The measurement pass over the real ledger must not touch disk."""
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    with receipt_path.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"event_type": "task_complete", "dispatch_id": "d1", "status": "success"}) + "\n")
+        fh.write(json.dumps({"event_type": "task_complete", "dispatch_id": "d1", "status": "success"}) + "\n")
+
+    stats = rebuild_outcome_index(receipt_path, write=False)
+    assert stats.booked == 1
+    assert stats.duplicates == 1
+
+    index_path = receipt_path.parent / OUTCOME_INDEX_FILENAME
+    assert not index_path.exists(), "dry-run rebuild must never write the index file"
+
+
+# ---------------------------------------------------------------------------
+# 6. VNX_CHAIN_RECEIPTS=0/unset -> existing chain tests stay green, and the
+#    append path writes no chain fields (outcome_id is the one deliberate new
+#    field, independent of the chain flag).
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_no_chain_fields_but_has_outcome_id(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+    receipt_path = tmp_path / "t0_receipts.ndjson"
+    r = {"event_type": "task_complete", "dispatch_id": "disp-chain-off", "status": "success"}
+
+    res = _append(receipt_path, r)
+    assert res.status == "appended"
+
+    lines = _read_lines(receipt_path)
+    assert len(lines) == 1
+    assert "prev_hash" not in lines[0], "VNX_CHAIN_RECEIPTS is off — no chain field must be stamped"
+    assert lines[0]["outcome_id"] == compute_outcome_id(r)


### PR DESCRIPTION
## Summary

- Two receipt-booking routes (the lane itself, and `report_to_receipt_converter` processing a report later) book the same dispatch outcome under different idempotency keys, because the existing key includes route fields (`source`, `report_path`, ...) that legitimately differ between routes for the same outcome — and the dedup cache is only a 300s window.
- Adds `outcome_id`, hashed over only the fields that identify the OUTCOME (`dispatch_id`, `event_type`, `status`, `commit_sha`, `gate`, `pr_number`), stamped on every receipt. A durable on-disk index (`receipt_outcome_index.json`) makes dedup span the whole ledger instead of a 5-minute window.
- A receipt for the same dispatch/event/gate/pr/commit but a *different* status is booked as a correction (`supersedes: <prior outcome_id>`), never dropped and never merged in place — per ADR-005 (corrections are new lines, never in-place edits). This keeps the 2026-09-04 fix (an `unavailable` booking must never block a later real verdict) durable across the whole ledger, not just 300s.
- New `--rebuild-outcome-index [--dry-run]` CLI flag on `scripts/append_receipt.py` rebuilds the index from the ledger (ADR-005: projections must be rebuildable) and doubles as a dry-run measurement tool.
- Full design + both measurements: `docs/governance/decisions/ADR-038-receipt-outcome-identity.md`.

## Measurement

Dry-run against the real central ledger (29166 lines, nothing written):
```
{"total_lines":29166,"considered":27023,"booked":13476,"duplicates":13547,"corrections":173}
```
Of the 13547 duplicates: 7696 are `source=pytest` test-fixture pollution (already documented elsewhere), 3349 are dev/smoke fixtures, and **2502 lines across 86 real production dispatch_ids** are the actual double-bookings this fix prevents going forward.

## Test plan

- [x] Red test first: `tests/test_receipt_outcome_identity.py` failed 5/7 before wiring (module existed, pure logic correct, write-lock not yet wired) — see report for full red output.
- [x] Green after wiring: `7 passed`.
- [x] Targeted regression (touched files + direct neighbours): `477 passed` across append_receipt/idempotency/hash-chain/dual-write/report-converter suites.
- [x] Hash-chain flag-off byte-identical invariant preserved (new test + existing 46-test hash-chain suites green).
- [x] One pre-existing, unrelated flake (`test_receipt_v2_pr4_wiring.py::test_t24_envelope_subpath_verification_from_report`) confirmed to fail identically on the pre-change code — not caused by this PR, excluded from the regression run.

Dispatch-ID: 20260906-f14-uitkomstidentiteit

🤖 Generated with [Claude Code](https://claude.com/claude-code)