### PR TITLE
fix(plan-gate): claude panel seats run on the headless lane; tmux delivery lost the prompt

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -49,7 +49,6 @@ from typing import Any, Callable, Dict, List, Optional
 
 HERE = Path(__file__).resolve().parent
 PROVIDER_DISPATCH = HERE / "provider_dispatch.py"
-TMUX_INTERACTIVE_DISPATCH = HERE / "tmux_interactive_dispatch.py"
 _SCRIPTS_DIR = HERE.parent
 PANEL_CONFIG_RELATIVE_PATH = Path("configs") / "plan_gate_panel.yaml"
 
@@ -89,11 +88,32 @@ DEFAULT_GOAL_MIN_CHARS = 200
 SEAT_LEDGER_RELPATH = ".vnx-attest/plan-gate-seats.ndjson"
 SEAT_RECORD_TYPE = "plan_gate_seat"
 
-# Claude is NOT a provider-lane provider — provider_dispatch refuses it. Claude lanes
-# route via the TMUX-SPAWN lane (interactive `claude` in an ephemeral isolated worktree),
-# which keeps billing on the SUBSCRIPTION (CLAUDE.md "June-15 escape"). They must NOT use
-# headless `claude -p`: post-cutover that bills API credits.
+# Claude is NOT a provider-lane provider — provider_dispatch refuses it. A claude seat
+# runs on the HEADLESS lane: `claude -p` through the door's own ClaudeSubprocessAdapter,
+# in the shared checkout (a plan review reads; it never commits). Billing stays on the
+# Max SUBSCRIPTION — measured 2026-08-11 from the auth state (no ANTHROPIC_API_KEY /
+# ANTHROPIC_BASE_URL, keychain subscriptionType: max) — and the single-entry door has
+# routed claude through this lane by default since A2 (2026-08-26).
+#
+# Until 2026-09-07 these seats ran on the TMUX-SPAWN lane instead, on the premise that
+# headless `claude -p` "bills API credits post-cutover". That premise was never true:
+# Anthropic never carried out that cutover. And the lane cost the gate its claude
+# verdict — bracketed-paste delivery handed the worker only the LAST LINE of the
+# instruction ("...as the very last step."), three times on 2026-09-06, so the opus seat
+# asked what it was supposed to do and then sat there until its deadline (906s, 907s,
+# 2400s). Every plan-gate with a claude seat that day ended without that seat's verdict
+# and was decided by the tiebreaker.
 _CLAUDE_PROVIDERS = {"claude"}
+
+# The lane label stamped on a claude seat's receipt — the same string the door's
+# headless lane uses (dispatch_envelope.run_envelope_headless_plan), so a seat receipt
+# and a door receipt name the same lane instead of two.
+_HEADLESS_LANE = "claude_headless"
+
+# The terminal every panel seat books its lane work under. Matches the --terminal-id the
+# provider branch below already passes, so seat receipts from both lanes land under one
+# name rather than splitting the audit trail by lane.
+_PANEL_TERMINAL_ID = "plan-gate"
 
 # Full diverse-family assurance panel: (label, provider string, model_arg).
 # One panelist per provider family (Anthropic / Moonshot / Zhipu / DeepSeek / OpenAI) so a
@@ -449,7 +469,7 @@ _VERDICT_CONTRACT = (
 # 60_000 was a 10x-too-conservative guess. Measured on this platform (macOS):
 # `getconf ARG_MAX` = 1_048_576 bytes — the ceiling execve() enforces on the COMBINED argv +
 # inherited-environment size for the provider_dispatch.py subprocess this doc is inlined
-# into (the claude/tmux lane instead writes the doc to a temp file and never inlines it, so
+# into (the claude seat instead writes the doc to a temp file and never inlines it, so
 # this cap only bites the kimi/glm/deepseek/codex provider lanes). Budget:
 #   - this module's own wrapper text (rubric + verdict contract + track/report boilerplate)
 #     measures ~1.2k chars around the doc body — negligible;
@@ -531,8 +551,8 @@ def build_plan_review_instruction(doc_text: str, track_id: str) -> str:
     """Render the plan-review instruction handed to each panelist (inline-doc form).
 
     Used by provider lanes (kimi, glm) where the instruction is passed as a
-    subprocess argument and the full inline doc is acceptable.  The claude/tmux
-    lane uses ``build_plan_review_instruction_fileref`` instead so the ~50k-char
+    subprocess argument and the full inline doc is acceptable.  The claude seat
+    uses ``build_plan_review_instruction_fileref`` instead so the ~50k-char
     doc body never inflates the instruction string.
     """
     doc_text = _sanitize_doc(doc_text)
@@ -550,11 +570,13 @@ def build_plan_review_instruction(doc_text: str, track_id: str) -> str:
 def build_plan_review_instruction_fileref(
     doc_path: str, track_id: str, report_path: str
 ) -> str:
-    """Render the plan-review instruction for the claude/tmux lane.
+    """Render the plan-review instruction for the claude seat.
 
     The plan doc is passed by FILE REFERENCE (not inlined) so the instruction
-    string stays short — avoiding the >120s bracketed-paste ingestion that trips
-    the WORK_START_GATE timeout on a large doc.
+    string stays short. It was written for the tmux lane, where a ~50k-char body
+    took >120s to ingest and tripped the WORK_START_GATE timeout; it survives the
+    move to the headless lane because a short prompt argument is worth having
+    there too — the seat reads the plan from disk with the tool it already has.
 
     ``report_path``: the absolute path where the worker MUST write its report.
     This makes the expectation explicit so the worker does not have to guess the
@@ -577,17 +599,17 @@ def build_plan_review_instruction_fileref(
 
 
 def build_generic_fileref_instruction(doc_path: str, report_path: str) -> str:
-    """Render a generic (NON-plan-review) file-ref instruction for the claude/tmux lane.
+    """Render a generic (NON-plan-review) file-ref instruction for the claude seat.
 
     OI-811: ``_make_default_dispatcher`` is reused by callers whose instruction is NOT a
     plan review — e.g. the deliberation panel's diverge/contrarian/verify/synthesis
     stages. Wrapping their prompt in ``build_plan_review_instruction_fileref`` (which
     tells the worker "you are an independent plan reviewer... review the IMPLEMENTATION
     PLAN") caused a plan-reviewer-role worker to correctly reject the file as not a plan,
-    corrupting the panel stage. This variant carries the file-ref benefit (short
-    instruction string, avoids the bracketed-paste ingestion timeout on a large prompt)
-    WITHOUT the plan-review framing — the worker is simply told to follow the referenced
-    instruction and write its response to ``report_path``.
+    corrupting the panel stage. This variant carries the file-ref benefit (a short
+    instruction string, whatever the size of the referenced prompt) WITHOUT the
+    plan-review framing — the worker is simply told to follow the referenced instruction
+    and write its response to ``report_path``.
     """
     return (
         f"Read your complete instruction from this file:\n\n"
@@ -1079,9 +1101,9 @@ def _resolve_data_dir(data_dir: Optional[str]) -> Path:
     gate will never find.
 
     A ``None`` base means ``_read_report``'s base-fallback path can never resolve the
-    claude/tmux-lane report: unlike ``provider_dispatch``, that lane prints no ``Report:``
-    stderr line, so the opus seat's authored report is never found -> NO-VERDICT rc=1
-    "staging_validator: unstaged dispatch override" (#1102 class bug).
+    claude seat's report: unlike ``provider_dispatch``, the headless lane prints no
+    ``Report:`` stderr line, so the opus seat's authored report is never found ->
+    NO-VERDICT rc=1 "staging_validator: unstaged dispatch override" (#1102 class bug).
     """
     if data_dir:
         return Path(data_dir)
@@ -1115,60 +1137,209 @@ def _resolve_data_dir(data_dir: Optional[str]) -> Path:
     return resolve_central_data_dir(project_id)
 
 
+def _seat_checkout() -> Path:
+    """The checkout a claude seat runs ``claude -p`` in.
+
+    A plan review READS: the plan from the temp file the instruction names, and the
+    repository it is reviewing against (git log/diff/show, grep — the whole bash
+    allow-list of the plan-reviewer profile). It WRITES exactly one file, the verdict
+    report, at an absolute path the instruction names. So the seat runs in the SHARED
+    checkout: no ``git worktree add`` per seat (on a large repo that cost more than the
+    review itself and timed the seat out), and the review is grounded against the real
+    tree instead of a copy of it.
+
+    Resolved from the INVOCATION context, never from this module's own location: in a
+    central install the panel code sits under ``~/.vnx-system/versions/<v>/``, and a seat
+    spawned there would review the keystone instead of the operator's project — the same
+    trap ``_resolve_data_dir`` documents for the data dir.
+    """
+    env_root = os.environ.get("VNX_PROJECT_ROOT", "").strip()
+    if env_root and Path(env_root).is_dir():
+        return Path(env_root).resolve()
+    if str(HERE) not in sys.path:
+        sys.path.insert(0, str(HERE))
+    from project_root import resolve_project_root  # noqa: PLC0415
+    return resolve_project_root()
+
+
+def _seat_lane_outcome(result: Any) -> str:
+    """One line naming what the lane did, stamped on the seat's synthesized receipt.
+
+    ``dispatch_govern.ensure_receipt`` writes this into ``failure_reason``. The tmux
+    lane's default there was a fixed literal ("tmux_receipt_deadline_exceeded") that
+    claimed a deadline for every outcome including success; the headless lane holds the
+    adapter result in-process, so the receipt can carry what actually happened.
+    """
+    if result.status == "success":
+        return "claude_headless_completed"
+    if result.status == "timeout":
+        return f"claude_headless_deadline_exceeded (rc={result.returncode})"
+    return (
+        f"claude_headless_{result.status} (rc={result.returncode}): "
+        f"{result.error or 'no error text from the lane'}"
+    )
+
+
+def _run_claude_headless_seat(
+    *,
+    dispatch_id: str,
+    model: str,
+    instruction: str,
+    role: str,
+    base: Path,
+    timeout_seconds: int,
+) -> str:
+    """Run ONE claude seat on the headless lane and return its report text.
+
+    Reuses the door's building blocks rather than growing a second ``claude -p``
+    wrapper: ``ClaudeSubprocessAdapter`` is the same adapter
+    ``dispatch_envelope.run_envelope_headless_plan`` runs the door's headless dispatches
+    through, and ``dispatch_govern.govern`` is the same GOVERN step the lanes share.
+    What this does NOT reuse is the envelope around them — a permit-carrying
+    ExecutionPlan, an isolated worktree, and push+PR enforcement are the shape of a
+    dispatch that DELIVERS code, and a plan review delivers a verdict file.
+
+    The env pins are set on ``os.environ`` for the duration of the run, not passed as a
+    child-only mapping, because they have to bind in BOTH directions:
+      - the child inherits them (``SubprocessAdapter.deliver`` builds the worker env
+        from ``os.environ.copy()``), which is what OI-1153 asks for — the seat's report
+        write path and ``_read_report``'s read-back base stay one directory;
+      - ``VNX_WORKER_SCOPED=1`` is read HERE, in this process, while
+        ``subprocess_adapter._build_worker_scope_args`` builds the argv. Without it the
+        seat spawns with blanket ``--dangerously-skip-permissions`` instead of the
+        plan-reviewer profile's read-only tool scope, which in a shared checkout is the
+        difference between a reviewer and a writer.
+    They are restored afterwards, so a seat never leaves a process-wide side effect
+    behind for the next seat or for the caller.
+
+    GOVERN always runs, exactly as the door's lanes do: the seat's report and receipt do
+    not become optional because the worker went quiet. That is also what keeps the panel's
+    three-way seat classification honest — when the worker authors nothing, govern writes
+    the body carrying ``SYNTHESIZED_REPORT_MARKER`` and the seat reads back as
+    ``no_verdict`` ("the lane never delivered") instead of as an abstention.
+
+    Raises RuntimeError when not even govern left a readable report — the seat then books
+    ``dispatched=False`` and the message carries the lane's own failure reason.
+    """
+    from envelope_adapters_claude import ClaudeSubprocessAdapter  # noqa: PLC0415
+    from envelope_types import EnvelopeSpec  # noqa: PLC0415
+
+    checkout = _seat_checkout()
+    spec = EnvelopeSpec(
+        dispatch_id=dispatch_id,
+        terminal_id=_PANEL_TERMINAL_ID,
+        provider="claude",
+        model=model,
+        instruction=instruction,
+        role=role,
+        pr_id=None,
+        state_dir=base / "state",
+        data_dir=base,
+        deadline_seconds=timeout_seconds,
+        # OI-1422: a seat is a read-only verdict worker, never a delivery worker.
+        # Same task_class the provider branch stamps, for the same reason — it is the
+        # fabric's canonical class for reviewer work and a member of
+        # phantom_guard.REVIEW_TASK_CLASSES.
+        task_class="research_structured",
+    )
+
+    pins = {
+        "VNX_DATA_DIR": str(base),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_WORKER_SCOPED": "1",
+    }
+    restore = {key: os.environ.get(key) for key in pins}
+    start = datetime.now(timezone.utc)
+    try:
+        os.environ.update(pins)
+        result = ClaudeSubprocessAdapter().run(spec, cwd=checkout)
+    finally:
+        for key, previous in restore.items():
+            if previous is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous
+    duration = (datetime.now(timezone.utc) - start).total_seconds()
+
+    from dispatch_govern import GovernRaw, GovernSpec, govern  # noqa: PLC0415
+    govern(
+        GovernSpec(
+            dispatch_id=dispatch_id,
+            terminal_id=_PANEL_TERMINAL_ID,
+            instruction=instruction,
+            data_dir=base,
+            state_dir=base / "state",
+            worktree_path=checkout,
+            model=model,
+            role=role,
+            task_class=spec.task_class,
+        ),
+        # receipt=None is what arms ensure_receipt's fallback: a seat worker writes a
+        # report, never its own receipt, so without this the seat's run would leave no
+        # ledger row at all.
+        GovernRaw(
+            receipt=None,
+            duration_seconds=duration,
+            failure_reason=_seat_lane_outcome(result),
+        ),
+        lane=_HEADLESS_LANE,
+    )
+
+    report = _read_report(base, dispatch_id, "")
+    if report is None:
+        raise RuntimeError(
+            f"no report for {dispatch_id} (rc={result.returncode} "
+            f"status={result.status}): {result.error or 'no error text from the lane'} "
+            f"| completion: {(result.completion_text or '')[-400:]}"
+        )
+    return report
+
+
 def _make_default_dispatcher(
     data_dir: Optional[str], timeout_seconds: int,
     *, role: str = "plan-reviewer",
 ) -> DispatcherFn:
     """Real dispatcher: run a panelist through its governed lane, return the report text.
 
-    INTERIM — PR-12 consolidation target. This calls the lane scripts DIRECTLY, which is a
-    side door. Once the single-entry dispatch door (`vnx dispatch` / dispatch_bridge) is
-    wired and flipped, this MUST route through that one door instead. The split below is
-    exactly what the door decides internally:
-      claude            -> tmux-spawn lane (interactive claude, ephemeral worktree;
-                           billing stays on the SUBSCRIPTION per the June-15 escape).
-                           NOT provider_dispatch (refuses claude), NOT headless `claude -p`
-                           (bills API credits post-cutover).
+    INTERIM — PR-12 consolidation target. This dispatches WITHOUT going through the
+    single-entry door (`vnx dispatch` / dispatch_bridge), which is a side door. Once the
+    door is wired and flipped, this MUST route through that one door instead. The split
+    below is exactly what the door decides internally:
+      claude            -> headless lane, `claude -p` via ClaudeSubprocessAdapter, on
+                           the SUBSCRIPTION (measured 2026-08-11; the door's default for
+                           claude since A2, 2026-08-26). NOT provider_dispatch — it
+                           refuses claude.
       kimi/glm/deepseek -> provider_dispatch (constraint-safe per provider).
 
     ``role``: OI-811 — this factory is reused by callers whose instruction is NOT a plan
     review (e.g. the deliberation panel's diverge/contrarian/verify/synthesis stages).
     Defaults to "plan-reviewer" for backward compatibility with ``run_panel``. A caller
     with a different role gets the generic (non-plan-framed) file-ref instruction on the
-    claude/tmux lane, and that role is stamped on both lanes' ``--role`` so govern() and
-    the phantom-guard evaluate it correctly instead of being told it is a plan review.
+    claude seat, and that role is stamped on both lanes so govern() and the phantom-guard
+    evaluate it correctly instead of being told it is a plan review.
     """
     base = _resolve_data_dir(data_dir)
 
     def _dispatch(provider: str, model_arg: str, instruction: str, dispatch_id: str) -> str:
         env = dict(os.environ)
         # OI-1153: pin the seat subprocess to the SAME data dir this dispatcher
-        # resolved (`base`), or the lane re-resolves its own. provider_dispatch /
-        # tmux_interactive_dispatch both honor the two-key VNX_DATA_DIR +
-        # VNX_DATA_DIR_EXPLICIT=1 contract (see their _resolve_data_dir/
-        # _resolve_state_dir); without it the seat's report write path can land
+        # resolved (`base`), or the lane re-resolves its own. provider_dispatch
+        # honors the two-key VNX_DATA_DIR + VNX_DATA_DIR_EXPLICIT=1 contract (see
+        # its _resolve_data_dir); without it the seat's report write path can land
         # outside the dir _read_report reads back from (e.g. the legacy
         # ~/.vnx-data/unified_reports root), and the seat report is silently
-        # never found. This applies to BOTH lanes: the claude/tmux branch below
-        # and the provider branch.
+        # never found. The claude branch pins the same two keys — see
+        # _run_claude_headless_seat, which sets them on os.environ because on that
+        # lane they must bind in this process as well as in the child.
         env["VNX_DATA_DIR"] = str(base)
         env["VNX_DATA_DIR_EXPLICIT"] = "1"
         _tmp_doc_path: Optional[str] = None
         try:
             if provider in _CLAUDE_PROVIDERS:
-                # Scoped-spawn fix (2026-07-14): --working-tree-only's commit/push deny
-                # only binds in the scoped detached spawn; tmux_interactive_dispatch.dispatch()
-                # fails CLOSED otherwise (its D2.2 scoping precondition), refusing the dispatch
-                # before any report is written -> silent NO-VERDICT for this seat. Opt this
-                # subprocess's env into the scoped posture so the --working-tree-only flag this
-                # lane already passes is actually honored. Provider (kimi/glm/deepseek) lanes
-                # below are untouched — this only applies to the claude/tmux branch.
-                env["VNX_WORKER_SCOPED"] = "1"
-
                 # BUG-2 FIX (file-ref): the instruction already has the full plan doc inlined
-                # by run_panel's build_plan_review_instruction call. For the claude/tmux lane
-                # we replace it with a compact file-ref instruction so the ~50k-char body never
-                # inflates the bracketed-paste and does not trip the WORK_START_GATE timeout.
+                # by run_panel's build_plan_review_instruction call. For the claude seat we
+                # replace it with a compact file-ref instruction so the ~50k-char body never
+                # has to travel as one prompt argument.
                 #
                 # We write the original inline instruction to a temp file so the worker can
                 # read the plan + rubric + verdict contract from a stable on-disk path.
@@ -1205,68 +1376,53 @@ def _make_default_dispatcher(
                         report_path=report_path_str,
                     )
 
-                cmd = [
-                    sys.executable, str(TMUX_INTERACTIVE_DISPATCH),
-                    "--dispatch-id", dispatch_id,
-                    "--model", model_arg,
-                    "--role", role,
-                    "--instruction", claude_instruction,
-                    "--deadline-seconds", str(timeout_seconds),
-                    # A plan review is READ-ONLY (reads the doc file, writes a verdict report) —
-                    # it needs no isolated worktree. --shared-worktree skips the expensive
-                    # `git worktree add`, which on a large repo (e.g. SEOcrawler) blows the
-                    # deadline and times opus out; it also grounds the review against the REAL
-                    # checkout.
-                    "--shared-worktree",
-                    "--allow-unstaged",
-                    # D2.2: a plan-review is working-tree-only — it reads the doc and
-                    # writes a verdict report; it must NOT commit/push (OI-097). The
-                    # flag denies git commit/push at the tool-permission layer.
-                    "--working-tree-only",
-                    "--reason", f"plan-gate panel {dispatch_id}",
-                ]
-                run_timeout = timeout_seconds + 180  # tmux warmup + teardown headroom
-            else:
-                claude_instruction = instruction  # provider lane: inline doc OK
-                cmd = [
-                    sys.executable, str(PROVIDER_DISPATCH),
-                    "--provider", provider,
-                    "--terminal-id", "plan-gate",
-                    "--dispatch-id", dispatch_id,
-                    "--model", model_arg,
-                    "--role", role,
-                    # OI-1422: every seat this dispatcher builds (plan-reviewer,
-                    # deliberation-panelist) is a read-only verdict/analysis worker —
-                    # it reads a doc and writes a report, it never touches repo files.
-                    # Without an explicit --task-class, provider_dispatch.py's
-                    # argparse default ("") falls through to VNX_TASK_CLASS, which is
-                    # unset here, so _build_frontmatter's own fallback stamps
-                    # task_class="implementation" on the receipt (provider_dispatch.py
-                    # _build_frontmatter). kimi_spawn.py's completion-vs-execution
-                    # fabrication guard (_finalize_kimi_result) keys off task_class
-                    # ALONE — it has no role parameter — so "implementation" leaves a
-                    # clean-worktree kimi seat classified as a delivery worker that
-                    # produced nothing, and the guard fires a false "completion
-                    # without execution" failure on real panel/review output.
-                    # "research_structured" is the fabric's own canonical task_class
-                    # for reviewer/architect/planner/security-engineer/data-analyst
-                    # work (dispatch_router.py SKILL_TO_TASK_CLASS) and is already a
-                    # member of phantom_guard.REVIEW_TASK_CLASSES, so this exempts the
-                    # seat through both guards without widening either SSOT.
-                    "--task-class", "research_structured",
-                    "--instruction", instruction,
-                    "--no-auto-commit",
-                ]
-                run_timeout = timeout_seconds
+                return _run_claude_headless_seat(
+                    dispatch_id=dispatch_id,
+                    model=model_arg,
+                    instruction=claude_instruction,
+                    role=role,
+                    base=base,
+                    timeout_seconds=timeout_seconds,
+                )
+
+            cmd = [
+                sys.executable, str(PROVIDER_DISPATCH),
+                "--provider", provider,
+                "--terminal-id", "plan-gate",
+                "--dispatch-id", dispatch_id,
+                "--model", model_arg,
+                "--role", role,
+                # OI-1422: every seat this dispatcher builds (plan-reviewer,
+                # deliberation-panelist) is a read-only verdict/analysis worker —
+                # it reads a doc and writes a report, it never touches repo files.
+                # Without an explicit --task-class, provider_dispatch.py's
+                # argparse default ("") falls through to VNX_TASK_CLASS, which is
+                # unset here, so _build_frontmatter's own fallback stamps
+                # task_class="implementation" on the receipt (provider_dispatch.py
+                # _build_frontmatter). kimi_spawn.py's completion-vs-execution
+                # fabrication guard (_finalize_kimi_result) keys off task_class
+                # ALONE — it has no role parameter — so "implementation" leaves a
+                # clean-worktree kimi seat classified as a delivery worker that
+                # produced nothing, and the guard fires a false "completion
+                # without execution" failure on real panel/review output.
+                # "research_structured" is the fabric's own canonical task_class
+                # for reviewer/architect/planner/security-engineer/data-analyst
+                # work (dispatch_router.py SKILL_TO_TASK_CLASS) and is already a
+                # member of phantom_guard.REVIEW_TASK_CLASSES, so this exempts the
+                # seat through both guards without widening either SSOT.
+                "--task-class", "research_structured",
+                "--instruction", instruction,
+                "--no-auto-commit",
+            ]
             proc = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=run_timeout, check=False, env=env,
+                cmd, capture_output=True, text=True, timeout=timeout_seconds,
+                check=False, env=env,
             )
             report = _read_report(base, dispatch_id, proc.stderr)
             if report is None:
-                # tmux_interactive_dispatch's CLI prints the InteractiveDispatchResult (incl.
-                # the actionable `failure_reason`) as JSON to STDOUT, not stderr -- surfacing
-                # only stderr here previously masked the real cause (e.g. the D2.2 scoping
-                # refusal) behind an unrelated last-stderr-line red herring.
+                # provider_dispatch prints its actionable detail across both streams —
+                # surfacing only stderr once masked the real cause behind an unrelated
+                # last-stderr-line red herring for a full day.
                 raise RuntimeError(
                     f"no report for {dispatch_id} (rc={proc.returncode}): "
                     f"stdout: {(proc.stdout or '')[-800:]} | stderr: {(proc.stderr or '')[-400:]}"

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -1149,6 +1149,41 @@
       "symbol": "_resolve_phantom_diff"
     },
     {
+      "file": "tests/test_plan_gate_panel.py",
+      "line": 33,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_plan_gate_panel.py",
+      "line": 1334,
+      "mechanism": "patch.object-attr",
+      "module_target": "envelope_adapters_claude",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_plan_gate_panel.py",
+      "line": 1335,
+      "mechanism": "direct-call",
+      "module_target": "envelope_adapters_claude",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_plan_gate_panel.py",
+      "line": 1675,
+      "mechanism": "patch.object-attr",
+      "module_target": "envelope_adapters_claude",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_plan_gate_panel.py",
+      "line": 1676,
+      "mechanism": "direct-call",
+      "module_target": "envelope_adapters_claude",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
       "file": "tests/test_provider_deadline_passthrough.py",
       "line": 66,
       "mechanism": "direct-call",

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -8,8 +8,11 @@ injectable dispatcher so the rule is tested without a live provider.
 """
 from __future__ import annotations
 
+import os
 import sqlite3
+import subprocess
 import sys
+import unittest.mock as mock
 from pathlib import Path
 
 import pytest
@@ -26,7 +29,14 @@ import tracks  # noqa: E402
 import track_reconciler  # noqa: E402
 import planning_cli  # noqa: E402
 import plan_gate_panel as pgp  # noqa: E402
+import envelope_adapters_claude  # noqa: E402
+from envelope_types import _AdapterResult  # noqa: E402
 from ndjson_hash_chain import walk_chain  # noqa: E402
+
+# Captured before any test patches plan_gate_panel.subprocess (which IS the stdlib
+# module), so a helper that intercepts lane spawns can still let ordinary
+# subprocesses — the git rev-parse that resolves the seat's checkout — through.
+_REAL_SUBPROCESS_RUN = subprocess.run
 
 
 @pytest.fixture(autouse=True)
@@ -1286,7 +1296,201 @@ def test_seat_ledger_no_verdict_value_is_not_abstain(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# BUG-2 (file-ref): the instruction passed to the claude/tmux lane must NOT
+# The claude seat runs on the HEADLESS lane (2026-09-07).
+#
+# These helpers patch the door's OWN ClaudeSubprocessAdapter by name, not a seam
+# the panel exposes for testing: a test that passes here proves the seat reached
+# `claude -p` through the same adapter run_envelope_headless_plan uses, and a
+# rename on the door's side breaks these tests instead of silently passing them.
+# --------------------------------------------------------------------------
+
+def _adapter_ok() -> _AdapterResult:
+    """What the adapter returns for a seat that ran to completion."""
+    return _AdapterResult(returncode=0, completion_text="", status="success")
+
+
+def _adapter_timeout() -> _AdapterResult:
+    """What the adapter returns for a seat that hit its deadline."""
+    return _AdapterResult(
+        returncode=1, completion_text="", status="timeout", timed_out=True,
+    )
+
+
+def _patch_headless_seat(calls: list, *, report_body=None, result=None):
+    """Patch ClaudeSubprocessAdapter.run and record every seat run.
+
+    ``report_body`` None means the worker authored nothing — the case
+    dispatch_govern covers by synthesizing a body carrying
+    SYNTHESIZED_REPORT_MARKER, which the panel reads as no_verdict.
+    """
+    def _run(self, spec, event_writer=None, cwd=None):
+        calls.append({"spec": spec, "cwd": cwd, "env": dict(os.environ)})
+        if report_body is not None:
+            out = Path(spec.data_dir) / "unified_reports" / f"{spec.dispatch_id}.md"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(report_body, encoding="utf-8")
+        return result if result is not None else _adapter_ok()
+
+    return mock.patch.object(
+        envelope_adapters_claude.ClaudeSubprocessAdapter, "run", _run,
+    )
+
+
+def _forbid_lane_subprocess(cmd, **kwargs):
+    """subprocess.run stand-in that fails the test if a seat shells out to a LANE.
+
+    ``plan_gate_panel.subprocess`` is the stdlib module itself, so patching it
+    intercepts every subprocess in the call tree — including the ``git rev-parse``
+    that resolves the seat's checkout. Only a lane script is the thing under test.
+    """
+    joined = " ".join(str(c) for c in cmd)
+    if "_dispatch.py" in joined:
+        raise AssertionError(
+            "the claude seat shelled out to a lane script instead of running "
+            f"headless: {joined}"
+        )
+    return _REAL_SUBPROCESS_RUN(cmd, **kwargs)
+
+
+def _single_claude_panel():
+    return [{"label": "opus", "provider": "claude", "model_arg": "opus"}]
+
+
+def test_claude_seat_runs_on_the_headless_lane_not_tmux(tmp_path):
+    """A claude seat reaches `claude -p` through the door's ClaudeSubprocessAdapter.
+
+    Until 2026-09-07 it shelled out to tmux_interactive_dispatch.py. That lane's
+    bracketed-paste delivery handed the worker only the LAST LINE of the
+    instruction ("...as the very last step."): on 2026-09-06 three opus seats
+    asked what the task was and then sat until their deadline (906s / 907s /
+    2400s), so every plan-gate with a claude seat that day ended without its
+    verdict and was decided by the tiebreaker.
+    """
+    calls: list = []
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
+    did = "plan-gate-feat-headless-aaa11111"
+
+    with _patch_headless_seat(calls, report_body=_make_report_with_fence("pass")):
+        with mock.patch.object(
+            pgp.subprocess, "run", side_effect=_forbid_lane_subprocess,
+        ):
+            report = dispatcher("claude", "opus", "PLAN_BODY_MARKER_HEADLESS\n", did)
+
+    assert pgp.VERDICT_FENCE in report
+    assert len(calls) == 1, "the claude seat must run exactly one headless dispatch"
+    spec = calls[0]["spec"]
+    assert spec.provider == "claude"
+    assert spec.model == "opus", "the seat's model_arg must reach the lane"
+    assert spec.role == "plan-reviewer"
+    assert spec.deadline_seconds == 60, "the seat timeout must be the lane deadline"
+    assert spec.dispatch_id == did
+    assert Path(spec.data_dir) == tmp_path
+    # The file-ref instruction survives the lane switch: the plan body is read
+    # from disk, never inlined into the prompt (BUG-2 stays fixed).
+    assert "PLAN_BODY_MARKER_HEADLESS" not in spec.instruction
+    assert "independent plan reviewer" in spec.instruction.lower()
+    assert str(tmp_path / "unified_reports" / f"{did}.md") in spec.instruction
+    # cwd is the shared checkout — a plan review reads, it never needs a worktree.
+    assert calls[0]["cwd"] is not None
+    assert Path(calls[0]["cwd"]).is_dir()
+
+
+def test_claude_seat_headless_pins_data_dir_and_scoped_env(tmp_path, monkeypatch):
+    """OI-1153 on the headless lane: the pins bind, and they are scoped to the seat.
+
+    ``VNX_DATA_DIR`` + ``VNX_DATA_DIR_EXPLICIT=1`` keep the seat's report write
+    path and ``_read_report``'s read-back base the same directory.
+    ``VNX_WORKER_SCOPED=1`` is what makes subprocess_adapter build the argv from
+    the plan-reviewer permission profile instead of the blanket
+    ``--dangerously-skip-permissions`` (subprocess_adapter._build_worker_scope_args
+    reads the flag in THIS process while building the argv, so a child-only env
+    would not bind it).
+    """
+    # An ambient value that is NOT the dispatcher's base, so a pass proves the seat
+    # pinned its own dir rather than inheriting whatever the process happened to carry.
+    ambient = tmp_path / "_ambient_store"
+    ambient.mkdir()
+    monkeypatch.setenv("VNX_DATA_DIR", str(ambient))
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+
+    calls: list = []
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
+    with _patch_headless_seat(calls, report_body=_make_report_with_fence("pass")):
+        dispatcher("claude", "opus", "plan text", "plan-gate-feat-env-bbb22222")
+
+    env = calls[0]["env"]
+    assert env.get("VNX_DATA_DIR") == str(tmp_path)
+    assert env.get("VNX_DATA_DIR_EXPLICIT") == "1"
+    assert env.get("VNX_WORKER_SCOPED") == "1"
+    # The pin is a seat-scoped loan: restored exactly, including the two keys that
+    # did not exist before the run.
+    assert os.environ.get("VNX_DATA_DIR") == str(ambient)
+    assert "VNX_DATA_DIR_EXPLICIT" not in os.environ
+    assert "VNX_WORKER_SCOPED" not in os.environ
+
+
+def test_headless_seat_that_authors_a_fenced_report_scores(tmp_path):
+    """A headless run whose worker writes a fenced report at the expected path scores."""
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+
+    calls: list = []
+    with _patch_headless_seat(calls, report_body=_make_report_with_fence("pass")):
+        out = pgp.run_panel(
+            doc,
+            track_id="feat-headless-scores",
+            project_id="p1",
+            panel=_single_claude_panel(),
+            data_dir=str(tmp_path),
+        )
+
+    opus = next(p for p in out["panelists"] if p["label"] == "opus")
+    assert opus["dispatched"] is True
+    assert opus["parse_error"] is False
+    assert opus["no_verdict"] is False
+    assert opus["verdict"] == "pass"
+    assert out["decision"] == "PASS"
+
+
+def test_headless_seat_that_writes_no_report_is_no_verdict_not_a_crash(
+    tmp_path, monkeypatch,
+):
+    """A headless run that authors nothing books no_verdict — it must not crash.
+
+    govern() synthesizes the body (SYNTHESIZED_REPORT_MARKER) exactly as it does
+    on the tmux lane, so the seat lands in the OI-1066 no-verdict category ("the
+    lane never delivered") rather than the abstain category ("the lane answered
+    but malformed its fence"), and the report + receipt still exist.
+    """
+    monkeypatch.setenv("VNX_PANEL_RETRY", "0")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    calls: list = []
+    with _patch_headless_seat(calls, report_body=None, result=_adapter_timeout()):
+        out = pgp.run_panel(
+            doc,
+            track_id="feat-headless-silent",
+            project_id="p1",
+            panel=_single_claude_panel(),
+            data_dir=str(tmp_path),
+        )
+
+    opus = next(p for p in out["panelists"] if p["label"] == "opus")
+    assert opus["dispatched"] is True
+    assert opus["no_verdict"] is True
+    assert opus["parse_error"] is False
+    # Every seat no-verdict -> the infrastructure floor, never a content REVISE.
+    assert out["decision"] == "INFRA_FAIL"
+    # Governance still produced the seat's report on the path the panel reads.
+    emitted = tmp_path / "unified_reports" / f"{opus['report_path']}.md"
+    assert emitted.is_file()
+    assert pgp.SYNTHESIZED_REPORT_MARKER in emitted.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# BUG-2 (file-ref): the instruction passed to the claude seat must NOT
 # contain the full plan doc body.
 # --------------------------------------------------------------------------
 
@@ -1326,92 +1530,59 @@ def test_claude_lane_instruction_does_not_contain_full_doc_body(tmp_path):
 
 def test_claude_lane_dispatcher_writes_temp_file_and_cleans_up(tmp_path):
     """The claude-lane dispatcher must write a temp file, pass its path, and clean up."""
-    import glob
-    import os
-    import tempfile as _tempfile
-
     plan_content = "PLAN_BODY_FOR_TEMPFILE_TEST\n"
     doc = tmp_path / "plan.md"
     doc.write_text(plan_content, encoding="utf-8")
 
-    seen_instructions: list = []
-    seen_tmp_paths: list = []
-
-    def _mock_subprocess_run(cmd, **kwargs):
-        # Intercept the subprocess call to tmux_interactive_dispatch.
-        # Extract the --instruction value from the command.
-        try:
-            idx = cmd.index("--instruction")
-            instr = cmd[idx + 1]
-            seen_instructions.append(instr)
-            # Find any temp file path referenced in the instruction (lines with absolute paths).
-            for line in instr.splitlines():
-                stripped = line.strip()
-                if stripped.startswith("/") and "vnx_plan_review" in stripped:
-                    seen_tmp_paths.append(stripped)
-        except (ValueError, IndexError):
-            pass
-
-        import subprocess as _sp
-        result = _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
-        return result
-
-    import plan_gate_panel as _pgp
-    import unittest.mock as mock
-
-    authored_report = _make_report_with_fence("pass")
-    with mock.patch.object(_pgp.subprocess, "run", side_effect=_mock_subprocess_run):
-        with mock.patch.object(_pgp, "_read_report", return_value=authored_report):
-            out = pgp.run_panel(
-                doc,
-                track_id="feat-tempfile",
-                project_id="p1",
-                panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
-                data_dir=str(tmp_path),
-            )
+    calls: list = []
+    with _patch_headless_seat(calls, report_body=_make_report_with_fence("pass")):
+        out = pgp.run_panel(
+            doc,
+            track_id="feat-tempfile",
+            project_id="p1",
+            panel=_single_claude_panel(),
+            data_dir=str(tmp_path),
+        )
 
     assert out["decision"] == "PASS"
-    # The instruction given to the tmux lane must NOT contain the plan body.
-    assert len(seen_instructions) == 1
-    assert "PLAN_BODY_FOR_TEMPFILE_TEST" not in seen_instructions[0], (
+    # The instruction given to the headless lane must NOT contain the plan body.
+    assert len(calls) == 1
+    instruction = calls[0]["spec"].instruction
+    assert "PLAN_BODY_FOR_TEMPFILE_TEST" not in instruction, (
         "full plan doc was inlined into the claude-lane instruction — BUG-2 not fixed"
     )
-    # The temp file must have been cleaned up after the subprocess returned.
+    # The temp file must have been cleaned up after the lane returned.
+    seen_tmp_paths = [
+        line.strip()
+        for line in instruction.splitlines()
+        if line.strip().startswith("/") and "vnx_plan_review" in line
+    ]
+    assert seen_tmp_paths, "the instruction must reference the temp plan doc"
     for p in seen_tmp_paths:
         assert not os.path.exists(p), f"temp doc file not cleaned up: {p}"
 
 
 # --------------------------------------------------------------------------
 # OI-811: _make_default_dispatcher is reused by non-plan-review callers (the vnx
-# deliberation panel). A caller-supplied ``role`` must (a) route the claude/tmux lane
+# deliberation panel). A caller-supplied ``role`` must (a) route the claude seat
 # through the GENERIC file-ref instruction, never the "you are an independent plan
-# reviewer... review the IMPLEMENTATION PLAN" framing, and (b) be stamped as --role on
-# both the claude/tmux lane and the provider lane so govern()/phantom-guard evaluate the
+# reviewer... review the IMPLEMENTATION PLAN" framing, and (b) be stamped as the role on
+# both the headless lane and the provider lane so govern()/phantom-guard evaluate the
 # dispatch under its real role instead of a hardcoded plan-reviewer.
 # --------------------------------------------------------------------------
 
 def test_default_role_is_still_plan_reviewer_for_backward_compat(tmp_path):
     """run_panel's own dispatcher (no role kwarg) must keep routing as plan-reviewer."""
-    import unittest.mock as mock
-
-    seen_cmds = []
-
-    def _mock_subprocess_run(cmd, **kwargs):
-        seen_cmds.append(cmd)
-        import subprocess as _sp
-        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
-
+    calls: list = []
     dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
 
-    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
-        with mock.patch.object(pgp, "_read_report", return_value=_make_report_with_fence("pass")):
-            dispatcher("claude", "opus", "some plan text", "plan-gate-feat-x-opus-abc123")
+    with _patch_headless_seat(calls, report_body=_make_report_with_fence("pass")):
+        dispatcher("claude", "opus", "some plan text", "plan-gate-feat-x-opus-abc123")
 
-    assert len(seen_cmds) == 1
-    cmd = seen_cmds[0]
-    assert cmd[cmd.index("--role") + 1] == "plan-reviewer"
-    instr = cmd[cmd.index("--instruction") + 1]
-    assert "independent plan reviewer" in instr.lower()
+    assert len(calls) == 1
+    spec = calls[0]["spec"]
+    assert spec.role == "plan-reviewer"
+    assert "independent plan reviewer" in spec.instruction.lower()
 
 
 def test_non_plan_role_claude_lane_uses_generic_instruction_not_plan_framing(tmp_path):
@@ -1419,29 +1590,21 @@ def test_non_plan_role_claude_lane_uses_generic_instruction_not_plan_framing(tmp
     'independent plan reviewer... IMPLEMENTATION PLAN' review — that framing caused a
     plan-reviewer-role worker to correctly reject a non-plan artifact ('this is not a
     plan'), corrupting the deliberation panel's stage output."""
-    import unittest.mock as mock
-
-    seen_cmds = []
-
-    def _mock_subprocess_run(cmd, **kwargs):
-        seen_cmds.append(cmd)
-        import subprocess as _sp
-        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
-
+    calls: list = []
     dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60, role="deliberation-panelist")
 
-    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
-        with mock.patch.object(pgp, "_read_report", return_value="panel seat analysis"):
-            dispatcher(
-                "claude", "sonnet",
-                "You are one seat on a deliberation panel. QUESTION: audit src/",
-                "panel-sweep-diverge-0-abc123",
-            )
+    with _patch_headless_seat(calls, report_body="panel seat analysis"):
+        dispatcher(
+            "claude", "sonnet",
+            "You are one seat on a deliberation panel. QUESTION: audit src/",
+            "panel-sweep-diverge-0-abc123",
+        )
 
-    assert len(seen_cmds) == 1
-    cmd = seen_cmds[0]
-    assert cmd[cmd.index("--role") + 1] == "deliberation-panelist"
-    instr = cmd[cmd.index("--instruction") + 1]
+    assert len(calls) == 1
+    spec = calls[0]["spec"]
+    assert spec.role == "deliberation-panelist"
+    assert spec.model == "sonnet"
+    instr = spec.instruction
     assert "independent plan reviewer" not in instr.lower()
     assert "implementation plan" not in instr.lower()
     # the file-ref benefit (short instruction, doc read from disk) is preserved
@@ -1475,56 +1638,57 @@ def test_non_plan_role_provider_lane_passes_role_through(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# scoped-spawn fix (2026-07-14): tmux_interactive_dispatch.dispatch()'s D2.2 scoping
-# precondition (tmux_interactive_dispatch.py, "D2.2 scoping precondition" -- fail-closed:
-# a working_tree_only dispatch is refused unless the env carries VNX_WORKER_SCOPED=1 or
-# VNX_ENFORCE_WORKER_PERMISSIONS=1) is deterministic and already has direct test coverage
-# in tests/test_working_tree_only.py (test_default_env_working_tree_only_is_rejected /
-# test_scoped_opt_in_working_tree_only_is_accepted_by_precondition) -- not duplicated here.
-# What's new in THIS module: the claude/tmux-lane subprocess env plan_gate_panel builds
-# must actually set the flag so that precondition is satisfied instead of tripping it.
+# scoped-spawn (2026-07-14, carried to the headless lane 2026-09-07): the tmux lane
+# needed VNX_WORKER_SCOPED=1 to satisfy its D2.2 --working-tree-only precondition. On the
+# headless lane the same flag does the job that precondition was standing in for: it
+# makes subprocess_adapter build the seat's argv from the ROLE's permission profile
+# instead of the blanket --dangerously-skip-permissions. So the pin is not a leftover —
+# without it a plan-review seat would run in the shared checkout with full write rights.
 # --------------------------------------------------------------------------
 
-def test_claude_lane_dispatcher_sets_scoped_spawn_env(tmp_path, monkeypatch):
-    """The claude/tmux-lane subprocess env must carry VNX_WORKER_SCOPED=1.
+def test_claude_seat_scoped_pin_binds_the_read_only_plan_reviewer_profile(
+    tmp_path, monkeypatch,
+):
+    """Under the dispatcher's pin, the seat's argv is role-scoped, not skip-permissions.
 
-    Without it, tmux_interactive_dispatch.dispatch()'s D2.2 scoping precondition
-    refuses every --working-tree-only dispatch this lane sends (working_tree_only
-    requires a scoped detached spawn) before any report is written -- the opus/claude
-    seat's silent NO-VERDICT root cause. The base env must NOT already carry the flag,
-    so a pass here proves the dispatcher sets it rather than an ambient leak.
+    Fed through the REAL subprocess_adapter._build_worker_scope_args (the function
+    that builds the claude argv head) so this proves the flag's effect, not just
+    its presence in a dict.
     """
     monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
-    doc = tmp_path / "plan.md"
-    doc.write_text("## Problem\n", encoding="utf-8")
+    monkeypatch.delenv("VNX_ENFORCE_WORKER_PERMISSIONS", raising=False)
 
-    seen_envs: list = []
+    import subprocess_adapter
 
-    def _mock_subprocess_run(cmd, **kwargs):
-        seen_envs.append(kwargs.get("env"))
-        import subprocess as _sp
-        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+    calls: list = []
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
+    scope_args: list = []
 
-    import plan_gate_panel as _pgp
-    import unittest.mock as mock
+    def _run(self, spec, event_writer=None, cwd=None):
+        calls.append(spec)
+        scope_args.extend(subprocess_adapter._build_worker_scope_args(spec.role))
+        out = Path(spec.data_dir) / "unified_reports" / f"{spec.dispatch_id}.md"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(_make_report_with_fence("pass"), encoding="utf-8")
+        return _adapter_ok()
 
-    authored_report = _make_report_with_fence("pass")
-    with mock.patch.object(_pgp.subprocess, "run", side_effect=_mock_subprocess_run):
-        with mock.patch.object(_pgp, "_read_report", return_value=authored_report):
-            pgp.run_panel(
-                doc,
-                track_id="feat-scoped",
-                project_id="p1",
-                panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
-                data_dir=str(tmp_path),
-            )
+    with mock.patch.object(
+        envelope_adapters_claude.ClaudeSubprocessAdapter, "run", _run,
+    ):
+        dispatcher("claude", "opus", "plan text", "plan-gate-feat-scoped-ccc33333")
 
-    assert len(seen_envs) == 1
-    assert seen_envs[0] is not None
-    assert seen_envs[0].get("VNX_WORKER_SCOPED") == "1", (
-        "claude/tmux-lane subprocess env must set VNX_WORKER_SCOPED=1 so the "
-        "--working-tree-only D2.2 fail-closed precondition is satisfied"
+    assert len(calls) == 1
+    assert "--dangerously-skip-permissions" not in scope_args, (
+        "the seat must not run with blanket permissions in the shared checkout"
     )
+    assert "--allowedTools" in scope_args
+    allowed = scope_args[scope_args.index("--allowedTools") + 1].split(",")
+    assert "Edit" not in allowed and "MultiEdit" not in allowed, (
+        "the plan-reviewer profile denies Edit — a review never mutates code"
+    )
+    assert "--disallowedTools" in scope_args
+    denied = scope_args[scope_args.index("--disallowedTools") + 1].split(",")
+    assert "Edit" in denied
 
 
 def test_provider_lane_dispatcher_does_not_set_scoped_spawn_env(tmp_path, monkeypatch):
@@ -1566,39 +1730,13 @@ def test_provider_lane_dispatcher_does_not_set_scoped_spawn_env(tmp_path, monkey
 # --------------------------------------------------------------------------
 # OI-1153: the seat subprocess must inherit VNX_DATA_DIR (+ VNX_DATA_DIR_EXPLICIT=1)
 # pinned to the data dir the dispatcher resolved, or the lane re-resolves its own
-# (provider_dispatch._resolve_data_dir / tmux lane _resolve_state_dir) and the seat
-# report lands outside the dir _read_report reads back from — e.g. the legacy
-# ~/.vnx-data/unified_reports root. The base env must NOT already carry the flag so a
-# pass proves the dispatcher sets it rather than an ambient leak.
+# (provider_dispatch._resolve_data_dir) and the seat report lands outside the dir
+# _read_report reads back from — e.g. the legacy ~/.vnx-data/unified_reports root. The
+# base env must NOT already carry the flag so a pass proves the dispatcher sets it
+# rather than an ambient leak. The claude seat's half of this lives in
+# test_claude_seat_headless_pins_data_dir_and_scoped_env (same two keys, plus the
+# restore-after check the subprocess form could not make).
 # --------------------------------------------------------------------------
-
-def test_claude_lane_dispatcher_sets_vnx_data_dir_env(tmp_path, monkeypatch):
-    """The claude/tmux-lane subprocess env must carry VNX_DATA_DIR + EXPLICIT pinned
-    to the dispatcher's resolved base so the seat writes its report where the panel
-    reads it back, not the legacy ~/.vnx-data/unified_reports root."""
-    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
-    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
-
-    seen_envs: list = []
-
-    def _mock_subprocess_run(cmd, **kwargs):
-        seen_envs.append(kwargs.get("env"))
-        import subprocess as _sp
-        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
-
-    import plan_gate_panel as _pgp
-    import unittest.mock as mock
-
-    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
-    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
-        with mock.patch.object(pgp, "_read_report", return_value="panel seat analysis"):
-            dispatcher("claude", "sonnet", "panel prompt", "panel-sweep-diverge-0-abc123")
-
-    assert len(seen_envs) == 1
-    assert seen_envs[0] is not None
-    assert seen_envs[0].get("VNX_DATA_DIR") == str(tmp_path)
-    assert seen_envs[0].get("VNX_DATA_DIR_EXPLICIT") == "1"
-
 
 def test_provider_lane_dispatcher_sets_vnx_data_dir_env(tmp_path, monkeypatch):
     """OI-1153 applies to provider lanes too: kimi/glm/deepseek route through
@@ -1732,49 +1870,43 @@ def test_provider_lane_task_class_disarms_kimi_fabrication_guard_on_clean_worktr
     mock_check.assert_not_called()
 
 
-def test_claude_lane_no_report_error_surfaces_stdout_failure_reason(tmp_path):
-    """The 'no report' RuntimeError must include proc.stdout, not just stderr.
+def test_claude_seat_no_report_error_surfaces_the_lane_failure(tmp_path, monkeypatch):
+    """When even govern() leaves no report, the seat error must name the lane failure.
 
-    tmux_interactive_dispatch's CLI prints the InteractiveDispatchResult (incl. the
-    actionable failure_reason, e.g. the D2.2 scoping refusal) as JSON to STDOUT. The
-    previous stderr-only message masked the real cause behind an unrelated red herring
-    (a stray 'staging_validator: unstaged dispatch override' stderr line) for a full day.
+    On the tmux lane the actionable reason (e.g. the D2.2 scoping refusal) was
+    printed as JSON to STDOUT and the stderr-only message masked it behind an
+    unrelated red herring for a full day. The headless lane hands that reason
+    back in-process on the adapter result, so it must reach the seat's error
+    instead of being swallowed.
     """
-    import json
-
+    monkeypatch.setenv("VNX_PANEL_RETRY", "0")
     doc = tmp_path / "plan.md"
     doc.write_text("## Problem\n", encoding="utf-8")
 
-    def _mock_subprocess_run(cmd, **kwargs):
-        import subprocess as _sp
-        stdout = json.dumps({
-            "success": False,
-            "dispatch_id": "whatever",
-            "failure_reason": "working_tree_only requires a scoped detached spawn",
-        })
-        return _sp.CompletedProcess(
-            cmd, returncode=1, stdout=stdout,
-            stderr="staging_validator: unstaged dispatch override",
-        )
+    failed = _AdapterResult(
+        returncode=1,
+        completion_text="",
+        status="failure",
+        error="unknown_role: plan-reviewer absent from every register",
+    )
 
-    import plan_gate_panel as _pgp
-    import unittest.mock as mock
-
-    with mock.patch.object(_pgp.subprocess, "run", side_effect=_mock_subprocess_run):
-        with mock.patch.object(_pgp, "_read_report", return_value=None):
+    calls: list = []
+    with _patch_headless_seat(calls, report_body=None, result=failed):
+        # govern() emits nothing either -> the seat has no report at all.
+        with mock.patch.object(pgp, "_read_report", return_value=None):
             out = pgp.run_panel(
                 doc,
                 track_id="feat-diag",
                 project_id="p1",
-                panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+                panel=_single_claude_panel(),
                 data_dir=str(tmp_path),
             )
 
     opus = next(p for p in out["panelists"] if p["label"] == "opus")
     assert opus["dispatched"] is False
-    assert "working_tree_only requires a scoped detached spawn" in opus["error"], (
-        "the real failure_reason (printed to stdout by tmux_interactive_dispatch's CLI) "
-        "must be surfaced, not swallowed behind a stderr-only error message"
+    assert "unknown_role" in opus["error"], (
+        "the adapter's failure reason must be surfaced, not swallowed behind a "
+        "bare returncode"
     )
 
 
@@ -1976,21 +2108,13 @@ def test_resolve_data_dir_unresolvable_project_id_fails_loudly(tmp_path, monkeyp
         pgp._resolve_data_dir(None)
 
 
-def _completed_process():
-    import subprocess as _sp
-    return _sp.CompletedProcess([], returncode=0, stdout="", stderr="")
-
-
 def test_claude_lane_report_path_uses_resolved_data_dir_when_none(tmp_path, monkeypatch):
     # Regression for the opus-seat NO-VERDICT bug: when run_panel is called with no
-    # data_dir, the claude/tmux lane's report path (and the read-back base) must still
+    # data_dir, the claude seat's report path (and the read-back base) must still
     # resolve to a real directory, not None -- _read_report(None, ...) can never find the
-    # worker-authored report when the tmux lane prints no `Report:` stderr line.
-    import unittest.mock as mock
-    import plan_gate_panel as _pgp
-
+    # worker-authored report, because the headless lane prints no `Report:` stderr line.
     fake_base = tmp_path / "resolved-data-dir"
-    monkeypatch.setattr(_pgp, "_resolve_data_dir", lambda data_dir: fake_base)
+    monkeypatch.setattr(pgp, "_resolve_data_dir", lambda data_dir: fake_base)
 
     authored_report = _make_report_with_fence("pass")
     seen_bases = []
@@ -2002,14 +2126,14 @@ def test_claude_lane_report_path_uses_resolved_data_dir_when_none(tmp_path, monk
     doc = tmp_path / "plan.md"
     doc.write_text("## Problem\n", encoding="utf-8")
 
-    with mock.patch.object(_pgp.subprocess, "run") as mock_run:
-        mock_run.return_value = _completed_process()
-        with mock.patch.object(_pgp, "_read_report", side_effect=_fake_read_report):
+    calls: list = []
+    with _patch_headless_seat(calls):
+        with mock.patch.object(pgp, "_read_report", side_effect=_fake_read_report):
             out = pgp.run_panel(
                 doc,
                 track_id="feat-nodatadir",
                 project_id="p1",
-                panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+                panel=_single_claude_panel(),
                 # data_dir intentionally omitted -> None
             )
 
@@ -2017,6 +2141,11 @@ def test_claude_lane_report_path_uses_resolved_data_dir_when_none(tmp_path, monk
     assert len(seen_bases) == 1
     assert seen_bases[0] == fake_base
     assert seen_bases[0] is not None
+    # The same resolved base reaches the lane, so the seat writes where the panel reads.
+    assert Path(calls[0]["spec"].data_dir) == fake_base
+    assert str(fake_base / "unified_reports" / f"{calls[0]['spec'].dispatch_id}.md") in (
+        calls[0]["spec"].instruction
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What broke

The plan-gate panel's claude seat shelled out to `tmux_interactive_dispatch.py`. Its bracketed-paste delivery handed the worker only the **last line** of the instruction (`"...as the very last step."`). Live on 2026-09-06, three times: the opus seat asked what the task was and then sat until its deadline — 906s, 907s, 2400s. Every plan-gate with a claude seat that day ended without that seat's verdict and was decided by the tiebreaker.

The lane choice rested on a premise that was never true: that headless `claude -p` bills API credits post-cutover. Anthropic never carried out that cutover. Measured 2026-08-11 from the auth state (no `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`, keychain `subscriptionType: max`), the headless lane runs on the Max subscription — and the single-entry door has routed claude through it by default since A2 (2026-08-26). The module comments said the opposite; they now say what was measured.

## What changed

A claude seat runs `claude -p` through the door's own `ClaudeSubprocessAdapter` — the same adapter `dispatch_envelope.run_envelope_headless_plan` uses — in the shared checkout, with the seat's `model_arg`, the seat timeout as deadline, and the existing file-ref instruction as prompt.

What it deliberately does **not** take from the door is the envelope around that adapter. A permit-carrying `ExecutionPlan`, an isolated worktree and push+PR enforcement are the shape of a dispatch that delivers code; a plan review delivers one verdict file. Building a worktree per seat is what timed the seat out on a large repo in the first place.

`dispatch_govern.govern` still runs — the same GOVERN step the lanes share — so:

- the seat's report and receipt do not become optional when the worker goes quiet;
- the panel's three-way seat classification stays honest. A worker that authors nothing gets the body carrying `SYNTHESIZED_REPORT_MARKER` and reads back as `no_verdict` ("the lane never delivered"), not as an abstention. On the tmux lane that distinction came from the same function; keeping govern keeps it.
- the seat receipt is stamped `lane=claude_headless`, the door's own label.

The env pins move from a child-only mapping onto `os.environ` for the duration of the run, restored afterwards. That is not cosmetic:

- `VNX_DATA_DIR` + `VNX_DATA_DIR_EXPLICIT=1` keep the seat's write path and `_read_report`'s read-back base one directory (OI-1153) — the child inherits them, since `SubprocessAdapter.deliver` builds the worker env from `os.environ.copy()`;
- `VNX_WORKER_SCOPED=1` has to bind in **this** process, because `subprocess_adapter._build_worker_scope_args` builds the argv here. Without it the seat spawns with blanket `--dangerously-skip-permissions` instead of the plan-reviewer profile's read-only tool scope — in a shared checkout that is the difference between a reviewer and a writer.

The provider branch (kimi / glm / deepseek via `provider_dispatch`) is unchanged.

## Verification

Red first, on `54943a2e`, 9 failed / 7 passed over the touched tests — the claude seat shelled out to `tmux_interactive_dispatch.py` in every one. Green after: 16 passed over the same selection, and **629 passed / 5 failed** across all 29 test files that import `plan_gate_panel`.

Those 5 are pre-existing and unrelated (`sqlite3.OperationalError: no such column: output_ref` in `track_reconciler.py:798`) — confirmed identical on pristine `54943a2e`.

Breakage proof: pointing the claude branch back at the tmux subprocess turns `test_claude_seat_runs_on_the_headless_lane_not_tmux` red with the lane argv in the message; restored.

A second throwaway guard patched `SubprocessAdapter.deliver` to raise across all 634 tests — nothing spawns a real worker.

## Open items

- `worker_permissions.build_claude_scope_args` takes `working_tree_only`, but `subprocess_adapter._build_worker_scope_args` does not thread it through, and `bash_deny_patterns` are never translated into `--disallowedTools`. So the headless seat is read-only through `denied_tools` (Edit/MultiEdit) but does not get the tmux lane's explicit `Bash(git commit:*)` / `Bash(git push:*)` denies. Both files are outside this dispatch's boundary.
- `dispatch_govern._synthesize` hardcodes `- Lane: tmux_interactive` in every body it fabricates, including for this lane. Cosmetic in the ledger, wrong in the report. Outside the boundary.
- The tmux lane's prompt-delivery bug itself is untouched and needs its own open item.
- `tests/test_plan_gate_panel_effectiveness.py` was in the file boundary but contains nothing lane-specific — left unchanged.

Dispatch-ID: 20260907-abis1-panel-claude-headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)