### PR TITLE
test(closure-verifier): pin the three signer classes per Gate value (OI-1645 follow-up)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -117,8 +117,44 @@ _NON_REVIEW_SIGNER_REASONS: Dict[str, str] = {
         "never a review peer signer"
     ),
 }
-_REVIEW_PEER_GATES = frozenset(
-    g.value for g in Gate if g.value not in _NON_REVIEW_SIGNER_REASONS
+
+
+def classify_gate_signers(
+    enum_values: Iterable[str],
+    not_implemented: frozenset,
+    non_review_reasons: Dict[str, str],
+) -> frozenset:
+    """Derive the review-peer gate set, refusing to let a gate the closure
+    verifier cannot even read (``not_implemented``) inherit peer-signing
+    rights by omission (OI-1645 follow-up, A6).
+
+    Before this function existed, ``_REVIEW_PEER_GATES`` was a plain
+    complement of ``_NON_REVIEW_SIGNER_REASONS`` with nothing comparing it to
+    ``_GATES_NOT_IMPLEMENTED_BY_CLOSURE``. A gate added to the enum and to
+    ``_GATES_NOT_IMPLEMENTED_BY_CLOSURE`` but forgotten in
+    ``_NON_REVIEW_SIGNER_REASONS`` would silently fall out of the complement
+    as a review peer — a gate the verifier cannot interpret would gain
+    signing power. This function makes that omission a hard failure instead.
+    """
+    non_review_set = frozenset(non_review_reasons)
+
+    unreadable_without_reason = sorted(not_implemented - non_review_set)
+    if unreadable_without_reason:
+        raise ValueError(
+            "gate(s) excluded from closure verification (not_implemented) "
+            "but missing a non-review-signer reason, so they cannot be "
+            f"classified as either a peer or a non-signer: {unreadable_without_reason}"
+        )
+
+    empty_reason = sorted(g for g, reason in non_review_reasons.items() if not reason)
+    if empty_reason:
+        raise ValueError(f"non-review-signer reason is empty for: {empty_reason}")
+
+    return frozenset(g for g in enum_values if g not in non_review_set)
+
+
+_REVIEW_PEER_GATES = classify_gate_signers(
+    (g.value for g in Gate), _GATES_NOT_IMPLEMENTED_BY_CLOSURE, _NON_REVIEW_SIGNER_REASONS
 )
 
 

--- a/tests/test_closure_verifier_gate_enum_drift.py
+++ b/tests/test_closure_verifier_gate_enum_drift.py
@@ -119,3 +119,55 @@ class TestKnownGatesDerivedFromEnum:
             "that would make closure for it structurally unreachable"
         )
         assert gate_name in cv._GATE_HANDLERS, f"{gate_name} must have a _GATE_HANDLERS entry"
+
+
+class TestGateSignerClassificationConsistency:
+    """OI-1645 follow-up (A6): _GATES_NOT_IMPLEMENTED_BY_CLOSURE and
+    _NON_REVIEW_SIGNER_REASONS are two independently-authored collections that
+    no existing test ever compared to each other. A gate added to the enum
+    and to _GATES_NOT_IMPLEMENTED_BY_CLOSURE but forgotten in
+    _NON_REVIEW_SIGNER_REASONS would, under the old plain complement
+    derivation (``enum minus _NON_REVIEW_SIGNER_REASONS``), silently land in
+    _REVIEW_PEER_GATES: a gate the closure verifier cannot even read would
+    gain peer-signing rights. These tests pin the missing comparison and the
+    pure function that now enforces it.
+    """
+
+    def test_not_implemented_is_a_subset_of_non_review_reasons(self):
+        """A gate the closure verifier cannot read can never sign — every
+        _GATES_NOT_IMPLEMENTED_BY_CLOSURE member must carry a matching
+        _NON_REVIEW_SIGNER_REASONS entry."""
+        assert cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE.issubset(
+            set(cv._NON_REVIEW_SIGNER_REASONS)
+        ), (
+            "gate(s) excluded from closure verification but missing a "
+            "non-review-signer reason: "
+            f"{sorted(cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE - set(cv._NON_REVIEW_SIGNER_REASONS))}"
+        )
+
+    def test_every_gate_value_lands_in_exactly_one_signer_class(self):
+        """Every Gate enum member is either a review peer or a non-review
+        signer with a non-empty reason. Never both, never neither."""
+        for gate in Gate:
+            is_peer = gate.value in cv._REVIEW_PEER_GATES
+            is_non_review = bool(cv._NON_REVIEW_SIGNER_REASONS.get(gate.value))
+            assert is_peer != is_non_review, (
+                f"{gate.value} must be in exactly one of _REVIEW_PEER_GATES or "
+                f"_NON_REVIEW_SIGNER_REASONS (with a non-empty reason); "
+                f"is_peer={is_peer}, is_non_review={is_non_review}"
+            )
+
+    def test_classify_gate_signers_rejects_unimplemented_gate_without_reason(self):
+        """The pure function behind _REVIEW_PEER_GATES must refuse to
+        classify a gate that is excluded from closure verification but has
+        no non-review-signer reason — the exact drift T0 measured on main
+        (f6bb65df): phantom_gate added to the enum and to
+        _GATES_NOT_IMPLEMENTED_BY_CLOSURE, forgotten in
+        _NON_REVIEW_SIGNER_REASONS, would otherwise silently gain
+        peer-signing rights via plain complement derivation."""
+        enum_values = {g.value for g in Gate} | {"phantom_gate"}
+        not_implemented = frozenset(cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE | {"phantom_gate"})
+        non_review_reasons = dict(cv._NON_REVIEW_SIGNER_REASONS)
+
+        with pytest.raises(ValueError, match="phantom_gate"):
+            cv.classify_gate_signers(enum_values, not_implemented, non_review_reasons)


### PR DESCRIPTION
## Summary
- Closes the gap where `_GATES_NOT_IMPLEMENTED_BY_CLOSURE` and `_NON_REVIEW_SIGNER_REASONS` were two independently-authored collections nothing ever compared to each other.
- A gate added to the `Gate` enum and to `_GATES_NOT_IMPLEMENTED_BY_CLOSURE` but forgotten in `_NON_REVIEW_SIGNER_REASONS` would, under the old plain-complement derivation, silently fall into `_REVIEW_PEER_GATES` — a gate the closure verifier cannot even read would gain peer-signing rights.
- Adds `classify_gate_signers()` (pure function) in `scripts/closure_verifier.py`, used to derive `_REVIEW_PEER_GATES` at import time. It raises `ValueError` when a gate excluded from closure verification has no non-review-signer reason, or when a reason string is empty — so the module itself fails at import instead of a fourth silently-drifting collection.
- Extends `tests/test_closure_verifier_gate_enum_drift.py` with `TestGateSignerClassificationConsistency` (3 tests): the subset invariant, the exactly-one-class invariant per `Gate` value, and a direct call into `classify_gate_signers` reproducing the exact `phantom_gate` drift T0 measured on main.

## Changes
- `scripts/closure_verifier.py` — lines 60-123 block only: added `classify_gate_signers()`, `_REVIEW_PEER_GATES` now derived through it instead of a bare complement.
- `tests/test_closure_verifier_gate_enum_drift.py` — added `TestGateSignerClassificationConsistency` with 3 new tests.

## Test plan
- [x] `pytest tests/test_closure_verifier_gate_enum_drift.py tests/test_oi1645_peer_is_review_gate.py` — 21 passed
- [x] `pytest tests/test_closure_verifier.py tests/test_closure_verifier_evidence_contract.py tests/test_closure_verifier_unknown_gate.py tests/test_closure_verifier_gate_enum_drift.py tests/test_oi1645_peer_is_review_gate.py` — 86 passed (no regressions in direct neighbours)
- [x] Manually reproduced the exact drift (`phantom_gate` in enum + in `_GATES_NOT_IMPLEMENTED_BY_CLOSURE`, missing from `_NON_REVIEW_SIGNER_REASONS`) against `classify_gate_signers` directly — confirmed `ValueError` raised naming `phantom_gate`
- [x] `dispatch_spec.py` unchanged in the final diff (`git diff --stat`)

Codex CLI and kimi are quota-unavailable per dispatch note; review via the glm-gate by T0.

Dispatch-ID: 20260906-a6-gate-enum-drift