### PR TITLE
fix(gates): execution_depth on every lane; a verdict without investigation is no verdict (OI-1618)

### DIFF
--- a/scripts/gate_reanchor_cli.py
+++ b/scripts/gate_reanchor_cli.py
@@ -43,6 +43,7 @@ for _p in (str(SCRIPT_DIR / "lib"), str(SCRIPT_DIR)):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+import gate_depth  # noqa: E402  OI-1618: carry the original run's depth forward, never re-measure
 import gate_reanchor  # noqa: E402
 from gate_artifacts import _compute_contract_hash  # noqa: E402  canonical hasher, never a second one
 from gate_register_emit import register_path  # noqa: E402  one resolver, not a second copy
@@ -315,6 +316,13 @@ def main(argv: Optional[list] = None) -> int:
     payload = build_reanchored_payload(
         record, new_sha=new_sha, new_branch=new_branch, decision=decision,
     )
+    # OI-1618: a re-anchor reviews nothing new — it carries the ORIGINAL run's
+    # own execution_depth forward, exactly as it already carries the original
+    # verdict forward, instead of manufacturing a fresh measurement.
+    # gate_depth.from_dict degrades gracefully to the unmeasured depth on a
+    # pre-OI-1618 record that has no execution_depth field at all, which
+    # record_terminal_result never reads as degenerate.
+    execution_depth = gate_depth.from_dict(record.get("execution_depth"))
     result_path = results_dir / f"pr-{args.pr}-{args.gate}.json"
     try:
         with exclusive_result_lock(result_path):
@@ -324,6 +332,7 @@ def main(argv: Optional[list] = None) -> int:
                 pr_id=str(args.pr),
                 result_path=result_path,
                 payload=payload,
+                execution_depth=execution_depth,
             )
     except (OSError, ValueError, ResultOverwriteRefused) as exc:
         print(f"gate-reanchor: the guarded write refused: {exc}", file=sys.stderr)

--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -102,6 +102,7 @@ from gate_recorder import (
     record_terminal_result,
     stamp_request_identity,
 )
+import gate_depth  # OI-1618: a verdict without investigation is no verdict, on every lane
 from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
 from gate_prompt import (  # OI-1442: the diff is data, not instruction
     build_review_prompt,
@@ -548,11 +549,26 @@ def main(argv: "list[str] | None" = None) -> int:
         # one commit to a verdict formalized against another.
         scan_findings: list = []
         duration = _frontmatter_duration_seconds(report_text)
+        # OI-1618: --reprocess never re-fetches the diff (see above), so there
+        # is nothing to measure here either — the "not measured" depth, which
+        # gate_depth.is_degenerate always reads as unmeasured rather than
+        # degenerate, never re-evaluated retroactively against a floor this
+        # run was never held to when it originally executed.
+        execution_depth = gate_depth.ExecutionDepth()
     else:
         diff = _get_diff(args.pr, args.diff_file)
         if not diff:
             print(f"glm_gate: no diff for PR {args.pr}", file=sys.stderr)
             return 1
+
+        # OI-1618: the diff IS the investigation for a single-shot lane — no
+        # agentic tool loop to measure. diff_chars is the post-strip length
+        # (the single-shot degeneracy floor), diff_truncated mirrors the same
+        # MAX_DIFF_CHARS cap gate_prompt.wrap_untrusted_diff applies to the
+        # raw (pre-strip) text.
+        execution_depth = gate_depth.single_shot_depth(
+            len(diff.strip()), len(diff) > MAX_DIFF_CHARS,
+        )
 
         # dispatch_id is already resolved above (shared with the request record).
         # role="review-gate" (dispatch-20260823-beta2-j): the default role of
@@ -900,6 +916,7 @@ def main(argv: "list[str] | None" = None) -> int:
     try:
         record_terminal_result(
             gate="glm_gate", pr_id=record["pr_id"], result_path=out, payload=record,
+            execution_depth=execution_depth,
         )
     except (OSError, ValueError) as exc:
         # A poort that cannot persist its own evidence must fail LOUDLY, not
@@ -907,6 +924,16 @@ def main(argv: "list[str] | None" = None) -> int:
         print(f"glm_gate: FAILED to write result record to {out}: {exc}", file=sys.stderr)
         return 1
     print(f"glm_gate: wrote {out}", file=sys.stderr)
+
+    # OI-1618: the recorder may have just downgraded a degenerate pass/fail to
+    # unavailable IN PLACE — `record` is the same dict object, so it already
+    # reflects that. Resync the locals so the printed VERDICT and the exit
+    # code below match what actually landed on disk, instead of echoing a
+    # verdict this run never earned.
+    status = record.get("status", status)
+    reason = record.get("reason", reason)
+    residual = record.get("residual_risk", residual)
+    blocking = record.get("blocking_findings", blocking)
 
     if args.json:
         print(json.dumps(record, indent=2))

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -114,6 +114,7 @@ from gate_recorder import (
     record_terminal_result,
     stamp_request_identity,
 )
+import gate_depth  # OI-1618: a verdict without investigation is no verdict, on every lane
 from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
 from gate_prompt import (  # OI-1442: the diff is data, not instruction
     build_review_prompt,
@@ -526,11 +527,26 @@ def main(argv: "list[str] | None" = None) -> int:
         # against another.
         scan_findings: list = []
         duration = _frontmatter_duration_seconds(report_text)
+        # OI-1618: --reprocess never re-fetches the diff (see above), so there
+        # is nothing to measure here either — the "not measured" depth, which
+        # gate_depth.is_degenerate always reads as unmeasured rather than
+        # degenerate, never re-evaluated retroactively against a floor this
+        # run was never held to when it originally executed.
+        execution_depth = gate_depth.ExecutionDepth()
     else:
         diff = _get_diff(args.pr, args.diff_file)
         if not diff:
             print(f"kimi_gate: no diff for PR {args.pr}", file=sys.stderr)
             return 1
+
+        # OI-1618: the diff IS the investigation for a single-shot lane — no
+        # agentic tool loop to measure. diff_chars is the post-strip length
+        # (the single-shot degeneracy floor), diff_truncated mirrors the same
+        # MAX_DIFF_CHARS cap gate_prompt.wrap_untrusted_diff applies to the
+        # raw (pre-strip) text.
+        execution_depth = gate_depth.single_shot_depth(
+            len(diff.strip()), len(diff) > MAX_DIFF_CHARS,
+        )
 
         # dispatch_id is already resolved above (shared with the request record).
         # role="review-gate" (dispatch-20260823-beta2-j): see glm_gate.py's
@@ -862,6 +878,7 @@ def main(argv: "list[str] | None" = None) -> int:
     try:
         record_terminal_result(
             gate="kimi_gate", pr_id=record["pr_id"], result_path=out, payload=record,
+            execution_depth=execution_depth,
         )
     except (OSError, ValueError) as exc:
         # A poort that cannot persist its own evidence must fail LOUDLY, not
@@ -869,6 +886,16 @@ def main(argv: "list[str] | None" = None) -> int:
         print(f"kimi_gate: FAILED to write result record to {out}: {exc}", file=sys.stderr)
         return 1
     print(f"kimi_gate: wrote {out}", file=sys.stderr)
+
+    # OI-1618: the recorder may have just downgraded a degenerate pass/fail to
+    # unavailable IN PLACE — `record` is the same dict object, so it already
+    # reflects that. Resync the locals so the printed VERDICT and the exit
+    # code below match what actually landed on disk, instead of echoing a
+    # verdict this run never earned.
+    status = record.get("status", status)
+    reason = record.get("reason", reason)
+    residual = record.get("residual_risk", residual)
+    blocking = record.get("blocking_findings", blocking)
 
     if args.json:
         print(json.dumps(record, indent=2))

--- a/scripts/lib/gate_depth.py
+++ b/scripts/lib/gate_depth.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
@@ -91,11 +91,23 @@ class ExecutionDepth:
     and zeros that mean "not measured" must never be read as zeros that mean
     "did nothing" — that is the difference between an unmeasured gate and a
     degenerate one, and collapsing it would fail every gate whose lane emits
-    no event stream. Only codex_gate emits one today; kimi_gate and glm_gate
-    reports carry no events at all.
+    no event stream. Only codex_gate/gemini_review emit one today.
+
+    ``mode`` distinguishes the TWO shapes this dataclass now carries (OI-1618):
+    ``"agentic"`` (the tool-call stream above, measured by
+    :func:`measure_execution_depth`) and ``"single_shot"`` (a one-shot API
+    lane — glm_gate/kimi_gate — measured by :func:`single_shot_depth`).
+    ``investigative_actions``/``shell_calls``/``files_read``/
+    ``agent_messages``/``unrecognised_item_types`` only ever mean anything in
+    agentic mode; ``diff_chars``/``diff_truncated`` only ever mean anything in
+    single_shot mode. One dataclass, not two, so
+    :func:`gate_recorder.record_terminal_result` can hold every terminal
+    writer to the same requirement without knowing which lane produced the
+    measurement.
     """
 
     parsed: bool = False
+    mode: str = "agentic"
     investigative_actions: int = 0
     shell_calls: int = 0
     files_read: int = 0
@@ -103,9 +115,22 @@ class ExecutionDepth:
     input_tokens: int = 0
     output_tokens: int = 0
     unrecognised_item_types: tuple = ()
+    diff_chars: int = 0
+    diff_truncated: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
+        """JSON-shaped dict: ``unrecognised_item_types`` normalizes to a list.
+
+        ``asdict()`` alone preserves the field's tuple type. JSON has no tuple
+        type, so a round trip through disk (write, then ``json.loads`` it back)
+        already turns it into a list -- normalizing here means the in-memory
+        dict a caller stamps onto its own payload (record_terminal_result does
+        exactly this) agrees with what a reader gets back from the file,
+        instead of silently disagreeing only on this one field's type.
+        """
+        data = asdict(self)
+        data["unrecognised_item_types"] = list(data["unrecognised_item_types"])
+        return data
 
 
 def measure_execution_depth(stdout: str) -> ExecutionDepth:
@@ -172,6 +197,7 @@ def measure_execution_depth(stdout: str) -> ExecutionDepth:
 
     return ExecutionDepth(
         parsed=True,
+        mode="agentic",
         investigative_actions=investigative,
         shell_calls=shell,
         files_read=reads,
@@ -182,6 +208,57 @@ def measure_execution_depth(stdout: str) -> ExecutionDepth:
     )
 
 
+def single_shot_depth(diff_chars: int, diff_truncated: bool) -> ExecutionDepth:
+    """Depth for a single-shot review lane (glm_gate/kimi_gate): one API call
+    against a diff, no agentic tool loop to count shell calls or file reads
+    from (OI-1618). The diff IS the investigation — there is nothing else the
+    run could have looked at — so the only question degeneracy can ask here is
+    whether the diff carried anything at all.
+
+    ``diff_chars`` is the caller's own post-strip length (``len(diff.strip())``),
+    not the raw byte count — :func:`is_degenerate` trusts this value directly
+    rather than re-deriving it, so the "0 chars after strip" rule lives in one
+    place (the caller that already has the raw text) instead of two.
+    ``diff_truncated`` records whether the gate's own ``MAX_DIFF_CHARS`` cap
+    fired; it is carried for the evidence trail only, never treated as
+    degenerate on its own (see :func:`is_degenerate`).
+    """
+    return ExecutionDepth(
+        parsed=True,
+        mode="single_shot",
+        diff_chars=diff_chars,
+        diff_truncated=diff_truncated,
+    )
+
+
+def from_dict(data: Any) -> ExecutionDepth:
+    """Reconstruct an :class:`ExecutionDepth` from its own ``to_dict()`` output.
+
+    Used to carry a depth measurement FORWARD without re-measuring — a
+    re-anchored verdict (``gate_reanchor_cli.py``) reviewed nothing new, so it
+    takes the ORIGINAL run's depth rather than manufacturing a fresh one
+    (OI-1618), exactly as it already carries the original verdict forward.
+
+    Anything that is not a dict, or a dict with no recognisable fields (a
+    record written before this module tracked ``execution_depth`` at all),
+    reconstructs to the default ``parsed=False`` depth — which
+    :func:`is_degenerate` always reads as "not measured", never as
+    "degenerate". That is the same never-guess-on-absence rule this module
+    already applies to a stream it cannot parse; a stale record must not be
+    retroactively held to a floor it was never measured against.
+    """
+    if not isinstance(data, dict):
+        return ExecutionDepth()
+    known = {f.name for f in fields(ExecutionDepth)}
+    kwargs = {k: v for k, v in data.items() if k in known}
+    if kwargs.get("unrecognised_item_types") is not None:
+        kwargs["unrecognised_item_types"] = tuple(kwargs["unrecognised_item_types"])
+    try:
+        return ExecutionDepth(**kwargs)
+    except TypeError:
+        return ExecutionDepth()
+
+
 def is_degenerate(depth: ExecutionDepth) -> bool:
     """True when the run reached a verdict without taking a single action.
 
@@ -189,9 +266,17 @@ def is_degenerate(depth: ExecutionDepth) -> bool:
     event stream must keep working exactly as before: this check exists to
     stop a measured emptiness from being accepted, not to demand that every
     lane become measurable first.
+
+    Single-shot mode (OI-1618) asks a different question than agentic mode:
+    there are no tool calls to count, so degeneracy is EXCLUSIVELY an empty
+    diff (0 characters after strip). Truncation is a fact about size, never
+    about content, and is never degenerate on its own — a diff capped at
+    ``MAX_DIFF_CHARS`` still handed the model real material to review.
     """
     if not depth.parsed:
         return False
+    if depth.mode == "single_shot":
+        return depth.diff_chars == 0
     if depth.unrecognised_item_types:
         # The stream carried an item type this module cannot classify, so the
         # action count is a floor and not a measurement. Refusing on it would
@@ -203,6 +288,12 @@ def is_degenerate(depth: ExecutionDepth) -> bool:
 
 def degenerate_detail(depth: ExecutionDepth) -> str:
     """The human-readable why, carried into the result record's reason_detail."""
+    if depth.mode == "single_shot":
+        return (
+            f"single-shot gate reviewed a diff of {depth.diff_chars} character(s) "
+            f"after strip (diff_truncated={depth.diff_truncated}) — a verdict "
+            "reached against an empty diff is not gate evidence"
+        )
     return (
         f"the run produced {depth.agent_messages} message(s) and "
         f"{depth.investigative_actions} investigative action(s) "
@@ -217,6 +308,8 @@ __all__ = [
     "ExecutionDepth",
     "MIN_INVESTIGATIVE_ACTIONS",
     "degenerate_detail",
+    "from_dict",
     "is_degenerate",
     "measure_execution_depth",
+    "single_shot_depth",
 ]

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from atomic_io import atomic_write_json, slot_lock
 from governance_receipts import utc_now_iso
+import gate_depth
 
 logger = logging.getLogger(__name__)
 
@@ -613,6 +614,7 @@ def record_terminal_result(
     pr_id: str,
     result_path: Path,
     payload: Dict[str, Any],
+    execution_depth: gate_depth.ExecutionDepth,
 ) -> Path:
     """Atomically persist a terminal (pass/fail) gate result at an explicit path.
 
@@ -637,8 +639,48 @@ def record_terminal_result(
     less-decided one — see :func:`_check_overwrite_guard`. glm_gate.py and
     kimi_gate.py already catch ``(OSError, ValueError)`` around this call and
     fail loudly rather than silently overwrite (OI-1469/OI-1470).
+
+    ``execution_depth`` has no default (OI-1618): every writer must supply
+    the depth it actually measured — agentic
+    (:func:`gate_depth.measure_execution_depth`), single-shot
+    (:func:`gate_depth.single_shot_depth`), or carried forward from a prior
+    record (:func:`gate_depth.from_dict`, used by a re-anchor, which reviewed
+    nothing new). A default would be exactly the silent "some investigation
+    happened" assumption this parameter exists to remove. A pass/fail verdict
+    whose depth is degenerate (:func:`gate_depth.is_degenerate`) is
+    reclassified HERE, unconditionally, to ``unavailable``/
+    ``gate_execution_degenerate`` — the SAME reclassification
+    :func:`gate_artifacts.materialize_artifacts` already applies to the
+    codex/gemini lane (OI-1485), lifted to the one place every lane's
+    terminal write passes through so a single-shot lane (glm_gate/kimi_gate)
+    gets it without reimplementing the check itself. The reclassification
+    mutates ``payload`` in place — the same convention
+    :func:`_write_result_atomic` already uses for ``failure_reason`` — so a
+    caller inspecting its own dict after the call sees the same verdict the
+    file carries, never a stale pass/fail the write itself overturned.
+    Scoped to :data:`gate_status.PASS_STATES`/:data:`gate_status.FAIL_STATES`
+    only: a ``not_executable`` record never ran in the first place, so
+    "did it investigate" does not apply to it.
     """
-    from gate_status import is_terminal, has_producer_identity  # noqa: PLC0415
+    from gate_status import (  # noqa: PLC0415
+        FAIL_STATES, PASS_STATES, canonical_status, has_producer_identity, is_terminal,
+    )
+
+    if canonical_status(payload) in (PASS_STATES | FAIL_STATES) and gate_depth.is_degenerate(execution_depth):
+        detail = gate_depth.degenerate_detail(execution_depth)
+        logger.warning(
+            "gate_recorder: REFUSING a degenerate %s verdict pr=%s — %s",
+            gate, pr_id, detail,
+        )
+        payload["status"] = "unavailable"
+        payload["reason"] = "gate_execution_degenerate"
+        payload["reason_detail"] = detail
+        payload["summary"] = (
+            f"{gate} UNAVAILABLE (gate_execution_degenerate: {detail}) — NOT a review fail"
+        )
+        payload["contract_hash"] = ""
+        payload["blocking_findings"] = []
+    payload["execution_depth"] = execution_depth.to_dict()
 
     if is_terminal(payload) and not has_producer_identity(payload):
         raise ValueError(

--- a/tests/fixtures/pr-1749-codex_gate.degenerate.json
+++ b/tests/fixtures/pr-1749-codex_gate.degenerate.json
@@ -1,0 +1,36 @@
+{
+  "gate": "codex_gate",
+  "pr_id": "1749",
+  "pr_number": 1749,
+  "status": "unavailable",
+  "reason": "gate_execution_degenerate",
+  "reason_detail": "the run produced 1 message(s) and 0 investigative action(s) (minimum 1); 0 shell call(s), 0 file read(s), 23914 input tokens — a verdict reached without looking at anything beyond the prompt is not gate evidence",
+  "duration_seconds": 18.078953791991808,
+  "partial_output_lines": 4,
+  "runner_pid": 10635,
+  "killed_at": "2026-09-04T08:17:02Z",
+  "summary": "codex_gate UNAVAILABLE (gate did not run — gate_execution_degenerate: the run produced 1 message(s) and 0 investigative action(s) (minimum 1); 0 shell call(s), 0 file read(s), 23914 input tokens — a verdict reached without looking at anything beyond the prompt is not gate evidence) — NOT a review fail",
+  "contract_hash": "",
+  "report_path": "",
+  "blocking_findings": [],
+  "advisory_findings": [],
+  "required_reruns": [
+    "codex_gate"
+  ],
+  "residual_risk": "Gate gate_execution_degenerate. Re-run required.",
+  "recorded_at": "2026-09-04T08:17:02Z",
+  "execution_depth": {
+    "parsed": true,
+    "investigative_actions": 0,
+    "shell_calls": 0,
+    "files_read": 0,
+    "agent_messages": 1,
+    "input_tokens": 23914,
+    "output_tokens": 591,
+    "unrecognised_item_types": []
+  },
+  "degenerate_report_path": "/Users/vincentvandeth/.vnx-data/vnx-dev/unified_reports/headless/20260904-081641-HEADLESS-codex_gate-pr-1749-4a6c8a.md",
+  "branch": "dispatch/20260903-deur-boekhouding-luid",
+  "commit_sha": "a9a2863e100b3cc18267d6a50f4af33101f91dbd",
+  "failure_reason": "the run produced 1 message(s) and 0 investigative action(s) (minimum 1); 0 shell call(s), 0 file read(s), 23914 input tokens — a verdict reached without looking at anything beyond the prompt is not gate evidence"
+}

--- a/tests/test_dlv1_glm_gate.py
+++ b/tests/test_dlv1_glm_gate.py
@@ -545,3 +545,61 @@ def test_glm_clean_diff_adds_no_scan_findings(glm_gate, tmp_path, monkeypatch):
         glm_gate, tmp_path, monkeypatch, _FAKE_DIFF, _REAL_PASS_REPORT, pr="4303",
     )
     assert record["advisory_findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# 11. OI-1618: a verdict without investigation is no verdict, on a
+#     single-shot lane too. glm_gate has no agentic tool loop to measure --
+#     the diff IS the investigation, so degeneracy here means the diff
+#     itself carried nothing. main()'s own `if not diff:` guard only catches
+#     a truly empty string; a whitespace-only file is still truthy in Python
+#     (`bool(" \n")` is True) and reaches the dispatcher, so an empty-after-
+#     strip diff is the one shape that must be caught downstream, by the
+#     recorder. Truncation (MAX_DIFF_CHARS) is a fact about size, never
+#     about content, and must never be read as degenerate.
+# ---------------------------------------------------------------------------
+
+
+def test_pass_verdict_on_whitespace_only_diff_becomes_unavailable_degenerate(
+    glm_gate, tmp_path, monkeypatch,
+):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text("   \n\t\n", encoding="utf-8")  # truthy string, strips to ""
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = glm_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-glm_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 1, "a degenerate verdict must exit as unavailable/infra, never 0 (pass) or 2 (fail)"
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "gate_execution_degenerate"
+    assert record["contract_hash"] == ""
+    assert record["execution_depth"]["mode"] == "single_shot"
+    assert record["execution_depth"]["diff_chars"] == 0
+
+
+def test_pass_verdict_on_truncated_but_nonempty_diff_stays_pass(glm_gate, tmp_path, monkeypatch):
+    """A ~60000-character diff capped at MAX_DIFF_CHARS (50000) still handed
+    the model real content to review — truncation alone must never flip a
+    real pass into unavailable."""
+    big_diff = "diff --git a/x b/x\n" + ("+ok\n" * 15000)
+    assert len(big_diff) > glm_gate.MAX_DIFF_CHARS
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(big_diff, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(
+        glm_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = glm_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-glm_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["execution_depth"]["mode"] == "single_shot"
+    assert record["execution_depth"]["diff_truncated"] is True

--- a/tests/test_dlv2_kimi_gate_evidence.py
+++ b/tests/test_dlv2_kimi_gate_evidence.py
@@ -314,3 +314,58 @@ def test_kimi_clean_diff_adds_no_scan_findings(tmp_path, monkeypatch):
         tmp_path, monkeypatch, _FAKE_DIFF, _REAL_PASS_REPORT, pr="4403",
     )
     assert record["advisory_findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# OI-1618: a verdict without investigation is no verdict, on a single-shot
+# lane too. kimi_gate has no agentic tool loop to measure -- the diff IS the
+# investigation, so degeneracy here means the diff itself carried nothing.
+# main()'s own `if not diff:` guard only catches a truly empty string; a
+# whitespace-only file is still truthy in Python and reaches the dispatcher,
+# so an empty-after-strip diff is the one shape that must be caught
+# downstream, by the recorder. Truncation (MAX_DIFF_CHARS) is a fact about
+# size, never about content, and must never be read as degenerate.
+# ---------------------------------------------------------------------------
+
+
+def test_pass_verdict_on_whitespace_only_diff_becomes_unavailable_degenerate(tmp_path, monkeypatch):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text("   \n\t\n", encoding="utf-8")  # truthy string, strips to ""
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 1, "a degenerate verdict must exit as unavailable/infra, never 0 (pass) or 2 (fail)"
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "gate_execution_degenerate"
+    assert record["contract_hash"] == ""
+    assert record["execution_depth"]["mode"] == "single_shot"
+    assert record["execution_depth"]["diff_chars"] == 0
+
+
+def test_pass_verdict_on_truncated_but_nonempty_diff_stays_pass(tmp_path, monkeypatch):
+    """A ~60000-character diff capped at MAX_DIFF_CHARS (50000) still handed
+    the model real content to review — truncation alone must never flip a
+    real pass into unavailable."""
+    big_diff = "diff --git a/x b/x\n" + ("+ok\n" * 15000)
+    assert len(big_diff) > kimi_gate.MAX_DIFF_CHARS
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text(big_diff, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(
+        kimi_gate, "_make_default_dispatcher", _fake_dispatcher_factory(data_dir, _REAL_PASS_REPORT),
+    )
+
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["execution_depth"]["mode"] == "single_shot"
+    assert record["execution_depth"]["diff_truncated"] is True

--- a/tests/test_gate_recorder_depth.py
+++ b/tests/test_gate_recorder_depth.py
@@ -1,0 +1,284 @@
+"""execution_depth is mandatory for every terminal gate write (OI-1618).
+
+A verdict without investigation is no verdict, on every lane. Agentic lanes
+(codex_gate/gemini_review) already refuse a zero-action run via
+``gate_artifacts.materialize_artifacts`` (OI-1485). Single-shot lanes
+(glm_gate/kimi_gate) had no equivalent floor at all: a "pass" against an
+empty diff passed every invariant ``record_terminal_result`` checked,
+because nothing there asked whether the diff carried anything to review.
+
+``gate_depth.single_shot_depth`` gives the single-shot lanes their own shape
+of the same measurement (an empty diff after strip, not a tool-call count),
+and ``gate_recorder.record_terminal_result`` now REQUIRES an
+``execution_depth`` for every terminal write and reclassifies a degenerate
+pass/fail to ``unavailable``/``gate_execution_degenerate`` itself -- the one
+place every lane's terminal write passes through, so glm_gate/kimi_gate get
+the floor without reimplementing gate_artifacts' check.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import gate_depth
+from gate_recorder import record_terminal_result
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "pr-1749-codex_gate.degenerate.json"
+
+
+def _fixture_record() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# 1. The mandatory argument -- rood op main: execution_depth did not exist
+#    as a parameter at all, so this call succeeded there.
+# ---------------------------------------------------------------------------
+
+
+def test_record_terminal_result_requires_execution_depth(tmp_path):
+    payload = {
+        "gate": "kimi_gate", "pr_id": "1", "status": "pass",
+        "contract_hash": "h", "report_path": "/r.md", "dispatch_id": "kimi-gate-pr1-1",
+    }
+    with pytest.raises(TypeError):
+        # execution_depth deliberately omitted -- that is what this test checks.
+        record_terminal_result(
+            gate="kimi_gate", pr_id="1", result_path=tmp_path / "pr-1-kimi_gate.json",
+            payload=payload,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Agentic depth: a pass with zero investigative actions is refused HERE,
+#    not only inside gate_artifacts.materialize_artifacts -- rood op main:
+#    the recorder booked `pass` unconditionally.
+# ---------------------------------------------------------------------------
+
+
+def test_pass_with_degenerate_agentic_depth_becomes_unavailable(tmp_path):
+    depth = gate_depth.ExecutionDepth(
+        parsed=True, mode="agentic", investigative_actions=0, agent_messages=1, input_tokens=100,
+    )
+    assert gate_depth.is_degenerate(depth) is True  # baseline
+
+    payload = {
+        "gate": "codex_gate", "pr_id": "42", "status": "pass",
+        "contract_hash": "realhash", "report_path": "/tmp/report.md",
+        "dispatch_id": "codex-gate-pr42-1", "blocking_findings": [],
+    }
+    out = tmp_path / "pr-42-codex_gate.json"
+    record_terminal_result(
+        gate="codex_gate", pr_id="42", result_path=out, payload=payload,
+        execution_depth=depth,
+    )
+
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == "unavailable"
+    assert written["reason"] == "gate_execution_degenerate"
+    assert written["contract_hash"] == ""
+    assert written["blocking_findings"] == []
+    assert written["execution_depth"]["investigative_actions"] == 0
+    # payload is mutated in place -- the caller's own dict matches the file.
+    assert payload["status"] == "unavailable"
+
+
+def test_pass_with_real_agentic_depth_stays_pass(tmp_path):
+    """Baseline: a real investigation is untouched."""
+    depth = gate_depth.ExecutionDepth(
+        parsed=True, mode="agentic", investigative_actions=16, shell_calls=16,
+        files_read=16, agent_messages=1, input_tokens=239992,
+    )
+    assert gate_depth.is_degenerate(depth) is False
+
+    payload = {
+        "gate": "codex_gate", "pr_id": "43", "status": "pass",
+        "contract_hash": "realhash", "report_path": "/tmp/report.md",
+        "dispatch_id": "codex-gate-pr43-1", "blocking_findings": [],
+    }
+    out = tmp_path / "pr-43-codex_gate.json"
+    record_terminal_result(
+        gate="codex_gate", pr_id="43", result_path=out, payload=payload,
+        execution_depth=depth,
+    )
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == "pass"
+    assert written["execution_depth"]["investigative_actions"] == 16
+
+
+# ---------------------------------------------------------------------------
+# 3. not_executable is out of scope for the degeneracy check -- it never ran,
+#    so "did it investigate" does not apply to it.
+# ---------------------------------------------------------------------------
+
+
+def test_not_executable_is_never_reclassified_by_depth(tmp_path):
+    depth = gate_depth.ExecutionDepth(parsed=True, mode="agentic", investigative_actions=0)
+    payload = {
+        "gate": "kimi_gate", "pr_id": "1", "status": "not_executable",
+        "reason": "provider_disabled", "contract_hash": "", "report_path": "",
+        "dispatch_id": "kimi-gate-pr1-1",
+    }
+    out = tmp_path / "pr-1-kimi_gate.json"
+    record_terminal_result(
+        gate="kimi_gate", pr_id="1", result_path=out, payload=payload,
+        execution_depth=depth,
+    )
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == "not_executable"
+
+
+# ---------------------------------------------------------------------------
+# 4. Single-shot depth: degenerate is EXCLUSIVELY an empty diff after strip.
+#    Truncation is recorded but never degenerate on its own.
+# ---------------------------------------------------------------------------
+
+
+def test_single_shot_empty_diff_is_degenerate():
+    depth = gate_depth.single_shot_depth(0, False)
+    assert depth.mode == "single_shot"
+    assert gate_depth.is_degenerate(depth) is True
+
+
+def test_single_shot_truncated_but_nonempty_diff_is_not_degenerate():
+    """A 60000-character diff capped at MAX_DIFF_CHARS still handed the model
+    real content — truncation is a fact about size, never about content."""
+    depth = gate_depth.single_shot_depth(50000, True)
+    assert gate_depth.is_degenerate(depth) is False
+
+
+def test_pass_with_degenerate_single_shot_depth_becomes_unavailable(tmp_path):
+    depth = gate_depth.single_shot_depth(0, False)
+    payload = {
+        "gate": "glm_gate", "pr_id": "99", "status": "pass",
+        "contract_hash": "realhash", "report_path": "/tmp/glm-report.md",
+        "dispatch_id": "glm-gate-pr99-1", "blocking_findings": [],
+    }
+    out = tmp_path / "pr-99-glm_gate.json"
+    record_terminal_result(
+        gate="glm_gate", pr_id="99", result_path=out, payload=payload,
+        execution_depth=depth,
+    )
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == "unavailable"
+    assert written["reason"] == "gate_execution_degenerate"
+    assert written["execution_depth"]["mode"] == "single_shot"
+    assert written["execution_depth"]["diff_chars"] == 0
+
+
+def test_pass_with_truncated_single_shot_diff_stays_pass(tmp_path):
+    depth = gate_depth.single_shot_depth(50000, True)
+    payload = {
+        "gate": "kimi_gate", "pr_id": "100", "status": "pass",
+        "contract_hash": "realhash", "report_path": "/tmp/kimi-report.md",
+        "dispatch_id": "kimi-gate-pr100-1", "blocking_findings": [],
+    }
+    out = tmp_path / "pr-100-kimi_gate.json"
+    record_terminal_result(
+        gate="kimi_gate", pr_id="100", result_path=out, payload=payload,
+        execution_depth=depth,
+    )
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == "pass"
+    assert written["execution_depth"]["diff_truncated"] is True
+
+
+# ---------------------------------------------------------------------------
+# 5. The real fixture: byte-copied from a genuine on-disk degenerate
+#    codex_gate record (measured 2026-09-04, PR #1749). Feeding its own
+#    execution_depth back into the recorder with a mocked `pass` verdict must
+#    refuse it the same way the original run was refused -- this is the exact
+#    shape the fix exists to catch, not a synthetic one.
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_degenerate_depth_refuses_a_mocked_pass(tmp_path):
+    fixture = _fixture_record()
+    depth = gate_depth.from_dict(fixture["execution_depth"])
+    assert depth.mode == "agentic"
+    assert gate_depth.is_degenerate(depth) is True
+
+    payload = {
+        "gate": "codex_gate", "pr_id": "1749", "status": "pass",
+        "contract_hash": "wouldbeahash", "report_path": "/tmp/pr1749-report.md",
+        "dispatch_id": "codex-gate-pr1749-mocked", "blocking_findings": [],
+    }
+    out = tmp_path / "pr-1749-codex_gate.json"
+    record_terminal_result(
+        gate="codex_gate", pr_id="1749", result_path=out, payload=payload,
+        execution_depth=depth,
+    )
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == "unavailable"
+    assert written["reason"] == "gate_execution_degenerate"
+
+
+# ---------------------------------------------------------------------------
+# 6. from_dict: round-trips a real record's execution_depth, and degrades
+#    gracefully on anything foreign -- used by gate_reanchor_cli.py to carry
+#    the ORIGINAL run's depth forward instead of re-measuring one.
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_round_trips_the_fixture_depth():
+    fixture = _fixture_record()
+    depth = gate_depth.from_dict(fixture["execution_depth"])
+    restored = depth.to_dict()
+    assert restored["investigative_actions"] == fixture["execution_depth"]["investigative_actions"]
+    assert restored["agent_messages"] == fixture["execution_depth"]["agent_messages"]
+    assert restored["input_tokens"] == fixture["execution_depth"]["input_tokens"]
+
+
+def test_from_dict_round_trips_single_shot_depth():
+    original = gate_depth.single_shot_depth(1234, True)
+    restored = gate_depth.from_dict(original.to_dict())
+    assert restored == original
+
+
+@pytest.mark.parametrize("bad", [None, "", [], 1, {}])
+def test_from_dict_degrades_gracefully_on_absent_or_foreign_data(bad):
+    """A record written before OI-1618 (or any non-dict) reconstructs to the
+    unmeasured depth -- never treated as degenerate."""
+    depth = gate_depth.from_dict(bad)
+    assert depth.parsed is False
+    assert gate_depth.is_degenerate(depth) is False
+
+
+# ---------------------------------------------------------------------------
+# 7. Kapotmaak-proef: lower the floor to 0 and prove the EXACT fixture shape
+#    this suite refuses would then be booked as `pass` -- the refusal above
+#    genuinely depends on MIN_INVESTIGATIVE_ACTIONS, not on something else in
+#    the wiring around it. Restored automatically by monkeypatch teardown.
+# ---------------------------------------------------------------------------
+
+
+def test_kapotmaak_zero_floor_would_have_accepted_the_degenerate_fixture(tmp_path, monkeypatch):
+    fixture = _fixture_record()
+    depth = gate_depth.from_dict(fixture["execution_depth"])
+
+    monkeypatch.setattr(gate_depth, "MIN_INVESTIGATIVE_ACTIONS", 0)
+    payload = {
+        "gate": "codex_gate", "pr_id": "1749", "status": "pass",
+        "contract_hash": "wouldbeahash", "report_path": "/tmp/pr1749-report.md",
+        "dispatch_id": "codex-gate-pr1749-kapotmaak", "blocking_findings": [],
+    }
+    out = tmp_path / "pr-1749-codex_gate-kapotmaak.json"
+    record_terminal_result(
+        gate="codex_gate", pr_id="1749", result_path=out, payload=payload,
+        execution_depth=depth,
+    )
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == "pass", (
+        "with MIN_INVESTIGATIVE_ACTIONS=0 the degenerate fixture must be "
+        "ACCEPTED as pass -- proving the real floor (not something else in "
+        "the wiring) is what refuses it in test_fixture_degenerate_depth_"
+        "refuses_a_mocked_pass above"
+    )

--- a/tests/test_gate_recorder_overwrite_guard.py
+++ b/tests/test_gate_recorder_overwrite_guard.py
@@ -32,6 +32,7 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+import gate_depth
 from gate_recorder import (
     ResultOverwriteRefused,
     record_failure,
@@ -40,6 +41,12 @@ from gate_recorder import (
     write_result_guarded,
 )
 from gate_request_handler import GateRequestHandlerMixin
+
+# OI-1618: record_terminal_result now requires execution_depth on every call.
+# This file is about the overwrite guard, not depth, so every call below
+# passes a single non-degenerate depth -- just enough to never trip the
+# (unrelated) gate_execution_degenerate reclassification.
+_OK_DEPTH = gate_depth.single_shot_depth(100, False)
 
 
 def _make_pass(**overrides):
@@ -68,7 +75,10 @@ class TestRecordTerminalResultOverwriteGuard:
         OpenRouter 402 must not erase the first run's real pass."""
         out = tmp_path / "pr-1691-glm_gate.json"
         pass_payload = _make_pass()
-        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=pass_payload)
+        record_terminal_result(
+            gate="glm_gate", pr_id="1691", result_path=out, payload=pass_payload,
+            execution_depth=_OK_DEPTH,
+        )
         assert json.loads(out.read_text(encoding="utf-8"))["status"] == "pass"
 
         outage_payload = {
@@ -80,7 +90,10 @@ class TestRecordTerminalResultOverwriteGuard:
             "reason": "dispatch_error",
         }
         with pytest.raises(ResultOverwriteRefused):
-            record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=outage_payload)
+            record_terminal_result(
+                gate="glm_gate", pr_id="1691", result_path=out, payload=outage_payload,
+                execution_depth=_OK_DEPTH,
+            )
 
         # The existing pass must be completely untouched.
         assert json.loads(out.read_text(encoding="utf-8")) == pass_payload
@@ -91,7 +104,10 @@ class TestRecordTerminalResultOverwriteGuard:
         erase a decided pass either — it goes through the SAME function."""
         out = tmp_path / "pr-1691-glm_gate.json"
         pass_payload = _make_pass()
-        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=pass_payload)
+        record_terminal_result(
+            gate="glm_gate", pr_id="1691", result_path=out, payload=pass_payload,
+            execution_depth=_OK_DEPTH,
+        )
 
         reprocess_refusal = {
             "gate": "glm_gate",
@@ -102,7 +118,10 @@ class TestRecordTerminalResultOverwriteGuard:
             "report_path": "",
         }
         with pytest.raises(ResultOverwriteRefused):
-            record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=reprocess_refusal)
+            record_terminal_result(
+                gate="glm_gate", pr_id="1691", result_path=out, payload=reprocess_refusal,
+                execution_depth=_OK_DEPTH,
+            )
         assert json.loads(out.read_text(encoding="utf-8")) == pass_payload
 
     def test_terminal_over_terminal_is_allowed(self, tmp_path):
@@ -110,26 +129,38 @@ class TestRecordTerminalResultOverwriteGuard:
         over an old pass — terminal may replace terminal."""
         out = tmp_path / "pr-1691-glm_gate.json"
         first_pass = _make_pass(dispatch_id="glm-gate-pr1691-1")
-        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=first_pass)
+        record_terminal_result(
+            gate="glm_gate", pr_id="1691", result_path=out, payload=first_pass,
+            execution_depth=_OK_DEPTH,
+        )
 
         second_pass = _make_pass(
             contract_hash="freshhash123456", report_path="/tmp/glm-report-2.md",
             dispatch_id="glm-gate-pr1691-2",
         )
-        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=second_pass)
+        record_terminal_result(
+            gate="glm_gate", pr_id="1691", result_path=out, payload=second_pass,
+            execution_depth=_OK_DEPTH,
+        )
         assert json.loads(out.read_text(encoding="utf-8")) == second_pass
 
     def test_fail_over_pass_is_allowed_when_both_carry_evidence(self, tmp_path):
         """A real fail (evidenced) may still supersede a real pass — the
         guard protects against DOWNGRADE, not against a real regression."""
         out = tmp_path / "pr-1691-glm_gate.json"
-        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=_make_pass())
+        record_terminal_result(
+            gate="glm_gate", pr_id="1691", result_path=out, payload=_make_pass(),
+            execution_depth=_OK_DEPTH,
+        )
 
         fail_payload = _make_pass(
             status="fail", contract_hash="failhash1", report_path="/tmp/glm-fail.md",
             dispatch_id="glm-gate-pr1691-3",
         )
-        record_terminal_result(gate="glm_gate", pr_id="1691", result_path=out, payload=fail_payload)
+        record_terminal_result(
+            gate="glm_gate", pr_id="1691", result_path=out, payload=fail_payload,
+            execution_depth=_OK_DEPTH,
+        )
         assert json.loads(out.read_text(encoding="utf-8"))["status"] == "fail"
 
     def test_not_executable_may_freely_overwrite_a_prior_not_executable(self, tmp_path):
@@ -150,7 +181,10 @@ class TestRecordTerminalResultOverwriteGuard:
             "reason": "provider_not_configured", "contract_hash": "", "report_path": "",
             "dispatch_id": "kimi-gate-pr1-2",
         }
-        record_terminal_result(gate="kimi_gate", pr_id="1", result_path=out, payload=second)
+        record_terminal_result(
+            gate="kimi_gate", pr_id="1", result_path=out, payload=second,
+            execution_depth=_OK_DEPTH,
+        )
         assert json.loads(out.read_text(encoding="utf-8"))["reason"] == "provider_not_configured"
 
     def test_no_existing_file_writes_unconditionally(self, tmp_path):
@@ -159,7 +193,10 @@ class TestRecordTerminalResultOverwriteGuard:
             "gate": "kimi_gate", "pr_id": "99", "status": "unavailable",
             "contract_hash": "", "report_path": "",
         }
-        record_terminal_result(gate="kimi_gate", pr_id="99", result_path=out, payload=payload)
+        record_terminal_result(
+            gate="kimi_gate", pr_id="99", result_path=out, payload=payload,
+            execution_depth=_OK_DEPTH,
+        )
         assert json.loads(out.read_text(encoding="utf-8")) == payload
 
 
@@ -448,6 +485,7 @@ class TestCorruptExistingResultFailsClosed:
                 payload={"gate": "glm_gate", "pr_id": "1691", "status": "pass",
                          "contract_hash": "newhash", "report_path": "/tmp/r.md",
                          "dispatch_id": "glm-gate-pr1691-2"},
+                execution_depth=_OK_DEPTH,
             )
         # The corrupt content must survive untouched -- never silently
         # replaced, since we cannot verify it wasn't a decided verdict.

--- a/tests/test_gate_recorder_provenance.py
+++ b/tests/test_gate_recorder_provenance.py
@@ -17,7 +17,14 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+import gate_depth
 from gate_recorder import record_terminal_result
+
+# OI-1618: record_terminal_result now requires execution_depth on every call.
+# This file is about producer identity, not depth, so every call below passes
+# a single non-degenerate depth -- just enough to never trip the (unrelated)
+# gate_execution_degenerate reclassification these tests do not exercise.
+_OK_DEPTH = gate_depth.single_shot_depth(100, False)
 
 
 def test_terminal_pass_without_dispatch_id_is_refused(tmp_path):
@@ -32,7 +39,7 @@ def test_terminal_pass_without_dispatch_id_is_refused(tmp_path):
         record_terminal_result(
             gate="kimi_gate", pr_id="378",
             result_path=tmp_path / "pr-378-kimi_gate.json",
-            payload=payload,
+            payload=payload, execution_depth=_OK_DEPTH,
         )
     assert not (tmp_path / "pr-378-kimi_gate.json").exists(), (
         "refused write must not leave a partial file behind"
@@ -45,7 +52,7 @@ def test_terminal_fail_without_dispatch_id_is_refused(tmp_path):
         record_terminal_result(
             gate="kimi_gate", pr_id="378",
             result_path=tmp_path / "pr-378-kimi_gate.json",
-            payload=payload,
+            payload=payload, execution_depth=_OK_DEPTH,
         )
 
 
@@ -61,8 +68,11 @@ def test_terminal_result_with_dispatch_id_writes_unchanged(tmp_path):
     out = tmp_path / "pr-904-kimi_gate.json"
     result_path = record_terminal_result(
         gate="kimi_gate", pr_id="904", result_path=out, payload=payload,
+        execution_depth=_OK_DEPTH,
     )
     assert result_path == out
+    # payload is mutated in place (execution_depth stamped on it too), so the
+    # caller's own dict and the file agree -- this is not a no-op comparison.
     assert json.loads(out.read_text(encoding="utf-8")) == payload
 
 
@@ -71,14 +81,20 @@ def test_non_terminal_result_without_dispatch_id_is_not_held_to_identity(tmp_pat
     not required to carry producer identity."""
     payload = {"gate": "kimi_gate", "pr_id": "1", "status": "pending"}
     out = tmp_path / "pr-1-kimi_gate.json"
-    record_terminal_result(gate="kimi_gate", pr_id="1", result_path=out, payload=payload)
+    record_terminal_result(
+        gate="kimi_gate", pr_id="1", result_path=out, payload=payload,
+        execution_depth=_OK_DEPTH,
+    )
     assert json.loads(out.read_text(encoding="utf-8")) == payload
 
 
 def test_write_is_atomic_no_tmp_file_left_behind(tmp_path):
     payload = {"gate": "kimi_gate", "pr_id": "905", "status": "pass", "dispatch_id": "kimi-gate-pr905-1"}
     out = tmp_path / "pr-905-kimi_gate.json"
-    record_terminal_result(gate="kimi_gate", pr_id="905", result_path=out, payload=payload)
+    record_terminal_result(
+        gate="kimi_gate", pr_id="905", result_path=out, payload=payload,
+        execution_depth=_OK_DEPTH,
+    )
     assert out.exists()
     assert not (tmp_path / "pr-905-kimi_gate.json.tmp").exists()
 
@@ -86,5 +102,8 @@ def test_write_is_atomic_no_tmp_file_left_behind(tmp_path):
 def test_creates_parent_directory(tmp_path):
     out = tmp_path / "nested" / "results" / "pr-1-kimi_gate.json"
     payload = {"gate": "kimi_gate", "pr_id": "1", "status": "pass", "dispatch_id": "kimi-gate-pr1-1"}
-    record_terminal_result(gate="kimi_gate", pr_id="1", result_path=out, payload=payload)
+    record_terminal_result(
+        gate="kimi_gate", pr_id="1", result_path=out, payload=payload,
+        execution_depth=_OK_DEPTH,
+    )
     assert out.exists()


### PR DESCRIPTION
## Summary

OI-1485 already refuses a codex/gemini "pass" that took zero investigative
actions (`gate_artifacts.materialize_artifacts`), but that check never
reached glm_gate/kimi_gate — single-shot API lanes with no agentic tool loop
to measure. A "pass" against an empty diff on those lanes passed every
existing invariant `gate_recorder.record_terminal_result` checked.

This PR gives `gate_depth.ExecutionDepth` a second shape (`mode="single_shot"`)
and moves the degeneracy check into `record_terminal_result` itself — the one
place every lane's terminal write passes through — so glm_gate, kimi_gate,
and `gate_reanchor_cli.py` (all three real callers in the repo) get the same
floor without reimplementing it per lane.

## Changes

- `scripts/lib/gate_depth.py`: `ExecutionDepth` gains `mode`, `diff_chars`,
  `diff_truncated`. New `single_shot_depth(diff_chars, diff_truncated)` and
  `from_dict(data)` (reconstructs a depth from its own `to_dict()` output,
  degrading gracefully on absent/foreign data). `is_degenerate`/
  `degenerate_detail` branch on `mode`: single-shot degenerate is
  *exclusively* an empty diff after strip — truncation is recorded but never
  degenerate on its own. `to_dict()` now normalizes `unrecognised_item_types`
  to a list so the in-memory dict a caller stamps onto its own payload
  agrees with what a reader gets back from disk.
- `scripts/lib/gate_recorder.py`: `record_terminal_result` requires
  `execution_depth` (no default). A pass/fail whose depth is degenerate is
  reclassified in place to `unavailable`/`gate_execution_degenerate`
  (contract_hash cleared, blocking_findings cleared), scoped to
  `PASS_STATES`/`FAIL_STATES` only — `not_executable` never ran, so the
  check doesn't apply to it.
- `scripts/glm_gate.py` / `scripts/kimi_gate.py`: pass
  `single_shot_depth(len(diff.strip()), len(diff) > MAX_DIFF_CHARS)` on a
  live run; the unmeasured depth on `--reprocess` (no diff is re-fetched
  there, so there's nothing new to measure). Locals are resynced after the
  recorder call so the printed VERDICT and exit code match what the recorder
  actually wrote, in case it downgraded the verdict.
- `scripts/gate_reanchor_cli.py`: passes
  `gate_depth.from_dict(record.get("execution_depth"))` — a re-anchor
  reviews nothing new, so it carries the original run's depth forward
  exactly as it already carries the original verdict forward.
- Fixture `tests/fixtures/pr-1749-codex_gate.degenerate.json`: byte-copy of
  a real on-disk degenerate codex_gate record (`~/.vnx-data/vnx-dev/state/review_gates/results/pr-1749-codex_gate.json`,
  measured 2026-09-04).
- New `tests/test_gate_recorder_depth.py`; `tests/test_dlv1_glm_gate.py` and
  `tests/test_dlv2_kimi_gate_evidence.py` gain empty-diff/truncated-diff
  end-to-end cases. `tests/test_gate_recorder_provenance.py` and
  `tests/test_gate_recorder_overwrite_guard.py` (outside the original file
  boundary, but every one of their `record_terminal_result` calls would
  otherwise TypeError on the new mandatory arg) get a non-degenerate
  `execution_depth` added to each call site — no assertions changed.

## Verification

Red run (production files stashed back to their pre-change, `main`-equivalent
state via `git stash push -u -- <5 source files>`, test files kept):

```
$ python3 -m pytest tests/test_gate_recorder_depth.py -q
17 failed in 0.21s   # AttributeError: no single_shot_depth/from_dict; TypeError on missing execution_depth

$ python3 -m pytest tests/test_gate_recorder_provenance.py tests/test_gate_recorder_overwrite_guard.py -q
2 errors during collection   # AttributeError: module 'gate_depth' has no attribute 'single_shot_depth'

$ python3 -m pytest tests/test_dlv1_glm_gate.py tests/test_dlv2_kimi_gate_evidence.py -q
4 failed, 30 passed in 0.56s   # the 4 new empty/truncated-diff cases red; pre-existing 30 still green
```

Stash restored (`git stash apply` + drop), green run:

```
$ python3 -m pytest tests/test_gate_recorder_depth.py tests/test_gate_recorder_provenance.py \
    tests/test_gate_recorder_overwrite_guard.py tests/test_dlv1_glm_gate.py \
    tests/test_dlv2_kimi_gate_evidence.py -q
81 passed in 0.85s (final run after fixing a to_dict() tuple/list equality snag, see below)
```

Neighbour files (touched indirectly: kimi/glm provenance & data-dir-guard,
gate_reanchor, oi1450, oi1472, audit_correctness_fixes, oi1485 agentic depth):

```
$ python3 -m pytest tests/test_oi1485_gate_execution_depth.py tests/test_kimi_gate_provenance.py \
    tests/test_kimi_gate_data_dir_guard.py tests/test_glm_gate_data_dir_guard.py tests/test_gate_reanchor.py \
    tests/test_oi1450_producer_identity_contradiction.py tests/test_oi1472_residual_guard_writers.py \
    tests/test_audit_correctness_fixes.py -q
217 passed in 5.36s
```

(`tests/test_gate_status_schema.py::test_closure_verifier_reads_status_completed_as_pass`
fails identically on unmodified `main` — verified by stashing again and running it in
isolation — unrelated to this change, not touched here.)

**Kapotmaak-proef** (literal, on top of the automated
`test_kapotmaak_zero_floor_would_have_accepted_the_degenerate_fixture`):
temporarily edited `MIN_INVESTIGATIVE_ACTIONS = 1` -> `0` in
`scripts/lib/gate_depth.py`:

```
$ python3 -m pytest tests/test_gate_recorder_depth.py::test_fixture_degenerate_depth_refuses_a_mocked_pass -q
1 failed  # AssertionError: assert False is True (gate_depth.is_degenerate no longer flags the fixture)
```

Restored to `1`, re-ran the full targeted suite: `81 passed in 0.89s`. Confirmed
`git diff` on `gate_depth.py` carries no residual value change.

## Open Items

- `test_gate_recorder_overwrite_guard.py` and `test_gate_recorder_provenance.py`
  were outside the dispatch's original file boundary (only
  `test_gate_recorder_provenance.py` **or** a new `test_gate_recorder_depth.py`
  was named), but grepping the repo turned up 11 more `record_terminal_result`
  call sites in the overwrite-guard file that would otherwise TypeError the
  moment `execution_depth` became mandatory. Extended the boundary to cover
  those mechanically (added `execution_depth=_OK_DEPTH`, a shared
  non-degenerate constant) — no assertion in either file was changed.
- No end-to-end test of `gate_reanchor_cli.py --apply` exists in
  `tests/test_gate_reanchor.py` (confirmed by inspection — it isn't in this
  dispatch's file boundary either), so the reanchor wiring is covered by the
  `gate_depth.from_dict` unit tests in `test_gate_recorder_depth.py`
  (round-trip fidelity, graceful degradation on a pre-OI-1618 record with no
  `execution_depth` field) plus code review, not a live CLI run.
- `--reprocess` on glm_gate/kimi_gate gets the unmeasured
  (`parsed=False`) depth rather than carrying the original run's depth
  forward the way the reanchor CLI does — the dispatch didn't specify this
  path, and since `is_degenerate` reads any unmeasured depth as "not
  degenerate", this is a conservative default (never blocks a legitimate
  reprocess-recovered verdict) rather than a gap, but a future pass could
  make it symmetric with the reanchor CLI if desired.
- Codex/kimi lanes are down for quota per the dispatch note; review via the
  glm gate by T0 after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)