### PR TITLE
feat(pr-merge): ADR-nummer-preflight tegen main plus uniciteitstest (golf B, B6)

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -154,12 +154,16 @@ jobs:
             #   * test_docs_archive.py         — docs/_archive integrity and the
             #                                    ARCHIVED_MANIFEST matches disk
             #   * test_subsystems_md_exists.py — docs/core/SUBSYSTEMS.md SSOT
-            # All three are stdlib-only (no DB, no heavy deps) and also run in
+            #   * test_adr_numbers_unique.py   — a docs-only PR can add a new
+            #                                    ADR-*.md; this catches a
+            #                                    duplicate number on disk (B6)
+            # All four are stdlib-only (no DB, no heavy deps) and also run in
             # the full sweep below, so they stay green on main.
             pytest -q \
               "$GITHUB_WORKSPACE/tests/test_docs_index.py" \
               "$GITHUB_WORKSPACE/tests/test_docs_archive.py" \
               "$GITHUB_WORKSPACE/tests/test_subsystems_md_exists.py" \
+              "$GITHUB_WORKSPACE/tests/test_adr_numbers_unique.py" \
               -p no:cacheprovider
             exit 0
           fi

--- a/scripts/lib/merge_preflight_adr_check.py
+++ b/scripts/lib/merge_preflight_adr_check.py
@@ -44,9 +44,14 @@ globally unique regardless of project_id.
 
 Fail-closed: any unreadable/unparseable API response (``gh`` missing, not
 authenticated, a non-zero exit, invalid JSON, an unexpected shape) is a NO-GO
-with its own message — never a silent pass. There is no override for this
-check (unlike the CI/review gates): a colliding ADR number is always wrong,
-never a legitimate reason to bypass.
+with its own message — never a silent pass. That holds per ENTRY too: a single
+element of either listing that is not an object, or that misses a field this
+check reads (``filename``/``status`` on the PR side, ``name``/``type`` on the
+base side), refuses the whole check naming that entry's index. Skipping it
+instead would build an incomplete picture out of a response the check could
+not read, and an incomplete picture reads exactly like "nothing collides".
+There is no override for this check (unlike the CI/review gates): a colliding
+ADR number is always wrong, never a legitimate reason to bypass.
 """
 
 from __future__ import annotations
@@ -118,6 +123,42 @@ def _go(message: str, **extra: Any) -> Dict[str, Any]:
 
 STATUSES_THAT_CAN_CLAIM_A_NEW_NUMBER = frozenset({"added", "renamed", "copied"})
 
+# A malformed entry is quoted back in the NO-GO message so the operator can
+# recognise WHICH entry broke the read, but capped: an API response can carry
+# an arbitrarily large blob and the merge output must stay readable.
+MALFORMED_ENTRY_PREVIEW_CHARS = 120
+
+
+def _describe_entry(entry: Any) -> str:
+    """Short, safe rendering of one API entry for a NO-GO message."""
+    try:
+        rendered = json.dumps(entry, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        rendered = repr(entry)
+    if len(rendered) > MALFORMED_ENTRY_PREVIEW_CHARS:
+        rendered = rendered[:MALFORMED_ENTRY_PREVIEW_CHARS] + "..."
+    return rendered
+
+
+def _malformed_entry_reason(entry: Any, required_fields: Tuple[str, ...]) -> Optional[str]:
+    """Why ``entry`` is unusable for this check, or None when it is readable.
+
+    Fail-closed: the check may only conclude "no collision" from entries it
+    fully understands. An entry that is not an object, or that misses (or
+    carries a non-string in) a field the check reads, is a refusal — never a
+    skip, because skipping builds an incomplete picture that reads exactly
+    like "nothing collides".
+    """
+    if not isinstance(entry, dict):
+        return "is geen object"
+    for field in required_fields:
+        if field not in entry:
+            return f"mist het veld '{field}'"
+        value = entry[field]
+        if not isinstance(value, str) or not value:
+            return f"heeft geen bruikbare string in '{field}'"
+    return None
+
 
 def get_pr_added_adr_files(
     pr_number: int, *, gh_bin: str = "gh", project_root: Optional[Path] = None
@@ -186,19 +227,33 @@ def get_pr_added_adr_files(
         files.extend(page)
 
     added: Dict[str, str] = {}
-    for entry in files:
-        if not isinstance(entry, dict):
-            continue
-        status = entry.get("status")
+    for index, entry in enumerate(files):
+        reason = _malformed_entry_reason(entry, ("filename", "status"))
+        if reason is not None:
+            return None, _no_go(
+                f"misvormde entry {index} in pulls/{pr_number}/files ({reason}): "
+                f"{_describe_entry(entry)} — ADR-preflight is niet toetsbaar"
+            )
+        status = entry["status"]
         if status not in STATUSES_THAT_CAN_CLAIM_A_NEW_NUMBER:
             continue
-        path = entry.get("filename") or ""
+        path = entry["filename"]
         m = ADR_PATH_RE.match(path)
         if not m:
             continue
         number = str(int(m.group(1)))
         if status in ("renamed", "copied"):
-            prev_m = ADR_PATH_RE.match(entry.get("previous_filename") or "")
+            previous = entry.get("previous_filename")
+            if previous is not None and not isinstance(previous, str):
+                # Feeding a non-string into the regex would raise out of the
+                # gate instead of refusing; an unreadable rename source is the
+                # same malformed-entry case as the fields above.
+                return None, _no_go(
+                    f"misvormde entry {index} in pulls/{pr_number}/files (heeft geen "
+                    f"bruikbare string in 'previous_filename'): {_describe_entry(entry)} "
+                    "— ADR-preflight is niet toetsbaar"
+                )
+            prev_m = ADR_PATH_RE.match(previous or "")
             if prev_m and str(int(prev_m.group(1))) == number:
                 # Same ADR number before and after: a wording/rename fix on
                 # the PR's own claim, not a new-number claim.
@@ -256,12 +311,16 @@ def get_main_adr_numbers(
         )
 
     numbers: Dict[str, str] = {}
-    for entry in entries:
-        if not isinstance(entry, dict):
+    for index, entry in enumerate(entries):
+        reason = _malformed_entry_reason(entry, ("name", "type"))
+        if reason is not None:
+            return None, _no_go(
+                f"misvormde entry {index} in de {ADR_DECISIONS_DIR}-listing op {base_ref} "
+                f"({reason}): {_describe_entry(entry)} — ADR-preflight is niet toetsbaar"
+            )
+        if entry["type"] != "file":
             continue
-        if entry.get("type") != "file":
-            continue
-        name = entry.get("name") or ""
+        name = entry["name"]
         m = ADR_FILENAME_RE.match(name)
         if m:
             numbers[str(int(m.group(1)))] = name

--- a/scripts/lib/merge_preflight_adr_check.py
+++ b/scripts/lib/merge_preflight_adr_check.py
@@ -9,20 +9,25 @@ neither run could see the other PR's number claim. A CI test on the merge-ref
 diff can never catch this; only a check that runs at merge time, against the
 REAL main, can.
 
-This module answers one question: does an ADR file *added* by this PR reuse
-a number that already exists on the real ``main``? It never trusts a local
-``origin/main`` ref (that is only as fresh as the last ``git fetch`` the door
-happened to run, and the door itself never fetches) — both sides are read
-live via the GitHub API:
+This module answers one question: does an ADR file *added* (or renamed/copied
+into a NEW number) by this PR reuse a number that already exists on the real
+base branch (``main`` by default)? It never trusts a local ``origin/main``
+ref (that is only as fresh as the last ``git fetch`` the door happened to
+run, and the door itself never fetches) — both sides are read live via the
+GitHub API:
 
   1. The PR's changed files, via ``gh api repos/{owner}/{repo}/pulls/<N>/files``
      — this endpoint carries a ``status`` per file (``added``, ``modified``,
-     ``removed``, ``renamed``, ...), which is exactly what distinguishes "this
-     PR claims a new number" from "this PR edits an existing ADR" (a rename or
-     a wording fix on an existing ADR is not a collision).
-  2. The real main's ADR directory listing, via
-     ``gh api repos/{owner}/{repo}/contents/docs/governance/decisions?ref=main``
-     — the live tree at the tip of main, not a cached/local ref.
+     ``removed``, ``renamed``, ``copied``, ...) plus a ``previous_filename``
+     for renames/copies. A rename/copy whose OWN number changes (the ADR
+     number embedded in ``previous_filename`` differs from the one in
+     ``filename``) is treated the same as ``added`` — it claims a new number
+     just as much as a brand-new file does. A rename/copy that keeps the same
+     number (a wording fix) is not a collision.
+  2. The base branch's ADR directory listing, via
+     ``gh api repos/{owner}/{repo}/contents/docs/governance/decisions?ref=<base_ref>``
+     — the live tree at the tip of ``base_ref`` (default ``main``, override
+     with the PR's actual ``baseRefName`` when known), not a cached/local ref.
 
 ADR-007 (composite ``project_id`` key on the central ``adrs`` DB table) does
 NOT apply here: this check never touches that table. Two projects may both
@@ -104,14 +109,22 @@ def _go(message: str, **extra: Any) -> Dict[str, Any]:
     return base
 
 
+STATUSES_THAT_CAN_CLAIM_A_NEW_NUMBER = frozenset({"added", "renamed", "copied"})
+
+
 def get_pr_added_adr_files(
     pr_number: int, *, gh_bin: str = "gh", project_root: Optional[Path] = None
 ) -> Tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]]]:
-    """Return ({number: path}, None) for ADR files ADDED by this PR, or (None, no_go).
+    """Return ({number: path}, None) for ADR files ADDED (or renamed/copied
+    into a NEW number) by this PR, or (None, no_go).
 
-    Only files whose ``status`` (from the GitHub API) is ``"added"`` count —
-    a modified or renamed existing ADR file is not a new-number claim and is
-    deliberately excluded here, not filtered by the caller.
+    A plain ``"modified"`` status is never a new-number claim and is excluded.
+    ``"renamed"``/``"copied"`` are ambiguous on their own: they cover both "I
+    reworded ADR-038" (same number before and after — not a claim) and "I
+    renamed ADR-031 into ADR-038" (claims 038 exactly as much as a brand-new
+    ``ADR-038-*.md`` would). The two are told apart by comparing the ADR
+    number in ``filename`` against the one in ``previous_filename`` — only a
+    CHANGED number counts.
     """
     result, err = _capture(
         [gh_bin, "api", f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/files", "--paginate"],
@@ -147,41 +160,53 @@ def get_pr_added_adr_files(
     for entry in files:
         if not isinstance(entry, dict):
             continue
-        if entry.get("status") != "added":
+        status = entry.get("status")
+        if status not in STATUSES_THAT_CAN_CLAIM_A_NEW_NUMBER:
             continue
         path = entry.get("filename") or ""
         m = ADR_PATH_RE.match(path)
-        if m:
-            added[str(int(m.group(1)))] = path
+        if not m:
+            continue
+        number = str(int(m.group(1)))
+        if status in ("renamed", "copied"):
+            prev_m = ADR_PATH_RE.match(entry.get("previous_filename") or "")
+            if prev_m and str(int(prev_m.group(1))) == number:
+                # Same ADR number before and after: a wording/rename fix on
+                # the PR's own claim, not a new-number claim.
+                continue
+        added[number] = path
     return added, None
 
 
 def get_main_adr_numbers(
-    *, gh_bin: str = "gh", project_root: Optional[Path] = None
+    *, gh_bin: str = "gh", project_root: Optional[Path] = None, base_ref: str = "main"
 ) -> Tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]]]:
-    """Return ({number: filename}, None) for ADR files on the real main, or (None, no_go).
+    """Return ({number: filename}, None) for ADR files on ``base_ref``, or (None, no_go).
 
     Reads the live directory listing via the contents API scoped to
-    ``ref=main`` — never a local ``origin/main`` ref, which the door never
-    freshens (see module docstring).
+    ``ref=<base_ref>`` — never a local ``origin/<base_ref>`` ref, which the
+    door never freshens (see module docstring). Defaults to ``"main"``, the
+    base every VNX PR targets today; pass the PR's actual ``baseRefName`` when
+    it is known so a PR targeting something other than main is compared
+    against its real base instead of silently assuming main.
     """
     result, err = _capture(
-        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/contents/{ADR_DECISIONS_DIR}?ref=main"],
+        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/contents/{ADR_DECISIONS_DIR}?ref={base_ref}"],
         timeout=GH_CONTENTS_TIMEOUT,
         cwd=str(project_root) if project_root else None,
     )
     if err == "missing":
         return None, _no_go(
-            "gh CLI niet beschikbaar: ADR-preflight is niet toetsbaar (main-listing)"
+            "gh CLI niet beschikbaar: ADR-preflight is niet toetsbaar (base-ref-listing)"
         )
     if err == "timeout":
         return None, _no_go(
-            "gh api contents-listing liep vast: ADR-preflight is niet toetsbaar (main-listing)"
+            "gh api contents-listing liep vast: ADR-preflight is niet toetsbaar (base-ref-listing)"
         )
     if result is None or result.returncode != 0:
         stderr = (result.stderr if result else "").strip()
         return None, _no_go(
-            f"gh api contents-listing van {ADR_DECISIONS_DIR} op main faalde: "
+            f"gh api contents-listing van {ADR_DECISIONS_DIR} op {base_ref} faalde: "
             "ADR-preflight is niet toetsbaar" + (f" ({stderr[:160]})" if stderr else "")
         )
     try:
@@ -210,14 +235,20 @@ def get_main_adr_numbers(
 
 
 def check_adr_numbers_for_pr(
-    pr_number: int, *, gh_bin: str = "gh", project_root: Optional[Path] = None
+    pr_number: int,
+    *,
+    gh_bin: str = "gh",
+    project_root: Optional[Path] = None,
+    base_ref: str = "main",
 ) -> Dict[str, Any]:
     """Fail-closed: an ADR file added by this PR must not reuse a number
-    already present on the real main.
+    already present on the real base branch (``main`` by default).
 
     Returns ``{"verdict": "GO"|"NO-GO", "message": str, ...}``. No new ADR
     files added by the PR is a GO (nothing to check). There is no override —
-    a colliding number is always refused.
+    a colliding number is always refused. Pass the PR's actual ``baseRefName``
+    as ``base_ref`` when known; a PR targeting something other than main is
+    otherwise silently compared against main's numbers instead of its own base.
     """
     if shutil.which(gh_bin) is None:
         return _no_go("gh CLI niet beschikbaar: ADR-preflight is niet toetsbaar")
@@ -230,7 +261,9 @@ def check_adr_numbers_for_pr(
     if not pr_adrs:
         return _go("Geen nieuwe ADR-bestanden in deze PR: geen ADR-nummerbotsing mogelijk")
 
-    main_numbers, err = get_main_adr_numbers(gh_bin=gh_bin, project_root=project_root)
+    main_numbers, err = get_main_adr_numbers(
+        gh_bin=gh_bin, project_root=project_root, base_ref=base_ref
+    )
     if err is not None:
         return err
     assert main_numbers is not None
@@ -239,16 +272,17 @@ def check_adr_numbers_for_pr(
         if number in main_numbers:
             pr_file = pr_adrs[number]
             main_file = main_numbers[number]
+            padded = f"{int(number):03d}"
             return _no_go(
-                f"ADR-{number} botst: deze PR voegt '{pr_file}' toe, maar ADR-{number} "
-                f"staat al op main als '{main_file}'. Kies een vrij ADR-nummer.",
+                f"ADR-{padded} botst: deze PR voegt '{pr_file}' toe, maar ADR-{padded} "
+                f"staat al op {base_ref} als '{main_file}'. Kies een vrij ADR-nummer.",
                 colliding_number=number,
                 pr_file=pr_file,
                 main_file=main_file,
             )
 
     return _go(
-        f"Geen ADR-nummerbotsing: {len(pr_adrs)} nieuw(e) ADR-bestand(en) getoetst tegen main"
+        f"Geen ADR-nummerbotsing: {len(pr_adrs)} nieuw(e) ADR-bestand(en) getoetst tegen {base_ref}"
     )
 
 

--- a/scripts/lib/merge_preflight_adr_check.py
+++ b/scripts/lib/merge_preflight_adr_check.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Fail-closed ADR-number preflight for ``vnx pr-merge`` (Golf B, B6).
+
+On 2026-09-06, #1790 and #1792 both landed a new ``ADR-038-*.md`` and
+collided: both CI runs read a checkout of ``main`` that still ended at
+ADR-037, because the VNX CI workflow runs on the PR's *merge ref* (not the
+real, post-merge main) and ``required_status_checks.strict`` is off — so
+neither run could see the other PR's number claim. A CI test on the merge-ref
+diff can never catch this; only a check that runs at merge time, against the
+REAL main, can.
+
+This module answers one question: does an ADR file *added* by this PR reuse
+a number that already exists on the real ``main``? It never trusts a local
+``origin/main`` ref (that is only as fresh as the last ``git fetch`` the door
+happened to run, and the door itself never fetches) — both sides are read
+live via the GitHub API:
+
+  1. The PR's changed files, via ``gh api repos/{owner}/{repo}/pulls/<N>/files``
+     — this endpoint carries a ``status`` per file (``added``, ``modified``,
+     ``removed``, ``renamed``, ...), which is exactly what distinguishes "this
+     PR claims a new number" from "this PR edits an existing ADR" (a rename or
+     a wording fix on an existing ADR is not a collision).
+  2. The real main's ADR directory listing, via
+     ``gh api repos/{owner}/{repo}/contents/docs/governance/decisions?ref=main``
+     — the live tree at the tip of main, not a cached/local ref.
+
+ADR-007 (composite ``project_id`` key on the central ``adrs`` DB table) does
+NOT apply here: this check never touches that table. Two projects may both
+have an "ADR-001" in the central DB by design (composite PK over
+``project_id``); this module only ever compares filenames within ONE repo's
+``docs/governance/decisions/`` tree, where ADR numbers are meant to be
+globally unique regardless of project_id.
+
+Fail-closed: any unreadable/unparseable API response (``gh`` missing, not
+authenticated, a non-zero exit, invalid JSON, an unexpected shape) is a NO-GO
+with its own message — never a silent pass. There is no override for this
+check (unlike the CI/review gates): a colliding ADR number is always wrong,
+never a legitimate reason to bypass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Matches an ADR file's repo-relative path, e.g.
+# "docs/governance/decisions/ADR-038-receipt-outcome-identity.md".
+ADR_PATH_RE = re.compile(r"^docs/governance/decisions/ADR-(\d+)-[^/]+\.md$")
+
+# Matches a bare ADR filename (used against the contents-API directory
+# listing, which returns names, not full paths).
+ADR_FILENAME_RE = re.compile(r"^ADR-(\d+)-[^/]+\.md$")
+
+ADR_DECISIONS_DIR = "docs/governance/decisions"
+
+GH_PR_FILES_TIMEOUT = 20
+GH_CONTENTS_TIMEOUT = 20
+
+
+def _capture(
+    argv: List[str], *, timeout: int, cwd: Optional[str] = None
+) -> Tuple[Optional["subprocess.CompletedProcess[str]"], Optional[str]]:
+    """Run a command and return (result, error_tag).
+
+    error_tag is one of "missing" (binary not found), "timeout", or None. A
+    non-zero exit is NOT an error_tag: the caller inspects ``returncode``.
+    """
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+        return result, None
+    except FileNotFoundError:
+        return None, "missing"
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+
+
+def _no_go(message: str, **extra: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "verdict": "NO-GO",
+        "message": message,
+        "colliding_number": None,
+        "pr_file": None,
+        "main_file": None,
+    }
+    base.update(extra)
+    return base
+
+
+def _go(message: str, **extra: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "verdict": "GO",
+        "message": message,
+        "colliding_number": None,
+        "pr_file": None,
+        "main_file": None,
+    }
+    base.update(extra)
+    return base
+
+
+def get_pr_added_adr_files(
+    pr_number: int, *, gh_bin: str = "gh", project_root: Optional[Path] = None
+) -> Tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]]]:
+    """Return ({number: path}, None) for ADR files ADDED by this PR, or (None, no_go).
+
+    Only files whose ``status`` (from the GitHub API) is ``"added"`` count —
+    a modified or renamed existing ADR file is not a new-number claim and is
+    deliberately excluded here, not filtered by the caller.
+    """
+    result, err = _capture(
+        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/files", "--paginate"],
+        timeout=GH_PR_FILES_TIMEOUT,
+        cwd=str(project_root) if project_root else None,
+    )
+    if err == "missing":
+        return None, _no_go("gh CLI niet beschikbaar: ADR-preflight is niet toetsbaar")
+    if err == "timeout":
+        return None, _no_go(
+            f"gh api pulls/{pr_number}/files liep vast: ADR-preflight is niet toetsbaar"
+        )
+    if result is None or result.returncode != 0:
+        stderr = (result.stderr if result else "").strip()
+        return None, _no_go(
+            f"gh api pulls/{pr_number}/files faalde: ADR-preflight is niet toetsbaar"
+            + (f" ({stderr[:160]})" if stderr else "")
+        )
+    try:
+        files = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return None, _no_go(
+            f"gh-uitvoer voor pulls/{pr_number}/files niet te parsen: "
+            f"ADR-preflight is niet toetsbaar ({exc})"
+        )
+    if not isinstance(files, list):
+        return None, _no_go(
+            f"onverwacht antwoordformaat voor pulls/{pr_number}/files: "
+            "ADR-preflight is niet toetsbaar"
+        )
+
+    added: Dict[str, str] = {}
+    for entry in files:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("status") != "added":
+            continue
+        path = entry.get("filename") or ""
+        m = ADR_PATH_RE.match(path)
+        if m:
+            added[str(int(m.group(1)))] = path
+    return added, None
+
+
+def get_main_adr_numbers(
+    *, gh_bin: str = "gh", project_root: Optional[Path] = None
+) -> Tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]]]:
+    """Return ({number: filename}, None) for ADR files on the real main, or (None, no_go).
+
+    Reads the live directory listing via the contents API scoped to
+    ``ref=main`` — never a local ``origin/main`` ref, which the door never
+    freshens (see module docstring).
+    """
+    result, err = _capture(
+        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/contents/{ADR_DECISIONS_DIR}?ref=main"],
+        timeout=GH_CONTENTS_TIMEOUT,
+        cwd=str(project_root) if project_root else None,
+    )
+    if err == "missing":
+        return None, _no_go(
+            "gh CLI niet beschikbaar: ADR-preflight is niet toetsbaar (main-listing)"
+        )
+    if err == "timeout":
+        return None, _no_go(
+            "gh api contents-listing liep vast: ADR-preflight is niet toetsbaar (main-listing)"
+        )
+    if result is None or result.returncode != 0:
+        stderr = (result.stderr if result else "").strip()
+        return None, _no_go(
+            f"gh api contents-listing van {ADR_DECISIONS_DIR} op main faalde: "
+            "ADR-preflight is niet toetsbaar" + (f" ({stderr[:160]})" if stderr else "")
+        )
+    try:
+        entries = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return None, _no_go(
+            f"gh-uitvoer voor de main-listing niet te parsen: "
+            f"ADR-preflight is niet toetsbaar ({exc})"
+        )
+    if not isinstance(entries, list):
+        return None, _no_go(
+            "onverwacht antwoordformaat voor de main-listing: ADR-preflight is niet toetsbaar"
+        )
+
+    numbers: Dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("type") != "file":
+            continue
+        name = entry.get("name") or ""
+        m = ADR_FILENAME_RE.match(name)
+        if m:
+            numbers[str(int(m.group(1)))] = name
+    return numbers, None
+
+
+def check_adr_numbers_for_pr(
+    pr_number: int, *, gh_bin: str = "gh", project_root: Optional[Path] = None
+) -> Dict[str, Any]:
+    """Fail-closed: an ADR file added by this PR must not reuse a number
+    already present on the real main.
+
+    Returns ``{"verdict": "GO"|"NO-GO", "message": str, ...}``. No new ADR
+    files added by the PR is a GO (nothing to check). There is no override —
+    a colliding number is always refused.
+    """
+    if shutil.which(gh_bin) is None:
+        return _no_go("gh CLI niet beschikbaar: ADR-preflight is niet toetsbaar")
+
+    pr_adrs, err = get_pr_added_adr_files(pr_number, gh_bin=gh_bin, project_root=project_root)
+    if err is not None:
+        return err
+    assert pr_adrs is not None  # narrows for type-checkers: err is None -> value set
+
+    if not pr_adrs:
+        return _go("Geen nieuwe ADR-bestanden in deze PR: geen ADR-nummerbotsing mogelijk")
+
+    main_numbers, err = get_main_adr_numbers(gh_bin=gh_bin, project_root=project_root)
+    if err is not None:
+        return err
+    assert main_numbers is not None
+
+    for number in sorted(pr_adrs, key=int):
+        if number in main_numbers:
+            pr_file = pr_adrs[number]
+            main_file = main_numbers[number]
+            return _no_go(
+                f"ADR-{number} botst: deze PR voegt '{pr_file}' toe, maar ADR-{number} "
+                f"staat al op main als '{main_file}'. Kies een vrij ADR-nummer.",
+                colliding_number=number,
+                pr_file=pr_file,
+                main_file=main_file,
+            )
+
+    return _go(
+        f"Geen ADR-nummerbotsing: {len(pr_adrs)} nieuw(e) ADR-bestand(en) getoetst tegen main"
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="merge_preflight_adr_check",
+        description="Fail-closed check: does an added ADR file collide with a number already on main?",
+    )
+    parser.add_argument("--pr", type=int, required=True, help="GitHub PR number")
+    parser.add_argument("--project-root", default=".", help="Directory whose PR is being checked")
+    parser.add_argument("--gh-bin", default="gh", help="Path/name of the gh binary")
+    parser.add_argument("--json", action="store_true", help="Emit the full result as JSON")
+    args = parser.parse_args(argv)
+
+    result = check_adr_numbers_for_pr(
+        args.pr, gh_bin=args.gh_bin, project_root=Path(args.project_root)
+    )
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(result["message"])
+    return 0 if result["verdict"] == "GO" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/merge_preflight_adr_check.py
+++ b/scripts/lib/merge_preflight_adr_check.py
@@ -16,14 +16,20 @@ ref (that is only as fresh as the last ``git fetch`` the door happened to
 run, and the door itself never fetches) — both sides are read live via the
 GitHub API:
 
-  1. The PR's changed files, via ``gh api repos/{owner}/{repo}/pulls/<N>/files``
-     — this endpoint carries a ``status`` per file (``added``, ``modified``,
+  1. The PR's changed files, via
+     ``gh api repos/{owner}/{repo}/pulls/<N>/files --paginate --slurp`` — this
+     endpoint carries a ``status`` per file (``added``, ``modified``,
      ``removed``, ``renamed``, ``copied``, ...) plus a ``previous_filename``
      for renames/copies. A rename/copy whose OWN number changes (the ADR
      number embedded in ``previous_filename`` differs from the one in
      ``filename``) is treated the same as ``added`` — it claims a new number
      just as much as a brand-new file does. A rename/copy that keeps the same
-     number (a wording fix) is not a collision.
+     number (a wording fix) is not a collision. ``--paginate`` alone prints
+     each page as a SEPARATE JSON document back-to-back (confirmed via
+     ``gh api --help``: "Each page is a separate JSON array or object"), which
+     is not valid JSON once a PR has more files than one page (30-100
+     depending on the endpoint) — ``--slurp`` wraps all pages into a single
+     outer JSON array of pages, which this module flattens.
   2. The base branch's ADR directory listing, via
      ``gh api repos/{owner}/{repo}/contents/docs/governance/decisions?ref=<base_ref>``
      — the live tree at the tip of ``base_ref`` (default ``main``, override
@@ -53,6 +59,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
 
 # Matches an ADR file's repo-relative path, e.g.
 # "docs/governance/decisions/ADR-038-receipt-outcome-identity.md".
@@ -127,7 +134,13 @@ def get_pr_added_adr_files(
     CHANGED number counts.
     """
     result, err = _capture(
-        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/files", "--paginate"],
+        [
+            gh_bin,
+            "api",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/files",
+            "--paginate",
+            "--slurp",
+        ],
         timeout=GH_PR_FILES_TIMEOUT,
         cwd=str(project_root) if project_root else None,
     )
@@ -138,23 +151,39 @@ def get_pr_added_adr_files(
             f"gh api pulls/{pr_number}/files liep vast: ADR-preflight is niet toetsbaar"
         )
     if result is None or result.returncode != 0:
+        # Fail-closed also catches an old gh binary that does not know
+        # --slurp yet (non-zero exit, "unknown flag" on stderr): there is no
+        # silent fallback to unpaginated/unslurped output here.
         stderr = (result.stderr if result else "").strip()
         return None, _no_go(
             f"gh api pulls/{pr_number}/files faalde: ADR-preflight is niet toetsbaar"
             + (f" ({stderr[:160]})" if stderr else "")
         )
     try:
-        files = json.loads(result.stdout)
+        pages = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
+        # Most likely cause: gh's --paginate prints one JSON document PER
+        # PAGE back-to-back without --slurp, which is not valid JSON as a
+        # whole once there is more than one page.
         return None, _no_go(
-            f"gh-uitvoer voor pulls/{pr_number}/files niet te parsen: "
-            f"ADR-preflight is niet toetsbaar ({exc})"
+            f"gh-uitvoer voor pulls/{pr_number}/files niet te parsen als geslurpte "
+            f"paginering (elke pagina moet een JSON-array binnen de buitenste "
+            f"array zijn): ADR-preflight is niet toetsbaar ({exc})"
         )
-    if not isinstance(files, list):
+    if not isinstance(pages, list):
         return None, _no_go(
             f"onverwacht antwoordformaat voor pulls/{pr_number}/files: "
             "ADR-preflight is niet toetsbaar"
         )
+
+    files: List[Any] = []
+    for page in pages:
+        if not isinstance(page, list):
+            return None, _no_go(
+                f"onverwacht antwoordformaat voor pulls/{pr_number}/files "
+                "(geslurpte pagina is geen array): ADR-preflight is niet toetsbaar"
+            )
+        files.extend(page)
 
     added: Dict[str, str] = {}
     for entry in files:
@@ -190,8 +219,13 @@ def get_main_adr_numbers(
     it is known so a PR targeting something other than main is compared
     against its real base instead of silently assuming main.
     """
+    encoded_base_ref = quote(base_ref, safe="")
     result, err = _capture(
-        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/contents/{ADR_DECISIONS_DIR}?ref={base_ref}"],
+        [
+            gh_bin,
+            "api",
+            f"repos/{{owner}}/{{repo}}/contents/{ADR_DECISIONS_DIR}?ref={encoded_base_ref}",
+        ],
         timeout=GH_CONTENTS_TIMEOUT,
         cwd=str(project_root) if project_root else None,
     )

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -86,6 +86,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt
 from merge_preflight_ci_check import check_ci_run_for_head, _resolve_override_reason
+from merge_preflight_adr_check import check_adr_numbers_for_pr
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -327,6 +328,20 @@ def _run_review_gate(
         head_sha=head_sha,
     )
     return gate, pr_data
+
+
+def _run_adr_gate(pr_number: int) -> Dict[str, Any]:
+    """Fail-closed merge gate (Golf B, B6): an ADR file added by this PR must
+    not reuse a number already on the real main.
+
+    Delegates to ``merge_preflight_adr_check.check_adr_numbers_for_pr``, which
+    reads the PR's added files and the real main tree via the GitHub API —
+    never a local ``origin/main`` ref (see that module's docstring for why:
+    the door never fetches, so a local ref is only as fresh as the last
+    incidental fetch). No override: a colliding ADR number is always a
+    refusal.
+    """
+    return check_adr_numbers_for_pr(pr_number, project_root=SCRIPT_DIR.parent)
 
 
 _HEAD_MOVED_MARKERS = (
@@ -700,6 +715,18 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"OVERRIDE: {review_gate['message']}")
     else:
         print(f"Review gate: {review_gate['message']}")
+
+    # ── ADR-number preflight: an added ADR file must not collide with a ────
+    # number already on main (Golf B, B6). No override — always a refusal.
+    adr_gate = _run_adr_gate(args.pr)
+    if adr_gate["verdict"] != "GO":
+        if args.json:
+            print(json.dumps({"success": False, "pr_number": args.pr,
+                               "error": adr_gate["message"], "adr_gate": adr_gate}, indent=2))
+        else:
+            print(f"NO-GO: {adr_gate['message']}", file=sys.stderr)
+        return EXIT_ERROR
+    print(f"ADR gate: {adr_gate['message']}")
 
     # The head SHA the gates approved is established once in _run_ci_gate; the
     # merge is pinned to it (--match-head-commit) so a post-gate push is refused.

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -330,18 +330,47 @@ def _run_review_gate(
     return gate, pr_data
 
 
-def _run_adr_gate(pr_number: int) -> Dict[str, Any]:
+def _run_adr_gate(pr_number: int, *, pr_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Fail-closed merge gate (Golf B, B6): an ADR file added by this PR must
-    not reuse a number already on the real main.
+    not reuse a number already on the real base branch.
 
     Delegates to ``merge_preflight_adr_check.check_adr_numbers_for_pr``, which
-    reads the PR's added files and the real main tree via the GitHub API —
-    never a local ``origin/main`` ref (see that module's docstring for why:
-    the door never fetches, so a local ref is only as fresh as the last
+    reads the PR's added files and the real base-branch tree via the GitHub
+    API — never a local ``origin/main`` ref (see that module's docstring for
+    why: the door never fetches, so a local ref is only as fresh as the last
     incidental fetch). No override: a colliding ADR number is always a
     refusal.
+
+    OI-1518 recovery (leeszetel finding 2): ``pr_data`` — already resolved by
+    ``_run_ci_gate`` — carries the PR's ``state``. When ``state == "MERGED"``,
+    this call is the OI-1518 recovery route: an operator re-running
+    ``pr_merge.py --pr N`` after a merge whose receipt did not land. The PR's
+    own ADR file is by then already sitting on the base branch (the merge put
+    it there), so the live check would refuse every such recovery run on an
+    ADR PR by construction (#1790/#1792 measured NO-GO once merged). Skipped
+    here, loudly, ONLY for an already-merged PR — never via an override flag,
+    which would defeat "a colliding number is always a refusal" for a PR that
+    is still open.
+
+    Leeszetel finding 7: the base branch to check against is the PR's own
+    ``baseRefName`` from ``pr_data``, not a hardcoded ``"main"`` — a PR
+    targeting a non-main base is compared against its real base instead of
+    silently assuming main.
     """
-    return check_adr_numbers_for_pr(pr_number, project_root=SCRIPT_DIR.parent)
+    if (pr_data or {}).get("state") == "MERGED":
+        return {
+            "verdict": "GO",
+            "message": (
+                f"ADR-preflight overgeslagen: PR #{pr_number} staat al op GitHub als "
+                "MERGED (OI-1518-herstelroute: dit ADR-nummer staat door de merge zelf "
+                "al op de basisbranch)"
+            ),
+            "colliding_number": None,
+            "pr_file": None,
+            "main_file": None,
+        }
+    base_ref = (pr_data or {}).get("baseRefName") or "main"
+    return check_adr_numbers_for_pr(pr_number, project_root=SCRIPT_DIR.parent, base_ref=base_ref)
 
 
 _HEAD_MOVED_MARKERS = (
@@ -718,7 +747,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     # ── ADR-number preflight: an added ADR file must not collide with a ────
     # number already on main (Golf B, B6). No override — always a refusal.
-    adr_gate = _run_adr_gate(args.pr)
+    adr_gate = _run_adr_gate(args.pr, pr_data=pr_data)
     if adr_gate["verdict"] != "GO":
         if args.json:
             print(json.dumps({"success": False, "pr_number": args.pr,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,54 @@ def _stub_gate_identity_gh_calls(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(gate_recorder.subprocess, "run", fake_run)
 
 
+@pytest.fixture(autouse=True)
+def _stub_adr_gate_gh_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Golfb-b6 fix-forward (leeszetel finding 1): keep pr_merge's ADR gate offline.
+
+    ``pr_merge.main()`` runs a third gate, ``_run_adr_gate``, which delegates
+    to ``merge_preflight_adr_check.check_adr_numbers_for_pr`` — a real
+    ``gh api pulls/<n>/files`` + ``gh api contents/...`` network call for
+    whatever PR number the test happens to drive ``main()`` with. Before this
+    fixture, only ``tests/test_pr_merge_ci_gate.py`` mocked that call per-file;
+    every other test that drives ``pr_merge.main()`` through the CI/review
+    gates also hit this live call. In CI (no ``GH_TOKEN``) it fails
+    fail-closed and turned unrelated CI/review-gate tests into a false NO-GO
+    (measured: CI run 34108139082, 7 failures across three files that never
+    touch the ADR gate:
+    ``test_pr_merge_match_head.py``, ``test_pr_merge_outcome_exitcode.py``,
+    ``test_pr_merge_review_gate.py``).
+
+    Stubs the NETWORK CALL (``pr_merge.check_adr_numbers_for_pr``, the name
+    ``_run_adr_gate`` calls into), not ``_run_adr_gate`` itself: the gate
+    function's own OI-1518-recovery and base-ref logic
+    (tests/test_merge_preflight_adr_check.py::TestRunAdrGateOi1518Recovery)
+    still runs for real against this stub. Tests that specifically exercise
+    the ADR gate's verdict (tests/test_merge_preflight_adr_check.py::
+    TestPrMergeAdrGateWiring) override ``_run_adr_gate`` wholesale in the test
+    body — same monkeypatch instance, later call wins.
+    """
+    try:
+        import pr_merge
+    except ImportError:
+        # pr_merge (scripts/, not scripts/lib/) is only on sys.path once a
+        # pr_merge test module has been collected and inserted it — see the
+        # sys.path.insert calls at the top of tests/test_pr_merge_*.py. A
+        # test run that never collects one of those files never imports
+        # pr_merge either, so there is nothing to stub.
+        return
+    monkeypatch.setattr(
+        pr_merge,
+        "check_adr_numbers_for_pr",
+        lambda *a, **k: {
+            "verdict": "GO",
+            "message": "Geen nieuwe ADR-bestanden in deze PR: geen ADR-nummerbotsing mogelijk",
+            "colliding_number": None,
+            "pr_file": None,
+            "main_file": None,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # DB / registry fixtures  (shared with test_burnin_certification)
 # ---------------------------------------------------------------------------

--- a/tests/test_adr_numbers_unique.py
+++ b/tests/test_adr_numbers_unique.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""ADR-nummer-uniciteit op de bestandsboom (Golf B, B6).
+
+#1790 en #1792 botsten op 06-09 allebei op ADR-038 omdat de VNX CI-workflow
+op de merge-ref draait (niet de echte, post-merge main) en
+``required_status_checks.strict`` uit staat — een CI-test op de PR-diff kan
+die botsing nooit vangen, want beide runs zien onafhankelijk een main die nog
+bij ADR-037 eindigt. Deze test toetst een andere, complementaire invariant:
+op de checkout zelf (waar ``pytest`` op draait, dus altijd de post-merge
+main in de CI-sweep) mag geen ADR-nummer dubbel voorkomen. De merge-time
+kant van dezelfde invariant — een PR die een nummer claimt dat al op de
+ECHTE main staat, bewaakt via de GitHub API — zit in
+``scripts/lib/merge_preflight_adr_check.py`` (getest in
+``test_merge_preflight_adr_check.py``); deze test hier is stdlib-only en
+draait daarom ook in de CI-light-lijst voor een docs-only PR.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+DECISIONS_DIR = VNX_ROOT / "docs" / "governance" / "decisions"
+
+ADR_FILENAME_RE = re.compile(r"^ADR-(\d+)-.+\.md$")
+
+
+def find_duplicate_adr_numbers(decisions_dir: Path) -> Dict[str, List[str]]:
+    """Return {number: [filenames, ...]} for every ADR number claimed by more
+    than one file in ``decisions_dir``. Numbers are normalised (int-cast) so
+    ``ADR-007`` and a hypothetical ``ADR-7`` collide too. Empty dict means
+    every number is unique.
+    """
+    by_number: Dict[str, List[str]] = defaultdict(list)
+    for path in sorted(decisions_dir.glob("ADR-*.md")):
+        m = ADR_FILENAME_RE.match(path.name)
+        if not m:
+            continue
+        number = str(int(m.group(1)))
+        by_number[number].append(path.name)
+    return {number: names for number, names in by_number.items() if len(names) > 1}
+
+
+def _format_duplicates(duplicates: Dict[str, List[str]]) -> str:
+    return "; ".join(
+        f"ADR-{number}: {', '.join(names)}" for number, names in sorted(duplicates.items(), key=lambda kv: int(kv[0]))
+    )
+
+
+class TestAdrNumbersUniqueOnRealTree:
+    def test_no_duplicate_adr_numbers(self):
+        duplicates = find_duplicate_adr_numbers(DECISIONS_DIR)
+        assert not duplicates, (
+            "ADR-nummer(s) dubbel geclaimd op docs/governance/decisions/: "
+            + _format_duplicates(duplicates)
+        )
+
+
+class TestFindDuplicateAdrNumbersDetection:
+    """Proves the detector actually fires (nul is eerst een meetfout): a
+    duplicate injected into a scratch copy of the real tree must be caught
+    and must name both files, not just report a bare count.
+    """
+
+    def test_injected_duplicate_is_detected_with_both_filenames(self, tmp_path):
+        scratch = tmp_path / "decisions"
+        shutil.copytree(DECISIONS_DIR, scratch)
+
+        existing = sorted(scratch.glob("ADR-038-*.md"))
+        assert existing, (
+            "fixture assumption failed: geen ADR-038-*.md op de echte boom om te dupliceren "
+            "(pas het nummer hierboven aan als ADR-038 ooit hernummerd wordt)"
+        )
+        original_name = existing[0].name
+        duplicate = scratch / "ADR-038-injected-duplicate-for-test.md"
+        duplicate.write_text("# injected duplicate for test\n")
+
+        duplicates = find_duplicate_adr_numbers(scratch)
+
+        assert "38" in duplicates
+        assert original_name in duplicates["38"]
+        assert duplicate.name in duplicates["38"]
+        assert len(duplicates) == 1, f"onverwachte extra botsingen: {duplicates}"
+
+    def test_no_false_positive_on_distinct_numbers(self, tmp_path):
+        scratch = tmp_path / "decisions"
+        scratch.mkdir()
+        (scratch / "ADR-001-a.md").write_text("# a\n")
+        (scratch / "ADR-002-b.md").write_text("# b\n")
+
+        assert find_duplicate_adr_numbers(scratch) == {}
+
+    def test_zero_padding_does_not_hide_a_collision(self, tmp_path):
+        """ADR-007 and a hypothetical ADR-7 must be treated as the same number."""
+        scratch = tmp_path / "decisions"
+        scratch.mkdir()
+        (scratch / "ADR-007-padded.md").write_text("# padded\n")
+        (scratch / "ADR-7-unpadded.md").write_text("# unpadded\n")
+
+        duplicates = find_duplicate_adr_numbers(scratch)
+
+        assert "7" in duplicates
+        assert set(duplicates["7"]) == {"ADR-007-padded.md", "ADR-7-unpadded.md"}

--- a/tests/test_adr_numbers_unique.py
+++ b/tests/test_adr_numbers_unique.py
@@ -53,6 +53,22 @@ def _format_duplicates(duplicates: Dict[str, List[str]]) -> str:
 
 class TestAdrNumbersUniqueOnRealTree:
     def test_no_duplicate_adr_numbers(self):
+        # Leeszetel finding 8: Path.glob() on a non-existent directory returns
+        # a silently empty iterator, not an error, so a moved/renamed
+        # decisions dir would make find_duplicate_adr_numbers return {} and
+        # this test would pass having checked nothing. Assert the directory
+        # exists and holds a real population of ADR files before trusting an
+        # empty duplicates dict as "no collisions" rather than "nothing found".
+        assert DECISIONS_DIR.is_dir(), (
+            f"{DECISIONS_DIR} bestaat niet: de uniciteits-invariant hieronder "
+            "zou dan stil slagen zonder ooit een ADR-nummer te hebben geteld"
+        )
+        adr_files = list(DECISIONS_DIR.glob("ADR-*.md"))
+        assert len(adr_files) >= 30, (
+            f"slechts {len(adr_files)} ADR-bestand(en) gevonden op {DECISIONS_DIR}: "
+            "te weinig om de uniciteits-invariant hieronder zinvol te laten falen"
+        )
+
         duplicates = find_duplicate_adr_numbers(DECISIONS_DIR)
         assert not duplicates, (
             "ADR-nummer(s) dubbel geclaimd op docs/governance/decisions/: "

--- a/tests/test_merge_preflight_adr_check.py
+++ b/tests/test_merge_preflight_adr_check.py
@@ -29,7 +29,11 @@ def _proc(stdout: str, returncode: int = 0, stderr: str = "") -> subprocess.Comp
 
 
 def _pr_files_json(entries: List[Dict[str, Any]]) -> str:
-    return json.dumps(entries)
+    """Simulate ``gh api ... --paginate --slurp`` output: a single outer
+    array wrapping one page (the entries list itself). Multi-page slurped
+    output is exercised separately in TestGetPrAddedAdrFilesPagination.
+    """
+    return json.dumps([entries])
 
 
 def _main_listing_json(names: List[str]) -> str:
@@ -134,6 +138,74 @@ class TestGetPrAddedAdrFiles:
         assert "niet te parsen" in err["message"]
 
 
+class TestGetPrAddedAdrFilesPagination:
+    """B6 fix-forward 2: ``gh api --paginate`` without ``--slurp`` prints one
+    JSON document PER PAGE back-to-back, which is not valid JSON once a PR
+    has more files than fit on one page. ``--slurp`` wraps all pages into a
+    single outer JSON array of pages; this module must flatten that, and
+    must refuse (not crash) on the old, un-slurped shape.
+    """
+
+    def test_multi_page_slurped_output_is_flattened_and_page_two_adr_is_caught(self, monkeypatch):
+        page_one = [
+            {"filename": "docs/governance/decisions/ADR-020-x.md", "status": "modified"},
+            {"filename": "scripts/pr_merge.py", "status": "modified"},
+        ]
+        page_two = [
+            {"filename": "docs/governance/decisions/ADR-041-late-page.md", "status": "added"},
+        ]
+        slurped_stdout = json.dumps([page_one, page_two])
+        seen_argv: List[List[str]] = []
+
+        def fake_capture(argv, *, timeout, cwd=None):
+            seen_argv.append(argv)
+            return _proc(slurped_stdout), None
+
+        monkeypatch.setattr(adr_check, "_capture", fake_capture)
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert err is None
+        assert added == {"41": "docs/governance/decisions/ADR-041-late-page.md"}
+        assert "--paginate" in seen_argv[0]
+        assert "--slurp" in seen_argv[0]
+
+    def test_unslurped_multi_document_output_is_no_go_not_a_crash(self, monkeypatch):
+        """The old, buggy shape: two JSON documents concatenated back-to-back
+        (what ``--paginate`` alone produces on a multi-page PR). This must
+        never crash the preflight — it must NO-GO with a message that points
+        at pagination/slurping, not a generic parse error.
+        """
+        unslurped_stdout = (
+            json.dumps([{"filename": "docs/governance/decisions/ADR-020-x.md", "status": "modified"}])
+            + json.dumps([{"filename": "docs/governance/decisions/ADR-041-y.md", "status": "added"}])
+        )
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(unslurped_stdout), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "slurp" in err["message"].lower() or "paginering" in err["message"].lower()
+
+    def test_slurped_page_that_is_not_an_array_is_no_go(self, monkeypatch):
+        """A slurped page must itself be an array (the files endpoint returns
+        an array per page); anything else is an unexpected shape, refused.
+        """
+        malformed_stdout = json.dumps([{"not": "an array"}])
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(malformed_stdout), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "onverwacht antwoordformaat" in err["message"]
+
+
 class TestGetMainAdrNumbers:
     def test_parses_directory_listing(self, monkeypatch):
         monkeypatch.setattr(
@@ -178,6 +250,27 @@ class TestGetMainAdrNumbers:
         assert numbers is None
         assert err["verdict"] == "NO-GO"
         assert "niet toetsbaar" in err["message"]
+
+    def test_base_ref_with_special_characters_is_url_encoded(self, monkeypatch):
+        """B6 fix-forward 2: ``base_ref`` is spliced straight into a query
+        string (``?ref={base_ref}``); a branch name carrying '?' or '&' must
+        be percent-encoded, not pasted in literally.
+        """
+        seen_argv: List[List[str]] = []
+
+        def fake_capture(argv, *, timeout, cwd=None):
+            seen_argv.append(argv)
+            return _proc(_main_listing_json([])), None
+
+        monkeypatch.setattr(adr_check, "_capture", fake_capture)
+
+        numbers, err = adr_check.get_main_adr_numbers(base_ref="weird?ref&name")
+
+        assert err is None
+        assert numbers == {}
+        call = " ".join(seen_argv[0])
+        assert "ref=weird%3Fref%26name" in call
+        assert "ref=weird?ref&name" not in call
 
 
 class TestCheckAdrNumbersForPr:

--- a/tests/test_merge_preflight_adr_check.py
+++ b/tests/test_merge_preflight_adr_check.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Tests for the ADR-number merge preflight (Golf B, B6).
+
+Covers ``merge_preflight_adr_check`` (the fail-closed check itself) and its
+wiring into ``pr_merge.main()`` via ``_run_adr_gate``. Every ``gh`` call is
+mocked at the ``_capture`` seam (same pattern as
+``test_merge_preflight_ci_check.py``): no real subprocess, no network, no gh
+auth dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import merge_preflight_adr_check as adr_check
+
+
+def _proc(stdout: str, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _pr_files_json(entries: List[Dict[str, Any]]) -> str:
+    return json.dumps(entries)
+
+
+def _main_listing_json(names: List[str]) -> str:
+    return json.dumps(
+        [{"name": n, "type": "file", "path": f"docs/governance/decisions/{n}"} for n in names]
+    )
+
+
+class TestGetPrAddedAdrFiles:
+    def test_only_added_status_counts(self, monkeypatch):
+        """A modified/renamed existing ADR, or an unrelated file, must not surface."""
+        entries = [
+            {"filename": "docs/governance/decisions/ADR-038-x.md", "status": "added"},
+            {"filename": "docs/governance/decisions/ADR-020-y.md", "status": "modified"},
+            {"filename": "docs/governance/decisions/ADR-021-renamed.md", "status": "renamed",
+             "previous_filename": "docs/governance/decisions/ADR-021-old-name.md"},
+            {"filename": "scripts/pr_merge.py", "status": "added"},
+        ]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert err is None
+        assert added == {"38": "docs/governance/decisions/ADR-038-x.md"}
+
+    def test_no_added_adr_files_yields_empty_dict(self, monkeypatch):
+        entries = [{"filename": "scripts/pr_merge.py", "status": "modified"}]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert err is None
+        assert added == {}
+
+    def test_gh_failure_is_no_go_fail_closed(self, monkeypatch):
+        monkeypatch.setattr(
+            adr_check, "_capture",
+            lambda argv, *, timeout, cwd=None: (_proc("", returncode=1, stderr="HTTP 404"), None),
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in err["message"]
+
+    def test_gh_missing_binary_is_no_go(self, monkeypatch):
+        monkeypatch.setattr(adr_check, "_capture", lambda argv, *, timeout, cwd=None: (None, "missing"))
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "gh CLI niet beschikbaar" in err["message"]
+
+    def test_unparseable_json_is_no_go(self, monkeypatch):
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc("not json"), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "niet te parsen" in err["message"]
+
+
+class TestGetMainAdrNumbers:
+    def test_parses_directory_listing(self, monkeypatch):
+        monkeypatch.setattr(
+            adr_check, "_capture",
+            lambda argv, *, timeout, cwd=None: (
+                _proc(_main_listing_json(["ADR-038-receipt-outcome-identity.md", "ADR-039-x.md"])), None,
+            ),
+        )
+
+        numbers, err = adr_check.get_main_adr_numbers()
+
+        assert err is None
+        assert numbers == {
+            "38": "ADR-038-receipt-outcome-identity.md",
+            "39": "ADR-039-x.md",
+        }
+
+    def test_non_adr_and_directory_entries_are_ignored(self, monkeypatch):
+        entries = [
+            {"name": "ADR-038-x.md", "type": "file"},
+            {"name": "README.md", "type": "file"},
+            {"name": "subdir", "type": "dir"},
+        ]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(json.dumps(entries)), None)
+        )
+
+        numbers, err = adr_check.get_main_adr_numbers()
+
+        assert err is None
+        assert numbers == {"38": "ADR-038-x.md"}
+
+    def test_api_failure_on_main_listing_is_fail_closed(self, monkeypatch):
+        """A broken main-listing call must refuse, never read as 'no ADRs on main'."""
+        monkeypatch.setattr(
+            adr_check, "_capture",
+            lambda argv, *, timeout, cwd=None: (_proc("", returncode=1, stderr="rate limited"), None),
+        )
+
+        numbers, err = adr_check.get_main_adr_numbers()
+
+        assert numbers is None
+        assert err["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in err["message"]
+
+
+class TestCheckAdrNumbersForPr:
+    def _mock_gh(self, monkeypatch, *, pr_entries, main_names=None, main_error=False, gh_present=True):
+        calls: Dict[str, int] = {"n": 0, "pulls": 0, "contents": 0}
+
+        def fake_capture(argv, *, timeout, cwd=None):
+            calls["n"] += 1
+            joined = " ".join(argv)
+            if "pulls" in joined:
+                calls["pulls"] += 1
+                return _proc(_pr_files_json(pr_entries)), None
+            if "contents" in joined:
+                calls["contents"] += 1
+                if main_error:
+                    return _proc("", returncode=1, stderr="boom"), None
+                return _proc(_main_listing_json(main_names or [])), None
+            raise AssertionError(f"unexpected gh call: {argv}")
+
+        monkeypatch.setattr(adr_check, "_capture", fake_capture)
+        monkeypatch.setattr(
+            adr_check.shutil, "which", lambda b: ("/usr/bin/gh" if gh_present else None)
+        )
+        return calls
+
+    def test_colliding_added_adr_number_is_no_go_naming_both_files(self, monkeypatch):
+        """PR adds ADR-038-x.md; main already has ADR-038-y.md -> NO-GO naming '038' and both files."""
+        self._mock_gh(
+            monkeypatch,
+            pr_entries=[{"filename": "docs/governance/decisions/ADR-038-x.md", "status": "added"}],
+            main_names=["ADR-038-y.md"],
+        )
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "NO-GO"
+        assert "038" in result["message"]
+        assert "ADR-038-x.md" in result["message"]
+        assert "ADR-038-y.md" in result["message"]
+        assert result["colliding_number"] == "38"
+        assert result["pr_file"] == "docs/governance/decisions/ADR-038-x.md"
+        assert result["main_file"] == "ADR-038-y.md"
+
+    def test_modified_existing_adr_is_not_a_collision(self, monkeypatch):
+        """Same number but the PR entry status is MODIFIED (not added) -> GO."""
+        self._mock_gh(
+            monkeypatch,
+            pr_entries=[{"filename": "docs/governance/decisions/ADR-038-x.md", "status": "modified"}],
+            main_names=["ADR-038-x.md"],
+        )
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "GO"
+
+    def test_renamed_existing_adr_is_not_a_collision(self, monkeypatch):
+        """A rename (status=renamed) of an existing ADR is not an add -> GO."""
+        self._mock_gh(
+            monkeypatch,
+            pr_entries=[{"filename": "docs/governance/decisions/ADR-038-x.md", "status": "renamed",
+                         "previous_filename": "docs/governance/decisions/ADR-038-old.md"}],
+            main_names=["ADR-038-old.md"],
+        )
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "GO"
+
+    def test_added_adr_with_a_free_number_is_go(self, monkeypatch):
+        self._mock_gh(
+            monkeypatch,
+            pr_entries=[{"filename": "docs/governance/decisions/ADR-040-new.md", "status": "added"}],
+            main_names=["ADR-038-x.md", "ADR-039-y.md"],
+        )
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "GO"
+
+    def test_main_listing_api_failure_is_fail_closed(self, monkeypatch):
+        """API failure on the main-listing call: refusal, never a silent pass."""
+        self._mock_gh(
+            monkeypatch,
+            pr_entries=[{"filename": "docs/governance/decisions/ADR-038-x.md", "status": "added"}],
+            main_error=True,
+        )
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in result["message"]
+
+    def test_no_new_adr_files_is_go_and_skips_the_main_call(self, monkeypatch):
+        """No added ADR files -> GO without ever querying the main-listing."""
+        calls = self._mock_gh(
+            monkeypatch, pr_entries=[{"filename": "scripts/pr_merge.py", "status": "modified"}],
+        )
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "GO"
+        assert calls["pulls"] == 1
+        assert calls["contents"] == 0, "main-listing must not be queried when there is nothing to check"
+
+    def test_gh_missing_is_no_go(self, monkeypatch):
+        self._mock_gh(monkeypatch, pr_entries=[], gh_present=False)
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "NO-GO"
+        assert "gh CLI niet beschikbaar" in result["message"]
+
+
+class TestPrMergeAdrGateWiring:
+    """pr_merge.main() refuses before merge on an ADR-number collision, in the
+    same fail-closed style as the CI and review gates.
+    """
+
+    def _no_go_adr(self):
+        return {
+            "verdict": "NO-GO",
+            "message": (
+                "ADR-038 botst: deze PR voegt 'docs/governance/decisions/ADR-038-x.md' toe, "
+                "maar ADR-038 staat al op main als 'ADR-038-y.md'. Kies een vrij ADR-nummer."
+            ),
+            "colliding_number": "38",
+            "pr_file": "docs/governance/decisions/ADR-038-x.md",
+            "main_file": "ADR-038-y.md",
+        }
+
+    def _go_adr(self):
+        return {
+            "verdict": "GO",
+            "message": "Geen ADR-nummerbotsing: 0 nieuw(e) ADR-bestand(en) getoetst tegen main",
+            "colliding_number": None, "pr_file": None, "main_file": None,
+        }
+
+    def _go_gate(self, **kw):
+        gate = {
+            "verdict": "GO",
+            "message": "VNX CI geslaagd op aaaaaaaaaaaa",
+            "ci_conclusion": "success", "ran_on_sha": True,
+            "head_sha": "a" * 40, "ci_run_id": 1, "workflow_name": "VNX CI",
+            "overridden": False, "override_reason": None,
+        }
+        gate.update(kw)
+        return gate
+
+    def _ok_dry_run_result(self):
+        return {
+            "success": True, "pr_number": 1790, "dispatch_id": "", "merge_method": "squash",
+            "pr_title": "", "branch": "", "receipt_status": None, "receipt_ok": False,
+            "register_ok": False, "error": "", "dry_run": True, "overlaps": [],
+        }
+
+    def test_adr_collision_refuses_before_merge(self, monkeypatch, capsys):
+        import pr_merge
+
+        merge_called = []
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (self._go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (self._go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: self._no_go_adr())
+        monkeypatch.setattr(
+            pr_merge, "merge_pr",
+            lambda **k: merge_called.append(1) or self._ok_dry_run_result(),
+        )
+
+        rc = pr_merge.main(["--pr", "1790", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not merge_called, "merge_pr must not run when the ADR gate is NO-GO"
+        err = capsys.readouterr().err
+        assert "NO-GO" in err
+        assert "ADR-038" in err
+        assert "botst" in err
+
+    def test_adr_collision_json_output(self, monkeypatch, capsys):
+        import pr_merge
+
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (self._go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (self._go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: self._no_go_adr())
+
+        rc = pr_merge.main(["--pr", "1790", "--json"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        # Pre-existing, out-of-scope quirk: main() unconditionally prints plain
+        # "CI gate: ..." / "Review gate: ..." text on a GO verdict, ignoring
+        # --json, so stdout is not pure JSON once an earlier gate has already
+        # succeeded. Isolate the JSON object itself rather than asserting the
+        # whole of stdout parses (not this gate's defect to fix; B6's file
+        # scope is the new call only).
+        stdout = capsys.readouterr().out
+        out = json.loads(stdout[stdout.index("{"):])
+        assert out["success"] is False
+        assert "ADR-038" in out["error"]
+        assert out["adr_gate"]["colliding_number"] == "38"
+
+    def test_adr_go_proceeds_to_merge(self, monkeypatch, capsys):
+        import pr_merge
+
+        merge_called = []
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (self._go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (self._go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: self._go_adr())
+        monkeypatch.setattr(
+            pr_merge, "merge_pr",
+            lambda **k: merge_called.append(1) or self._ok_dry_run_result(),
+        )
+
+        rc = pr_merge.main(["--pr", "1790", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert merge_called, "merge_pr must run when all three gates are GO"
+        assert "ADR gate" in capsys.readouterr().out

--- a/tests/test_merge_preflight_adr_check.py
+++ b/tests/test_merge_preflight_adr_check.py
@@ -57,6 +57,39 @@ class TestGetPrAddedAdrFiles:
         assert err is None
         assert added == {"38": "docs/governance/decisions/ADR-038-x.md"}
 
+    def test_renamed_to_a_different_number_is_a_new_number_claim(self, monkeypatch):
+        """A rename that changes the ADR NUMBER (not just wording) claims the
+        new number exactly as much as a brand-new file would — unlike
+        test_only_added_status_counts's rename, which keeps the same number.
+        """
+        entries = [
+            {"filename": "docs/governance/decisions/ADR-038-my-new-decision.md",
+             "status": "renamed",
+             "previous_filename": "docs/governance/decisions/ADR-031-orchestration-target-ratification.md"},
+        ]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert err is None
+        assert added == {"38": "docs/governance/decisions/ADR-038-my-new-decision.md"}
+
+    def test_copied_to_a_different_number_is_a_new_number_claim(self, monkeypatch):
+        entries = [
+            {"filename": "docs/governance/decisions/ADR-040-copy.md", "status": "copied",
+             "previous_filename": "docs/governance/decisions/ADR-010-source.md"},
+        ]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert err is None
+        assert added == {"40": "docs/governance/decisions/ADR-040-copy.md"}
+
     def test_no_added_adr_files_yields_empty_dict(self, monkeypatch):
         entries = [{"filename": "scripts/pr_merge.py", "status": "modified"}]
         monkeypatch.setattr(
@@ -181,9 +214,10 @@ class TestCheckAdrNumbersForPr:
         result = adr_check.check_adr_numbers_for_pr(1790)
 
         assert result["verdict"] == "NO-GO"
-        assert "038" in result["message"]
-        assert "ADR-038-x.md" in result["message"]
-        assert "ADR-038-y.md" in result["message"]
+        assert result["message"] == (
+            "ADR-038 botst: deze PR voegt 'docs/governance/decisions/ADR-038-x.md' toe, "
+            "maar ADR-038 staat al op main als 'ADR-038-y.md'. Kies een vrij ADR-nummer."
+        )
         assert result["colliding_number"] == "38"
         assert result["pr_file"] == "docs/governance/decisions/ADR-038-x.md"
         assert result["main_file"] == "ADR-038-y.md"
@@ -257,6 +291,29 @@ class TestCheckAdrNumbersForPr:
         assert result["verdict"] == "NO-GO"
         assert "gh CLI niet beschikbaar" in result["message"]
 
+    def test_renamed_into_a_number_already_on_main_is_a_collision(self, monkeypatch):
+        """Leeszetel finding 3: main has ADR-038; a PR renames an UNRELATED
+        existing ADR (031) to claim 038 too. Before the fix, status="renamed"
+        was skipped outright and this returned a false GO with a message that
+        claimed "no new ADR files" even though the PR does claim a new number.
+        """
+        self._mock_gh(
+            monkeypatch,
+            pr_entries=[{
+                "filename": "docs/governance/decisions/ADR-038-my-new-decision.md",
+                "status": "renamed",
+                "previous_filename": "docs/governance/decisions/ADR-031-orchestration-target-ratification.md",
+            }],
+            main_names=["ADR-038-receipt-outcome-identity.md"],
+        )
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "NO-GO"
+        assert result["colliding_number"] == "38"
+        assert result["pr_file"] == "docs/governance/decisions/ADR-038-my-new-decision.md"
+        assert result["main_file"] == "ADR-038-receipt-outcome-identity.md"
+
 
 class TestPrMergeAdrGateWiring:
     """pr_merge.main() refuses before merge on an ADR-number collision, in the
@@ -306,7 +363,7 @@ class TestPrMergeAdrGateWiring:
         merge_called = []
         monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (self._go_gate(), None))
         monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (self._go_gate(), None))
-        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: self._no_go_adr())
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr, **k: self._no_go_adr())
         monkeypatch.setattr(
             pr_merge, "merge_pr",
             lambda **k: merge_called.append(1) or self._ok_dry_run_result(),
@@ -322,15 +379,26 @@ class TestPrMergeAdrGateWiring:
         assert "botst" in err
 
     def test_adr_collision_json_output(self, monkeypatch, capsys):
+        """Leeszetel finding 4: without --dry-run and a merge_pr mock, a GO
+        verdict here (e.g. if the ADR gate regresses) would fall through into
+        a REAL `gh pr merge` on a real PR number. Mirrors the sibling test
+        above: --dry-run plus a merge_pr mock that proves it never ran.
+        """
         import pr_merge
 
+        merge_called = []
         monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (self._go_gate(), None))
         monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (self._go_gate(), None))
-        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: self._no_go_adr())
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr, **k: self._no_go_adr())
+        monkeypatch.setattr(
+            pr_merge, "merge_pr",
+            lambda **k: merge_called.append(1) or self._ok_dry_run_result(),
+        )
 
-        rc = pr_merge.main(["--pr", "1790", "--json"])
+        rc = pr_merge.main(["--pr", "1790", "--dry-run", "--json"])
 
         assert rc == pr_merge.EXIT_ERROR
+        assert not merge_called, "merge_pr must not run when the ADR gate is NO-GO"
         # Pre-existing, out-of-scope quirk: main() unconditionally prints plain
         # "CI gate: ..." / "Review gate: ..." text on a GO verdict, ignoring
         # --json, so stdout is not pure JSON once an earlier gate has already
@@ -349,7 +417,7 @@ class TestPrMergeAdrGateWiring:
         merge_called = []
         monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (self._go_gate(), None))
         monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (self._go_gate(), None))
-        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: self._go_adr())
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr, **k: self._go_adr())
         monkeypatch.setattr(
             pr_merge, "merge_pr",
             lambda **k: merge_called.append(1) or self._ok_dry_run_result(),
@@ -360,3 +428,91 @@ class TestPrMergeAdrGateWiring:
         assert rc == pr_merge.EXIT_OK
         assert merge_called, "merge_pr must run when all three gates are GO"
         assert "ADR gate" in capsys.readouterr().out
+
+
+class TestRunAdrGateOi1518Recovery:
+    """pr_merge._run_adr_gate's own logic (leeszetel findings 2 + 7): the
+    OI-1518-recovery skip for an already-MERGED PR, and reading the check's
+    base branch from the PR's real ``baseRefName`` instead of a hardcoded
+    "main". These call ``pr_merge._run_adr_gate`` directly (not via
+    ``main()``) and stub only ``pr_merge.check_adr_numbers_for_pr`` — the
+    live-gh delegate — so the gate function's own branching runs for real.
+    """
+
+    def test_already_merged_pr_skips_the_live_check_entirely(self, monkeypatch):
+        import pr_merge
+
+        called = []
+        monkeypatch.setattr(
+            pr_merge, "check_adr_numbers_for_pr",
+            lambda *a, **k: called.append(1) or {"verdict": "NO-GO", "message": "must not run"},
+        )
+
+        result = pr_merge._run_adr_gate(
+            1790, pr_data={"state": "MERGED", "mergedAt": "2026-09-06T10:00:00Z"}
+        )
+
+        assert result["verdict"] == "GO"
+        assert "MERGED" in result["message"]
+        assert not called, "an already-merged PR must skip the live ADR check entirely"
+
+    def test_open_pr_still_runs_the_live_check(self, monkeypatch):
+        import pr_merge
+
+        seen = {}
+
+        def fake_check(pr_number, *, project_root=None, base_ref="main"):
+            seen["pr_number"] = pr_number
+            seen["base_ref"] = base_ref
+            return {"verdict": "GO", "message": "checked"}
+
+        monkeypatch.setattr(pr_merge, "check_adr_numbers_for_pr", fake_check)
+
+        result = pr_merge._run_adr_gate(1790, pr_data={"state": "OPEN"})
+
+        assert result == {"verdict": "GO", "message": "checked"}
+        assert seen["pr_number"] == 1790
+
+    def test_closed_but_not_merged_pr_still_runs_the_live_check(self, monkeypatch):
+        """CLOSED (never merged) is not MERGED: the collision can still be real."""
+        import pr_merge
+
+        called = []
+        monkeypatch.setattr(
+            pr_merge, "check_adr_numbers_for_pr",
+            lambda *a, **k: called.append(1) or {"verdict": "GO", "message": "checked"},
+        )
+
+        pr_merge._run_adr_gate(1790, pr_data={"state": "CLOSED"})
+
+        assert called, "a CLOSED-but-not-merged PR must still run the live check"
+
+    def test_base_ref_is_taken_from_pr_datas_base_ref_name(self, monkeypatch):
+        import pr_merge
+
+        seen = {}
+
+        def fake_check(pr_number, *, project_root=None, base_ref="main"):
+            seen["base_ref"] = base_ref
+            return {"verdict": "GO", "message": "checked"}
+
+        monkeypatch.setattr(pr_merge, "check_adr_numbers_for_pr", fake_check)
+
+        pr_merge._run_adr_gate(1790, pr_data={"state": "OPEN", "baseRefName": "release/1.6"})
+
+        assert seen["base_ref"] == "release/1.6"
+
+    def test_missing_pr_data_defaults_base_ref_to_main(self, monkeypatch):
+        import pr_merge
+
+        seen = {}
+
+        def fake_check(pr_number, *, project_root=None, base_ref="main"):
+            seen["base_ref"] = base_ref
+            return {"verdict": "GO", "message": "checked"}
+
+        monkeypatch.setattr(pr_merge, "check_adr_numbers_for_pr", fake_check)
+
+        pr_merge._run_adr_gate(1790)
+
+        assert seen["base_ref"] == "main"

--- a/tests/test_merge_preflight_adr_check.py
+++ b/tests/test_merge_preflight_adr_check.py
@@ -206,6 +206,186 @@ class TestGetPrAddedAdrFilesPagination:
         assert "onverwacht antwoordformaat" in err["message"]
 
 
+class TestMalformedApiEntriesFailClosed:
+    """B6 fix-forward 3 (codex round 2): an entry the check cannot READ must
+    never be skipped. A ``continue`` on a malformed entry lets a partially
+    unreadable response build an incomplete picture and answer "no collision"
+    — a silent pass through a fail-closed gate. Both live reads (the PR's file
+    list and the base-branch contents listing) must refuse instead, naming the
+    index of the offending entry.
+    """
+
+    def test_pr_files_non_dict_entry_between_valid_ones_is_no_go_with_its_index(self, monkeypatch):
+        entries = [
+            {"filename": "docs/governance/decisions/ADR-020-x.md", "status": "modified"},
+            "not-an-object",
+            {"filename": "docs/governance/decisions/ADR-041-y.md", "status": "added"},
+        ]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "entry 1" in err["message"]
+        assert "not-an-object" in err["message"]
+        assert "niet toetsbaar" in err["message"]
+
+    def test_pr_entry_without_filename_is_no_go(self, monkeypatch):
+        entries = [{"status": "added"}]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "entry 0" in err["message"]
+        assert "filename" in err["message"]
+
+    def test_pr_entry_without_status_is_no_go(self, monkeypatch):
+        entries = [{"filename": "docs/governance/decisions/ADR-041-y.md"}]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "entry 0" in err["message"]
+        assert "status" in err["message"]
+
+    def test_pr_entry_with_non_string_filename_is_no_go(self, monkeypatch):
+        entries = [{"filename": 42, "status": "added"}]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "filename" in err["message"]
+
+    def test_rename_with_non_string_previous_filename_is_no_go_not_a_crash(self, monkeypatch):
+        """``previous_filename`` is fed straight into a regex; a non-string
+        value would raise TypeError out of the gate instead of refusing.
+        """
+        entries = [
+            {"filename": "docs/governance/decisions/ADR-041-y.md", "status": "renamed",
+             "previous_filename": {"unexpected": "object"}},
+        ]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert err["verdict"] == "NO-GO"
+        assert "previous_filename" in err["message"]
+
+    def test_main_listing_non_dict_entry_is_no_go_with_its_index(self, monkeypatch):
+        entries = [
+            {"name": "ADR-038-x.md", "type": "file"},
+            ["not", "an", "object"],
+        ]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(json.dumps(entries)), None)
+        )
+
+        numbers, err = adr_check.get_main_adr_numbers()
+
+        assert numbers is None
+        assert err["verdict"] == "NO-GO"
+        assert "entry 1" in err["message"]
+        assert "niet toetsbaar" in err["message"]
+
+    def test_main_listing_entry_without_name_is_no_go(self, monkeypatch):
+        entries = [{"type": "file"}]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(json.dumps(entries)), None)
+        )
+
+        numbers, err = adr_check.get_main_adr_numbers()
+
+        assert numbers is None
+        assert err["verdict"] == "NO-GO"
+        assert "name" in err["message"]
+
+    def test_main_listing_entry_without_type_is_no_go(self, monkeypatch):
+        entries = [{"name": "ADR-038-x.md"}]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(json.dumps(entries)), None)
+        )
+
+        numbers, err = adr_check.get_main_adr_numbers()
+
+        assert numbers is None
+        assert err["verdict"] == "NO-GO"
+        assert "type" in err["message"]
+
+    def test_malformed_entry_preview_is_truncated(self, monkeypatch):
+        """A huge malformed blob must not flood the merge output: the entry is
+        shown in shortened form, not in full.
+        """
+        entries = [{"filename": "docs/governance/decisions/ADR-041-y.md", "status": "added"}, "z" * 5000]
+        monkeypatch.setattr(
+            adr_check, "_capture", lambda argv, *, timeout, cwd=None: (_proc(_pr_files_json(entries)), None)
+        )
+
+        added, err = adr_check.get_pr_added_adr_files(1)
+
+        assert added is None
+        assert len(err["message"]) < 600
+
+    def test_check_refuses_end_to_end_on_a_malformed_pr_files_entry(self, monkeypatch):
+        """The whole gate, not just the reader: a malformed PR-files response
+        must reach pr_merge as NO-GO, never as 'no new ADR files -> GO'.
+        """
+        def fake_capture(argv, *, timeout, cwd=None):
+            joined = " ".join(argv)
+            if "pulls" in joined:
+                return _proc(json.dumps([["not-an-object"]])), None
+            return _proc(_main_listing_json(["ADR-038-x.md"])), None
+
+        monkeypatch.setattr(adr_check, "_capture", fake_capture)
+        monkeypatch.setattr(adr_check.shutil, "which", lambda b: "/usr/bin/gh")
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in result["message"]
+
+    def test_check_refuses_end_to_end_on_a_malformed_main_listing_entry(self, monkeypatch):
+        """Same for the base-branch listing: an unreadable entry there could
+        hide a real collision, so it must refuse before the comparison. The
+        READABLE listing entries here do not collide with the PR's number, so
+        the old ``continue`` answered GO on a response it could not fully read.
+        """
+        def fake_capture(argv, *, timeout, cwd=None):
+            joined = " ".join(argv)
+            if "pulls" in joined:
+                return _proc(
+                    _pr_files_json(
+                        [{"filename": "docs/governance/decisions/ADR-038-x.md", "status": "added"}]
+                    )
+                ), None
+            return _proc(json.dumps([{"name": "ADR-039-y.md", "type": "file"}, 7])), None
+
+        monkeypatch.setattr(adr_check, "_capture", fake_capture)
+        monkeypatch.setattr(adr_check.shutil, "which", lambda b: "/usr/bin/gh")
+
+        result = adr_check.check_adr_numbers_for_pr(1790)
+
+        assert result["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in result["message"]
+
+
 class TestGetMainAdrNumbers:
     def test_parses_directory_listing(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_pr_merge_ci_gate.py
+++ b/tests/test_pr_merge_ci_gate.py
@@ -52,21 +52,6 @@ def _no_go_gate(message="Geen VNX CI-run gevonden: deze merge is niet toetsbaar"
     }
 
 
-def _go_adr_gate():
-    """GO verdict for the ADR-number preflight (golfb-b6). Without this mock,
-    main() would run the real check (an unmocked `gh` call) — see
-    test_merge_preflight_adr_check.py::TestPrMergeAdrGateWiring for that gate's
-    own coverage; here it just needs to stay out of the way for CI-gate tests.
-    """
-    return {
-        "verdict": "GO",
-        "message": "Geen ADR-nummerbotsing: 0 nieuw(e) ADR-bestand(en) getoetst tegen main",
-        "colliding_number": None,
-        "pr_file": None,
-        "main_file": None,
-    }
-
-
 class TestRunCiGate:
     def test_go_uses_pr_head_and_branch(self, monkeypatch):
         """A resolvable PR head is passed to the check verbatim (exact head SHA)."""
@@ -180,7 +165,6 @@ class TestMainGateWiring:
         merge_called = []
         monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (_go_gate(), None))
         monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (_go_gate(), None))
-        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: _go_adr_gate())
         monkeypatch.setattr(
             pr_merge, "merge_pr",
             lambda **k: merge_called.append(1) or self._ok_result(),
@@ -203,7 +187,6 @@ class TestMainGateWiring:
             ),
         )
         monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (_go_gate(), None))
-        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: _go_adr_gate())
         monkeypatch.setattr(pr_merge, "merge_pr", lambda **k: self._ok_result())
 
         rc = pr_merge.main(["--pr", "5", "--dry-run"])

--- a/tests/test_pr_merge_ci_gate.py
+++ b/tests/test_pr_merge_ci_gate.py
@@ -52,6 +52,21 @@ def _no_go_gate(message="Geen VNX CI-run gevonden: deze merge is niet toetsbaar"
     }
 
 
+def _go_adr_gate():
+    """GO verdict for the ADR-number preflight (golfb-b6). Without this mock,
+    main() would run the real check (an unmocked `gh` call) — see
+    test_merge_preflight_adr_check.py::TestPrMergeAdrGateWiring for that gate's
+    own coverage; here it just needs to stay out of the way for CI-gate tests.
+    """
+    return {
+        "verdict": "GO",
+        "message": "Geen ADR-nummerbotsing: 0 nieuw(e) ADR-bestand(en) getoetst tegen main",
+        "colliding_number": None,
+        "pr_file": None,
+        "main_file": None,
+    }
+
+
 class TestRunCiGate:
     def test_go_uses_pr_head_and_branch(self, monkeypatch):
         """A resolvable PR head is passed to the check verbatim (exact head SHA)."""
@@ -165,6 +180,7 @@ class TestMainGateWiring:
         merge_called = []
         monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (_go_gate(), None))
         monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (_go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: _go_adr_gate())
         monkeypatch.setattr(
             pr_merge, "merge_pr",
             lambda **k: merge_called.append(1) or self._ok_result(),
@@ -187,6 +203,7 @@ class TestMainGateWiring:
             ),
         )
         monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (_go_gate(), None))
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr: _go_adr_gate())
         monkeypatch.setattr(pr_merge, "merge_pr", lambda **k: self._ok_result())
 
         rc = pr_merge.main(["--pr", "5", "--dry-run"])


### PR DESCRIPTION
## Summary
- Nieuwe fail-closed merge-gate (`scripts/lib/merge_preflight_adr_check.py`) in `pr_merge.py::main()`: een ADR-bestand dat deze PR **toevoegt** mag geen nummer claimen dat al op de echte `main` staat. Leest de PR-diff en de main-tree via de GitHub API (`gh api .../pulls/<N>/files`, `gh api .../contents/docs/governance/decisions?ref=main`) — nooit een lokale `origin/main`-ref, die de merge-deur nooit ververst.
- Directe aanleiding: #1790 en #1792 botsten op 06-09 allebei op ADR-038 omdat de CI-workflow op de merge-ref draait en `required_status_checks.strict` uit staat, dus geen van beide CI-runs kon de botsing zien.
- Nieuwe stdlib-only uniciteitstest (`tests/test_adr_numbers_unique.py`) op `docs/governance/decisions/` zelf, nu ook expliciet in de CI-light-lijst (`.github/workflows/vnx-ci.yml:159-165`).
- Geen override-vlag voor deze check: een botsend ADR-nummer is altijd fout.

## Test plan
- [x] `pytest tests/test_merge_preflight_adr_check.py tests/test_adr_numbers_unique.py tests/test_pr_merge_ci_gate.py tests/test_merge_preflight_ci_check.py tests/test_adr_indexer.py -q` → 87 passed
- [x] Rood-eerst aangetoond (gequoteerd in het dispatch-rapport): wiring-tests falen tegen de ongewijzigde `pr_merge.py` (`AttributeError: ... has no attribute '_run_adr_gate'`); uniciteitstest faalt met beide bestandsnamen zodra een echte duplicaat-ADR tijdelijk op de boom staat, en is weer groen zodra die weg is.
- [x] `python3 scripts/pr_merge.py --pr <dit-PR-nummer> --dry-run` toont de nieuwe `ADR gate: ...`-regel naast de bestaande CI- en review-gate-regels.