### PR TITLE
fix(door): refuse the fire when the gate obligation cannot be registered; bookkeeping failures reach stderr and the receipt (OI-1617)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1153,6 +1153,18 @@ def _record_bookkeeping_failure(
     five (or a future sixth) call sites distinguishable in that ledger; "iets
     ging mis in de deur" would be too coarse to act on.
 
+    OI-1617 part 2: two more independent sinks were added alongside the
+    register-event above. First, a literal line written directly to
+    ``sys.stderr`` — never routed through ``logger.warning`` alone, because
+    this process's root logger carries no handler and a WARNING only reaches
+    stderr via Python's fragile lastResort handler (silenced the moment any
+    handler is attached to the root logger, e.g. pytest's ``caplog``).
+    Second, the same ``door_bookkeeping_failed`` fact is ALSO appended to
+    ``t0_receipts.ndjson`` (the actual receipt ledger, via the canonical
+    ``append_receipt`` path) — ``dispatch_register.ndjson`` is folded into
+    ``dispatch_register_events`` by ``build_t0_state.py`` alone; the receipt
+    ledger is what every other receipt reader already scans.
+
     Never raises: recording the failure must never itself become a second,
     worse failure. ``dispatch_register.append_event`` already swallows
     everything internally and returns False on any failure, so the try/except
@@ -1161,10 +1173,18 @@ def _record_bookkeeping_failure(
     other ``dispatch_register.append_event`` call site in this file already
     honors (see the register-emit and route-decision persist sites below):
     a test that lost its isolation must fail loudly, never be swallowed here.
+    The same re-raise contract applies to the ``append_receipt`` write below.
     """
     logger.warning(
         "[dispatch_cli] door bookkeeping failed site=%s dispatch=%s: %s",
         site, dispatch_id, exc,
+    )
+    # OI-1617 part 2: a direct stderr line, independent of logger handler
+    # configuration — see the docstring above for why logger.warning() alone
+    # is not a reliable stderr sink.
+    print(
+        f"[dispatch_cli] door bookkeeping failed site={site} dispatch={dispatch_id}: {exc}",
+        file=sys.stderr,
     )
     from vnx_paths import TestIsolationGuardError  # noqa: PLC0415
     try:
@@ -1180,6 +1200,29 @@ def _record_bookkeeping_failure(
     except Exception:  # vnx-silent-except: recording the failure must never raise a second, worse one
         logger.warning(
             "[dispatch_cli] door bookkeeping failure-record itself failed site=%s dispatch=%s",
+            site, dispatch_id,
+        )
+
+    try:
+        from append_receipt import append_receipt_payload  # noqa: PLC0415
+        append_receipt_payload(
+            {
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "event_type": "door_bookkeeping_failed",
+                "source": "dispatch_cli",
+                "dispatch_id": dispatch_id,
+                "site": site,
+                "error": f"{type(exc).__name__}: {exc}",
+            },
+            receipts_file=str(state_dir / "t0_receipts.ndjson"),
+            cache_window_seconds=0,
+            skip_enrichment=True,
+        )
+    except TestIsolationGuardError:  # vnx-silent-except: OI-1079 — must fail the test loudly, never swallowed here
+        raise
+    except Exception:  # vnx-silent-except: recording the failure must never raise a second, worse one
+        logger.warning(
+            "[dispatch_cli] door bookkeeping failure-record (receipt ledger) itself failed site=%s dispatch=%s",
             site, dispatch_id,
         )
 
@@ -1326,8 +1369,10 @@ def _spec_is_writing(spec: DispatchSpec) -> bool:
     return role_grants_write(spec.role)
 
 
-def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
-    """Best-effort: register the review-gate obligation for a door-accepted dispatch.
+def _register_gate_obligation(
+    spec: DispatchSpec, *, state_dir: Path,
+) -> Optional[ConstraintVerdict]:
+    """Register the review-gate obligation for a door-accepted dispatch.
 
     OI-876/OI-881: before this hook, ``spec.gate`` was read exactly once (by
     ``load_spec``) and then never consumed — a dispatch could declare
@@ -1345,17 +1390,34 @@ def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
     trace. A writing dispatch with an empty gate never reaches here — the door
     refuses it earlier (see the gate-required reject in ``run_dispatch``).
 
-    Never raises: bookkeeping must never block the door (same contract as
-    ``_persist_dispatch_row``).
+    dispatch-20260906-a3-obligation-loud / OI-1617: the gate-bearing branch
+    (``gate`` non-empty) is no longer best-effort. Before this, EVERY
+    exception here — including ``register_obligation`` itself failing — was
+    swallowed and the fire proceeded with no obligation on record. That is
+    the exact 2026-09-03 incident (OI-1617): ``_register_gate_obligation``
+    failed silently, the gate later PASSed on real evidence, and the door
+    still answered "NOT READY — no review-gate obligation declared" with no
+    trace of why. A registration failure on the gate-bearing route is
+    returned as a BLOCKING ``ConstraintVerdict`` instead, so ``run_dispatch``
+    refuses the fire rather than let an unreviewed or untraceable dispatch
+    through. The failure is still recorded via ``_record_bookkeeping_failure``
+    (stderr + both ledgers) before the verdict is returned, so the refusal
+    itself is never silent either.
+
+    The no-gate branch (read-only dispatch, ``gate`` empty) keeps the
+    original best-effort contract: recording "no gate was required" is
+    housekeeping, not a review obligation — a failure there still only
+    records a fact and lets the dispatch proceed, same as
+    ``_persist_dispatch_row``.
     """
     gate = (spec.gate or "").strip()
-    try:
-        from gate_obligations import (
-            pr_number_from_pr_id,
-            register_no_gate_obligation,
-            register_obligation,
-        )
-        if not gate:
+
+    if not gate:
+        try:
+            from gate_obligations import (
+                pr_number_from_pr_id,
+                register_no_gate_obligation,
+            )
             register_no_gate_obligation(
                 state_dir,
                 dispatch_id=spec.dispatch_id,
@@ -1368,7 +1430,17 @@ def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
                     "— no review gate required"
                 ),
             )
-            return
+        except Exception as exc:  # vnx-silent-except: the no-gate record is housekeeping, not a review obligation — bookkeeping must never block the door
+            _record_bookkeeping_failure(
+                "_register_gate_obligation", spec.dispatch_id, exc, state_dir=state_dir,
+            )
+        return None
+
+    try:
+        from gate_obligations import (
+            pr_number_from_pr_id,
+            register_obligation,
+        )
         # OI-1462: stamp what THIS process (the eiser) resolved for the
         # gate-requirement flags at registration time, so a fulfiller running
         # later in a different environment can be checked against it
@@ -1376,7 +1448,10 @@ def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
         # two sides silently disagreeing. A capture FAILURE is a distinct,
         # loud state (status="failed") -- never collapsed into "never
         # attempted" (None), which would blind check_gate_requirement_mismatch
-        # to exactly the broken-read scenario OI-1462 exists to catch.
+        # to exactly the broken-read scenario OI-1462 exists to catch. This
+        # inner capture stays best-effort/non-blocking on purpose: it
+        # annotates the obligation, it does not gate whether one gets
+        # registered.
         try:
             import config_runtime
             gate_requirement_resolution = {
@@ -1403,10 +1478,24 @@ def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
             pr_id=spec.pr_id,
             gate_requirement_resolution=gate_requirement_resolution,
         )
-    except Exception as exc:  # vnx-silent-except: door bookkeeping must never raise
+    except Exception as exc:
         _record_bookkeeping_failure(
             "_register_gate_obligation", spec.dispatch_id, exc, state_dir=state_dir,
         )
+        return ConstraintVerdict(
+            code="gate-obligation-registration-failed",
+            severity="blocking",
+            message=(
+                f"dispatch={spec.dispatch_id!r} gate={gate!r}: the review-gate "
+                f"obligation could not be registered ({type(exc).__name__}: {exc}). "
+                "Firing without a registered obligation reproduces OI-1617 (a "
+                "gate can PASS on real evidence while the door still answers "
+                "\"no review-gate obligation declared\", with no trace of why); "
+                "refusing to fire rather than risk an unreviewed or untraceable "
+                "dispatch. Fix the underlying failure and refire."
+            ),
+        )
+    return None
 
 
 def _persist_track_id(spec: DispatchSpec, *, state_dir: Path) -> None:
@@ -3184,7 +3273,14 @@ def run_dispatch(
             # Registered here — right after the dispatch is irrevocably
             # accepted — so every accepted dispatch with gate=<name> has a
             # checkable evidence trail from this point on.
-            _register_gate_obligation(vspec.spec, state_dir=state_dir)
+            # OI-1617: a gate-bearing dispatch whose obligation could not be
+            # registered is refused here, before any worker/adapter is
+            # invoked — see _register_gate_obligation's docstring for why a
+            # swallowed failure on this route reproduces OI-1617.
+            gate_obligation_verdict = _register_gate_obligation(vspec.spec, state_dir=state_dir)
+            if gate_obligation_verdict is not None:
+                _emit_reject(Reject(gate_obligation_verdict.code, gate_obligation_verdict.message))
+                return 1
 
             # TL-D1: export the resolved track_id alongside VNX_CURRENT_DISPATCH_ID and
             # persist it onto the dispatch tracker row so D2 can propagate it to

--- a/tests/test_dispatch_cli_obligation_loud.py
+++ b/tests/test_dispatch_cli_obligation_loud.py
@@ -1,0 +1,285 @@
+"""test_dispatch_cli_obligation_loud.py — dispatch-20260906-a3-obligation-loud / OI-1617:
+the door must not silently fire when a gate-bearing dispatch's review-gate obligation
+cannot be registered.
+
+Root cause under test (main f6bb65df): ``dispatch_cli._register_gate_obligation`` caught
+EVERY exception from ``gate_obligations.register_obligation`` — including the gate-bearing
+route — and called ``_record_bookkeeping_failure`` (a fact-recording, never-raise contract),
+then returned normally. The fire proceeded with no obligation on record. That is the exact
+2026-09-03 incident (OI-1617): the obligation failed to register, the gate later PASSed on
+real evidence, and the door still answered "NOT READY — no review-gate obligation declared"
+with zero trace of why.
+
+The fix has two parts, each pinned by tests here:
+
+  1. The gate-bearing route (``spec.gate`` non-empty) is no longer best-effort:
+     ``_register_gate_obligation`` returns a BLOCKING ``ConstraintVerdict`` (code
+     ``gate-obligation-registration-failed``) when ``register_obligation`` raises, and
+     ``run_dispatch`` refuses the fire — no adapter/worker is ever invoked. RED on
+     main: the fire proceeds anyway (see ``TestGateBearingRegistrationFailureRefusesFire``).
+  2. The no-gate route (read-only dispatch, ``spec.gate`` empty) keeps its original
+     best-effort contract — a failure there is still just a recorded fact, never a
+     refusal (``TestNoGateRouteStaysBestEffort``).
+
+A third class (``TestRecordBookkeepingFailureReachesStderrAndReceiptLedger``) pins the
+companion fix to ``_record_bookkeeping_failure`` itself: a bookkeeping failure now writes
+a literal line to stderr (not only through the logger, which has no handler on this
+process and is therefore an unreliable stderr sink) and appends a ``door_bookkeeping_failed``
+event to ``t0_receipts.ndjson`` (the actual receipt ledger every receipt reader scans), in
+addition to the existing ``dispatch_register.ndjson`` write. RED on main: neither the direct
+stderr line nor the receipt-ledger event exist.
+
+Fixture pattern (bundle layout, ``force_tmux`` opt-out) mirrors
+``tests/test_gate_obligations.py`` — the existing, working door-obligation test suite —
+rather than inventing a new one.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import dispatch_cli
+import gate_obligations
+from dispatch_cli import run_dispatch
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirrors tests/test_gate_obligations.py's _make_bundle)
+# ---------------------------------------------------------------------------
+
+
+def _make_bundle(
+    tmp_path: Path,
+    *,
+    staging_id: str,
+    dispatch_id: str,
+    gate: str,
+    dispatch_paths: "list[str] | None" = None,
+    role: str = "backend-developer",
+) -> "tuple[Path, Path]":
+    """A promoted-style staged bundle (spec + instruction inside the bundle dir).
+
+    ``force_tmux=True`` pins the claude lane to ``claude_tmux_subscription``
+    (``_execute_claude``) instead of the new-default ``claude_headless`` lane —
+    tmp_path is not a real git repo, and the headless lane's worktree creation
+    correctly hard-aborts on a non-git cwd. These tests assert on door-level
+    gate-obligation state, not on lane execution, so the tmux opt-out (same one
+    tests/test_gate_obligations.py uses) keeps the fixture out of that guard's way.
+    """
+    data_dir = tmp_path / "vnx-data"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    instruction = bundle_dir / "instruction.md"
+    instruction.write_text("Do something useful.", encoding="utf-8")
+    spec = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": dispatch_id,
+        "staging_id": staging_id,
+        "instruction_file": str(instruction),
+        "role": role,
+        "target_slot": "T0",
+        "gate": gate,
+        "dispatch_paths": [{"path": p} for p in (dispatch_paths or [])],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+        "force_tmux": True,
+        "force_tmux_reason": "door test asserts gate obligation state, not lane behavior; tmp_path is not a real git repo",
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return data_dir, spec_file
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "vnx-data" / "state"
+    (state_dir / "review_gates" / "requests").mkdir(parents=True, exist_ok=True)
+    (state_dir / "review_gates" / "results").mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _read_ndjson(path: Path) -> "list[dict]":
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Part 1: gate-bearing registration failure refuses the fire.
+# ---------------------------------------------------------------------------
+
+
+class TestGateBearingRegistrationFailureRefusesFire:
+    def test_register_obligation_raising_refuses_the_fire_no_worker_invoked(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        data_dir, spec_file = _make_bundle(
+            tmp_path,
+            staging_id="20260906-staging-gate-fail",
+            dispatch_id="20260906-a3-gate-fail",
+            gate="codex_gate",
+            dispatch_paths=["scripts/lib/dispatch_cli.py"],
+            role="backend-developer",
+        )
+        _make_state_dir(tmp_path)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        def _raising_register_obligation(*_args, **_kwargs):
+            raise OSError("simulated: obligation write failed")
+
+        monkeypatch.setattr(gate_obligations, "register_obligation", _raising_register_obligation)
+
+        with patch("dispatch_cli._execute_claude", return_value=0) as mock_tmux:
+            with patch("dispatch_cli._execute_claude_headless", return_value=0) as mock_headless:
+                rc = run_dispatch(spec_file)
+
+        assert rc == 1, "a gate-bearing dispatch whose obligation cannot be registered must be refused"
+        mock_tmux.assert_not_called()
+        mock_headless.assert_not_called()
+
+        err = capsys.readouterr().err
+        assert "gate-obligation-registration-failed" in err
+        assert "obligation write failed" in err
+
+    def test_verdict_is_returned_directly_from_register_gate_obligation(self, tmp_path, monkeypatch):
+        """Narrower unit-level pin on _register_gate_obligation itself, independent
+        of the full run_dispatch plumbing above."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+
+        def _raising_register_obligation(*_args, **_kwargs):
+            raise OSError("simulated: obligation write failed")
+
+        monkeypatch.setattr(gate_obligations, "register_obligation", _raising_register_obligation)
+
+        import types
+        spec = types.SimpleNamespace(
+            gate="codex_gate", dispatch_id="20260906-a3-unit-gate-fail",
+            project_id="vnx-dev", pr_id=None,
+        )
+
+        verdict = dispatch_cli._register_gate_obligation(spec, state_dir=state_dir)
+
+        assert verdict is not None
+        assert verdict.code == "gate-obligation-registration-failed"
+        assert verdict.severity == "blocking"
+        assert "obligation write failed" in verdict.message
+
+        # The failure is still recorded as a fact (both ledgers), never silent.
+        facts = [
+            r for r in _read_ndjson(state_dir / "dispatch_register.ndjson")
+            if r.get("event") == "door_bookkeeping_failed"
+        ]
+        assert facts, "expected a door_bookkeeping_failed record in dispatch_register.ndjson"
+        assert facts[-1]["extra"]["site"] == "_register_gate_obligation"
+
+
+# ---------------------------------------------------------------------------
+# Part 2: the no-gate route keeps its original best-effort contract.
+# ---------------------------------------------------------------------------
+
+
+class TestNoGateRouteStaysBestEffort:
+    def test_register_no_gate_obligation_raising_does_not_block_a_read_only_fire(
+        self, tmp_path, monkeypatch,
+    ):
+        data_dir, spec_file = _make_bundle(
+            tmp_path,
+            staging_id="20260906-staging-nogate-fail",
+            dispatch_id="20260906-a3-nogate-fail",
+            gate="",
+            dispatch_paths=[],
+            role="code-reviewer",
+        )
+        _make_state_dir(tmp_path)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        import smart_router
+
+        def _router_boom(**_kwargs):
+            raise RuntimeError("smart-router derivation exploded")
+
+        monkeypatch.setattr(smart_router, "resolve_gate", _router_boom)
+
+        def _raising_register_no_gate_obligation(*_args, **_kwargs):
+            raise OSError("simulated: no-gate record write failed")
+
+        monkeypatch.setattr(
+            gate_obligations, "register_no_gate_obligation", _raising_register_no_gate_obligation,
+        )
+
+        with patch("dispatch_cli._execute_claude", return_value=0) as mock_tmux:
+            rc = run_dispatch(spec_file)
+
+        assert rc == 0, "a read-only dispatch must still fire even when its no-gate record fails"
+        mock_tmux.assert_called_once()
+
+        facts = [
+            r for r in _read_ndjson(data_dir / "state" / "dispatch_register.ndjson")
+            if r.get("event") == "door_bookkeeping_failed"
+        ]
+        assert facts, "expected a door_bookkeeping_failed record for the failed no-gate write"
+        assert facts[-1]["dispatch_id"] == "20260906-a3-nogate-fail"
+        assert facts[-1]["extra"]["site"] == "_register_gate_obligation"
+        assert "no-gate record write failed" in facts[-1]["extra"]["error"]
+
+        receipt_facts = [
+            r for r in _read_ndjson(data_dir / "state" / "t0_receipts.ndjson")
+            if r.get("event_type") == "door_bookkeeping_failed"
+        ]
+        assert receipt_facts, "expected a door_bookkeeping_failed receipt in t0_receipts.ndjson"
+        assert receipt_facts[-1]["dispatch_id"] == "20260906-a3-nogate-fail"
+        assert receipt_facts[-1]["site"] == "_register_gate_obligation"
+
+
+# ---------------------------------------------------------------------------
+# Part 3: _record_bookkeeping_failure reaches stderr (directly) and the
+# receipt ledger, in addition to the pre-existing dispatch_register.ndjson write.
+# ---------------------------------------------------------------------------
+
+
+class TestRecordBookkeepingFailureReachesStderrAndReceiptLedger:
+    def test_stderr_and_receipt_ledger_both_carry_the_fact(self, tmp_path, capsys):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+
+        dispatch_cli._record_bookkeeping_failure(
+            "unit-test-site", "20260906-a3-direct-unit", ValueError("boom"), state_dir=state_dir,
+        )
+
+        err = capsys.readouterr().err
+        assert "door bookkeeping failed site=unit-test-site" in err
+        assert "20260906-a3-direct-unit" in err
+        assert "boom" in err
+
+        receipt_facts = [
+            r for r in _read_ndjson(state_dir / "t0_receipts.ndjson")
+            if r.get("event_type") == "door_bookkeeping_failed"
+        ]
+        assert receipt_facts, "expected a door_bookkeeping_failed receipt in t0_receipts.ndjson"
+        fact = receipt_facts[-1]
+        assert fact["dispatch_id"] == "20260906-a3-direct-unit"
+        assert fact["site"] == "unit-test-site"
+        assert "boom" in fact["error"]
+
+        # The pre-existing dispatch_register.ndjson write must still happen —
+        # this fix is additive, not a replacement.
+        register_facts = [
+            r for r in _read_ndjson(state_dir / "dispatch_register.ndjson")
+            if r.get("event") == "door_bookkeeping_failed"
+        ]
+        assert register_facts, "the original dispatch_register.ndjson fact must still be written"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- `_register_gate_obligation`'s gate-bearing branch (`spec.gate` non-empty) no longer swallows a `register_obligation` failure and fires anyway. It now returns a BLOCKING `ConstraintVerdict` (`gate-obligation-registration-failed`), and `run_dispatch` refuses the fire before any worker/adapter is invoked — closing the exact OI-1617 gap (2026-09-03: obligation registration failed silently, gate later PASSed on real evidence, door still answered "no review-gate obligation declared" with zero trace of why).
- The no-gate route (read-only dispatch, `spec.gate` empty) keeps its original best-effort contract: a failure there is still just a recorded fact, never a refusal.
- `_record_bookkeeping_failure` now writes a direct `sys.stderr` line (a bare `logger.warning` is not a reliable stderr sink on this process — no handler on the root logger) and appends the `door_bookkeeping_failed` fact to `t0_receipts.ndjson` via the canonical `append_receipt` path, in addition to the pre-existing `dispatch_register.ndjson` write.

## Changes
- `scripts/lib/dispatch_cli.py`
  - `_record_bookkeeping_failure`: added a direct stderr print and a `door_bookkeeping_failed` receipt-ledger append (via `append_receipt.append_receipt_payload`, `skip_enrichment=True`), both re-raising `TestIsolationGuardError` per the existing contract.
  - `_register_gate_obligation`: split into a no-gate branch (unchanged best-effort contract, own try/except) and a gate-bearing branch that returns `Optional[ConstraintVerdict]` — `None` on success, a blocking verdict on registration failure.
  - `run_dispatch`: checks the new return value; on a non-`None` verdict it emits the reject and returns 1 before touching the lane executor.
- `tests/test_dispatch_cli_obligation_loud.py` (new): 4 tests covering the gate-bearing refusal (full `run_dispatch` + a narrower unit-level check), the no-gate best-effort contract, and the stderr/receipt-ledger sinks on `_record_bookkeeping_failure` directly.

## Test plan
- [x] `pytest tests/test_dispatch_cli_obligation_loud.py -v` → 4 passed (after the fix)
- [x] Same 4 tests run against unmodified `main` (`git stash` of `dispatch_cli.py` only) → all 4 RED, confirming they exercise the actual defect
- [x] Kapotmaak-proef: temporarily reverted the gate-bearing branch to `return None` (old best-effort shape) → the 2 fire-refusal tests turned red, the 2 no-gate/bookkeeping tests stayed green; reverted back → green again
- [x] `pytest tests/test_door_bookkeeping_facts_contract.py tests/test_gate_obligations.py tests/test_dispatch_cli_obligation_loud.py -q` → 80 passed
- [x] `pytest tests/test_dispatch_cli.py -q` → 226 passed, 6 pre-existing failures unrelated to this change (nested-worktree nested-worktree artifact — `.git/worktrees` not a directory — confirmed present on unmodified `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)