### PR TITLE
fix(hooks): worker-scope hook emits hookSpecificOutput deny form (OI-1644)

### DIFF
--- a/scripts/hooks/pretooluse_worker_scope_enforce.py
+++ b/scripts/hooks/pretooluse_worker_scope_enforce.py
@@ -21,10 +21,19 @@ Feasibility proven by docs/investigations/spike-worker-scope-hook-feasibility.md
 (E1-E4): PreToolUse hooks fire under --dangerously-skip-permissions, worktree-
 local settings are honored via cwd-based discovery, and config live-reloads.
 
-Claude Code hook contract (2.1+):
+Claude Code hook contract (2.1+), PreToolUse:
   stdin  : JSON {tool_name, tool_input, session_id, cwd, transcript_path}
-  stdout : {"decision":"block","reason":"..."} to block, empty to allow
+  stdout : {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+            "permissionDecision":"deny","permissionDecisionReason":"..."}}
+           to deny, empty to allow
   exit   : 0 always — decision is communicated via JSON output, never exit code
+
+OI-1644: this hook used to emit the deprecated flat
+{"decision":"block","reason":"..."} form, which is the PostToolUse/Stop/
+UserPromptSubmit contract, not PreToolUse. Claude Code's PreToolUse event
+reads hookSpecificOutput.permissionDecision instead, so blocked tool calls
+were silently allowed through. Fixed to the hookSpecificOutput wrapper — same
+class as OI-1643 (#1789), which fixed the other two hooks.
 
 Gate: VNX_ENFORCE_WORKER_PERMISSIONS (see worker_permissions.
 worker_permission_enforcement_enabled(); default OFF since 15-08 — the flip was
@@ -278,7 +287,18 @@ def main() -> None:
         decision, reason = evaluate(payload)
 
         if decision == "block":
-            sys.stdout.write(json.dumps({"decision": "block", "reason": reason}) + "\n")
+            sys.stdout.write(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": reason,
+                        }
+                    }
+                )
+                + "\n"
+            )
             _emit_audit(tool_name_ctx, decision, reason)
     except Exception:  # absolute fail-open, never crash the hook
         logger.exception(

--- a/tests/test_pretooluse_worker_scope_enforce.py
+++ b/tests/test_pretooluse_worker_scope_enforce.py
@@ -16,7 +16,9 @@ are covered by TestDefaultEnforcement.
 
 Plus unit coverage of evaluate() semantics (role resolution, path relativizing,
 malformed payloads) and the JSON/exit-code hook contract (exit 0 always,
-{"decision":"block","reason":...} on stdout only for blocks).
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":
+"deny","permissionDecisionReason":...}} on stdout only for blocks — OI-1644,
+same class as OI-1643/#1789).
 
 Audit side effects are redirected to a tmp dir via VNX_DATA_DIR +
 VNX_DATA_DIR_EXPLICIT=1 so no test ever writes into real .vnx-data state.
@@ -107,13 +109,18 @@ def run_hook(
 
 
 def parse_block(stdout: str) -> dict:
-    """Assert stdout is exactly one block decision and return it."""
+    """Assert stdout is exactly one deny decision (PreToolUse hookSpecificOutput
+    contract, OI-1644) and return it unwrapped as {"decision": "block",
+    "reason": ...} so existing callers keep reading it unchanged."""
     lines = [ln for ln in stdout.strip().splitlines() if ln.strip()]
     assert len(lines) == 1, f"expected exactly one JSON line on stdout, got: {stdout!r}"
-    decision = json.loads(lines[0])
-    assert decision["decision"] == "block"
-    assert decision.get("reason")
-    return decision
+    data = json.loads(lines[0])
+    assert "decision" not in data, "deprecated flat form must not reappear"
+    hso = data["hookSpecificOutput"]
+    assert hso.get("hookEventName") == "PreToolUse"
+    assert hso.get("permissionDecision") == "deny"
+    assert hso.get("permissionDecisionReason")
+    return {"decision": "block", "reason": hso["permissionDecisionReason"]}
 
 
 class HookTestCase(unittest.TestCase):
@@ -404,6 +411,30 @@ class TestDefaultEnforcement(HookTestCase):
 
 class TestHookContract(HookTestCase):
     """Hook contract: exit 0 always; stdout empty unless blocking."""
+
+    def test_block_uses_hookspecificoutput_envelope(self):
+        """OI-1644 regression guard: PreToolUse must use hookSpecificOutput.
+        permissionDecision, not the deprecated flat {"decision":"block"} form
+        (that form is the PostToolUse/Stop/UserPromptSubmit contract and is
+        silently ignored for PreToolUse — the bug this fix closes; same class
+        as OI-1643, fixed for the other two hooks in #1789).
+        """
+        res = run_hook(
+            make_payload("Bash", {"command": "git push --force origin main"}),
+            enforce=True,
+            data_dir=self.data_dir,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        lines = [ln for ln in res.stdout.strip().splitlines() if ln.strip()]
+        self.assertEqual(
+            len(lines), 1, f"expected exactly one JSON line on stdout, got: {res.stdout!r}"
+        )
+        data = json.loads(lines[0])
+        self.assertNotIn("decision", data, "deprecated flat form must not reappear")
+        hso = data["hookSpecificOutput"]
+        self.assertEqual(hso["hookEventName"], "PreToolUse")
+        self.assertEqual(hso["permissionDecision"], "deny")
+        self.assertTrue(hso["permissionDecisionReason"])
 
     def test_malformed_json_stdin_allow(self):
         res = run_hook("not json at all", enforce=True, data_dir=self.data_dir)


### PR DESCRIPTION
## Summary
`scripts/hooks/pretooluse_worker_scope_enforce.py:281` emitted the deprecated flat `{"decision":"block","reason":...}` form on stdout for PreToolUse block decisions. Claude Code's PreToolUse event reads `hookSpecificOutput.permissionDecision`, not the flat form — that's the PostToolUse/Stop/UserPromptSubmit contract. As a result, blocked Bash/Write/Edit/MultiEdit calls were silently allowed through. Same class of bug as OI-1643, fixed for the other two hooks in #1789 (merge 5f456538).

## Changes
- `scripts/hooks/pretooluse_worker_scope_enforce.py`: block decisions now emit `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":<reason>}}`. `_emit_audit` and the reason text are unchanged. Module docstring's documented hook contract updated to match.
- `tests/test_pretooluse_worker_scope_enforce.py`: `parse_block()` helper updated to unwrap the new envelope (asserts no top-level `decision` key, `hookEventName == "PreToolUse"`, `permissionDecision == "deny"`, non-empty `permissionDecisionReason`) so the 15 existing tests that call it keep reading `decision["reason"]` unchanged. Added a dedicated regression guard, `TestHookContract::test_block_uses_hookspecificoutput_envelope`.
- `.sh` wrapper untouched: it delegates to the `.py` core via `python3 "$CORE" || true` and never prints JSON itself, so it's out of scope per the dispatch's file boundary.

## Verification

Red (before fix, new regression test only):
```
$ python3 -m pytest tests/test_pretooluse_worker_scope_enforce.py::TestHookContract::test_block_uses_hookspecificoutput_envelope -v
...
>       self.assertNotIn("decision", data, "deprecated flat form must not reappear")
E       AssertionError: 'decision' unexpectedly found in {'decision': 'block', 'reason': "worker-scope: Bash command matches bash_deny_patterns entry 'git push --force*' for role 'quality-engineer'"} : deprecated flat form must not reappear
FAILED tests/test_pretooluse_worker_scope_enforce.py::TestHookContract::test_block_uses_hookspecificoutput_envelope
1 failed in 0.23s
```

Green (after fix, full target file + neighbour):
```
$ python3 -m pytest tests/test_pretooluse_worker_scope_enforce.py tests/test_worker_scoped_default.py -q
.............................................                            [100%]
45 passed in 2.17s
```

Break-it-again proof (temporarily reverted the fix in-place, reran the regression test, restored):
```
--- reverted, running test ---
>       self.assertNotIn("decision", data, "deprecated flat form must not reappear")
E       AssertionError: 'decision' unexpectedly found in {'decision': 'block', 'reason': "worker-scope: Bash command matches bash_deny_patterns entry 'git push --force*' for role 'quality-engineer'"} : deprecated flat form must not reappear
FAILED tests/test_pretooluse_worker_scope_enforce.py::TestHookContract::test_block_uses_hookspecificoutput_envelope
1 failed in 0.23s
--- restoring fix ---
```
Post-restore full run confirmed green again (45 passed).

## Open Items
None. Codex CLI and kimi are out (quota per dispatch note) — review via the glm-gate is expected from T0.

Dispatch-ID: 20260906-a5-hook-hookspecificoutput

🤖 Generated with [Claude Code](https://claude.com/claude-code)