### PR TITLE
fix(receipt): recover stranded reports refused for a missing model (F1-3)

### DIFF
--- a/docs/operations/RECEIPT_PIPELINE.md
+++ b/docs/operations/RECEIPT_PIPELINE.md
@@ -169,6 +169,66 @@ Common causes: processor not running; report predates monitor-mode startup (use 
 
 As of ADR-035 §5.3 (§9 PR-8), `VNX_RECEIPT_T0_PUSH` defaults to `0` — the tmux pane paste is suppressed by default, and T0 is expected to pull instead: `python3 scripts/receipt_query.py pull --state-dir <state-dir>` (cadence + rationale: `docs/core/DISPATCH_RULES.md` §13). Set `VNX_RECEIPT_T0_PUSH=1` to re-enable the legacy pane push as a transition escape hatch — it works from a CLI or desktop tmux session but not from a mobile remote-control session. Either way, if receipts are on disk (`tail .vnx-data/state/t0_receipts.ndjson`) but T0 shows nothing, check the delivery/pull surface before suspecting the pipeline — the audit write already succeeded.
 
+### Stranded reports — refused for a missing/invalid model
+
+`append_receipt_internals/validation.py::_validate_model_present` fail-closed
+refuses (`AppendReceiptError` code `missing_model` / `invalid_model_shape`)
+any dispatch-lane report whose resolved `model` is absent or a sentinel
+value (`"unknown"`, `"none"`, ...). Unlike a malformed report, this is never
+auto-retried into success: the report sits in `unified_reports/` forever
+once the converter has logged the refusal, because nothing re-derives the
+model on its own.
+
+The converter's own health beacon (`health/report_to_receipt_converter.json`)
+carries `details.rejected_count` (an integer, per scan) AND, as of F1-3
+(20260906-f13-gestrande-rapporten), `details.rejected` — a history of
+`{dispatch_id, file, reason, rejected_at}` per rejection, accumulated across
+scans and capped at 200 entries (oldest evicted). A bare count with no name
+attached is not actionable; read `details.rejected` first to see WHICH
+reports are stranded before reaching for the recovery tool below.
+
+```bash
+jq '.details.rejected' .vnx-data/health/report_to_receipt_converter.json
+```
+
+`scripts/restore_stranded_reports.py` recovers these reports — but ONLY when
+a real model can be VERIFIED, never guessed or defaulted:
+
+```bash
+# Scan only — lists every stranded report and its candidate source (or
+# "UNRESTORABLE" when none exists). Makes no changes.
+python3 scripts/restore_stranded_reports.py --list
+
+# Restore + book receipts for every report a source was found for.
+python3 scripts/restore_stranded_reports.py --apply
+```
+
+Verified sources, tried in this fixed order — the first hit wins:
+
+1. the dispatch's own `dispatch-spec.json` (`model`/`provider`);
+2. an earlier ledger receipt for the same `dispatch_id` that carries a real
+   `model` (any `event_type` — not scoped to a specific one, since the
+   canonical dispatch-lifecycle events this might suggest do not occur in
+   practice; see the module docstring for the measurement);
+3. the report's own frontmatter `model:`/`provider:`, or a bullet-form
+   `- Model: x` line the converter's own parser does not recognise (it only
+   reads `**Model**:` bold fields).
+
+A report with no verifiable source in any of the three is listed
+UNRESTORABLE and is never touched — no default, no guessed value, ever.
+
+Restoring never rewrites a report's existing bytes: it only APPENDS a
+`## Restored identity` section at the end (which source, and when), after
+the receipt has been booked with `identity_restored: true`. The resulting
+receipt still goes through every OTHER fail-closed check the converter
+itself applies (branch-on-origin, body contract, ...) — supplying the model
+unblocks the model check specifically, it does not bypass the rest of the
+pipeline, so a restored report can still legitimately land as `task_failed`
+if e.g. its branch was since deleted from origin. Re-running `--apply` on an
+already-restored report is a no-op (the `## Restored identity` marker is
+checked before anything else runs) — safe to run repeatedly, e.g. after
+fixing one more `dispatch-spec.json` by hand.
+
 ### Verify ledger integrity
 
 ```bash
@@ -188,4 +248,5 @@ python3 scripts/audit_chain.py walk   .vnx-data/state/t0_receipts.ndjson | tail 
 - `scripts/receipt_processor.sh`, `scripts/report_parser.py`, `scripts/append_receipt.py` — Path 2
 - `scripts/lib/append_receipt_internals/idempotency.py::_write_receipt_under_lock` — the shared append primitive both paths write through
 - `scripts/receipt_query.py` — the pull/by-dispatch/by-pr/since/by-track/digest/reconcile-oi-pending interface
+- `scripts/restore_stranded_reports.py` — recovers reports fail-closed refused for a missing/invalid model (verified sources only, never a guessed value)
 - `scripts/lib/report_body_contract.py` — the mandatory report contract

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -1260,6 +1260,7 @@ def _convert_one_detailed(
     receipts_file: Optional[str] = None,
     cache_window_seconds: int = 300,
     dry_run: bool = False,
+    rejected_detail_sink: Optional[List[Dict[str, Any]]] = None,
 ) -> Tuple[Optional[Any], str]:  # (Optional[AppendResult], outcome_tag)
     """Convert one report file to a governed receipt; classify the outcome.
 
@@ -1433,6 +1434,13 @@ def _convert_one_detailed(
                 "report_to_receipt_converter: REJECTED (fail-closed) dispatch=%s file=%s reason=%s",
                 receipt.get("dispatch_id"), report_path.name, exc.message,
             )
+            if rejected_detail_sink is not None:
+                rejected_detail_sink.append({
+                    "dispatch_id": str(receipt.get("dispatch_id") or ""),
+                    "file": report_path.name,
+                    "reason": exc.message,
+                    "rejected_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                })
             return None, "rejected"
         logger.warning(
             "report_to_receipt_converter: append failed for %s: %s",
@@ -1502,6 +1510,10 @@ def convert_report_to_receipt(
 
 _HEALTH_COMPONENT = "report_to_receipt_converter"
 _HEALTH_EXPECTED_INTERVAL_SECONDS = 3600
+# F1-3: bound on details.rejected history carried on this beacon (below) —
+# the oldest entries are evicted once the accumulated history exceeds this,
+# so the file never grows without bound across an unattended fleet.
+_HEALTH_REJECTED_HISTORY_MAX = 200
 
 
 @dataclass(frozen=True)
@@ -1534,6 +1546,12 @@ class ScanStats:
     # zero success", and _write_scan_heartbeat is skipped entirely for a
     # dry-run so this count never influences health status either way.
     would_append_count: int = 0
+    # F1-3: per-rejection detail ({dispatch_id, file, reason, rejected_at})
+    # for THIS scan's missing-model rejections — see _write_scan_heartbeat,
+    # which merges this into the beacon's accumulated details.rejected
+    # history. A tuple (not a list) so the frozen dataclass never exposes a
+    # mutable default shared across instances.
+    rejected: Tuple[Dict[str, Any], ...] = ()
 
     @property
     def attempted_count(self) -> int:
@@ -1544,6 +1562,30 @@ class ScanStats:
             + self.malformed_count
             + self.error_count
         )
+
+
+def _load_prior_rejected_history(state_dir: Path) -> List[Dict[str, Any]]:
+    """Load this beacon's OWN accumulated ``details.rejected`` history.
+
+    ``HealthBeacon.heartbeat()`` atomically REPLACES the whole payload on
+    every call (tmp + os.replace) — it has no append mode. Without reading
+    the prior history back first, each scan's heartbeat would overwrite the
+    previous scan's rejection list instead of accumulating it, and a
+    dispatch rejected once and never retried again (e.g. its report gets
+    fixed by hand) would silently drop out of view on the very next scan.
+
+    Best-effort: a missing, unreadable, or malformed health file yields an
+    empty history rather than raising — a corrupt beacon must never block a
+    scan from completing.
+    """
+    path = state_dir.parent / "health" / f"{_HEALTH_COMPONENT}.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    details = payload.get("details") if isinstance(payload, dict) else None
+    prior = details.get("rejected") if isinstance(details, dict) else None
+    return [entry for entry in prior if isinstance(entry, dict)] if isinstance(prior, list) else []
 
 
 def _write_scan_heartbeat(state_dir: Path, stats: ScanStats) -> None:
@@ -1584,6 +1626,16 @@ def _write_scan_heartbeat(state_dir: Path, stats: ScanStats) -> None:
     if stats.attempted_count > 0 and stats.new_count == 0 and stats.duplicate_count == 0:
         status = "fail"
 
+    # F1-3: rejected_count alone (below) is an anonymous number — a fleet
+    # operator sees "27 rejected" with no way to find out which reports or
+    # why without re-running the scan by hand. Accumulate per-rejection
+    # detail across scans (bounded, oldest evicted) so the identity of every
+    # rejection survives on this beacon, not just its count.
+    rejected_history = _load_prior_rejected_history(state_dir)
+    rejected_history.extend(stats.rejected)
+    if len(rejected_history) > _HEALTH_REJECTED_HISTORY_MAX:
+        rejected_history = rejected_history[-_HEALTH_REJECTED_HISTORY_MAX:]
+
     beacon = HealthBeacon(
         state_dir.parent, _HEALTH_COMPONENT, expected_interval_seconds=_HEALTH_EXPECTED_INTERVAL_SECONDS,
     )
@@ -1596,6 +1648,7 @@ def _write_scan_heartbeat(state_dir: Path, stats: ScanStats) -> None:
             "malformed_count": stats.malformed_count,
             "error_count": stats.error_count,
             "skipped_non_dispatch_count": stats.skipped_non_dispatch_count,
+            "rejected": rejected_history,
         },
     )
 
@@ -1661,6 +1714,7 @@ def scan_and_convert(
     error_count = 0
     skipped_non_dispatch_count = 0
     would_append_count = 0
+    rejected_details: List[Dict[str, Any]] = []
 
     for reports_dir in reports_dirs:
         if not isinstance(reports_dir, Path):
@@ -1685,6 +1739,7 @@ def scan_and_convert(
                     receipts_file=receipts_file,
                     cache_window_seconds=cache_window_seconds,
                     dry_run=dry_run,
+                    rejected_detail_sink=rejected_details,
                 )
             except Exception as exc:
                 # Belt-and-suspenders: _convert_one_detailed() already catches
@@ -1763,6 +1818,7 @@ def scan_and_convert(
         error_count=error_count,
         skipped_non_dispatch_count=skipped_non_dispatch_count,
         would_append_count=would_append_count,
+        rejected=tuple(rejected_details),
     )
     # dry_run: no write happened, so no heartbeat about a scan cycle either —
     # a dry-run must leave zero observable state behind.
@@ -1831,6 +1887,7 @@ def convert_dispatch_ids(
     error_count = 0
     skipped_non_dispatch_count = 0
     would_append_count = 0
+    rejected_details: List[Dict[str, Any]] = []
 
     for dispatch_id in ids:
         # Codex finding (PR #1635): dispatch_id is caller-supplied CLI input
@@ -1883,6 +1940,7 @@ def convert_dispatch_ids(
                 receipts_file=receipts_file,
                 cache_window_seconds=cache_window_seconds,
                 dry_run=dry_run,
+                rejected_detail_sink=rejected_details,
             )
         except Exception as exc:
             logger.error(
@@ -1946,6 +2004,7 @@ def convert_dispatch_ids(
         error_count=error_count,
         skipped_non_dispatch_count=skipped_non_dispatch_count,
         would_append_count=would_append_count,
+        rejected=tuple(rejected_details),
     )
     if not dry_run:
         _write_scan_heartbeat(state_dir, stats)

--- a/scripts/restore_stranded_reports.py
+++ b/scripts/restore_stranded_reports.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""restore_stranded_reports.py — recover reports stranded by a missing model.
+
+F1-3 (20260906-f13-gestrande-rapporten): report_to_receipt_converter.py
+refuses (fail-closed, ``AppendReceiptError`` code ``missing_model`` /
+``invalid_model_shape``) any dispatch-lane report whose resolved ``model``
+is absent or a sentinel like ``"unknown"`` — see
+``append_receipt_internals/validation.py::_validate_model_present``. Such a
+report never gets a receipt and never gets retried automatically once the
+underlying cause (a lane that never stamped a real model) is fixed
+elsewhere; it just sits in ``unified_reports/`` forever.
+
+This script finds those reports and — ONLY when a real model can be
+VERIFIED from one of three sources, never invented — restores their
+identity and books the receipt the converter itself would have booked had
+the model been present from the start:
+
+  a. the dispatch's own ``dispatch-spec.json`` (``model``/``provider``);
+  b. an earlier ledger receipt for the same ``dispatch_id`` that carries a
+     real ``model``;
+  c. the report's own frontmatter ``model:``/``provider:``, or a
+     bullet-form ``- Model: x`` / ``* Model: x`` line the converter's own
+     parser does not recognise (it only reads ``**Model**:`` bold fields
+     and, for Dispatch-ID only, a bare ``Dispatch-ID:`` line).
+
+A report with no verifiable source in any of the three is listed as
+UNRESTORABLE and is never touched — no default, no guessed value.
+
+Restoring NEVER rewrites the report's existing bytes. It only APPENDS a
+``## Restored identity`` section at the end (audit trail: which source, and
+when) after the receipt has been booked with ``identity_restored: true``.
+Re-running ``--apply`` on an already-restored report is a no-op — the
+``## Restored identity`` marker is checked before anything else runs.
+
+Usage:
+    restore_stranded_reports.py --list    # scan only, changes nothing
+    restore_stranded_reports.py --apply   # restore + book receipts
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_LIB_DIR = _SCRIPT_DIR / "lib"
+for _p in (_SCRIPT_DIR, _LIB_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import report_to_receipt_converter as rc  # noqa: E402
+import append_receipt  # noqa: E402  — registers facade, exposes append_receipt_payload
+from append_receipt_internals.validation import _validate_model_present  # noqa: E402
+from append_receipt_internals.common import AppendReceiptError  # noqa: E402
+
+_RESTORED_MARKER = "## Restored identity"
+_BAD_MODEL_SENTINELS = {"unknown", "none", "null", "n/a", "na", "unset", "-", ""}
+_LEDGER_FILENAME = "t0_receipts.ndjson"
+
+# Bullet-form ``Model:``/``Provider:`` lines — deliberately NOT anchored the
+# way report_to_receipt_converter._DISPATCH_PLAIN_RE is (list marker + single
+# space only): this is a one-shot recovery scan over a small, already-
+# filtered candidate set, not a hot per-scan parser, so favouring recall over
+# the converter's diff-quoting-safety trade-off is the right call here.
+_BULLET_MODEL_RE = re.compile(r"^[-*]\s*Model:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE)
+_BULLET_PROVIDER_RE = re.compile(r"^[-*]\s*Provider:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE)
+
+
+def _is_real_model(value: Any) -> bool:
+    return bool(str(value or "").strip()) and str(value).strip().lower() not in _BAD_MODEL_SENTINELS
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A dispatch-lane report that would be refused for a missing/invalid model."""
+
+    path: Path
+    dispatch_id: str
+    reason_code: str
+    receipt: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """A verified (model, provider) pulled from one of the three allowed sources."""
+
+    model: str
+    provider: Optional[str]
+    source_kind: str  # "dispatch_spec" | "ledger" | "frontmatter" | "bullet"
+    source_detail: str
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    total_scanned: int
+    already_handled: int
+    skipped_non_dispatch: int
+    candidates: Tuple[Candidate, ...]
+
+
+def find_stranded_reports(data_dir: Path, state_dir: Path) -> ScanResult:
+    """Scan ``unified_reports/`` for dispatch-lane reports stranded on model.
+
+    Uses ``report_to_receipt_converter``'s OWN classification and receipt
+    builder (``_classify_non_dispatch_report``, ``_build_receipt_from_report_
+    core``) so "which reports would the converter scan" is answered by the
+    same code the converter itself runs — never a re-implemented guess.
+
+    Deliberately uses the CORE builder, not the public ``build_receipt_from_
+    report`` wrapper: the wrapper's ``_resolve_pr_link`` step can WRITE to a
+    gate obligation file as a side effect, and a scan (used by both --list
+    and the detection half of --apply) must never mutate state — only an
+    actual restoration should.
+    """
+    reports_dir = data_dir / "unified_reports"
+    watermark = rc._load_watermark(state_dir / rc._WATERMARK_FILENAME)
+    bash_watermark = rc._load_watermark(state_dir / rc._BASH_WATERMARK_FILENAME)
+
+    total = 0
+    already_handled = 0
+    skipped_non_dispatch = 0
+    candidates: List[Candidate] = []
+
+    for path in sorted(reports_dir.glob("*.md")):
+        if not path.is_file():
+            continue
+        total += 1
+
+        if rc._classify_non_dispatch_report(path) is not None:
+            skipped_non_dispatch += 1
+            continue
+
+        try:
+            file_hash = rc._compute_sha256(path)
+        except OSError:
+            continue
+        if file_hash in watermark or file_hash in bash_watermark:
+            already_handled += 1
+            continue
+
+        try:
+            text = path.read_text(encoding="utf-8")
+            receipt = rc._build_receipt_from_report_core(path, text, state_dir=state_dir)
+        except Exception:
+            continue
+        if receipt is None:
+            continue
+
+        try:
+            _validate_model_present(receipt)
+        except AppendReceiptError as exc:
+            if exc.code in ("missing_model", "invalid_model_shape"):
+                candidates.append(Candidate(
+                    path=path,
+                    dispatch_id=str(receipt.get("dispatch_id") or ""),
+                    reason_code=exc.code,
+                    receipt=receipt,
+                ))
+
+    return ScanResult(
+        total_scanned=total,
+        already_handled=already_handled,
+        skipped_non_dispatch=skipped_non_dispatch,
+        candidates=tuple(candidates),
+    )
+
+
+def _resolve_from_dispatch_spec(dispatch_id: str, data_dir: Path) -> Optional[Resolution]:
+    """Source (a): the dispatch's own ``dispatch-spec.json``.
+
+    Globs every status directory (``dispatches/*/<dispatch_id>/``) since a
+    dispatch can sit in ``pending``, ``completed``, ``failed``, etc. — the
+    status at scan time is not part of this contract.
+    """
+    for spec_path in sorted(data_dir.glob(f"dispatches/*/{dispatch_id}/dispatch-spec.json")):
+        try:
+            spec = json.loads(spec_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        model = str(spec.get("model") or "").strip()
+        if _is_real_model(model):
+            provider = str(spec.get("provider") or "").strip() or None
+            return Resolution(
+                model=model, provider=provider,
+                source_kind="dispatch_spec", source_detail=str(spec_path),
+            )
+    return None
+
+
+def build_ledger_model_index(state_dir: Path) -> Dict[str, Resolution]:
+    """Source (b), pre-indexed: one pass over the ledger instead of one pass
+    per candidate. Keeps the EARLIEST record with a real model per
+    dispatch_id — 'een eerdere receipt' — regardless of ``event_type``.
+
+    T0's dispatch text names ``dispatch_registered``/``task_start``/a
+    review-gate event as the expected carriers; measured against the live
+    ledger (2026-09-06) both ``dispatch_registered`` and ``task_start``
+    occur ZERO times — no lane ever wrote them. Scoping to those literal
+    event types would make source (b) permanently empty. Any event_type
+    carrying a real model for the dispatch_id serves the same purpose here.
+    """
+    index: Dict[str, Resolution] = {}
+    ledger_path = state_dir / _LEDGER_FILENAME
+    if not ledger_path.exists():
+        return index
+    try:
+        with ledger_path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                dispatch_id = record.get("dispatch_id")
+                if not dispatch_id or dispatch_id in index:
+                    continue
+                model = str(record.get("model") or "").strip()
+                if not _is_real_model(model):
+                    continue
+                provider = str(record.get("provider") or "").strip() or None
+                event_name = record.get("event_type") or record.get("event") or "unknown_event"
+                timestamp = record.get("timestamp") or "unknown_timestamp"
+                index[dispatch_id] = Resolution(
+                    model=model, provider=provider, source_kind="ledger",
+                    source_detail=f"event_type={event_name} timestamp={timestamp}",
+                )
+    except OSError:
+        pass
+    return index
+
+
+def _resolve_from_report_text(text: str) -> Optional[Resolution]:
+    """Source (c): the report's own frontmatter, or an unparsed bullet line."""
+    fm = rc.parse_frontmatter(text)
+    model = str(fm.get("model") or "").strip()
+    if _is_real_model(model):
+        provider = str(fm.get("provider") or "").strip() or None
+        return Resolution(
+            model=model, provider=provider,
+            source_kind="frontmatter", source_detail="frontmatter 'model:' field",
+        )
+
+    match = _BULLET_MODEL_RE.search(text)
+    if match and _is_real_model(match.group(1)):
+        model = match.group(1).strip()
+        provider_match = _BULLET_PROVIDER_RE.search(text)
+        provider = provider_match.group(1).strip() if provider_match else None
+        quoted_line = match.group(0).strip()
+        return Resolution(
+            model=model, provider=provider,
+            source_kind="bullet", source_detail=f"quoted line: {quoted_line!r}",
+        )
+    return None
+
+
+def resolve_identity(
+    candidate: Candidate, data_dir: Path, ledger_index: Dict[str, Resolution], text: str,
+) -> Optional[Resolution]:
+    """Try sources (a), (b), (c) in that fixed order; first hit wins."""
+    return (
+        _resolve_from_dispatch_spec(candidate.dispatch_id, data_dir)
+        or ledger_index.get(candidate.dispatch_id)
+        or _resolve_from_report_text(text)
+    )
+
+
+def apply_restoration(
+    candidate: Candidate, resolution: Resolution, *, data_dir: Path, state_dir: Path,
+) -> Tuple[bool, str]:
+    """Restore one candidate: book the receipt, then append the audit block.
+
+    Returns ``(restored, detail)``. Never touches the file if a receipt
+    cannot be booked (e.g. the report fails some OTHER fail-closed check
+    even after the model is supplied) — the restore is all-or-nothing per
+    report, and a failed booking leaves the report byte-for-byte untouched.
+    """
+    original_text = candidate.path.read_text(encoding="utf-8")
+    if _RESTORED_MARKER in original_text:
+        return False, "already restored (## Restored identity marker present) — skipped"
+
+    # Rebuild via the full converter pipeline (PR-link included) — this is
+    # the function the converter itself would call to book this report for
+    # real; the core-only builder used for scanning deliberately skips the
+    # PR-link side effect, which is appropriate for detection but not here.
+    receipt = rc.build_receipt_from_report(candidate.path, original_text, state_dir=state_dir)
+    if receipt is None:
+        return False, "dispatch_id no longer resolvable — report changed since scan"
+
+    receipt["model"] = resolution.model
+    if resolution.provider:
+        try:
+            receipt["provider"] = rc._normalise_provider(resolution.provider)
+        except rc.UnrecognizedProviderError:
+            pass  # keep whatever the lane/body already resolved for provider
+    receipt["identity_restored"] = True
+
+    receipts_file = str(state_dir / _LEDGER_FILENAME)
+    try:
+        result = append_receipt.append_receipt_payload(
+            receipt,
+            receipts_file=receipts_file,
+            cache_window_seconds=300,
+            skip_enrichment=True,
+        )
+    except append_receipt.AppendReceiptError as exc:
+        return False, f"append still failed after model restore: {exc.code}: {exc.message}"
+
+    if result is None or result.status not in ("appended", "duplicate"):
+        return False, f"append returned unexpected result: {result!r}"
+
+    restored_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    annotation = (
+        f"\n\n{_RESTORED_MARKER}\n\n"
+        f"**Model**: {resolution.model}\n"
+        f"**Provider**: {receipt.get('provider') or resolution.provider or ''}\n"
+        f"**Restored-from**: {resolution.source_kind} ({resolution.source_detail})\n"
+        f"**Restored-at**: {restored_at}\n"
+    )
+    with candidate.path.open("a", encoding="utf-8") as fh:
+        fh.write(annotation)
+
+    return True, f"receipt booked (status={result.status}), restored from {resolution.source_kind}: {resolution.source_detail}"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--state-dir", default=None, help="Override $VNX_STATE_DIR")
+    parser.add_argument("--data-dir", default=None, help="Override $VNX_DATA_DIR")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--list", action="store_true", help="Scan and report only — changes nothing")
+    mode.add_argument("--apply", action="store_true", help="Restore identity + book receipts for restorable reports")
+    args = parser.parse_args(argv)
+
+    if args.data_dir and args.state_dir:
+        data_dir = Path(args.data_dir)
+        state_dir = Path(args.state_dir)
+    else:
+        from vnx_paths import ensure_env  # noqa: PLC0415
+        paths = ensure_env()
+        data_dir = Path(args.data_dir) if args.data_dir else Path(paths["VNX_DATA_DIR"])
+        state_dir = Path(args.state_dir) if args.state_dir else Path(paths["VNX_STATE_DIR"])
+
+    scan = find_stranded_reports(data_dir, state_dir)
+    ledger_index = build_ledger_model_index(state_dir)
+
+    print(
+        f"Scanned {scan.total_scanned} report file(s) in {data_dir / 'unified_reports'}: "
+        f"{scan.skipped_non_dispatch} non-dispatch (skipped), "
+        f"{scan.already_handled} already handled (watermarked), "
+        f"{len(scan.candidates)} stranded on model validation."
+    )
+
+    restorable: List[Tuple[Candidate, Resolution]] = []
+    unrestorable: List[Candidate] = []
+    for candidate in scan.candidates:
+        text = candidate.path.read_text(encoding="utf-8")
+        resolution = resolve_identity(candidate, data_dir, ledger_index, text)
+        if resolution is not None:
+            restorable.append((candidate, resolution))
+        else:
+            unrestorable.append(candidate)
+
+    for candidate, resolution in restorable:
+        print(
+            f"RESTORABLE    dispatch_id={candidate.dispatch_id} file={candidate.path.name} "
+            f"reason={candidate.reason_code} -> model={resolution.model} "
+            f"provider={resolution.provider or '?'} source={resolution.source_kind} "
+            f"({resolution.source_detail})"
+        )
+    for candidate in unrestorable:
+        print(
+            f"UNRESTORABLE  dispatch_id={candidate.dispatch_id} file={candidate.path.name} "
+            f"reason={candidate.reason_code} -> no verifiable model source in "
+            "dispatch-spec.json, the ledger, or the report itself"
+        )
+
+    if args.list:
+        print(f"\n--list: {len(restorable)} restorable, {len(unrestorable)} unrestorable. Nothing changed.")
+        return 0
+
+    restored = 0
+    already_restored = 0
+    failed = 0
+    for candidate, resolution in restorable:
+        ok, detail = apply_restoration(candidate, resolution, data_dir=data_dir, state_dir=state_dir)
+        if ok:
+            restored += 1
+            print(f"RESTORED      dispatch_id={candidate.dispatch_id} {detail}")
+        elif "already restored" in detail:
+            already_restored += 1
+            print(f"SKIPPED       dispatch_id={candidate.dispatch_id} {detail}")
+        else:
+            failed += 1
+            print(f"FAILED        dispatch_id={candidate.dispatch_id} {detail}")
+
+    print(
+        f"\n--apply summary: {restored} restored, {already_restored} already restored, "
+        f"{failed} failed after a source was found, {len(unrestorable)} unrestorable (no source)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_receipt_ci_guard.py
+++ b/tests/test_receipt_ci_guard.py
@@ -16,6 +16,10 @@ APPROVED_WRITERS = {
     "report_watcher.sh",
     "heartbeat_ack_monitor.py",
     "check_active_drain.py",
+    # restore_stranded_reports.py: recovers reports stranded by a missing
+    # model, and books the receipt ONLY from a verified model source, with
+    # identity_restored=true (F1-3, 20260906-f13-gestrande-rapporten).
+    "restore_stranded_reports.py",
 }
 
 APPEND_HELPER_MARKERS = (

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -1249,6 +1249,79 @@ class TestRejectionVisibility:
         assert beacon["status"] == "ok"
 
 
+class TestRejectedDetailHistory:
+    """F1-3: a rejected_count integer alone is anonymous — nobody can tell
+    WHICH report was refused or WHY without re-running the scan by hand.
+    details.rejected on this beacon carries {dispatch_id, file, reason,
+    rejected_at} per rejection, accumulated across scans (bounded, oldest
+    evicted) so identity survives even once the offending report is fixed
+    or removed and the rejection stops recurring."""
+
+    def _rejected_entries(self, state_dir: Path) -> list:
+        beacon_path = state_dir.parent / "health" / "report_to_receipt_converter.json"
+        beacon = json.loads(beacon_path.read_text(encoding="utf-8"))
+        return beacon["details"]["rejected"]
+
+    def test_rejected_detail_carries_dispatch_id_and_reason(self, reports_dir, state_dir):
+        _write_report_without_model(
+            reports_dir / "20260906-stranded-a.md", "20260906-stranded-a"
+        )
+
+        scan_and_convert([reports_dir], state_dir)
+
+        entries = self._rejected_entries(state_dir)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["dispatch_id"] == "20260906-stranded-a"
+        assert entry["file"] == "20260906-stranded-a.md"
+        assert "model" in entry["reason"].lower()
+        assert entry["rejected_at"]  # non-empty ISO8601 timestamp
+
+    def test_rejected_history_accumulates_across_scans_not_overwritten(
+        self, reports_dir, state_dir
+    ):
+        """HealthBeacon.heartbeat() replaces the WHOLE payload on every call
+        — without reading prior history back first, scan 2's heartbeat would
+        wipe scan 1's rejection out of the record the moment the first
+        report stopped recurring (e.g. it got fixed by hand)."""
+        _write_report_without_model(
+            reports_dir / "20260906-stranded-a.md", "20260906-stranded-a"
+        )
+        scan_and_convert([reports_dir], state_dir)
+
+        # Scan 1's offending report is now "fixed" (removed) — a scan that
+        # only reflects the CURRENT cycle would show zero rejections here.
+        (reports_dir / "20260906-stranded-a.md").unlink()
+        _write_report_without_model(
+            reports_dir / "20260906-stranded-b.md", "20260906-stranded-b"
+        )
+        scan_and_convert([reports_dir], state_dir)
+
+        entries = self._rejected_entries(state_dir)
+        dispatch_ids = {e["dispatch_id"] for e in entries}
+        assert dispatch_ids == {"20260906-stranded-a", "20260906-stranded-b"}
+
+    def test_rejected_history_capped_oldest_evicted(self, reports_dir, state_dir):
+        """The history never grows without bound across an unattended
+        fleet — once it exceeds the cap, the OLDEST entries are dropped
+        first, not the newest."""
+        from report_to_receipt_converter import _HEALTH_REJECTED_HISTORY_MAX
+
+        # One rejection per scan cycle, one cycle more than the cap allows.
+        for i in range(_HEALTH_REJECTED_HISTORY_MAX + 1):
+            name = f"20260906-cap-{i:04d}"
+            report = reports_dir / f"{name}.md"
+            _write_report_without_model(report, name)
+            scan_and_convert([reports_dir], state_dir)
+            report.unlink()
+
+        entries = self._rejected_entries(state_dir)
+        assert len(entries) == _HEALTH_REJECTED_HISTORY_MAX
+        dispatch_ids = [e["dispatch_id"] for e in entries]
+        assert "20260906-cap-0000" not in dispatch_ids  # oldest evicted
+        assert f"20260906-cap-{_HEALTH_REJECTED_HISTORY_MAX:04d}" in dispatch_ids  # newest kept
+
+
 # ---------------------------------------------------------------------------
 # Part 11: fail-closed gate — OI-1035, OI-1011, OI-1002, OI-659, OI-1017
 # ---------------------------------------------------------------------------

--- a/tests/test_restore_stranded_reports.py
+++ b/tests/test_restore_stranded_reports.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Tests for restore_stranded_reports — recovering model-stranded reports.
+
+F1-3 (20260906-f13-gestrande-rapporten): report_to_receipt_converter.py
+fail-closed refuses (AppendReceiptError code missing_model/invalid_model_
+shape) a dispatch-lane report whose resolved model is absent or a sentinel
+("unknown"). Such a report sits stranded in unified_reports/ forever with
+no automatic retry once the underlying cause is fixed. This module recovers
+those reports ONLY when a real model can be verified from one of three
+sources (dispatch-spec.json, an earlier ledger receipt, or the report's own
+frontmatter/an unparsed bullet line) — never a default, never a guess.
+
+Covers:
+  1. find_stranded_reports() correctly classifies a stranded report and
+     skips a healthy one, a non-dispatch report, and an already-watermarked
+     one.
+  2. Restoration via source (a) dispatch-spec.json: annotation block
+     appended, original bytes preceding it byte-for-byte unchanged, receipt
+     booked with identity_restored=True.
+  3. No source anywhere: file untouched (sha256 identical), no receipt,
+     listed as unrestorable.
+  4. Restoration via source (c) bullet form (`- Model: x`, a form the
+     converter's own bold-field parser does not recognise): the quoted
+     line is cited in the annotation.
+  5. Idempotency: two --apply passes on the same report produce exactly one
+     annotation block and exactly one receipt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+_SCRIPTS_LIB = _SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(_SCRIPTS_LIB))
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from restore_stranded_reports import (  # noqa: E402
+    _RESTORED_MARKER,
+    apply_restoration,
+    build_ledger_model_index,
+    find_stranded_reports,
+    resolve_identity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def data_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "data"
+    (d / "unified_reports").mkdir(parents=True)
+    (d / "dispatches").mkdir(parents=True)
+    return d
+
+
+@pytest.fixture()
+def state_dir(data_dir: Path) -> Path:
+    sd = data_dir / "state"
+    sd.mkdir(parents=True)
+    return sd
+
+
+@pytest.fixture()
+def reports_dir(data_dir: Path) -> Path:
+    return data_dir / "unified_reports"
+
+
+def _write_stranded_report(path: Path, dispatch_id: str, *, extra_frontmatter: str = "", extra_body: str = "") -> Path:
+    """A dispatch report whose frontmatter carries model: unknown — the
+    real-world shape found in the live store (the emitter stamps the
+    sentinel rather than omitting the key). No status/exit_code (mirrors
+    report_to_receipt_converter tests' own `_write_report_without_model`)
+    so the fail-closed branch/PR-delivery checks — which shell out to git/gh
+    — are never reached; only the model check matters here."""
+    path.write_text(
+        f"---\ndispatch_id: {dispatch_id}\nprovider: claude\nmodel: unknown\n"
+        f"{extra_frontmatter}---\n\n"
+        "## Summary\n\nImplemented the feature per dispatch specification. "
+        "All tests pass and coverage is at target.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 42 passed\n\n"
+        "## Open Items\n\nNone\n"
+        f"{extra_body}",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_healthy_report(path: Path, dispatch_id: str) -> Path:
+    path.write_text(
+        f"---\ndispatch_id: {dispatch_id}\nprovider: claude\nmodel: sonnet\n---\n\n"
+        "## Summary\n\nImplemented the feature per dispatch specification. "
+        "All tests pass and coverage is at target.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 42 passed\n\n"
+        "## Open Items\n\nNone\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_dispatch_spec(
+    data_dir: Path, dispatch_id: str, *, model: str, provider: str = "claude", status_dir: str = "completed",
+) -> Path:
+    spec_dir = data_dir / "dispatches" / status_dir / dispatch_id
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec_path = spec_dir / "dispatch-spec.json"
+    spec_path.write_text(
+        json.dumps({"dispatch_id": dispatch_id, "model": model, "provider": provider}),
+        encoding="utf-8",
+    )
+    return spec_path
+
+
+def _sha256_prefix(path: Path, n: int) -> str:
+    return hashlib.sha256(path.read_bytes()[:n]).hexdigest()
+
+
+def _receipts(state_dir: Path) -> list:
+    receipts_file = state_dir / "t0_receipts.ndjson"
+    if not receipts_file.exists():
+        return []
+    return [json.loads(line) for line in receipts_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Part 1: find_stranded_reports() classification
+# ---------------------------------------------------------------------------
+
+class TestFindStrandedReports:
+    def test_finds_report_with_sentinel_model(self, data_dir, state_dir, reports_dir):
+        _write_stranded_report(reports_dir / "20260906-a.md", "20260906-a")
+
+        scan = find_stranded_reports(data_dir, state_dir)
+
+        assert scan.total_scanned == 1
+        assert len(scan.candidates) == 1
+        assert scan.candidates[0].dispatch_id == "20260906-a"
+        assert scan.candidates[0].reason_code == "missing_model"
+
+    def test_skips_healthy_report(self, data_dir, state_dir, reports_dir):
+        _write_healthy_report(reports_dir / "20260906-healthy.md", "20260906-healthy")
+
+        scan = find_stranded_reports(data_dir, state_dir)
+
+        assert scan.total_scanned == 1
+        assert len(scan.candidates) == 0
+
+    def test_skips_non_dispatch_report(self, data_dir, state_dir, reports_dir):
+        (reports_dir / "worktree-release-20260906.md").write_text(
+            "no dispatch_id, no model — a tool-output report", encoding="utf-8",
+        )
+
+        scan = find_stranded_reports(data_dir, state_dir)
+
+        assert scan.skipped_non_dispatch == 1
+        assert len(scan.candidates) == 0
+
+    def test_skips_already_watermarked_report(self, data_dir, state_dir, reports_dir):
+        import report_to_receipt_converter as rc
+
+        report = _write_stranded_report(reports_dir / "20260906-b.md", "20260906-b")
+        file_hash = rc._compute_sha256(report)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / rc._WATERMARK_FILENAME).write_text(file_hash + "\n", encoding="utf-8")
+
+        scan = find_stranded_reports(data_dir, state_dir)
+
+        assert scan.already_handled == 1
+        assert len(scan.candidates) == 0
+
+
+# ---------------------------------------------------------------------------
+# Part 2: restoration via source (a) — dispatch-spec.json
+# ---------------------------------------------------------------------------
+
+class TestRestoreFromDispatchSpec:
+    def test_restore_appends_block_preserves_bytes_books_receipt(self, data_dir, state_dir, reports_dir):
+        dispatch_id = "20260906-spec-restore"
+        report = _write_stranded_report(reports_dir / f"{dispatch_id}.md", dispatch_id)
+        _write_dispatch_spec(data_dir, dispatch_id, model="sonnet", provider="claude")
+
+        original_bytes_len = len(report.read_bytes())
+        original_prefix_sha = _sha256_prefix(report, original_bytes_len)
+
+        scan = find_stranded_reports(data_dir, state_dir)
+        assert len(scan.candidates) == 1
+        candidate = scan.candidates[0]
+        ledger_index = build_ledger_model_index(state_dir)
+        resolution = resolve_identity(candidate, data_dir, ledger_index, report.read_text(encoding="utf-8"))
+        assert resolution is not None
+        assert resolution.source_kind == "dispatch_spec"
+        assert resolution.model == "sonnet"
+
+        ok, detail = apply_restoration(candidate, resolution, data_dir=data_dir, state_dir=state_dir)
+
+        assert ok is True
+        new_text = report.read_text(encoding="utf-8")
+        assert _RESTORED_MARKER in new_text
+        assert "**Model**: sonnet" in new_text
+        # Bytes preceding the appended block are byte-for-byte unchanged.
+        assert _sha256_prefix(report, original_bytes_len) == original_prefix_sha
+        assert new_text[:original_bytes_len] == report.read_bytes()[:original_bytes_len].decode("utf-8")
+
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        assert receipts[0]["dispatch_id"] == dispatch_id
+        assert receipts[0]["model"] == "sonnet"
+        assert receipts[0]["identity_restored"] is True
+
+    def test_dispatch_spec_takes_precedence_over_ledger_and_report(self, data_dir, state_dir, reports_dir):
+        """Source order is fixed: (a) dispatch-spec.json wins even when (b)
+        the ledger and (c) the report text both also carry a candidate
+        value — the dispatch's own spec is the most authoritative source."""
+        dispatch_id = "20260906-precedence"
+        report = _write_stranded_report(
+            reports_dir / f"{dispatch_id}.md", dispatch_id,
+            extra_body="\n- Model: bullet-value\n",
+        )
+        _write_dispatch_spec(data_dir, dispatch_id, model="spec-value", provider="claude")
+        ledger_path = state_dir / "t0_receipts.ndjson"
+        ledger_path.write_text(
+            json.dumps({"dispatch_id": dispatch_id, "event_type": "task_complete", "model": "ledger-value", "provider": "claude"}) + "\n",
+            encoding="utf-8",
+        )
+
+        scan = find_stranded_reports(data_dir, state_dir)
+        candidate = scan.candidates[0]
+        ledger_index = build_ledger_model_index(state_dir)
+        resolution = resolve_identity(candidate, data_dir, ledger_index, report.read_text(encoding="utf-8"))
+
+        assert resolution.source_kind == "dispatch_spec"
+        assert resolution.model == "spec-value"
+
+
+# ---------------------------------------------------------------------------
+# Part 3: no source anywhere — must NOT restore
+# ---------------------------------------------------------------------------
+
+class TestNoSourceNeverRestores:
+    def test_no_source_leaves_file_untouched_and_lists_unrestorable(self, data_dir, state_dir, reports_dir):
+        dispatch_id = "20260906-no-source"
+        report = _write_stranded_report(reports_dir / f"{dispatch_id}.md", dispatch_id)
+        original_sha = hashlib.sha256(report.read_bytes()).hexdigest()
+
+        scan = find_stranded_reports(data_dir, state_dir)
+        assert len(scan.candidates) == 1
+        candidate = scan.candidates[0]
+        ledger_index = build_ledger_model_index(state_dir)
+        resolution = resolve_identity(candidate, data_dir, ledger_index, report.read_text(encoding="utf-8"))
+
+        assert resolution is None
+        # Simulate what main() does for the unrestorable bucket: nothing
+        # is ever written to the file and no receipt is ever attempted.
+        assert hashlib.sha256(report.read_bytes()).hexdigest() == original_sha
+        assert _receipts(state_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# Part 4: restoration via source (c) — unparsed bullet line
+# ---------------------------------------------------------------------------
+
+class TestRestoreFromBulletLine:
+    def test_bullet_form_restored_with_quoted_line(self, data_dir, state_dir, reports_dir):
+        dispatch_id = "20260906-bullet-restore"
+        report = _write_stranded_report(
+            reports_dir / f"{dispatch_id}.md", dispatch_id,
+            extra_body="\n- Model: kimi-k3\n",
+        )
+        # No dispatch-spec.json and no ledger entry — only source (c) applies.
+
+        scan = find_stranded_reports(data_dir, state_dir)
+        candidate = scan.candidates[0]
+        ledger_index = build_ledger_model_index(state_dir)
+        resolution = resolve_identity(candidate, data_dir, ledger_index, report.read_text(encoding="utf-8"))
+
+        assert resolution is not None
+        assert resolution.source_kind == "bullet"
+        assert resolution.model == "kimi-k3"
+        assert "Model: kimi-k3" in resolution.source_detail
+
+        ok, detail = apply_restoration(candidate, resolution, data_dir=data_dir, state_dir=state_dir)
+        assert ok is True
+        new_text = report.read_text(encoding="utf-8")
+        assert "**Model**: kimi-k3" in new_text
+        assert "bullet" in new_text.lower()
+        assert "Model: kimi-k3" in new_text  # the cited source line
+
+
+# ---------------------------------------------------------------------------
+# Part 5: idempotency — two --apply passes, one block, one receipt
+# ---------------------------------------------------------------------------
+
+class TestApplyIsIdempotent:
+    def test_second_apply_is_a_no_op(self, data_dir, state_dir, reports_dir):
+        dispatch_id = "20260906-idempotent"
+        report = _write_stranded_report(reports_dir / f"{dispatch_id}.md", dispatch_id)
+        _write_dispatch_spec(data_dir, dispatch_id, model="sonnet", provider="claude")
+
+        # First pass.
+        scan1 = find_stranded_reports(data_dir, state_dir)
+        candidate1 = scan1.candidates[0]
+        ledger_index1 = build_ledger_model_index(state_dir)
+        resolution1 = resolve_identity(candidate1, data_dir, ledger_index1, report.read_text(encoding="utf-8"))
+        ok1, _ = apply_restoration(candidate1, resolution1, data_dir=data_dir, state_dir=state_dir)
+        assert ok1 is True
+
+        text_after_first = report.read_text(encoding="utf-8")
+        assert text_after_first.count(_RESTORED_MARKER) == 1
+        assert len(_receipts(state_dir)) == 1
+
+        # Second pass: frontmatter `model: unknown` OUTRANKS the body in the
+        # merge (`{**body, **fm}` — frontmatter is spread last), so the
+        # report STILL scans as stranded even after the annotation block is
+        # appended (measured — a body-only fix can never out-rank an
+        # explicit frontmatter sentinel). The real safety net is
+        # apply_restoration()'s own marker check, exercised below.
+        scan2 = find_stranded_reports(data_dir, state_dir)
+        assert len(scan2.candidates) == 1
+        candidate2 = scan2.candidates[0]
+        ledger_index2 = build_ledger_model_index(state_dir)
+        resolution2 = resolve_identity(candidate2, data_dir, ledger_index2, report.read_text(encoding="utf-8"))
+        assert resolution2 is not None
+
+        ok2, detail2 = apply_restoration(
+            candidate2, resolution2, data_dir=data_dir, state_dir=state_dir,
+        )
+        assert ok2 is False
+        assert "already restored" in detail2
+
+        text_after_second = report.read_text(encoding="utf-8")
+        assert text_after_second == text_after_first  # byte-for-byte: no new block
+        assert text_after_second.count(_RESTORED_MARKER) == 1
+        assert len(_receipts(state_dir)) == 1  # no second receipt


### PR DESCRIPTION
## Summary

`report_to_receipt_converter.py` fail-closed refuses a dispatch-lane report whose resolved `model` is absent or a sentinel (`"unknown"`, ...) via `_validate_model_present`. The converter's own health beacon carried only `rejected_count` — an anonymous number, with no way to find out which report was refused or why once the log line rolled off (measured: last run 2026-09-03 reported `rejected_count: 27`, but `logs/receipt_processor.log` had zero matching lines left — the identity of those 27 was nowhere).

This PR:
1. Adds `details.rejected` (a `{dispatch_id, file, reason, rejected_at}` history, accumulated across scans, capped at 200 / oldest evicted) to the converter's own health beacon — scan-telling/health-details only, the emit/append call itself is untouched.
2. Adds `scripts/restore_stranded_reports.py`, which recovers reports stranded on this check — **only** when a real model can be verified from one of three sources (the dispatch's own `dispatch-spec.json`, an earlier ledger receipt, or the report's own frontmatter/an unparsed bullet line), in that fixed order. No source → listed `UNRESTORABLE`, never touched. Restoring only appends a `## Restored identity` audit block; it never rewrites existing bytes, and a second `--apply` on an already-restored report is a no-op.
3. Adds a runbook section to `docs/operations/RECEIPT_PIPELINE.md`.

## Measured deviations from the dispatch brief

- The dispatch cites 27 rejected reports (03-09 beacon snapshot). A fresh scan on 2026-09-06 found **30** currently model-stranded — drift over 3 days, not a discrepancy in method.
- Source (b) was specified as `dispatch_registered`/`task_start`/a review-gate event. Measured against the live ledger, `dispatch_registered` and `task_start` occur **zero** times — no lane has ever written them. Source (b) is implemented as "any ledger record for this `dispatch_id` carrying a real `model`, regardless of `event_type`" instead, or it would be permanently empty.
- A same-day, adjacent PR (#1780, merged 2026-09-06 14:16) added `scripts/lib/receipt_conversion_rejection_beacon.py`, a separate beacon (`health/receipt_conversion_rejections.json`) populated by parsing `receipt_processor.sh`'s captured converter stderr. It solves a similar problem via the bash wrapper and is out of this PR's file scope (`receipt_processor.sh`/that module are untouched). This PR's `details.rejected` lives on the converter's own native beacon and fires for any caller of `scan_and_convert()`/`convert_dispatch_ids()`, not only the bash-wrapper invocation path — the two are complementary, not conflicting (both test suites pass together).

## Changes

- `scripts/lib/report_to_receipt_converter.py` — `ScanStats.rejected`, `_load_prior_rejected_history`, `_write_scan_heartbeat` now merges/caps history into `details.rejected`; `_convert_one_detailed` gained an optional `rejected_detail_sink` param populated on the `missing_model` rejection branch; both `scan_and_convert` and `convert_dispatch_ids` wire it through. No change to the `append_receipt_payload` call itself.
- `scripts/restore_stranded_reports.py` (new) — `find_stranded_reports`, `_resolve_from_dispatch_spec`/`build_ledger_model_index`/`_resolve_from_report_text`, `apply_restoration`, `--list`/`--apply` CLI.
- `tests/test_report_to_receipt_converter.py` — `TestRejectedDetailHistory` (3 tests): detail captured, history accumulates across scans, capped with oldest evicted.
- `tests/test_restore_stranded_reports.py` (new, 9 tests): classification, restore-from-dispatch-spec (byte-preservation + `identity_restored: true`), source precedence, no-source-never-restores, restore-from-bullet-line, apply-is-idempotent.
- `docs/operations/RECEIPT_PIPELINE.md` — new "Stranded reports" troubleshooting subsection + See-also entry.

## Verification

**Red (pre-implementation):** temporarily stashed only the converter changes (test file left in place) and confirmed all 3 new `TestRejectedDetailHistory` tests failed — `KeyError: 'rejected'` (x2) and `ImportError: cannot import name '_HEALTH_REJECTED_HISTORY_MAX'` — then reapplied.

**Green:**
```
python3 -m pytest tests/test_report_to_receipt_converter.py -q          # 174 passed
python3 -m pytest tests/test_restore_stranded_reports.py -q             #   9 passed
python3 -m pytest tests/test_worker_heartbeat_silence.py tests/test_tmux_interactive_dispatch.py tests/test_report_parser_model_provider.py tests/test_open_items_from_report.py tests/test_dispatch_push_verified.py -q   # 329 passed (neighbors importing the converter module)
python3 -m pytest tests/test_receipt_conversion_rejection_beacon.py tests/test_receipt_processor_poll_converter_rejection_visible.py tests/test_beacon_register.py -q  # 27 passed (adjacent PR #1780 mechanism, unaffected)
```

Mutation check on the idempotency guard: temporarily disabled the `## Restored identity` marker check in `apply_restoration` — `test_second_apply_is_a_no_op` went red (`assert True is False`); reverted, green again.

**Applied to the live `vnx-dev` store** (authorized by the dispatch): `--list` → 30 stranded, 16 restorable / 14 unrestorable, made zero changes (verified: report mtimes unchanged, ledger line count unchanged). `--apply` → 16 restored (receipts booked with `identity_restored: true`, spot-checked in the ledger — outcomes ranged honestly over `task_complete`/`task_failed`/`report_contract_invalid` since the OTHER fail-closed checks, e.g. branch-on-origin, still apply after the model is supplied), 14 correctly left untouched as unrestorable. Re-ran `--apply` a second time on the live store: 0 restored, 16 "already restored", 14 unrestorable — ledger line count for `identity_restored: true` receipts stayed at exactly 16 (no duplicate booking).

## Open Items

None.