### PR TITLE
fix(plan-gate): tiebreaker outcome lands in decision_ref; backfill recognises tiebreak reports

### DIFF
--- a/scripts/backfill_track_decision_ref.py
+++ b/scripts/backfill_track_decision_ref.py
@@ -309,6 +309,60 @@ class TiebreakReportUnparseable(ValueError):
     """The youngest report for a track is a tiebreak report with no parseable fence."""
 
 
+def _read_and_parse_tiebreak_report(reports_dir: Path, tiebreak_file: TiebreakReportFile):
+    """Read + strictly parse a tiebreak report's ``vnx-plan-tiebreak`` fence.
+
+    Shared by ``build_tiebreak_payload_for_track`` (generic empty-field backfill)
+    and ``build_supersede_tiebreak_payload`` (scoped --supersede-panel-with-tiebreak):
+    both need the same read-and-parse step before building their own
+    ``previous_decision_ref``. Returns ``(report_text, TiebreakResult)``.
+
+    Raises ``TiebreakReportUnparseable`` when the file cannot be read or the fence
+    does not satisfy the strict contract — the caller skips this track with a
+    reason rather than guessing a decision.
+    """
+    try:
+        text = (reports_dir / tiebreak_file.filename).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TiebreakReportUnparseable(
+            f"could not read {tiebreak_file.filename}: {exc}"
+        ) from exc
+    try:
+        tb_result = pgt.parse_tiebreaker(text)
+    except pgt.TiebreakerParseError as exc:
+        raise TiebreakReportUnparseable(
+            f"tiebreak report {tiebreak_file.filename} has no parseable fence: {exc}"
+        ) from exc
+    return text, tb_result
+
+
+def _tiebreak_result_to_payload(
+    tiebreak_file: TiebreakReportFile,
+    text: str,
+    tb_result,
+    *,
+    previous_decision_ref: Optional[str],
+    set_at: str,
+) -> str:
+    report_path = (
+        tiebreak_file.filename[:-3]
+        if tiebreak_file.filename.endswith(".md")
+        else tiebreak_file.filename
+    )
+    return pgp.build_tiebreak_decision_ref(
+        {
+            "outcome": tb_result.outcome,
+            "model": _extract_model_field(text),
+            "round": None,
+            "required_change": tb_result.required_change,
+            "rationale": tb_result.rationale,
+            "report_path": report_path,
+        },
+        previous_decision_ref=previous_decision_ref,
+        set_at=set_at,
+    )
+
+
 def build_tiebreak_payload_for_track(
     reports_dir: Path,
     track_id: str,
@@ -334,18 +388,7 @@ def build_tiebreak_payload_for_track(
     strict contract — the caller skips this track with a reason rather than
     guessing a decision.
     """
-    try:
-        text = (reports_dir / tiebreak_file.filename).read_text(encoding="utf-8")
-    except OSError as exc:
-        raise TiebreakReportUnparseable(
-            f"could not read {tiebreak_file.filename}: {exc}"
-        ) from exc
-    try:
-        tb_result = pgt.parse_tiebreaker(text)
-    except pgt.TiebreakerParseError as exc:
-        raise TiebreakReportUnparseable(
-            f"tiebreak report {tiebreak_file.filename} has no parseable fence: {exc}"
-        ) from exc
+    text, tb_result = _read_and_parse_tiebreak_report(reports_dir, tiebreak_file)
 
     previous_payload: Optional[str] = None
     if panel_files:
@@ -354,28 +397,157 @@ def build_tiebreak_payload_for_track(
             source=source, set_at=set_at,
         )
 
-    report_path = (
-        tiebreak_file.filename[:-3]
-        if tiebreak_file.filename.endswith(".md")
-        else tiebreak_file.filename
+    return _tiebreak_result_to_payload(
+        tiebreak_file, text, tb_result,
+        previous_decision_ref=previous_payload, set_at=set_at,
     )
-    return pgp.build_tiebreak_decision_ref(
-        {
-            "outcome": tb_result.outcome,
-            "model": _extract_model_field(text),
-            "round": None,
-            "required_change": tb_result.required_change,
-            "rationale": tb_result.rationale,
-            "report_path": report_path,
-        },
-        previous_decision_ref=previous_payload,
-        set_at=set_at,
+
+
+def build_supersede_tiebreak_payload(
+    reports_dir: Path,
+    tiebreak_file: TiebreakReportFile,
+    existing_decision_ref: str,
+    *,
+    set_at: str,
+) -> str:
+    """Build the superseding payload for ``--track --supersede-panel-with-tiebreak``.
+
+    Unlike ``build_tiebreak_payload_for_track`` (which reconstructs the round
+    being superseded FROM REPORT FILES, for the generic empty-field backfill),
+    this takes the track's CURRENT ``decision_ref`` verbatim as
+    ``previous_decision_ref`` — the existing payload IS the panel decision being
+    superseded, whether it was written by a live plan-gate round or an earlier
+    backfill run. ``plan_gate_panel.build_tiebreak_decision_ref`` already treats
+    an unparseable ``previous_decision_ref`` as absent rather than raising, so a
+    malformed existing payload degrades to ``superseded_decision: None`` instead
+    of failing the whole operation.
+
+    Raises ``TiebreakReportUnparseable`` when the tiebreak report itself cannot
+    be read or its fence does not satisfy the strict contract.
+    """
+    text, tb_result = _read_and_parse_tiebreak_report(reports_dir, tiebreak_file)
+    return _tiebreak_result_to_payload(
+        tiebreak_file, text, tb_result,
+        previous_decision_ref=existing_decision_ref, set_at=set_at,
     )
 
 
 def _track_decision_ref(state_dir: Path, track_id: str, project_id: str) -> Optional[str]:
     t = tracks.get_track(state_dir, track_id, project_id)
     return (t or {}).get("decision_ref")
+
+
+def _youngest_tiebreak_if_latest(reports_dir: Path, track_id: str) -> Optional[TiebreakReportFile]:
+    """The track's youngest tiebreak report, but ONLY if it is also the track's
+    youngest report overall (mirrors the mtime rule ``apply_backfill`` already
+    applies fleet-wide). ``None`` when the track has no tiebreak reports, or
+    when a panel report is younger — a re-reviewed track must not be superseded
+    by a stale tiebreak file.
+    """
+    panel_files = [f for f in discover_reports(reports_dir) if f.track_id == track_id]
+    tb_files = [f for f in discover_tiebreak_reports(reports_dir) if f.track_id == track_id]
+    youngest_panel_mtime = max((f.mtime for f in panel_files), default=-1.0)
+    youngest_tb = max(tb_files, key=lambda f: f.mtime, default=None)
+    if youngest_tb is not None and youngest_tb.mtime > youngest_panel_mtime:
+        return youngest_tb
+    return None
+
+
+def _decision_ref_set_at_epoch(decision_ref_json: str) -> Optional[float]:
+    """Parse an existing ``decision_ref`` payload's own ``set_at`` into a POSIX
+    epoch, for comparison against a report file's mtime. ``None`` on anything
+    that is not parseable JSON with a non-empty ``set_at`` — the caller treats
+    that as "cannot establish a comparison, refuse rather than guess".
+    """
+    try:
+        data = json.loads(decision_ref_json)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    set_at = data.get("set_at")
+    if not set_at:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(str(set_at).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class SupersedeResult:
+    track_id: str
+    action: str  # "would_supersede" | "skipped"
+    reason: str
+    old_decision_ref: Optional[str]
+    new_decision_ref: Optional[str]
+
+
+def compute_supersede_panel_with_tiebreak(
+    state_dir: Path,
+    reports_dir: Path,
+    project_id: str,
+    track_id: str,
+    *,
+    set_at: str,
+) -> SupersedeResult:
+    """Compute (never write) the ``--track --supersede-panel-with-tiebreak`` outcome.
+
+    Scoped to exactly one track: reads its CURRENT decision_ref straight from the
+    store (whatever wrote it — live plan-gate or an earlier backfill run), and
+    proposes replacing it ONLY when ALL of:
+      (a) the track's youngest report on disk is a parseable tiebreak report, and
+      (b) that report's mtime is strictly younger than the existing payload's
+          own ``set_at``.
+    Every other track, and every other reason a track might be unreadable, is
+    out of scope for this function and is never touched — the caller applies
+    the result for exactly the one track_id given, nothing else.
+    """
+    track = tracks.get_track(state_dir, track_id, project_id)
+    if track is None:
+        return SupersedeResult(track_id, "skipped", f"track not found: {track_id!r}", None, None)
+
+    current = track.get("decision_ref")
+    if not current:
+        return SupersedeResult(
+            track_id, "skipped",
+            "decision_ref is already empty — nothing to supersede; use the generic "
+            "(unscoped) backfill for this track instead",
+            current, None,
+        )
+
+    youngest_tb = _youngest_tiebreak_if_latest(reports_dir, track_id)
+    if youngest_tb is None:
+        return SupersedeResult(
+            track_id, "skipped",
+            "the track's youngest report on disk is not a parseable tiebreak report",
+            current, None,
+        )
+
+    existing_set_at_epoch = _decision_ref_set_at_epoch(current)
+    if existing_set_at_epoch is None:
+        return SupersedeResult(
+            track_id, "skipped",
+            "existing decision_ref has no parseable set_at — refusing to supersede blindly",
+            current, None,
+        )
+
+    if youngest_tb.mtime <= existing_set_at_epoch:
+        return SupersedeResult(
+            track_id, "skipped",
+            f"tiebreak report {youngest_tb.filename} is not newer than the existing "
+            "decision_ref's set_at",
+            current, None,
+        )
+
+    try:
+        new_payload = build_supersede_tiebreak_payload(
+            reports_dir, youngest_tb, current, set_at=set_at,
+        )
+    except TiebreakReportUnparseable as exc:
+        return SupersedeResult(track_id, "skipped", str(exc), current, None)
+
+    return SupersedeResult(track_id, "would_supersede", "", current, new_payload)
 
 
 # ---------------------------------------------------------------------------
@@ -564,6 +736,69 @@ def apply_to_live(state_dir: Path, reports_dir: Path, project_id: str) -> int:
 
 
 # ---------------------------------------------------------------------------
+# --track + --supersede-panel-with-tiebreak — scoped, explicit override of the
+# "never overwrite" rule for exactly one operator-named track (PR #1801
+# fix-forward). Never touches any other track.
+# ---------------------------------------------------------------------------
+
+
+def print_supersede_result(result: SupersedeResult, file=None) -> None:
+    out = file or sys.stdout
+    print(f"\n{'='*64}", file=out)
+    print(f"  SUPERSEDE PANEL WITH TIEBREAK — track: {result.track_id}", file=out)
+    print(f"{'='*64}", file=out)
+    if result.action == "would_supersede":
+        print(f"  action                : REPLACE", file=out)
+        print(f"  old decision_ref      : {result.old_decision_ref}", file=out)
+        print(f"  new decision_ref      : {result.new_decision_ref}", file=out)
+    else:
+        print(f"  action                : SKIP", file=out)
+        print(f"  reason                : {result.reason}", file=out)
+        print(f"  current decision_ref  : {result.old_decision_ref}", file=out)
+    print(f"{'='*64}\n", file=out)
+
+
+def dry_run_supersede(state_dir: Path, reports_dir: Path, project_id: str, track_id: str) -> int:
+    print(
+        f"\n  DRY-RUN MODE (--track {track_id} --supersede-panel-with-tiebreak) — "
+        f"operating on a temp copy of: {state_dir / DB_FILENAME}"
+    )
+    tmp_dir = Path(tempfile.mkdtemp(prefix="vnx_decision_ref_supersede_dryrun_"))
+    tmp_state = tmp_dir / "state"
+    tmp_state.mkdir(parents=True)
+    try:
+        shutil.copy2(str(state_dir / DB_FILENAME), str(tmp_state / DB_FILENAME))
+        result = compute_supersede_panel_with_tiebreak(
+            tmp_state, reports_dir, project_id, track_id, set_at=_utc_iso(),
+        )
+        print_supersede_result(result)
+        if result.action == "would_supersede":
+            print("  Dry-run successful. Review the proposed replacement, then run --apply.")
+        return 0
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def apply_supersede_live(state_dir: Path, reports_dir: Path, project_id: str, track_id: str) -> int:
+    print(
+        f"\n  --APPLY MODE (--track {track_id} --supersede-panel-with-tiebreak) — "
+        f"backfilling live store: {state_dir / DB_FILENAME}"
+    )
+    result = compute_supersede_panel_with_tiebreak(
+        state_dir, reports_dir, project_id, track_id, set_at=_utc_iso(),
+    )
+    print_supersede_result(result)
+    if result.action != "would_supersede":
+        print("  No change made.")
+        return 0
+    tracks.set_decision_ref(
+        state_dir, track_id, project_id, result.new_decision_ref, actor="system",
+    )
+    print("  Supersede complete.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -590,7 +825,27 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
         help="Project id to scope the backfill (default: env VNX_PROJECT_ID or 'vnx-dev').",
     )
+    parser.add_argument(
+        "--track",
+        default=None,
+        help="Scope to a single track_id. Required by --supersede-panel-with-tiebreak; "
+        "has no other effect on its own.",
+    )
+    parser.add_argument(
+        "--supersede-panel-with-tiebreak",
+        action="store_true",
+        help="Only with --track: replace that ONE track's existing decision_ref with a "
+        "younger tiebreak report's outcome. The only way this backfill ever overwrites "
+        "a non-empty decision_ref; every other track is unaffected.",
+    )
     args = parser.parse_args(argv)
+
+    if args.supersede_panel_with_tiebreak and not args.track:
+        print(
+            "  [ERROR] --supersede-panel-with-tiebreak requires --track <track_id>.",
+            file=sys.stderr,
+        )
+        return 2
 
     if args.data_dir:
         data_dir = args.data_dir.expanduser().resolve()
@@ -612,6 +867,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 1
     if not reports_dir.is_dir():
         print(f"  [WARNING] unified_reports dir not found: {reports_dir} — nothing to backfill.")
+
+    if args.track and args.supersede_panel_with_tiebreak:
+        if args.apply:
+            return apply_supersede_live(state_dir, reports_dir, args.project_id, args.track)
+        return dry_run_supersede(state_dir, reports_dir, args.project_id, args.track)
 
     if args.apply:
         return apply_to_live(state_dir, reports_dir, args.project_id)

--- a/scripts/backfill_track_decision_ref.py
+++ b/scripts/backfill_track_decision_ref.py
@@ -63,11 +63,27 @@ if str(_LIB) not in sys.path:
 
 import tracks  # noqa: E402
 import plan_gate_panel as pgp  # noqa: E402
+import plan_gate_tiebreaker as pgt  # noqa: E402
 
 DB_FILENAME = "runtime_coordination.db"
 REPORTS_DIRNAME = "unified_reports"
 _REPORT_PREFIX = "plan-gate-"
+_TIEBREAK_REPORT_PREFIX = "plan-tiebreak-"
 _HASH_RE = re.compile(r"[0-9a-f]{8}$")
+_MODEL_FIELD_RE = re.compile(r"^\*\*Model\*\*:\s*(.+)$", re.MULTILINE)
+
+
+def _extract_model_field(text: str) -> str:
+    """Best-effort ``**Model**: <value>`` extraction from a report body.
+
+    The report contract (CLAUDE.md) requires every dispatch report to carry a
+    Model/Provider identity block, so this is present on every real tiebreak
+    report; an absent match (a malformed/legacy report) yields "" rather than
+    raising — the tiebreaker_model field on the backfilled payload is
+    best-effort context, not a hard requirement.
+    """
+    m = _MODEL_FIELD_RE.search(text)
+    return m.group(1).strip() if m else ""
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +189,64 @@ def discover_reports(reports_dir: Path) -> list[ReportFile]:
     return found
 
 
+@dataclass(frozen=True)
+class TiebreakReportFile:
+    filename: str       # e.g. plan-tiebreak-<track>-<hash>.md
+    track_id: str
+    hash: str
+    mtime: float
+
+
+def _parse_tiebreak_report_filename(filename: str) -> Optional[TiebreakReportFile]:
+    """Parse ``plan-tiebreak-<track_id>-<hash>.md`` into its parts.
+
+    Right-anchored like ``_parse_report_filename``: the trailing
+    ``-<8-hex-hash>`` is stripped first, everything before is the track_id.
+    There is no label segment — exactly one tiebreaker runs per round, never a
+    panel of several seats.
+    """
+    stem = filename
+    if stem.endswith(".md"):
+        stem = stem[:-3]
+    if not stem.startswith(_TIEBREAK_REPORT_PREFIX):
+        return None
+    stem = stem[len(_TIEBREAK_REPORT_PREFIX):]
+    if not stem:
+        return None
+    m = _HASH_RE.search(stem)
+    if not m:
+        return None
+    hash_part = m.group(0)
+    track_id = stem[: m.start()].rstrip("-")
+    if not track_id:
+        return None
+    return TiebreakReportFile(filename=filename, track_id=track_id, hash=hash_part, mtime=0.0)
+
+
+def discover_tiebreak_reports(reports_dir: Path) -> list[TiebreakReportFile]:
+    """Scan ``reports_dir`` for ``plan-tiebreak-*.md`` files, parsing each filename.
+
+    Mirrors ``discover_reports``: files whose name does not parse are skipped
+    silently — out of scope for this backfill, not an error.
+    """
+    found: list[TiebreakReportFile] = []
+    if not reports_dir.is_dir():
+        return found
+    for path in sorted(reports_dir.glob(f"{_TIEBREAK_REPORT_PREFIX}*.md")):
+        parsed = _parse_tiebreak_report_filename(path.name)
+        if parsed is None:
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        found.append(TiebreakReportFile(
+            filename=parsed.filename, track_id=parsed.track_id,
+            hash=parsed.hash, mtime=mtime,
+        ))
+    return found
+
+
 def _latest_per_label(reports: list[ReportFile]) -> list[ReportFile]:
     """Dedupe a track's reports to one per seat label (latest mtime wins).
 
@@ -231,6 +305,74 @@ def build_payload_for_track(
     )
 
 
+class TiebreakReportUnparseable(ValueError):
+    """The youngest report for a track is a tiebreak report with no parseable fence."""
+
+
+def build_tiebreak_payload_for_track(
+    reports_dir: Path,
+    track_id: str,
+    tiebreak_file: TiebreakReportFile,
+    panel_files: list[ReportFile],
+    *,
+    source: str,
+    set_at: str,
+) -> str:
+    """Reconstruct a track's decision_ref payload from a tiebreak report.
+
+    Parses the tiebreak report's ``vnx-plan-tiebreak`` fence via the SAME
+    strict parser the live tiebreaker uses (``plan_gate_tiebreaker.parse_tiebreaker``),
+    then wraps it with ``plan_gate_panel.build_tiebreak_decision_ref`` — the same
+    builder the live plan-gate uses on the tiebreaker path. When the track also
+    has panel report files, they are reconstructed into a panel-shaped payload
+    first (via ``build_payload_for_track``) and passed in as
+    ``previous_decision_ref`` so the tiebreak's inherited history (which
+    reports, which rejected alternatives, what decision it superseded) matches
+    a live write exactly.
+
+    Raises ``TiebreakReportUnparseable`` when the fence does not satisfy the
+    strict contract — the caller skips this track with a reason rather than
+    guessing a decision.
+    """
+    try:
+        text = (reports_dir / tiebreak_file.filename).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TiebreakReportUnparseable(
+            f"could not read {tiebreak_file.filename}: {exc}"
+        ) from exc
+    try:
+        tb_result = pgt.parse_tiebreaker(text)
+    except pgt.TiebreakerParseError as exc:
+        raise TiebreakReportUnparseable(
+            f"tiebreak report {tiebreak_file.filename} has no parseable fence: {exc}"
+        ) from exc
+
+    previous_payload: Optional[str] = None
+    if panel_files:
+        previous_payload = build_payload_for_track(
+            reports_dir, track_id, _latest_per_label(panel_files),
+            source=source, set_at=set_at,
+        )
+
+    report_path = (
+        tiebreak_file.filename[:-3]
+        if tiebreak_file.filename.endswith(".md")
+        else tiebreak_file.filename
+    )
+    return pgp.build_tiebreak_decision_ref(
+        {
+            "outcome": tb_result.outcome,
+            "model": _extract_model_field(text),
+            "round": None,
+            "required_change": tb_result.required_change,
+            "rationale": tb_result.rationale,
+            "report_path": report_path,
+        },
+        previous_decision_ref=previous_payload,
+        set_at=set_at,
+    )
+
+
 def _track_decision_ref(state_dir: Path, track_id: str, project_id: str) -> Optional[str]:
     t = tracks.get_track(state_dir, track_id, project_id)
     return (t or {}).get("decision_ref")
@@ -283,9 +425,18 @@ def apply_backfill(
     for r in reports:
         by_track.setdefault(r.track_id, []).append(r)
 
-    for track_id, files in by_track.items():
+    tiebreak_reports = discover_tiebreak_reports(reports_dir)
+    tiebreak_by_track: dict[str, list[TiebreakReportFile]] = {}
+    for r in tiebreak_reports:
+        tiebreak_by_track.setdefault(r.track_id, []).append(r)
+
+    for track_id in sorted(set(by_track) | set(tiebreak_by_track)):
+        panel_files = by_track.get(track_id, [])
+        tb_files = tiebreak_by_track.get(track_id, [])
+
         if track_id not in db_track_ids:
-            report["orphan_reports"].extend((track_id, f.filename) for f in files)
+            report["orphan_reports"].extend((track_id, f.filename) for f in panel_files)
+            report["orphan_reports"].extend((track_id, f.filename) for f in tb_files)
             continue
         report["tracks_with_reports"] += 1
 
@@ -294,11 +445,35 @@ def apply_backfill(
             report["already_filled"].append(track_id)
             continue
 
+        # The YOUNGEST report for this track decides the proposal's shape
+        # (OI-1618 follow-up): a track whose latest activity is a tiebreaker
+        # round must be proposed as ``tiebreak:<outcome>`` (the actual
+        # clearing decision), never re-derived from the panel round it
+        # superseded. A track with no tiebreak reports at all falls straight
+        # through to the pre-existing panel-only path (regression-safe).
+        youngest_panel_mtime = max((f.mtime for f in panel_files), default=-1.0)
+        youngest_tb = max(tb_files, key=lambda f: f.mtime, default=None)
+
+        if youngest_tb is not None and youngest_tb.mtime > youngest_panel_mtime:
+            try:
+                payload = build_tiebreak_payload_for_track(
+                    reports_dir, track_id, youngest_tb, panel_files,
+                    source=source, set_at=set_at,
+                )
+            except TiebreakReportUnparseable as exc:
+                report["errors"].append(f"{track_id}: {exc}")
+                continue
+        else:
+            try:
+                payload = build_payload_for_track(
+                    reports_dir, track_id, _latest_per_label(panel_files),
+                    source=source, set_at=set_at,
+                )
+            except Exception as exc:  # vnx-silent-except: one bad track must not abort the run
+                report["errors"].append(f"{track_id}: {exc}")
+                continue
+
         try:
-            payload = build_payload_for_track(
-                reports_dir, track_id, _latest_per_label(files),
-                source=source, set_at=set_at,
-            )
             tracks.set_decision_ref(state_dir, track_id, project_id, payload, actor="system")
             report["filled"].append(track_id)
         except tracks.DecisionRefColumnMissingError:

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -1761,3 +1761,78 @@ def build_decision_ref(
         "source": source,
     }
     return json.dumps(payload, sort_keys=True)
+
+
+def build_tiebreak_decision_ref(
+    result: Dict[str, Any],
+    *,
+    previous_decision_ref: Optional[str],
+    reports_base: str = "unified_reports",
+    set_at: Optional[str] = None,
+) -> str:
+    """Render the JSON ``decision_ref`` payload for a tiebreaker outcome.
+
+    A tiebreaker round resolves a plan blocker that a full panel round left
+    stuck (REVISE/BLOCK with no PASS after ``max_rounds``). Without this
+    builder, ``tracks.decision_ref`` keeps showing the last PANEL round's
+    verdict forever — a reader who only checks ``decision_ref`` never sees
+    that a tiebreaker actually cleared (or upheld) the gate.
+
+    ``result`` carries the tiebreaker's own facts: ``outcome`` ("START" or
+    "STOP"), ``report_path`` (the tiebreak report's own filename, with or
+    without ``.md`` — omitted from ``reports`` when falsy, e.g. the report
+    could not be located), and best-effort ``model`` / ``round`` /
+    ``required_change`` / ``rationale`` (a historical reconstruction, such as
+    the backfill, may not know all of them — an absent value renders as
+    empty/``None`` rather than being guessed at).
+
+    ``previous_decision_ref`` is the track's ``decision_ref`` BEFORE the
+    tiebreaker ran (typically the superseded panel round's
+    ``build_decision_ref`` payload). When present and parseable, its
+    ``reports`` and ``rejected_alternatives`` are carried forward (appended
+    after the tiebreak's own report) and its ``decision`` is recorded as
+    ``superseded_decision`` — so the full history (which panel reports were
+    read, which alternatives were rejected, and what round finally decided)
+    survives on the track. An absent or unparseable ``previous_decision_ref``
+    is never guessed at: the payload then carries only the tiebreak's own
+    report and ``superseded_decision: None``.
+
+    Returns a compact JSON string (the ``tracks.decision_ref`` payload written
+    via ``tracks.set_decision_ref``).
+    """
+    reports: List[str] = []
+    report_path = str(result.get("report_path") or "").strip()
+    if report_path:
+        path = report_path if report_path.endswith(".md") else f"{report_path}.md"
+        reports.append(f"{reports_base}/{path}")
+
+    rejected: List[Dict[str, Any]] = []
+    superseded_decision: Optional[str] = None
+    if previous_decision_ref:
+        try:
+            prev = json.loads(previous_decision_ref)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            prev = None
+        if isinstance(prev, dict):
+            superseded_decision = prev.get("decision")
+            prev_reports = prev.get("reports")
+            if isinstance(prev_reports, list):
+                reports.extend(str(r) for r in prev_reports)
+            prev_rejected = prev.get("rejected_alternatives")
+            if isinstance(prev_rejected, list):
+                rejected.extend(prev_rejected)
+
+    outcome = str(result.get("outcome") or "").strip()
+    payload = {
+        "decision": f"tiebreak:{outcome}",
+        "reports": reports,
+        "rejected_alternatives": rejected,
+        "superseded_decision": superseded_decision,
+        "tiebreaker_model": result.get("model") or "",
+        "round": result.get("round"),
+        "required_change": result.get("required_change") or "",
+        "rationale": result.get("rationale") or "",
+        "set_at": set_at or datetime.now(timezone.utc).isoformat(),
+        "source": "plan-gate-tiebreak",
+    }
+    return json.dumps(payload, sort_keys=True)

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -3075,11 +3075,49 @@ def _run_tiebreaker_for_track(
     than one change) is a loud failure: exit 1, the track stays blocked, the
     operator sees the raw model output. We never silently fill in a decision.
     """
+    import plan_gate_panel
     import plan_gate_tiebreaker
 
     stderr_lines: list = []
     stdout_text: list = []
     stdout_json: Optional[str] = None
+
+    # Captured BEFORE the tiebreaker touches anything: the panel round's
+    # decision_ref (if any) is what the tiebreak payload below supersedes.
+    # Best-effort — a failed read just means the tiebreak payload carries no
+    # inherited history, never a hard dependency for the gate itself.
+    previous_decision_ref: Optional[str] = None
+    try:
+        pre_track = tracks_lib.get_track(state_dir, track_id, project_id)
+        previous_decision_ref = (pre_track or {}).get("decision_ref")
+    except Exception:  # vnx-silent-except: reading prior decision_ref is best-effort context only
+        previous_decision_ref = None
+
+    def _find_tiebreak_report_path() -> Optional[str]:
+        """The tiebreak report's own filename (no ``.md``), or ``None``.
+
+        ``run_tiebreaker`` generates its own dispatch id internally
+        (``plan-tiebreak-<track_id>-<8-hex>``) and does not return it, so the
+        actual report file is discovered post-hoc the same way the backfill
+        script does: youngest matching file by mtime wins. The hash suffix is
+        validated (8 lowercase hex chars) so a track_id that is itself a
+        prefix of another track_id (e.g. ``foo`` vs ``foo-bar``) cannot match
+        the wrong track's report.
+        """
+        reports_dir = Path(data_dir) / "unified_reports"
+        if not reports_dir.is_dir():
+            return None
+        prefix = f"plan-tiebreak-{track_id}-"
+        hexdigits = set("0123456789abcdef")
+        candidates = []
+        for p in reports_dir.glob(f"{prefix}*.md"):
+            suffix = p.stem[len(prefix):]
+            if len(suffix) == 8 and set(suffix) <= hexdigits:
+                candidates.append(p)
+        if not candidates:
+            return None
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        return candidates[0].stem
 
     def _result(**kw) -> PlanGateRunResult:
         return PlanGateRunResult(
@@ -3152,6 +3190,36 @@ def _run_tiebreaker_for_track(
         governance_variant="tiebreaker", gov_trace=gov_trace,
         scored_seats=0,
     )
+
+    # Persist the durable half of the tiebreak decision onto the track — the
+    # SAME contract the panel path uses (OI-1190's build_decision_ref /
+    # set_decision_ref), but for the tiebreaker outcome. Without this the
+    # track's decision_ref keeps showing the last PANEL round (e.g. REVISE)
+    # even after a tiebreaker START clears the gate — a reader who only
+    # checks decision_ref never sees the actual clearing decision. Written for
+    # BOTH START and STOP, and BEFORE _resolve_plan_blocker below so a failed
+    # unblock never loses a decision_ref that was already recorded.
+    # Best-effort: a decision_ref write must never break the gate it hangs off
+    # (same contract as the panel path).
+    try:
+        tb_payload = plan_gate_panel.build_tiebreak_decision_ref(
+            {
+                "outcome": result.outcome,
+                "model": result.model,
+                "round": result.round,
+                "required_change": result.required_change,
+                "rationale": result.rationale,
+                "report_path": _find_tiebreak_report_path(),
+            },
+            previous_decision_ref=previous_decision_ref,
+        )
+        tracks_lib.set_decision_ref(
+            state_dir, track_id, project_id, tb_payload, actor="system"
+        )
+    except Exception as exc:  # vnx-silent-except: decision_ref persistence must never break the gate
+        stderr_lines.append(
+            f"WARNING: could not persist tiebreak decision_ref for track {track_id}: {exc}"
+        )
 
     if result.outcome == plan_gate_tiebreaker.STOP:
         # Punt 9: the last round's findings become open items via the existing

--- a/tests/fixtures/plan-tiebreak-review-gate-secure-04990c59.md
+++ b/tests/fixtures/plan-tiebreak-review-gate-secure-04990c59.md
@@ -1,0 +1,64 @@
+# Plan-gate tiebreak — review-gate-secure
+
+**Dispatch-ID**: plan-tiebreak-review-gate-secure-04990c59
+**Model**: deepseek-v4-pro
+**Provider**: deepseek-harness
+**Role**: plan-gate tiebreaker (na 2 panelrondes zonder PASS)
+
+## Summary
+
+Beslissing: **START**, geen verplichte wijziging.
+
+Ik heb niet opnieuw als zetel gereviewd. Ik heb getoetst of dit plan convergeert
+of rondjes draait, aan twee vragen: kloppen de dragende regelverwijzingen op de
+boom, en is de scope na twee rondes gekrompen in plaats van gegroeid. Beide zijn
+waar.
+
+Alle zeven probleemgaten (OI-1442, OI-1618, OI-1617, OI-1434/OI-1280, OI-1644,
+OI-1645) hebben elk een concrete deliverable met een rode test die op main faalt,
+en de volgorde-eis (A5/A6 eerst, dan A1+A3 parallel, A2 na A1, A4 apart) is
+vrij van bestandsoverlap. De ronde-1- en ronde-2-bevindingen zijn stuk voor stuk
+verwerkt in de tabel, met bewijs waar de auteur een eigen claim moest corrigeren
+(bijv. A3 "stale door #1749" is toegespitst op het restgat dat #1749 expliciet
+niet dichtte).
+
+De opus-zetel gaf tweemaal geen oordeel. Dat is gemeten als een tmux-
+leveringsdefect (alleen de laatste promptregel komt aan, blocker-OI gefiled),
+geen planoordeel. Er zit geen stille REVISE achter die time-outs.
+
+## Changes
+
+Geen code gewijzigd. Review-only rol; niets anders geschreven dan dit rapport.
+
+## Verification
+
+Elke dragende verwijzing tegen de huidige boom nagelopen. Allemaal exact.
+
+| claim | bewijs |
+|---|---|
+| glm diff gaat ongemarkeerd de prompt in | `scripts/glm_gate.py:181-191` `_build_prompt` plakt `diff_text` kaal achter instructie + `_VERDICT_CONTRACT`; `grep -ciE "sanitiz|escape|neutral|untrusted"` = 0/0 |
+| diepte hangt alleen op de codex-lane | `grep -rln gate_depth scripts/` → alleen `scripts/lib/gate_artifacts.py`; glm/kimi kennen geen diepte |
+| deur slikt poortverplichting stil in | `dispatch_cli.py:1329 _register_gate_obligation`, `:1128 _record_bookkeeping_failure` met contract "bookkeeping must never block the door"; ~29 `except Exception`-plekken |
+| leeg en onleesbaar zijn niet-scorend | `plan_gate_panel.py:114 VERDICT_FENCE`, parse `:641` (empty) en `:646` (no verdict block found) beide `parse_error` |
+| tiebreaker telt alleen ronden | `plan_gate_tiebreaker.py:472 should_run_tiebreaker`, `:362 read_round_count`, drempelcheck `:490` |
+| derde hook stuurt de dode vorm | `pretooluse_worker_scope_enforce.py:281` emitteert `{"decision": "block", "reason": ...}` |
+| derde aanroeper van de recorder | `gate_reanchor_cli.py:322` roept `record_terminal_result` aan |
+| enum-drift-gat is reëel | `test_oi1645_peer_is_review_gate.py` bestaat; `test_closure_verifier_gate_enum_drift.py` heeft 0 treffers op `_REVIEW_PEER_GATES`/`_NON_REVIEW_SIGNER_REASONS` |
+
+ADR-007: geen deliverable voegt een central-DB-tabel toe; niet van toepassing.
+
+## Open Items
+
+De twee open vragen zijn correct gescoped. Vraag 1 (`claude_github_optional`
+als review-peer) is een operator-besluit en A6 pint de huidige keuze tegen
+drift. Vraag 2 (blocking vs advisory voor "instructie in de diff") hoeft de
+build niet te blokkeren: de canary-test in A1 pint het gedrag ongeacht de
+severity; de severity zelf is een label dat later gewijzigd kan worden.
+
+```vnx-plan-tiebreak
+{
+  "outcome": "START",
+  "required_change": "",
+  "rationale": "Het plan is na twee rondes geconvergeerd: elke dragende file:line-verwijzing klopt op main, beide REVISE-rondes zijn met bewijs verwerkt, en de volgorde-eis is vrij van bestandsoverlap. De opus-afwezigheid is een gemeten tmux-leveringsdefect, geen planoordeel; er is geen gat dat een derde ronde zou dichten."
+}
+```

--- a/tests/test_backfill_track_decision_ref.py
+++ b/tests/test_backfill_track_decision_ref.py
@@ -289,6 +289,161 @@ def test_print_report_without_reports_not_reduced_by_orphans(tmp_path, capsys):
     assert "tracks without plan-gate reports     : 1" in out
 
 
+# ---------------------------------------------------------------------------
+# Tiebreak reports (OI-1618 follow-up)
+# ---------------------------------------------------------------------------
+
+_TIEBREAK_FIXTURE = _ROOT / "tests" / "fixtures" / "plan-tiebreak-review-gate-secure-04990c59.md"
+
+
+def _tiebreak_report(outcome: str, required_change: str = "", rationale: str = "ok") -> str:
+    body = json.dumps({
+        "outcome": outcome, "required_change": required_change, "rationale": rationale,
+    })
+    return (
+        "# tiebreak\n\n**Dispatch-ID**: plan-tiebreak-x\n**Model**: deepseek-v4-pro\n"
+        "**Provider**: deepseek-harness\n\n## Summary\n\nok\n\n"
+        f"```vnx-plan-tiebreak\n{body}\n```\n"
+    )
+
+
+def test_parse_tiebreak_report_filename():
+    r = b._parse_tiebreak_report_filename("plan-tiebreak-review-gate-secure-04990c59.md")
+    assert r is not None
+    assert (r.track_id, r.hash) == ("review-gate-secure", "04990c59")
+
+
+def test_parse_tiebreak_report_filename_rejects_unparseable():
+    assert b._parse_tiebreak_report_filename("plan-gate-x-opus-deadbeef.md") is None
+    assert b._parse_tiebreak_report_filename("plan-tiebreak-nohash.md") is None
+    assert b._parse_tiebreak_report_filename("plan-tiebreak--deadbeef.md") is None  # empty track
+
+
+def test_apply_backfill_proposes_tiebreak_when_youngest_report_is_tiebreak(tmp_path):
+    """The real historical tiebreak report for review-gate-secure (byte-exact
+    fixture) is YOUNGER than its two panel reports — the backfill must propose
+    ``tiebreak:START`` with the tiebreak report first, the panel reports
+    inherited behind it, and the panel round's rejected alternative preserved.
+    """
+    import os
+
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+
+    tracks_lib.create_track(state_dir, "review-gate-secure", "proj-x", "T", "shipped")
+
+    panel_a = reports_dir / "plan-gate-review-gate-secure-opus-11111111.md"
+    panel_a.write_text(_report("revise", ["gap one"], "needs more"), encoding="utf-8")
+    panel_b = reports_dir / "plan-gate-review-gate-secure-kimi-22222222.md"
+    panel_b.write_text(_report("pass"), encoding="utf-8")
+    os.utime(panel_a, (1_000_000, 1_000_000))
+    os.utime(panel_b, (1_000_100, 1_000_100))
+
+    tb_path = reports_dir / _TIEBREAK_FIXTURE.name
+    tb_path.write_text(_TIEBREAK_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    os.utime(tb_path, (2_000_000, 2_000_000))
+
+    report = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-09-06T00:00:00Z")
+    assert report["filled"] == ["review-gate-secure"]
+    assert report["errors"] == []
+
+    payload = json.loads(_decision_ref(state_dir, "review-gate-secure"))
+    assert payload["decision"] == "tiebreak:START"
+    assert payload["source"] == "plan-gate-tiebreak"
+    assert payload["superseded_decision"] == "REVISE"
+    assert payload["tiebreaker_model"] == "deepseek-v4-pro"
+    assert payload["reports"][0] == f"unified_reports/{_TIEBREAK_FIXTURE.name}"
+    assert len(payload["reports"]) == 3  # tiebreak report + 2 panel reports
+    assert len(payload["rejected_alternatives"]) == 1  # only opus (revise)
+    assert payload["rejected_alternatives"][0]["panelist"] == "opus"
+
+
+def test_apply_backfill_tiebreak_only_track_has_no_superseded_decision(tmp_path):
+    """A track with ONLY a tiebreak report (no panel reports at all) is never
+    guessed at: ``superseded_decision`` is ``None`` and ``reports`` carries
+    just the tiebreak report itself.
+    """
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "feat-tbonly", "proj-x", "T", "shipped")
+    (reports_dir / "plan-tiebreak-feat-tbonly-cafef00d.md").write_text(
+        _tiebreak_report("STOP", "", "no panel history for this track"),
+        encoding="utf-8",
+    )
+
+    report = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-09-06T00:00:00Z")
+    assert report["filled"] == ["feat-tbonly"]
+
+    payload = json.loads(_decision_ref(state_dir, "feat-tbonly"))
+    assert payload["decision"] == "tiebreak:STOP"
+    assert payload["superseded_decision"] is None
+    assert payload["reports"] == ["unified_reports/plan-tiebreak-feat-tbonly-cafef00d.md"]
+    assert payload["rejected_alternatives"] == []
+
+
+def test_backfill_dry_run_shows_tiebreak_proposal_without_writing(tmp_path, capsys):
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "review-gate-secure", "proj-x", "T", "shipped")
+    (reports_dir / _TIEBREAK_FIXTURE.name).write_text(
+        _TIEBREAK_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    rc = b.dry_run(state_dir, reports_dir, "proj-x")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "review-gate-secure" in out
+    # The live store was not touched by the dry-run.
+    assert _decision_ref(state_dir, "review-gate-secure") is None
+
+
+def test_apply_backfill_panel_stays_on_panel_path_when_report_is_youngest(tmp_path):
+    """Regression: a track whose YOUNGEST report is a panel report is unaffected
+    by the new tiebreak-awareness, even when an OLDER tiebreak report also
+    exists for the same track (e.g. an earlier tie later re-reviewed by a
+    fresh panel round).
+    """
+    import os
+
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "feat-repanel", "proj-x", "T", "shipped")
+
+    old_tb = reports_dir / "plan-tiebreak-feat-repanel-99999999.md"
+    old_tb.write_text(_tiebreak_report("STOP", "x", "old"), encoding="utf-8")
+    os.utime(old_tb, (1_000_000, 1_000_000))
+
+    panel = reports_dir / "plan-gate-feat-repanel-opus-aaaaaaaa.md"
+    panel.write_text(_report("pass"), encoding="utf-8")
+    os.utime(panel, (2_000_000, 2_000_000))
+
+    report = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-09-06T00:00:00Z")
+    assert report["filled"] == ["feat-repanel"]
+
+    payload = json.loads(_decision_ref(state_dir, "feat-repanel"))
+    assert payload["decision"] == "PASS"
+    assert payload["source"] == "backfill"
+
+
+def test_apply_backfill_unparseable_tiebreak_report_skipped_with_reason(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "feat-badtb", "proj-x", "T", "shipped")
+    (reports_dir / "plan-tiebreak-feat-badtb-abcdef01.md").write_text(
+        "# tiebreak\n\nno fence here at all.\n", encoding="utf-8",
+    )
+
+    report = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-09-06T00:00:00Z")
+    assert report["filled"] == []
+    assert any("feat-badtb" in e for e in report["errors"])
+    assert _decision_ref(state_dir, "feat-badtb") is None
+
+
 def test_apply_backfill_is_idempotent_second_run_is_noop(tmp_path):
     state_dir = _make_state_dir(tmp_path)
     reports_dir = tmp_path / "unified_reports"

--- a/tests/test_backfill_track_decision_ref.py
+++ b/tests/test_backfill_track_decision_ref.py
@@ -458,3 +458,169 @@ def test_apply_backfill_is_idempotent_second_run_is_noop(tmp_path):
     assert first["filled"] == ["feat-a"]
     assert second["filled"] == []          # nothing left to fill
     assert second["already_filled"] == ["feat-a"]  # the first run's write is seen
+
+
+# ---------------------------------------------------------------------------
+# --track + --supersede-panel-with-tiebreak (PR #1801 fix-forward)
+#
+# Scoped, explicit override of the "never overwrite" rule: only for exactly
+# one operator-named track, and only when its youngest report on disk is a
+# parseable tiebreak report strictly younger (mtime) than the EXISTING
+# decision_ref's own "set_at". Every other track — including one with an
+# empty decision_ref sitting in the same store — must be provably untouched.
+# ---------------------------------------------------------------------------
+
+import datetime as _dt  # noqa: E402
+
+
+def _iso_from_epoch(epoch: float) -> str:
+    return _dt.datetime.fromtimestamp(epoch, tz=_dt.timezone.utc).isoformat()
+
+
+def _seed_revise_decision_ref(state_dir: Path, track_id: str, project_id: str, set_at_iso: str) -> str:
+    payload = json.dumps({
+        "reports": [f"unified_reports/plan-gate-{track_id}-opus-11111111.md"],
+        "decision": "REVISE",
+        "rejected_alternatives": [
+            {"panelist": "opus", "verdict": "revise", "findings": ["gap one"], "rationale": "needs more"},
+        ],
+        "set_at": set_at_iso,
+        "source": "plan-gate",
+    }, sort_keys=True)
+    tracks_lib.set_decision_ref(state_dir, track_id, project_id, payload, actor="system")
+    return payload
+
+
+def test_generic_run_never_supersedes_existing_panel_decision_ref_even_with_younger_tiebreak(tmp_path):
+    """Regression on the pre-existing 'never overwrite' rule: a track that already
+    carries a panel decision_ref (REVISE) must stay untouched by the GENERIC
+    (unscoped) backfill even when a younger, parseable tiebreak report exists for
+    it on disk. Only the scoped --track --supersede-panel-with-tiebreak mode may
+    replace it.
+    """
+    import os
+
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "review-gate-secure", "proj-x", "T", "shipped")
+
+    existing = _seed_revise_decision_ref(
+        state_dir, "review-gate-secure", "proj-x", _iso_from_epoch(500_000)
+    )
+
+    tb_path = reports_dir / _TIEBREAK_FIXTURE.name
+    tb_path.write_text(_TIEBREAK_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    os.utime(tb_path, (1_000_000, 1_000_000))
+
+    report = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-09-06T00:00:00Z")
+    assert report["already_filled"] == ["review-gate-secure"]
+    assert report["filled"] == []
+    assert _decision_ref(state_dir, "review-gate-secure") == existing
+
+
+def test_supersede_panel_with_tiebreak_dry_run_shows_replacement_without_writing(tmp_path, capsys):
+    import os
+
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "review-gate-secure", "proj-x", "T", "shipped")
+
+    existing = _seed_revise_decision_ref(
+        state_dir, "review-gate-secure", "proj-x", _iso_from_epoch(500_000)
+    )
+    tb_path = reports_dir / _TIEBREAK_FIXTURE.name
+    tb_path.write_text(_TIEBREAK_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    os.utime(tb_path, (1_000_000, 1_000_000))
+
+    rc = b.dry_run_supersede(state_dir, reports_dir, "proj-x", "review-gate-secure")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "review-gate-secure" in out
+    assert "REVISE" in out
+    assert "tiebreak:START" in out
+    # The live store is untouched by the dry-run.
+    assert _decision_ref(state_dir, "review-gate-secure") == existing
+
+
+def test_supersede_panel_with_tiebreak_apply_writes_and_second_apply_is_noop(tmp_path):
+    import os
+
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "review-gate-secure", "proj-x", "T", "shipped")
+
+    _seed_revise_decision_ref(
+        state_dir, "review-gate-secure", "proj-x", _iso_from_epoch(500_000)
+    )
+    tb_path = reports_dir / _TIEBREAK_FIXTURE.name
+    tb_path.write_text(_TIEBREAK_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    os.utime(tb_path, (1_000_000, 1_000_000))
+
+    rc = b.apply_supersede_live(state_dir, reports_dir, "proj-x", "review-gate-secure")
+    assert rc == 0
+    payload = json.loads(_decision_ref(state_dir, "review-gate-secure"))
+    assert payload["decision"] == "tiebreak:START"
+    assert payload["superseded_decision"] == "REVISE"
+    assert payload["source"] == "plan-gate-tiebreak"
+    assert payload["reports"][0] == f"unified_reports/{_TIEBREAK_FIXTURE.name}"
+
+    # A second --apply is a no-op: the tiebreak report is no longer younger
+    # than the (now recent) decision_ref.set_at that the first apply wrote.
+    after_first = _decision_ref(state_dir, "review-gate-secure")
+    rc2 = b.apply_supersede_live(state_dir, reports_dir, "proj-x", "review-gate-secure")
+    assert rc2 == 0
+    assert _decision_ref(state_dir, "review-gate-secure") == after_first
+
+
+def test_supersede_panel_with_tiebreak_older_report_no_replacement(tmp_path):
+    import os
+
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "review-gate-secure", "proj-x", "T", "shipped")
+
+    existing = _seed_revise_decision_ref(
+        state_dir, "review-gate-secure", "proj-x", _iso_from_epoch(500_000)
+    )
+    tb_path = reports_dir / _TIEBREAK_FIXTURE.name
+    tb_path.write_text(_TIEBREAK_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    os.utime(tb_path, (100_000, 100_000))  # older than the existing set_at (500_000)
+
+    result = b.compute_supersede_panel_with_tiebreak(
+        state_dir, reports_dir, "proj-x", "review-gate-secure", set_at="2026-09-06T00:00:00Z",
+    )
+    assert result.action == "skipped"
+    assert "not newer" in result.reason
+    assert _decision_ref(state_dir, "review-gate-secure") == existing
+
+
+def test_supersede_panel_with_tiebreak_leaves_other_tracks_untouched(tmp_path):
+    import os
+
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    tracks_lib.create_track(state_dir, "review-gate-secure", "proj-x", "T", "shipped")
+    tracks_lib.create_track(state_dir, "feat-untouched", "proj-x", "U", "shipped")
+
+    _seed_revise_decision_ref(
+        state_dir, "review-gate-secure", "proj-x", _iso_from_epoch(500_000)
+    )
+    tb_path = reports_dir / _TIEBREAK_FIXTURE.name
+    tb_path.write_text(_TIEBREAK_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    os.utime(tb_path, (1_000_000, 1_000_000))
+
+    rc = b.apply_supersede_live(state_dir, reports_dir, "proj-x", "review-gate-secure")
+    assert rc == 0
+    assert _decision_ref(state_dir, "feat-untouched") is None
+
+
+def test_main_supersede_without_track_is_an_error(capsys):
+    rc = b.main(["--supersede-panel-with-tiebreak"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "--track" in err

--- a/tests/test_plan_gate_tiebreaker.py
+++ b/tests/test_plan_gate_tiebreaker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -1275,6 +1276,134 @@ def test_cmd_plan_gate_run_records_the_scoring_seat_count_of_the_round(tmp_path,
     assert rounds[0][pgt.SCORED_SEATS_KEY] == 2
     # And that round now counts as READ, so the stop-rule can engage later.
     assert pgt.readable_round_count(ledger, "feat-count", "p1") == 1
+
+
+# --------------------------------------------------------------------------
+# Tiebreak outcome lands in decision_ref (OI-1618 follow-up)
+# --------------------------------------------------------------------------
+
+def _seed_previous_decision_ref(state_dir: Path, track_id: str, project_id: str) -> str:
+    """A REVISE panel-round decision_ref, as ``build_decision_ref`` would write it."""
+    payload = pgp.build_decision_ref(
+        "REVISE",
+        [
+            {"label": "opus", "dispatched": True,
+             "report_path": "plan-gate-x-opus-aaaaaaaa", "verdict": "revise",
+             "blocking_findings": ["gap one"], "rationale": "needs a rollback plan"},
+            {"label": "kimi", "dispatched": True,
+             "report_path": "plan-gate-x-kimi-bbbbbbbb", "verdict": "pass",
+             "blocking_findings": [], "rationale": "fine"},
+        ],
+        source="plan-gate", set_at="2026-09-01T00:00:00Z",
+    )
+    tracks.set_decision_ref(state_dir, track_id, project_id, payload, actor="system")
+    return payload
+
+
+def _write_tiebreak_report(track_id: str, hash_suffix: str) -> Path:
+    """Simulate the governed dispatch side effect: the tiebreak report file
+    landing in ``unified_reports/`` BEFORE ``run_tiebreaker`` returns."""
+    data_dir = Path(os.environ["VNX_DATA_DIR"])
+    reports_dir = data_dir / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    report = reports_dir / f"plan-tiebreak-{track_id}-{hash_suffix}.md"
+    report.write_text(
+        f"# tiebreak\n\n**Dispatch-ID**: plan-tiebreak-{track_id}-{hash_suffix}\n"
+        "**Model**: deepseek-v4-pro\n**Provider**: deepseek-harness\n\n"
+        "## Summary\n\nok\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def test_cmd_plan_gate_run_tiebreaker_start_writes_tiebreak_decision_ref(tmp_path, monkeypatch):
+    """A tiebreaker START must land in ``decision_ref`` as ``tiebreak:START`` —
+    not leave the last panel round's REVISE standing, which a reader checking
+    decision_ref alone would otherwise mistake for the gate still being stuck.
+    """
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-tbref", "p1", "t", "shipped", phase="queued")
+    planning_cli._seed_plan_blocker(state_dir, "feat-tbref", "p1")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+    ledger = _isolate_seat_ledger(monkeypatch, tmp_path)
+    pgt.record_round(ledger, track_id="feat-tbref", project_id="p1",
+                     round_number=1, outcome="panel", scored_seats=1)
+    pgt.record_round(ledger, track_id="feat-tbref", project_id="p1",
+                     round_number=2, outcome="panel", scored_seats=1)
+
+    previous_payload = _seed_previous_decision_ref(state_dir, "feat-tbref", "p1")
+
+    def _start_tiebreaker(doc_path, *, doc_text=None, track_id, project_id, round_number,
+                          last_round_findings, data_dir, timeout_seconds, config, model_arg=None):
+        _write_tiebreak_report(track_id, "04990c59")
+        return pgt.TiebreakerResult(
+            outcome="START", model="deepseek-v4-pro", round=round_number,
+            required_change="", rationale="converged",
+        )
+
+    monkeypatch.setattr(pgt, "run_tiebreaker", _start_tiebreaker)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
+
+    rc = planning_cli.cmd_plan_gate_run(_gate_args(state_dir, doc, track_id="feat-tbref"))
+    assert rc == 0
+
+    track = tracks.get_track(state_dir, "feat-tbref", "p1")
+    payload = json.loads(track["decision_ref"])
+    assert payload["decision"] == "tiebreak:START"
+    assert payload["source"] == "plan-gate-tiebreak"
+    assert payload["superseded_decision"] == "REVISE"
+    assert payload["tiebreaker_model"] == "deepseek-v4-pro"
+    assert payload["round"] == 3
+    assert payload["reports"][0] == "unified_reports/plan-tiebreak-feat-tbref-04990c59.md"
+    prev = json.loads(previous_payload)
+    assert payload["reports"][1:] == prev["reports"]
+    assert payload["rejected_alternatives"] == prev["rejected_alternatives"]
+
+    summary = planning_cli._format_decision_ref(track["decision_ref"])
+    assert summary == "tiebreak:START (3 report(s), 1 rejected alternative(s))"
+
+
+def test_cmd_plan_gate_run_tiebreaker_stop_writes_tiebreak_decision_ref(tmp_path, monkeypatch):
+    """A tiebreaker STOP must ALSO land in decision_ref as ``tiebreak:STOP`` —
+    the gate clears via open items rather than a PASS, but decision_ref must
+    still reflect the tiebreak, never the superseded panel REVISE."""
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-tbstop", "p1", "t", "shipped", phase="queued")
+    planning_cli._seed_plan_blocker(state_dir, "feat-tbstop", "p1")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+    ledger = _isolate_seat_ledger(monkeypatch, tmp_path)
+    pgt.record_round(ledger, track_id="feat-tbstop", project_id="p1",
+                     round_number=1, outcome="panel", scored_seats=1)
+    pgt.record_round(ledger, track_id="feat-tbstop", project_id="p1",
+                     round_number=2, outcome="panel", scored_seats=1)
+
+    _seed_previous_decision_ref(state_dir, "feat-tbstop", "p1")
+
+    def _stop_tiebreaker(doc_path, *, doc_text=None, track_id, project_id, round_number,
+                         last_round_findings, data_dir, timeout_seconds, config, model_arg=None):
+        _write_tiebreak_report(track_id, "deadbeef")
+        return pgt.TiebreakerResult(
+            outcome="STOP", model="deepseek-v4-pro", round=round_number,
+            required_change="tighten the rollback section", rationale="not converging",
+        )
+
+    monkeypatch.setattr(pgt, "run_tiebreaker", _stop_tiebreaker)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
+
+    rc = planning_cli.cmd_plan_gate_run(_gate_args(state_dir, doc, track_id="feat-tbstop"))
+    assert rc == 0  # STOP clears the gate (exit 0, like a PASS)
+
+    track = tracks.get_track(state_dir, "feat-tbstop", "p1")
+    payload = json.loads(track["decision_ref"])
+    assert payload["decision"] == "tiebreak:STOP"
+    assert payload["source"] == "plan-gate-tiebreak"
+    assert payload["superseded_decision"] == "REVISE"
+    assert payload["required_change"] == "tighten the rollback section"
+    assert payload["reports"][0] == "unified_reports/plan-tiebreak-feat-tbstop-deadbeef.md"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `_run_tiebreaker_for_track` (`scripts/planning_cli.py`) now writes `tracks.decision_ref` for BOTH tiebreaker outcomes (START/STOP), via a new `plan_gate_panel.build_tiebreak_decision_ref` builder. Before this, the tiebreaker resolved the plan blocker but decision_ref kept showing the last PANEL round's REVISE/BLOCK verdict — a reader checking decision_ref alone never saw that a tiebreaker actually cleared (or upheld) the gate.
- The new payload's `decision` is `tiebreak:START`/`tiebreak:STOP`, `reports` starts with the tiebreak report itself followed by the superseded panel round's reports, `rejected_alternatives` is inherited from that panel round, and `superseded_decision`/`tiebreaker_model`/`round`/`required_change` are recorded alongside. An unparseable/absent previous decision_ref is never guessed at — only the tiebreak's own report is kept, with `superseded_decision: null`.
- Since `run_tiebreaker()` generates its own dispatch id internally and doesn't return it, the tiebreak report's filename is discovered post-hoc (youngest `plan-tiebreak-<track_id>-<8-hex>.md` under `unified_reports/`, hash-suffix validated to avoid a `foo`/`foo-bar` track collision).
- `scripts/backfill_track_decision_ref.py` now also scans `plan-tiebreak-*.md` reports. When a track's YOUNGEST report is a tiebreak report, the backfill proposes `tiebreak:<outcome>` (parsed via the same strict `plan_gate_tiebreaker.parse_tiebreaker`), with that track's panel reports reconstructed as the inherited history. A track whose newest report is still a panel report is unaffected (regression-safe). An unparseable tiebreak fence is skipped with a reason rather than guessed at.
- `_format_decision_ref` required no changes — the new payload shares the same `decision`/`reports`/`rejected_alternatives` keys it already reads.

## Test plan
- [x] `pytest tests/test_plan_gate_tiebreaker.py tests/test_backfill_track_decision_ref.py -q` → 70 passed
- [x] Confirmed RED on `main` for both new-behavior test sets (scoped `git stash` of just the 3 source files, tests still show old decision_ref / missing tiebreak-awareness), then restored
- [x] Kapotmaak-proef: temporarily removed the new `set_decision_ref(...)` call in `_run_tiebreaker_for_track` → both new tiebreaker tests went red; restored → green
- [x] Confirmed the 32 pre-existing failures in `test_plan_gate_panel.py`/`test_planning_cli.py` (a migration-bootstrap ordering issue, `Migration 0030 requires migration 0029`) are unrelated — same failures reproduce on `main` before this change
- [x] `python3 -m py_compile` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)