### PR TITLE
fix(headless): worker gets the absolute report path; govern adopts a stray worker report before synthesising

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -819,7 +820,28 @@ def run_envelope_headless_plan(
         work_ref=plan.work_ref,
     )
 
-    enriched_instruction = _prepare(spec)
+    # A-bis-2: _prepare() (via _inject_skill_context -> PromptAssembler.assemble())
+    # fills base_worker.md's REPORT_PATH_PLACEHOLDER from dispatch_metadata["data_dir"]
+    # when present, else the ambient VNX_DATA_DIR + VNX_DATA_DIR_EXPLICIT=1 two-key
+    # contract already used fleet-wide (plan_gate_panel._resolve_data_dir). The
+    # headless lane's dispatch_metadata carries no data_dir key, so the ambient
+    # contract is set here — scoped and restored so a resolved data_dir never leaks
+    # into an unrelated dispatch processed later in the same orchestrator process.
+    _prev_vnx_data_dir = os.environ.get("VNX_DATA_DIR")
+    _prev_vnx_data_dir_explicit = os.environ.get("VNX_DATA_DIR_EXPLICIT")
+    os.environ["VNX_DATA_DIR"] = str(spec.data_dir)
+    os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
+    try:
+        enriched_instruction = _prepare(spec)
+    finally:
+        if _prev_vnx_data_dir is None:
+            os.environ.pop("VNX_DATA_DIR", None)
+        else:
+            os.environ["VNX_DATA_DIR"] = _prev_vnx_data_dir
+        if _prev_vnx_data_dir_explicit is None:
+            os.environ.pop("VNX_DATA_DIR_EXPLICIT", None)
+        else:
+            os.environ["VNX_DATA_DIR_EXPLICIT"] = _prev_vnx_data_dir_explicit
     enriched_spec = EnvelopeSpec(
         dispatch_id=spec.dispatch_id,
         terminal_id=spec.terminal_id,

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -186,6 +186,7 @@ def ensure_receipt(
     contract_status: str,
     permission_enforcement: str,
     status: Optional[str] = None,
+    report_relocated_from: Optional[str] = None,
 ) -> None:
     """Append a lane-synthesized completion receipt when the worker never emitted one.
 
@@ -196,6 +197,11 @@ def ensure_receipt(
     The synthesized receipt uses source="tmux_interactive_lane_synthesized" so
     dedup_completion_receipts() can distinguish it from a worker-authored one.
     If the worker later emits its own receipt, the authored one wins on readback.
+
+    ``report_relocated_from`` (A-bis-2): set by ``_govern_impl`` to the ORIGINAL
+    stray path when it adopted a worker report found outside the central store
+    (worktree or repo-root). Stamped as a ``warnings`` entry on the receipt so
+    the relocation is auditable, never silent.
     """
     if os.environ.get("VNX_RECEIPT_FALLBACK", "1").strip() == "0":
         return
@@ -262,6 +268,13 @@ def ensure_receipt(
         permission_allow_pattern_count=_posture.get("permission_allow_pattern_count"),
     ).to_dict()
 
+    if report_relocated_from:
+        synthesized_receipt["warnings"] = [{
+            "code": "report_relocated",
+            "severity": "info",
+            "message": f"report_relocated_from={report_relocated_from}",
+        }]
+
     try:
         if _SCRIPTS_DIR not in sys.path:
             sys.path.insert(0, _SCRIPTS_DIR)
@@ -324,6 +337,17 @@ class GovernSpec:
     # govern() callers), in which case ensure_receipt() omits the fields
     # exactly as before this change (no default-changing behavior).
     permission_posture: Optional[dict] = None
+    # A-bis-2: the MAIN checkout root — distinct from worktree_path (an
+    # ephemeral per-dispatch worktree that may already be torn down, or may
+    # simply be a different directory than the outer checkout the worker
+    # guessed relative to). A worker that could not see VNX_DATA_DIR
+    # sometimes resolves "$VNX_DATA_DIR/unified_reports/<id>.md" against the
+    # outer checkout's own .vnx-data instead of the central store or the
+    # worktree — that report survives worktree teardown (unlike a copy left
+    # under worktree_path) but is invisible to govern() without this second
+    # search location. None when the caller does not know it, in which case
+    # the stray-report search below simply has one fewer candidate.
+    repo_root: Optional[Path] = None
 
 
 @dataclass
@@ -552,6 +576,56 @@ def _govern_error_fallback(
     )
 
 
+# A-bis-2: adopt a stray worker report before synthesizing over it. The
+# worker guesses "$VNX_DATA_DIR/unified_reports/<id>.md" whenever the caller
+# never exported VNX_DATA_DIR — resolve_report_path() already covers the
+# central store and spec.worktree_path; this adds spec.repo_root (the outer
+# checkout) as a THIRD, lower-priority search location, only consulted when
+# neither of the first two found anything.
+def _resolve_worker_report_with_adoption(
+    spec: "GovernSpec",
+) -> "tuple[Optional[Path], Optional[Path]]":
+    """Resolve the worker-authored report, locating a stray copy for adoption.
+
+    Search order: central (``<data_dir>/unified_reports/<id>.md``), then
+    ``<worktree_path>/.vnx-data/unified_reports/<id>.md``, then
+    ``<repo_root>/.vnx-data/unified_reports/<id>.md``.
+
+    Returns ``(candidate_path, stray_path)``: ``candidate_path`` is the file
+    to read as the worker-authored body (or ``None`` if nothing was found
+    anywhere); ``stray_path`` is set to the same path when it was found
+    somewhere OTHER than the central location (signalling that, once
+    validated, it should be relocated there) and ``None`` when the candidate
+    is already at the canonical central path or nothing was found.
+    """
+    from report_path import resolve_report_path  # noqa: PLC0415
+
+    dispatch_id = spec.dispatch_id
+    central_path = Path(spec.data_dir) / "unified_reports" / f"{dispatch_id}.md"
+
+    resolved = resolve_report_path(
+        dispatch_id, data_dir=spec.data_dir,
+        repo_root=spec.worktree_path,
+    )
+    candidate_path = resolved.path if resolved is not None else None
+
+    if candidate_path is None and spec.repo_root is not None:
+        stray = Path(spec.repo_root) / ".vnx-data" / "unified_reports" / f"{dispatch_id}.md"
+        if stray.is_file():
+            candidate_path = stray
+
+    if candidate_path is None:
+        return None, None
+
+    try:
+        if candidate_path.resolve() == central_path.resolve():
+            return candidate_path, None
+    except OSError:
+        pass
+
+    return candidate_path, candidate_path
+
+
 def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome:
     """Core govern logic. Called by govern(); any exception is caught there."""
     from report_body_contract import CONTRACT_INVALID_STATUS, validate_body  # noqa: PLC0415
@@ -567,17 +641,13 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
     body: Optional[str] = None
     contract_status = "synthesized"
 
-    # OI-989/OI-993: use the shared resolver instead of hand-rolling path
-    # candidates. The resolver checks all three filename forms (canonical
-    # <id>.md, legacy dispatch-<id>.md, legacy <id>_report.md) and sets
-    # ambiguous=True when more than one exists — govern() logs that so the
-    # receipt never silently picks the wrong file.
-    from report_path import resolve_report_path
-    resolved = resolve_report_path(
-        dispatch_id, data_dir=spec.data_dir,
-        repo_root=spec.worktree_path,
-    )
-    candidate_path = resolved.path if resolved is not None else None
+    # OI-989/OI-993 + A-bis-2: use the shared resolver instead of hand-rolling
+    # path candidates, extended with a stray-report adoption search (central
+    # store, then worktree_path, then repo_root — see
+    # _resolve_worker_report_with_adoption's docstring). ``_stray_path`` is
+    # set only when the candidate was found somewhere other than the central
+    # location, in which case it is relocated there once validated as authored.
+    candidate_path, _stray_path = _resolve_worker_report_with_adoption(spec)
 
     if candidate_path is not None:
         try:
@@ -637,6 +707,27 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
                     )
         except OSError as exc:
             logger.warning("govern: could not read worker report for %s: %s", dispatch_id, exc)
+
+    # -- a2. Relocate an adopted stray report to the central path -------------
+    # Only a VALIDATED authored candidate gets relocated — an invalid stray
+    # report (placeholder/missing headings) falls through to synthesis exactly
+    # as before, and is left where it was found (A-bis-2 regression guard).
+    _report_relocated_from: Optional[str] = None
+    if contract_status == "authored" and _stray_path is not None:
+        _central_path = Path(spec.data_dir) / "unified_reports" / f"{dispatch_id}.md"
+        try:
+            _central_path.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(_stray_path, _central_path)
+            _report_relocated_from = str(_stray_path)
+            logger.info(
+                "govern: adopted stray worker report for dispatch=%s: %s -> %s",
+                dispatch_id, _stray_path, _central_path,
+            )
+        except OSError as exc:
+            logger.warning(
+                "govern: could not relocate stray report %s -> %s for dispatch=%s: %s",
+                _stray_path, _central_path, dispatch_id, exc,
+            )
 
     # -- b. Synthesize if no valid authored body found ------------------------
     if body is None:
@@ -810,6 +901,7 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
             contract_status=contract_status,
             permission_enforcement=permission_enforcement,
             status=receipt_status,
+            report_relocated_from=_report_relocated_from,
         )
         return GovernedOutcome(
             report_path=None,
@@ -825,6 +917,7 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
         contract_status=contract_status,
         permission_enforcement=permission_enforcement,
         status=receipt_status,
+        report_relocated_from=_report_relocated_from,
     )
 
     return GovernedOutcome(

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -583,13 +583,23 @@ def _govern_error_fallback(
 # checkout) as a THIRD, lower-priority search location, only consulted when
 # neither of the first two found anything.
 def _resolve_worker_report_with_adoption(
-    spec: "GovernSpec",
+    dispatch_id: str,
+    data_dir: "Path",
+    *,
+    worktree_path: "Optional[Path]" = None,
+    repo_root: "Optional[Path]" = None,
 ) -> "tuple[Optional[Path], Optional[Path]]":
     """Resolve the worker-authored report, locating a stray copy for adoption.
 
     Search order: central (``<data_dir>/unified_reports/<id>.md``), then
     ``<worktree_path>/.vnx-data/unified_reports/<id>.md``, then
     ``<repo_root>/.vnx-data/unified_reports/<id>.md``.
+
+    Takes plain values rather than a ``GovernSpec`` so callers with no
+    worktree/repo-root concept of their own (the envelope lane's
+    ``EnvelopeSpec`` carries neither field) can call it with just what they
+    have — ``envelope_govern._govern`` derives ``worktree_path``/``repo_root``
+    itself (via ``dispatch_worktree_isolation``) and passes them through here.
 
     Returns ``(candidate_path, stray_path)``: ``candidate_path`` is the file
     to read as the worker-authored body (or ``None`` if nothing was found
@@ -600,17 +610,16 @@ def _resolve_worker_report_with_adoption(
     """
     from report_path import resolve_report_path  # noqa: PLC0415
 
-    dispatch_id = spec.dispatch_id
-    central_path = Path(spec.data_dir) / "unified_reports" / f"{dispatch_id}.md"
+    central_path = Path(data_dir) / "unified_reports" / f"{dispatch_id}.md"
 
     resolved = resolve_report_path(
-        dispatch_id, data_dir=spec.data_dir,
-        repo_root=spec.worktree_path,
+        dispatch_id, data_dir=data_dir,
+        repo_root=worktree_path,
     )
     candidate_path = resolved.path if resolved is not None else None
 
-    if candidate_path is None and spec.repo_root is not None:
-        stray = Path(spec.repo_root) / ".vnx-data" / "unified_reports" / f"{dispatch_id}.md"
+    if candidate_path is None and repo_root is not None:
+        stray = Path(repo_root) / ".vnx-data" / "unified_reports" / f"{dispatch_id}.md"
         if stray.is_file():
             candidate_path = stray
 
@@ -647,7 +656,11 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
     # _resolve_worker_report_with_adoption's docstring). ``_stray_path`` is
     # set only when the candidate was found somewhere other than the central
     # location, in which case it is relocated there once validated as authored.
-    candidate_path, _stray_path = _resolve_worker_report_with_adoption(spec)
+    candidate_path, _stray_path = _resolve_worker_report_with_adoption(
+        spec.dispatch_id, spec.data_dir,
+        worktree_path=spec.worktree_path,
+        repo_root=spec.repo_root,
+    )
 
     if candidate_path is not None:
         try:

--- a/scripts/lib/envelope_adapters_claude.py
+++ b/scripts/lib/envelope_adapters_claude.py
@@ -122,6 +122,21 @@ class ClaudeSubprocessAdapter:
         from env_scrub_patterns import DEFAULT_SCRUB_KEY_PATTERNS  # noqa: PLC0415
         from provider_spawns.claude_spawn import spawn_claude  # noqa: PLC0415
 
+        # A-bis-2: the headless lane never exported VNX_DATA_DIR into the
+        # worker's own shell, so a worker guessing "$VNX_DATA_DIR/unified_reports/
+        # <id>.md" (base_worker.md) resolved it wherever its cwd happened to
+        # land — often not the central store GOVERN reads back from (measured
+        # 2026-09-06: reports orphaned in a repo-local .vnx-data instead of the
+        # central one). VNX_REPORT_PATH gives the worker the exact absolute
+        # file to write, no guessing required; VNX_DATA_DIR/_EXPLICIT mirror
+        # the two-key contract other lanes already export (plan_gate_panel.py).
+        _report_path = Path(spec.data_dir) / "unified_reports" / f"{spec.dispatch_id}.md"
+        extra_env = {
+            "VNX_DATA_DIR": str(spec.data_dir),
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "VNX_REPORT_PATH": str(_report_path),
+        }
+
         try:
             result = spawn_claude(
                 prompt=spec.instruction,
@@ -133,6 +148,7 @@ class ClaudeSubprocessAdapter:
                 role=spec.role,
                 total_deadline=float(spec.deadline_seconds),
                 scrub_env_keys=DEFAULT_SCRUB_KEY_PATTERNS,
+                extra_env=extra_env,
             )
         except BrokenPipeError as exc:
             return _AdapterResult(

--- a/scripts/lib/envelope_govern.py
+++ b/scripts/lib/envelope_govern.py
@@ -194,6 +194,52 @@ def _govern(
     # series leaked its events into the live file.
     events_path, _events_archive_ok = _archive_dispatch_events(spec.terminal_id, spec.dispatch_id)
 
+    # A-bis-2 (envelope lane): adopt a stray worker report BEFORE emitting the
+    # wrapper — mirrors dispatch_govern._govern_impl's a/a2 steps and reuses its
+    # shared resolver (never a second implementation, see
+    # dispatch_govern._resolve_worker_report_with_adoption). Search order:
+    # central store (nothing to do here — emit_unified_report's own idempotent
+    # early-return below already preserves it), then the ephemeral per-dispatch
+    # worktree (derived the same way run_envelope_headless_plan creates it —
+    # usually already torn down by GOVERN time, since run_envelope_headless_plan
+    # calls remove_dispatch_worktree() in a `finally` BEFORE invoking _govern, so
+    # this is best-effort), then the outer/consumer checkout root — the location
+    # that actually caught the 2026-09-06 incident (A5/A1): a worker that could
+    # not see VNX_DATA_DIR guessed the outer checkout's own .vnx-data instead of
+    # the central store.
+    _report_relocated_from: Optional[Path] = None
+    try:
+        from dispatch_govern import _resolve_worker_report_with_adoption  # noqa: PLC0415
+        from dispatch_worktree_isolation import (  # noqa: PLC0415
+            _dispatch_worktree_dir,
+            resolve_consumer_project_root,
+        )
+        from report_body_contract import validate_body as _validate_stray_body  # noqa: PLC0415
+
+        _consumer_root = resolve_consumer_project_root()
+        _stray_candidate, _stray_path = _resolve_worker_report_with_adoption(
+            spec.dispatch_id, spec.data_dir,
+            worktree_path=_dispatch_worktree_dir(_consumer_root, spec.dispatch_id),
+            repo_root=_consumer_root,
+        )
+        if _stray_path is not None:
+            _stray_text = _stray_candidate.read_text(encoding="utf-8")
+            _stray_result = _validate_stray_body(_stray_text, pr_id=spec.pr_id)
+            if _stray_result.valid and not _stray_result.placeholder:
+                _central_path = Path(spec.data_dir) / "unified_reports" / f"{spec.dispatch_id}.md"
+                _central_path.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(_stray_path, _central_path)
+                _report_relocated_from = _stray_path
+                logger.info(
+                    "envelope._govern: adopted stray worker report for dispatch=%s: %s -> %s",
+                    spec.dispatch_id, _stray_path, _central_path,
+                )
+    except Exception as exc:  # noqa: BLE001 — adoption is best-effort, never blocks GOVERN
+        logger.warning(
+            "envelope._govern: stray-report adoption failed dispatch=%s (non-fatal): %s",
+            spec.dispatch_id, exc,
+        )
+
     # REPORT first — idempotent: worker-written file is preserved, not overwritten.
     # OI-903: on failure/timeout, a killed worker's partial report is preserved
     # under a .partial.md sidecar so the canonical report stays contract-compliant
@@ -233,6 +279,12 @@ def _govern(
     # audit-trail queryability.
     _contract_warnings: List[Dict[str, Any]] = []
     _effective_status: str = adapter_result.status
+    if _report_relocated_from is not None:
+        _contract_warnings.append({
+            "code": "report_relocated",
+            "severity": "info",
+            "message": f"report_relocated_from={_report_relocated_from}",
+        })
     if report_path is not None:
         try:
             from report_body_contract import CONTRACT_INVALID_STATUS, validate_body  # noqa: PLC0415

--- a/scripts/lib/prompt_assembler.py
+++ b/scripts/lib/prompt_assembler.py
@@ -19,6 +19,7 @@ BILLING SAFETY: No Anthropic SDK imports. No api.anthropic.com calls. CLI-only.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -31,6 +32,18 @@ _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 
 # Regex to strip [[TARGET:TX]] dispatch header line
 _TARGET_HEADER_RE = re.compile(r"^\[\[TARGET:T\d+\]\]\s*\n?", re.MULTILINE)
+
+# A-bis-2: base_worker.md carries this placeholder instead of a bare
+# "$VNX_DATA_DIR" reference. assemble() fills it in with the absolute report
+# path so the worker never has to guess where VNX_DATA_DIR actually resolves
+# to (the headless lane does not export that variable into the worker's own
+# shell — see envelope_adapters_claude.ClaudeSubprocessAdapter.run).
+REPORT_PATH_PLACEHOLDER = "{{REPORT_PATH}}"
+
+# Fallback text when dispatch_id or data_dir cannot be resolved — byte-identical
+# to the historical templated text so callers that supply neither key keep
+# their previous prompt content instead of leaking the raw placeholder token.
+_REPORT_PATH_FALLBACK = "$VNX_DATA_DIR/unified_reports/<dispatch_id>.md"
 
 
 @dataclass
@@ -145,6 +158,10 @@ class PromptAssembler:
         else:
             context = f"{layer1}\n\n---\n\n{layer2}"
 
+        context = context.replace(
+            REPORT_PATH_PLACEHOLDER, self._resolve_report_path(dispatch_metadata)
+        )
+
         # ---- Layer 3: Dispatch payload ------------------------------------
         cleaned_instruction = _TARGET_HEADER_RE.sub("", instruction).strip()
         layer3 = self._build_layer3(cleaned_instruction, dispatch_metadata)
@@ -176,6 +193,37 @@ class PromptAssembler:
     # ------------------------------------------------------------------
     # Layer loaders
     # ------------------------------------------------------------------
+
+    def _resolve_report_path(self, dispatch_metadata: dict) -> str:
+        """Resolve the text that fills base_worker.md's REPORT_PATH_PLACEHOLDER.
+
+        A-bis-2: the worker used to see a bare ``$VNX_DATA_DIR`` reference and
+        had to guess the real directory — the headless lane never exported
+        that variable into the worker's own shell, so reports landed wherever
+        the guess resolved (often not the store GOVERN reads back from).
+
+        Resolution order:
+          1. ``dispatch_metadata["data_dir"]`` — explicit override (tests,
+             programmatic callers).
+          2. The ambient ``VNX_DATA_DIR`` + ``VNX_DATA_DIR_EXPLICIT=1``
+             two-key contract already used fleet-wide (e.g.
+             ``plan_gate_panel._resolve_data_dir``) — a bare inherited
+             ``VNX_DATA_DIR`` is pollution, not config, so it is only honored
+             with the explicit flag set.
+          3. Falls back to the historical templated text when dispatch_id or
+             data_dir cannot be resolved, so the placeholder never leaks into
+             the prompt unresolved.
+        """
+        dispatch_id = str(dispatch_metadata.get("dispatch_id") or "").strip()
+
+        raw_data_dir = dispatch_metadata.get("data_dir")
+        data_dir = str(raw_data_dir).strip() if raw_data_dir else ""
+        if not data_dir and os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
+            data_dir = os.environ.get("VNX_DATA_DIR", "").strip()
+
+        if dispatch_id and data_dir:
+            return str(Path(data_dir) / "unified_reports" / f"{dispatch_id}.md")
+        return _REPORT_PATH_FALLBACK
 
     def _load_base(self) -> str:
         """Load Layer 1 from scripts/lib/prompts/base_worker.md."""

--- a/scripts/lib/prompts/base_worker.md
+++ b/scripts/lib/prompts/base_worker.md
@@ -74,11 +74,11 @@ Dispatch-ID: <dispatch_id>
 2. Run relevant tests and record exact pass/fail counts
 3. Commit changes with conventional commit message
 4. Push to branch (unless dispatch says otherwise)
-5. Write completion report to `$VNX_DATA_DIR/unified_reports/<dispatch_id>.md`
+5. Write completion report to `{{REPORT_PATH}}`
 
 ## Report Location
 Write your completion report to:
-`$VNX_DATA_DIR/unified_reports/<dispatch_id>.md`
+`{{REPORT_PATH}}`
 
 Use the dispatch ID from the dispatch metadata footer.
 

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -1345,6 +1345,20 @@
       "symbol": "_verification_from_report"
     },
     {
+      "file": "tests/test_report_path.py",
+      "line": 383,
+      "mechanism": "direct-call",
+      "module_target": "envelope_adapters_claude",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_report_path.py",
+      "line": 384,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "EnvelopeSpec"
+    },
+    {
       "file": "tests/test_role_applied_provider_lane.py",
       "line": 46,
       "mechanism": "direct-call",

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -624,6 +624,20 @@
       "symbol": "_govern"
     },
     {
+      "file": "tests/test_envelope_claude_adapter_report_env.py",
+      "line": 27,
+      "mechanism": "direct-call",
+      "module_target": "envelope_adapters_claude",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_envelope_claude_adapter_report_env.py",
+      "line": 28,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "EnvelopeSpec"
+    },
+    {
       "file": "tests/test_envelope_govern_contract_enforce.py",
       "line": 39,
       "mechanism": "direct-call",

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -687,6 +687,48 @@
       "symbol": "_receipt_exists_for_dispatch"
     },
     {
+      "file": "tests/test_envelope_govern_report_adoption.py",
+      "line": 40,
+      "mechanism": "direct-call",
+      "module_target": "envelope_govern",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_envelope_govern_report_adoption.py",
+      "line": 41,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_envelope_govern_report_adoption.py",
+      "line": 41,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_envelope_govern_report_adoption.py",
+      "line": 113,
+      "mechanism": "patch-string",
+      "module_target": "envelope_govern",
+      "symbol": "_archive_dispatch_events"
+    },
+    {
+      "file": "tests/test_envelope_govern_report_adoption.py",
+      "line": 115,
+      "mechanism": "patch-string",
+      "module_target": "envelope_govern",
+      "symbol": "_clear_dispatch_events"
+    },
+    {
+      "file": "tests/test_envelope_govern_report_adoption.py",
+      "line": 117,
+      "mechanism": "patch-string",
+      "module_target": "envelope_govern",
+      "symbol": "_receipt_exists_for_dispatch"
+    },
+    {
       "file": "tests/test_envelope_provider_adapter_role_env.py",
       "line": 37,
       "mechanism": "direct-call",

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -71,6 +71,7 @@ def _make_spec(data_dir: Path, state_dir: Path, **kwargs) -> GovernSpec:
         task_class=kwargs.get("task_class"),
         tier_from=kwargs.get("tier_from"),
         tier_to=kwargs.get("tier_to"),
+        repo_root=kwargs.get("repo_root"),
     )
 
 
@@ -1916,3 +1917,119 @@ def test_synthesize_work_delivered_keeps_commit_message_and_verdict(tmp_path):
     assert "- delivery_verdict: work_delivered" in body
     assert "feat(oi-1363): real worker delivery" in body
     print(f"\n--- ## Response (work_delivered) ---\n{body}")
+
+
+# ---------------------------------------------------------------------------
+# A-bis-2: GOVERN adopts a stray worker report before synthesizing.
+#
+# A worker that could not see VNX_DATA_DIR guesses "$VNX_DATA_DIR/unified_reports/
+# <id>.md" from wherever its cwd happens to resolve — sometimes the ephemeral
+# per-dispatch worktree (torn down by the time GOVERN runs on the headless
+# lane), sometimes the outer checkout's own .vnx-data (repo_root, which
+# survives worktree teardown). Measured 2026-09-06: five real worker reports
+# landed in the outer checkout's .vnx-data/unified_reports/ while the central
+# store received a synthesized wrapper for the same dispatches.
+# ---------------------------------------------------------------------------
+
+def test_govern_adopts_stray_report_from_repo_root(tmp_data, tmp_state, tmp_path):
+    """A valid worker report sitting in <repo_root>/.vnx-data/unified_reports/
+    with nothing central is adopted: outcome is authored, the file is moved to
+    the central path, the stray original is gone, and the receipt records a
+    report_relocated_from warning."""
+    repo_root = tmp_path / "repo"
+    stray_dir = repo_root / ".vnx-data" / "unified_reports"
+    stray_dir.mkdir(parents=True)
+    stray_path = stray_dir / "test-govern-001.md"
+    stray_path.write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, repo_root=repo_root)
+    raw = GovernRaw(receipt=None, duration_seconds=5.0)
+
+    outcome = govern(spec, raw, lane="claude_headless")
+
+    assert outcome.contract_status == "authored"
+    central_path = tmp_data / "unified_reports" / "test-govern-001.md"
+    assert outcome.report_path == central_path
+    assert central_path.exists()
+    assert "Implemented the feature correctly" in central_path.read_text(encoding="utf-8")
+    assert not stray_path.exists(), "stray original must be relocated, not copied"
+
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+    receipt = json.loads(receipts_file.read_text().splitlines()[0])
+    warnings = receipt.get("warnings") or []
+    assert any(
+        w.get("code") == "report_relocated" and str(stray_path) in w.get("message", "")
+        for w in warnings
+    ), f"expected a report_relocated warning naming {stray_path}, got {warnings!r}"
+
+
+def test_govern_invalid_repo_root_stray_report_still_synthesizes(tmp_data, tmp_state, tmp_path):
+    """An INVALID stray report at repo_root falls through to synthesis exactly
+    as before (regression guard) — and is left in place, not moved."""
+    repo_root = tmp_path / "repo"
+    stray_dir = repo_root / ".vnx-data" / "unified_reports"
+    stray_dir.mkdir(parents=True)
+    stray_path = stray_dir / "test-govern-001.md"
+    stray_path.write_text("not a valid report body\n", encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, repo_root=repo_root)
+    raw = GovernRaw(receipt=None, duration_seconds=5.0)
+
+    with patch("dispatch_govern._git_summary",
+               return_value="feat: something real with enough chars to pass the fifty-char minimum check"), \
+         patch("dispatch_govern._git_changes", return_value="scripts/lib/foo.py | 10 ++"):
+        outcome = govern(spec, raw, lane="claude_headless")
+
+    assert outcome.contract_status == "synthesized"
+    assert stray_path.exists(), "an invalid stray report must not be relocated"
+    assert stray_path.read_text(encoding="utf-8") == "not a valid report body\n"
+
+
+def test_govern_worktree_report_wins_over_repo_root(tmp_data, tmp_state, tmp_path):
+    """Search order: worktree_path is consulted BEFORE repo_root. When both
+    hold a valid report, the worktree one is adopted and the repo_root one is
+    left untouched."""
+    worktree = tmp_path / "worktree"
+    worktree_stray_dir = worktree / ".vnx-data" / "unified_reports"
+    worktree_stray_dir.mkdir(parents=True)
+    worktree_stray = worktree_stray_dir / "test-govern-001.md"
+    worktree_stray.write_text(
+        _valid_body().replace("Implemented the feature correctly", "WORKTREE body marker"),
+        encoding="utf-8",
+    )
+
+    repo_root = tmp_path / "repo"
+    repo_root_stray_dir = repo_root / ".vnx-data" / "unified_reports"
+    repo_root_stray_dir.mkdir(parents=True)
+    repo_root_stray = repo_root_stray_dir / "test-govern-001.md"
+    repo_root_stray.write_text(
+        _valid_body().replace("Implemented the feature correctly", "REPO ROOT body marker"),
+        encoding="utf-8",
+    )
+
+    spec = _make_spec(tmp_data, tmp_state, worktree_path=worktree, repo_root=repo_root)
+    raw = GovernRaw(receipt=None, duration_seconds=5.0)
+
+    outcome = govern(spec, raw, lane="claude_headless")
+
+    assert outcome.contract_status == "authored"
+    content = outcome.report_path.read_text(encoding="utf-8")
+    assert "WORKTREE body marker" in content
+    assert "REPO ROOT body marker" not in content
+    assert not worktree_stray.exists(), "the adopted worktree stray must be relocated"
+    assert repo_root_stray.exists(), "the un-adopted repo_root stray must be left in place"
+
+
+def test_govern_repo_root_none_does_not_break_normal_synthesis(tmp_data, tmp_state):
+    """Regression: spec.repo_root defaults to None and must not change the
+    existing no-worker-report synthesis path."""
+    spec = _make_spec(tmp_data, tmp_state)
+    assert spec.repo_root is None
+    raw = _make_raw()
+
+    with patch("dispatch_govern._git_summary",
+               return_value="feat: implement X with full coverage. Worker status: done. Synthesized."), \
+         patch("dispatch_govern._git_changes", return_value="scripts/lib/foo.py | 10 +++++"):
+        outcome = govern(spec, raw, lane="claude_headless")
+
+    assert outcome.contract_status == "synthesized"

--- a/tests/test_envelope_claude_adapter_report_env.py
+++ b/tests/test_envelope_claude_adapter_report_env.py
@@ -1,0 +1,118 @@
+"""test_envelope_claude_adapter_report_env.py — A-bis-2: the headless
+(claude_headless) lane must export VNX_DATA_DIR / VNX_DATA_DIR_EXPLICIT=1 /
+VNX_REPORT_PATH into the ``claude -p`` worker's own environment.
+
+Measured root cause (T0, main 54943a2e, 2026-09-06): base_worker.md tells the
+worker to write its report to ``$VNX_DATA_DIR/unified_reports/<dispatch_id>.md``,
+but ``ClaudeSubprocessAdapter.run`` called ``spawn_claude`` with no ``extra_env``
+at all (grep on VNX_DATA_DIR across envelope_adapters_claude.py / dispatch_envelope.py
+/ headless_adapter.py: zero hits). The worker therefore guessed the directory —
+sometimes landing in the wrong store — and GOVERN, which only reads the CENTRAL
+``unified_reports/<dispatch_id>.md``, synthesized over a real, valid worker report.
+
+These tests pin the fix at the adapter (mocking spawn_claude, no real subprocess):
+RED on main (no extra_env kwarg at all), GREEN after the fix.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from envelope_adapters_claude import ClaudeSubprocessAdapter  # noqa: E402
+from envelope_types import EnvelopeSpec  # noqa: E402
+
+
+class _OkSpawnResult:
+    """Minimal ClaudeSpawnResult-shaped stub with the attributes .run() reads."""
+
+    returncode = 0
+    error = None
+    timed_out = False
+    stopped_early = False
+    completion_text = "done"
+    session_id = "sess-1"
+    token_usage = {"input_tokens": 1, "output_tokens": 1}
+    model = None
+
+
+def _spec(tmp_path: Path, **overrides) -> EnvelopeSpec:
+    defaults = dict(
+        dispatch_id="20260907-abis2-report-path-central",
+        terminal_id="T1",
+        provider="claude",
+        model="sonnet",
+        instruction="do the thing",
+        role="backend-developer",
+        pr_id=None,
+        state_dir=tmp_path / "state",
+        data_dir=tmp_path / "data",
+        deadline_seconds=900,
+    )
+    defaults.update(overrides)
+    return EnvelopeSpec(**defaults)
+
+
+def test_spawn_receives_vnx_data_dir_env(tmp_path: Path) -> None:
+    """extra_env must carry VNX_DATA_DIR set to the resolved data_dir."""
+    spec = _spec(tmp_path)
+
+    with patch(
+        "provider_spawns.claude_spawn.spawn_claude", return_value=_OkSpawnResult()
+    ) as mock_spawn:
+        ClaudeSubprocessAdapter().run(spec)
+
+    mock_spawn.assert_called_once()
+    kwargs = mock_spawn.call_args.kwargs
+    assert "extra_env" in kwargs, "spawn_claude was called without an extra_env kwarg"
+    assert kwargs["extra_env"].get("VNX_DATA_DIR") == str(spec.data_dir)
+
+
+def test_spawn_receives_vnx_data_dir_explicit_flag(tmp_path: Path) -> None:
+    """extra_env must carry VNX_DATA_DIR_EXPLICIT=1 — the two-key contract
+    other lanes already export (plan_gate_panel.py) so a bare VNX_DATA_DIR
+    is never mistaken for pollution downstream."""
+    spec = _spec(tmp_path)
+
+    with patch(
+        "provider_spawns.claude_spawn.spawn_claude", return_value=_OkSpawnResult()
+    ) as mock_spawn:
+        ClaudeSubprocessAdapter().run(spec)
+
+    kwargs = mock_spawn.call_args.kwargs
+    assert kwargs["extra_env"].get("VNX_DATA_DIR_EXPLICIT") == "1"
+
+
+def test_spawn_receives_vnx_report_path_env(tmp_path: Path) -> None:
+    """extra_env must carry the exact absolute report path — no guessing."""
+    spec = _spec(tmp_path)
+
+    with patch(
+        "provider_spawns.claude_spawn.spawn_claude", return_value=_OkSpawnResult()
+    ) as mock_spawn:
+        ClaudeSubprocessAdapter().run(spec)
+
+    kwargs = mock_spawn.call_args.kwargs
+    expected = str(spec.data_dir / "unified_reports" / f"{spec.dispatch_id}.md")
+    assert kwargs["extra_env"].get("VNX_REPORT_PATH") == expected
+
+
+def test_report_path_env_uses_this_dispatch_id_not_another(tmp_path: Path) -> None:
+    """Regression guard: the report path must be keyed on THIS spec's
+    dispatch_id, not some other/cached value."""
+    spec = _spec(tmp_path, dispatch_id="some-other-dispatch-id")
+
+    with patch(
+        "provider_spawns.claude_spawn.spawn_claude", return_value=_OkSpawnResult()
+    ) as mock_spawn:
+        ClaudeSubprocessAdapter().run(spec)
+
+    kwargs = mock_spawn.call_args.kwargs
+    assert kwargs["extra_env"]["VNX_REPORT_PATH"].endswith(
+        "unified_reports/some-other-dispatch-id.md"
+    )

--- a/tests/test_envelope_govern_report_adoption.py
+++ b/tests/test_envelope_govern_report_adoption.py
@@ -1,0 +1,255 @@
+"""test_envelope_govern_report_adoption.py — fix-forward on PR #1802:
+the headless envelope lane adopts a stray worker report before synthesising
+over it, exactly like dispatch_govern already does for the tmux/subprocess
+lanes.
+
+Measured 2026-09-06 (head e156e543): five real worker reports on the
+claude_headless lane landed outside the central store while envelope_govern.
+_govern() wrote the generic ## Response wrapper over them — the wrapper then
+failed the report-body contract (missing ## Summary/## Changes/
+## Verification/## Open Items) and the receipt status was overridden to
+"contract_invalid" even though a perfectly good worker report existed on
+disk. dispatch_govern._resolve_worker_report_with_adoption already covered
+this for the tmux/subprocess lanes (A-bis-2); this fix wires the SAME shared
+helper into envelope_govern._govern, which never called it.
+
+Without the fix: a valid report sitting at the worktree path or the outer
+consumer-checkout path is invisible to _govern() — it emits the generic
+wrapper and the receipt carries no report_relocated warning.
+
+With the fix: _govern() searches central -> worktree -> repo-root (consumer
+project root) BEFORE emitting the wrapper; a validated find is relocated to
+the central path and the receipt's warnings[] carries a report_relocated
+entry naming the original stray path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from dispatch_worktree_isolation import _dispatch_worktree_dir  # noqa: E402
+from envelope_govern import _govern  # noqa: E402
+from envelope_types import EnvelopeSpec, _AdapterResult  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def spec(tmp_path):
+    data_dir = tmp_path / "data"
+    state_dir = tmp_path / "state"
+    data_dir.mkdir()
+    state_dir.mkdir()
+    return EnvelopeSpec(
+        dispatch_id="test-envelope-adopt-001",
+        terminal_id="T1",
+        provider="claude",
+        model="sonnet",
+        instruction="do the thing",
+        role="backend-developer",
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+
+@pytest.fixture()
+def success_result():
+    return _AdapterResult(
+        returncode=0,
+        completion_text="Worker output without contract headings.",
+        status="success",
+    )
+
+
+@pytest.fixture()
+def consumer_root(tmp_path):
+    root = tmp_path / "consumer-repo"
+    root.mkdir()
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_body(marker: str = "Implemented the feature correctly") -> str:
+    return (
+        "## Summary\n\n"
+        f"{marker} with full test coverage. All tests pass and the "
+        "implementation is complete and correct in every regard.\n\n"
+        "## Changes\n\n- Implemented feature X\n\n"
+        "## Verification\n\n- pytest passed: 5/5\n\n"
+        "## Open Items\n\nNone\n"
+    )
+
+
+def _run_govern(spec, result, consumer_root):
+    """Run _govern() with the emission/receipt seam mocked exactly like
+    test_envelope_govern_contract_enforce.py, EXCEPT emit_unified_report is
+    left REAL (unmocked): the mechanism under test is emit_unified_report's
+    own idempotent early-return picking up the file _govern's adoption step
+    already relocated to the central path, and that can only be observed by
+    letting the real function run.
+    """
+    receipts_file = spec.state_dir / "t0_receipts.ndjson"
+    receipts_file.write_text("")
+
+    mock_emit_receipt = MagicMock(return_value=receipts_file)
+
+    with patch(
+        "envelope_govern._archive_dispatch_events", return_value=("", True)
+    ), patch(
+        "envelope_govern._clear_dispatch_events"
+    ), patch(
+        "envelope_govern._receipt_exists_for_dispatch", return_value=False
+    ), patch(
+        "dispatch_worktree_isolation.resolve_consumer_project_root",
+        return_value=consumer_root,
+    ), patch(
+        "governance_emit.emit_dispatch_receipt", mock_emit_receipt
+    ):
+        report_path, _receipt_path = _govern(
+            spec,
+            result,
+            start_time=datetime(2026, 9, 7, 12, 0, 0),
+            end_time=datetime(2026, 9, 7, 12, 1, 0),
+        )
+
+    return report_path, mock_emit_receipt
+
+
+# ---------------------------------------------------------------------------
+# Tests — stray-report adoption
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeGovernReportAdoption:
+
+    def test_adopts_stray_report_from_repo_root(self, spec, success_result, consumer_root):
+        """A valid worker report sitting at <consumer_root>/.vnx-data/
+        unified_reports/<id>.md with nothing central and nothing at the
+        worktree path is adopted: the central file gets the authored body,
+        the stray original is gone, and the receipt records a
+        report_relocated warning."""
+        stray_dir = consumer_root / ".vnx-data" / "unified_reports"
+        stray_dir.mkdir(parents=True)
+        stray_path = stray_dir / f"{spec.dispatch_id}.md"
+        stray_path.write_text(_valid_body(), encoding="utf-8")
+
+        report_path, mock_emit_receipt = _run_govern(spec, success_result, consumer_root)
+
+        central_path = spec.data_dir / "unified_reports" / f"{spec.dispatch_id}.md"
+        assert report_path == central_path
+        assert central_path.exists()
+        assert "Implemented the feature correctly" in central_path.read_text(encoding="utf-8")
+        assert not stray_path.exists(), "stray original must be relocated, not copied"
+
+        call_kwargs = mock_emit_receipt.call_args.kwargs
+        warnings = call_kwargs.get("warnings") or []
+        assert any(
+            w.get("code") == "report_relocated" and str(stray_path) in w.get("message", "")
+            for w in warnings
+        ), f"expected a report_relocated warning naming {stray_path}, got {warnings!r}"
+        # The relocated report passes the body contract — no
+        # report_contract_violated entry, and status is not downgraded.
+        assert not any(w.get("code") == "report_contract_violated" for w in warnings)
+        assert call_kwargs["status"] == "success"
+
+    def test_adopts_stray_report_from_worktree_path(self, spec, success_result, consumer_root):
+        """Same adoption, but the stray report sits at the ephemeral
+        per-dispatch worktree path (the same path run_envelope_headless_plan
+        derives via dispatch_worktree_isolation._dispatch_worktree_dir)."""
+        worktree = _dispatch_worktree_dir(consumer_root, spec.dispatch_id)
+        stray_dir = worktree / ".vnx-data" / "unified_reports"
+        stray_dir.mkdir(parents=True)
+        stray_path = stray_dir / f"{spec.dispatch_id}.md"
+        stray_path.write_text(_valid_body("WORKTREE body marker"), encoding="utf-8")
+
+        report_path, mock_emit_receipt = _run_govern(spec, success_result, consumer_root)
+
+        central_path = spec.data_dir / "unified_reports" / f"{spec.dispatch_id}.md"
+        assert report_path == central_path
+        assert "WORKTREE body marker" in central_path.read_text(encoding="utf-8")
+        assert not stray_path.exists(), "stray original must be relocated, not copied"
+
+        call_kwargs = mock_emit_receipt.call_args.kwargs
+        warnings = call_kwargs.get("warnings") or []
+        assert any(
+            w.get("code") == "report_relocated" and str(stray_path) in w.get("message", "")
+            for w in warnings
+        )
+
+    def test_worktree_report_wins_over_repo_root(self, spec, success_result, consumer_root):
+        """Search order: the worktree path is consulted before repo-root.
+        When both hold a valid report, the worktree one is adopted and the
+        repo-root one is left untouched."""
+        worktree = _dispatch_worktree_dir(consumer_root, spec.dispatch_id)
+        worktree_stray_dir = worktree / ".vnx-data" / "unified_reports"
+        worktree_stray_dir.mkdir(parents=True)
+        worktree_stray = worktree_stray_dir / f"{spec.dispatch_id}.md"
+        worktree_stray.write_text(_valid_body("WORKTREE body marker"), encoding="utf-8")
+
+        repo_root_stray_dir = consumer_root / ".vnx-data" / "unified_reports"
+        repo_root_stray_dir.mkdir(parents=True)
+        repo_root_stray = repo_root_stray_dir / f"{spec.dispatch_id}.md"
+        repo_root_stray.write_text(_valid_body("REPO ROOT body marker"), encoding="utf-8")
+
+        report_path, _mock_emit_receipt = _run_govern(spec, success_result, consumer_root)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "WORKTREE body marker" in content
+        assert "REPO ROOT body marker" not in content
+        assert not worktree_stray.exists(), "the adopted worktree stray must be relocated"
+        assert repo_root_stray.exists(), "the un-adopted repo_root stray must be left in place"
+
+    def test_invalid_repo_root_stray_report_still_synthesizes(
+        self, spec, success_result, consumer_root,
+    ):
+        """An INVALID stray report at repo_root falls through to the
+        existing generic-wrapper synthesis exactly as before (regression
+        guard) — and is left in place, not moved."""
+        stray_dir = consumer_root / ".vnx-data" / "unified_reports"
+        stray_dir.mkdir(parents=True)
+        stray_path = stray_dir / f"{spec.dispatch_id}.md"
+        stray_path.write_text("not a valid report body\n", encoding="utf-8")
+
+        report_path, mock_emit_receipt = _run_govern(spec, success_result, consumer_root)
+
+        assert stray_path.exists(), "an invalid stray report must not be relocated"
+        assert stray_path.read_text(encoding="utf-8") == "not a valid report body\n"
+        # Falls through to the generic ## Response wrapper, which fails the
+        # body contract — same pre-existing contract_invalid override.
+        content = report_path.read_text(encoding="utf-8")
+        assert "## Response" in content
+        call_kwargs = mock_emit_receipt.call_args.kwargs
+        warnings = call_kwargs.get("warnings") or []
+        assert any(w.get("code") == "report_contract_violated" for w in warnings)
+        assert call_kwargs["status"] == "contract_invalid"
+
+    def test_no_stray_report_anywhere_falls_through_unchanged(
+        self, spec, success_result, consumer_root,
+    ):
+        """Regression: nothing at central, worktree, or repo-root — _govern
+        must behave exactly as before this fix (generic wrapper, no
+        report_relocated warning)."""
+        report_path, mock_emit_receipt = _run_govern(spec, success_result, consumer_root)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "## Response" in content
+        call_kwargs = mock_emit_receipt.call_args.kwargs
+        warnings = call_kwargs.get("warnings") or []
+        assert not any(w.get("code") == "report_relocated" for w in warnings)

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -604,3 +604,98 @@ def test_for_litellm_provider_returns_messages_with_system_role(assembler: Promp
     assert result["messages"][1]["content"] == "litellm-test"
     assert "system" not in result
     assert result["metadata"]["provider"] == "kimi"
+
+
+# ---------------------------------------------------------------------------
+# A-bis-2: REPORT_PATH_PLACEHOLDER fill-in — the worker sees the absolute
+# report path, not a bare "$VNX_DATA_DIR" it has to guess (the headless lane
+# never exported that variable into the worker's own shell).
+# ---------------------------------------------------------------------------
+
+def test_report_path_filled_from_explicit_data_dir(
+    assembler: PromptAssembler, basic_instruction: str, monkeypatch,
+) -> None:
+    """dispatch_metadata["data_dir"] resolves the absolute report path — the
+    bare $VNX_DATA_DIR template must not survive into the assembled prompt."""
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    prompt = assembler.assemble(
+        dispatch_metadata={
+            "role": "backend-developer",
+            "dispatch_id": "20260907-abis2-report-path-central",
+            "data_dir": "/Users/ops/.vnx-data/vnx-dev",
+        },
+        instruction=basic_instruction,
+    )
+
+    expected = "/Users/ops/.vnx-data/vnx-dev/unified_reports/20260907-abis2-report-path-central.md"
+    assert expected in prompt.context
+    assert "{{REPORT_PATH}}" not in prompt.context
+    # Layer 1 (base_worker.md) must no longer show the bare template — Layer 2
+    # role prompts (out of scope for this fix) may still legitimately carry
+    # their own separate "$VNX_DATA_DIR" reference, so the check is scoped to
+    # the Layer-1-only slice, not the whole combined context.
+    layer1_only = prompt.context.split("\n\n---\n\n", 1)[0]
+    assert "$VNX_DATA_DIR" not in layer1_only
+    assert layer1_only.count(expected) == 2, (
+        "base_worker.md references the report path in two places "
+        "(Expected Output Structure + Report Location)"
+    )
+
+
+def test_report_path_falls_back_without_data_dir(
+    assembler: PromptAssembler, basic_instruction: str, monkeypatch,
+) -> None:
+    """No data_dir anywhere (metadata or ambient env) -> the historical
+    templated text is used, never the raw unresolved placeholder token."""
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    prompt = assembler.assemble(
+        dispatch_metadata={"role": "backend-developer", "terminal": "T1"},
+        instruction=basic_instruction,
+    )
+
+    assert "$VNX_DATA_DIR/unified_reports/<dispatch_id>.md" in prompt.context
+    assert "{{REPORT_PATH}}" not in prompt.context
+
+
+def test_report_path_filled_from_ambient_two_key_contract(
+    assembler: PromptAssembler, basic_instruction: str, monkeypatch,
+) -> None:
+    """No explicit data_dir in metadata: falls back to the ambient VNX_DATA_DIR
+    + VNX_DATA_DIR_EXPLICIT=1 two-key contract already used fleet-wide
+    (plan_gate_panel._resolve_data_dir et al.)."""
+    monkeypatch.setenv("VNX_DATA_DIR", "/tmp/ambient-vnx-data")
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    prompt = assembler.assemble(
+        dispatch_metadata={
+            "role": "backend-developer",
+            "dispatch_id": "ambient-001",
+        },
+        instruction=basic_instruction,
+    )
+
+    assert "/tmp/ambient-vnx-data/unified_reports/ambient-001.md" in prompt.context
+
+
+def test_report_path_ignores_ambient_data_dir_without_explicit_flag(
+    assembler: PromptAssembler, basic_instruction: str, monkeypatch,
+) -> None:
+    """A bare inherited VNX_DATA_DIR without VNX_DATA_DIR_EXPLICIT=1 is
+    pollution, not config — same rule as plan_gate_panel._resolve_data_dir."""
+    monkeypatch.setenv("VNX_DATA_DIR", "/tmp/should-not-be-used")
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    prompt = assembler.assemble(
+        dispatch_metadata={
+            "role": "backend-developer",
+            "dispatch_id": "ambient-002",
+        },
+        instruction=basic_instruction,
+    )
+
+    assert "/tmp/should-not-be-used" not in prompt.context
+    assert "$VNX_DATA_DIR/unified_reports/<dispatch_id>.md" in prompt.context

--- a/tests/test_report_path.py
+++ b/tests/test_report_path.py
@@ -362,18 +362,96 @@ def test_worker_rules_footer_produces_canonical_path():
 
 
 def test_base_worker_md_contains_canonical_path():
-    """base_worker.md must prescribe the canonical path, not the old _report.md form."""
+    """base_worker.md must prescribe the canonical path, not the old _report.md
+    form -- and, since A-bis-2 (PR #1802), not a literal bare $VNX_DATA_DIR
+    string either.
+
+    base_worker.md now carries the {{REPORT_PATH}} placeholder instead of a
+    literal path: PromptAssembler.assemble() fills it in with the absolute
+    path under the central data dir, <data_dir>/unified_reports/<dispatch_id>.md
+    -- the exact path envelope_adapters_claude.ClaudeSubprocessAdapter also
+    exports to the worker's own shell as VNX_REPORT_PATH, so the worker never
+    has to guess where VNX_DATA_DIR actually resolves to (see
+    prompt_assembler._resolve_report_path). If someone reverts base_worker.md
+    to a literal bare "$VNX_DATA_DIR/..." string as the only report-path
+    indication, the placeholder has nothing left to replace: the rendered
+    prompt below keeps the bare text instead of the filled absolute path, and
+    this test goes red.
+    """
+    from unittest.mock import patch
+
+    from envelope_adapters_claude import ClaudeSubprocessAdapter
+    from envelope_types import EnvelopeSpec
+    from prompt_assembler import PromptAssembler
+
     path = Path(__file__).resolve().parent.parent / "scripts" / "lib" / "prompts" / "base_worker.md"
     content = path.read_text()
 
-    # Must have canonical env-var form
-    assert "$VNX_DATA_DIR/unified_reports" in content
+    # The raw template must carry the placeholder, not a literal path baked in
+    assert content.count("{{REPORT_PATH}}") == 2
 
     # Must NOT have old _report suffix
     assert "_report.md" not in content
 
     # Must NOT have old repo-local path
     assert ".vnx-data/unified_reports/" not in content
+
+    dispatch_id = "20260907-abis2-report-path-test"
+    data_dir = Path(tempfile.gettempdir()) / "vnx-canonical-path-test"
+    canonical_path = str(data_dir / "unified_reports" / f"{dispatch_id}.md")
+
+    prompt = PromptAssembler().assemble(
+        dispatch_metadata={
+            "role": "backend-developer",
+            "dispatch_id": dispatch_id,
+            "data_dir": str(data_dir),
+        },
+        instruction="Do the thing.",
+    )
+
+    # The rendered prompt must carry the filled absolute path, not the bare
+    # fallback -- that fallback only fires when dispatch_id/data_dir cannot
+    # be resolved at all. Scoped to Layer 1 (base_worker.md) only: Layer 2
+    # role prompts may legitimately carry their own separate "$VNX_DATA_DIR"
+    # reference, out of scope for this fix.
+    layer1_only = prompt.context.split("\n\n---\n\n", 1)[0]
+    assert canonical_path in layer1_only
+    assert "{{REPORT_PATH}}" not in layer1_only
+    assert "$VNX_DATA_DIR/unified_reports/<dispatch_id>.md" not in layer1_only
+
+    # The same absolute path must be what the headless lane exports to the
+    # worker's own shell as VNX_REPORT_PATH -- one canonical path, not two
+    # independent mechanisms that can silently drift apart.
+    class _OkSpawnResult:
+        returncode = 0
+        error = None
+        timed_out = False
+        stopped_early = False
+        completion_text = "done"
+        session_id = "sess-1"
+        token_usage = {"input_tokens": 1, "output_tokens": 1}
+        model = None
+
+    spec = EnvelopeSpec(
+        dispatch_id=dispatch_id,
+        terminal_id="T1",
+        provider="claude",
+        model="sonnet",
+        instruction="do the thing",
+        role="backend-developer",
+        pr_id=None,
+        state_dir=data_dir / "state",
+        data_dir=data_dir,
+        deadline_seconds=900,
+    )
+
+    with patch(
+        "provider_spawns.claude_spawn.spawn_claude", return_value=_OkSpawnResult()
+    ) as mock_spawn:
+        ClaudeSubprocessAdapter().run(spec)
+
+    kwargs = mock_spawn.call_args.kwargs
+    assert kwargs["extra_env"].get("VNX_REPORT_PATH") == canonical_path
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The headless (`claude_headless`) lane never exported `VNX_DATA_DIR` into the `claude -p` worker's own shell, so `base_worker.md`'s `$VNX_DATA_DIR/unified_reports/<dispatch_id>.md` instruction forced the worker to guess where to write. Measured 2026-09-06: five real worker reports landed in a repo-local `.vnx-data` store while the central ledger received a synthesized wrapper for the same dispatches (receipts `contract_invalid`).
- `envelope_adapters_claude.ClaudeSubprocessAdapter.run` now threads `extra_env` (`VNX_DATA_DIR`, `VNX_DATA_DIR_EXPLICIT=1`, `VNX_REPORT_PATH`) into `spawn_claude`, giving the worker's own shell the resolved values.
- `dispatch_envelope.run_envelope_headless_plan` scopes the same two-key contract around `_prepare()` (restored via try/finally afterward) so `PromptAssembler` can resolve the same absolute path in the assembled prompt text.
- `prompt_assembler.PromptAssembler.assemble` fills a new `{{REPORT_PATH}}` placeholder in `base_worker.md` with the absolute report path — from `dispatch_metadata["data_dir"]` or the ambient `VNX_DATA_DIR`/`VNX_DATA_DIR_EXPLICIT=1` contract already used fleet-wide (`plan_gate_panel._resolve_data_dir`) — falling back to the historical templated text when neither is resolvable, so any lane running through the same assembler benefits automatically.
- `dispatch_govern.GovernSpec` gains a `repo_root` field; `govern()` now searches `worktree_path` then `repo_root` for a stray worker report before synthesizing, relocates a validated find to the central path, and stamps a `report_relocated` warning on the receipt — an invalid stray report still falls through to synthesis unchanged (regression-guarded).

## Test plan

- [x] `tests/test_prompt_assembler.py` — 4 new tests for the `{{REPORT_PATH}}` fill-in (explicit `data_dir`, fallback, ambient two-key contract, ambient without the explicit flag); full file green (137 tests).
- [x] `tests/test_envelope_claude_adapter_report_env.py` (new) — 4 tests pinning `extra_env` on the claude spawn; RED on `main` (`KeyError: 'extra_env'`), GREEN after the fix.
- [x] `tests/test_dispatch_govern.py` — 4 new tests for stray-report adoption (repo-root adoption + relocation + receipt warning, invalid-stray regression, worktree-wins-over-repo-root ordering, `repo_root=None` regression); RED on `main` (`TypeError: unexpected keyword argument 'repo_root'`), GREEN after the fix.
- [x] Break-and-restore proof: temporarily removed the `repo_root` search branch in `dispatch_govern.py` — the adoption test went red (`assert 'synthesized' == 'authored'`) while the other 3 new tests stayed green; restored.
- [x] `tests/data/dispatch_envelope_census.json` regenerated (`python3 tests/dispatch_envelope_census_scanner.py`) so the new test file's direct calls to `ClaudeSubprocessAdapter`/`EnvelopeSpec` don't trip the census fixture.
- [x] Full targeted run: `pytest tests/test_dispatch_envelope*.py tests/test_envelope_*.py tests/test_dispatch_govern.py tests/test_prompt_assembler.py tests/test_subprocess_dispatch_govern.py -q` → 306 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)