### PR TITLE
feat(pr-merge): contract_invalid als fail-closed merge-check met eigen override (golf B, B7)

### DIFF
--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -261,13 +261,21 @@ receipt, or (b) an operator explicitly overrides.
    that dispatch is contract_invalid, `(True, reason)` otherwise (including
    the case where no receipt exists at all — absence is not this function's
    concern, per the same "absence is never a rejection" precedent as
-   OI-1624). This dispatch (OI-1638) does not own `closure_verifier.py` —
-   the intended call site is `verify_pr_closure()`
-   (`scripts/closure_verifier.py:1405`), immediately after the "PR must be
-   completed per reconciliation" check (around line 1472), reading the
-   dispatch id off `pr_reconciled.provenance.get("dispatch_id")` and gating
-   the closure verdict on the result. A future PR must wire that call
-   explicitly — this module only provides the gate function.
+   OI-1624). **Wired (Golf B, B7):** the call site is the merge door itself
+   — `pr_merge.py::main()`'s `_run_contract_invalid_gate`, run after the CI
+   gate, the review gate, and the ADR-number preflight, before the merge —
+   not `closure_verifier.py::verify_pr_closure()` as originally planned here:
+   the closure verifier only reads *after* a merge already happened and
+   cannot stop one in flight, while the merge door is the one place that
+   sees the real `main` at the moment of merge. Given `--dispatch-id`
+   (skipped loudly when absent — existing `pr_merge` behaviour, not a new
+   hole), a `contract_invalid` latest receipt refuses the merge with the
+   dispatch id and the reason on stderr/exit-nonzero. The escape hatch is
+   its own flag, `--override-contract-invalid "<reason>"`, separate from
+   `--override-reason` (which already drives the CI and review gates): a
+   non-empty reason overrides visibly and is stamped onto the `pr_merged`
+   receipt as `contract_invalid_override` (`{"flag", "reason"}`); an empty
+   reason is refused (no silent bypass).
 
 Staleness windowing (a frozen historical batch should not read as live
 churn) is delegated to the existing `contract_invalid_window.py` — not

--- a/scripts/lib/contract_invalid_ledger.py
+++ b/scripts/lib/contract_invalid_ledger.py
@@ -26,13 +26,20 @@ at session start. This module is the missing read side:
     ``_run_contract_invalid_gate``).
 
 Which receipts that gate may judge is itself the thing that decides whether
-it fires at all. Every plane writes on the SAME dispatch_id — the worker's
-outcome, the review gate's request, state mutations — so "the latest
-receipt for this dispatch" is normally a gate-plane record, not the
-deliverable. Measured 07-09 over the live ledger: all 8 dispatch-ids with a
-contract_invalid receipt before their ``pr_merged`` had a
-``review_gate_request`` in between, so the unfiltered version passed all 8.
-``DELIVERABLE_OUTCOME_EVENT_TYPES`` is the fix and carries the counts.
+it fires at all, and it takes TWO filters to get there:
+
+  - WHICH PLANE. Every plane writes on the SAME dispatch_id — the worker's
+    outcome, the review gate's request, state mutations — so "the latest
+    receipt for this dispatch" is normally a gate-plane record, not the
+    deliverable. Measured 07-09 over the live ledger: all 8 dispatch-ids
+    with a contract_invalid receipt before their ``pr_merged`` had a
+    ``review_gate_request`` in between, so the unfiltered version passed all
+    8. ``DELIVERABLE_OUTCOME_EVENT_TYPES`` is that filter.
+  - WHETHER IT DECIDES ANYTHING. An outcome receipt whose status says
+    nothing about the deliverable (``unknown``, ``no_signal``, empty) must
+    not lift an earlier refusal just by being later. It did: the plane
+    filter alone still passed 2 of those 8.
+    ``DECIDED_OUTCOME_STATUSES`` is that filter and carries the counts.
 
 Staleness windowing is delegated to the existing
 ``contract_invalid_window.is_stale_contract_invalid`` / the effective
@@ -84,21 +91,60 @@ OPEN_LEDGER_FILENAME = "contract_invalid_open.json"
 # their last receipt before the merge — the gate would have said GO on every
 # single one.
 #
-# What this filter does NOT fix, measured on the same 8: it refuses 6. The
-# other 2 (20260830-140500-d6a2…, 20260830-145100-d5…) have a later
-# ``task_complete`` outcome with ``status: "unknown"``, which this module
-# accepts because it is not the contract_invalid literal — while
-# ``event_outcome_semantics.classify_event_outcome("task_complete",
-# "unknown")`` returns None, i.e. neither success nor failure. 3897 records
-# carry that status. Widening "not contract_invalid" to "a governed success"
-# is a separate policy change with a much larger blast radius (it would also
-# flip task_failed/timeout/no_signal chains) and is deliberately NOT made
-# here; it is reported as an open item for the operator to decide.
+# What this filter alone did NOT fix, measured on the same 8: it refuses 6.
+# The other 2 are what ``DECIDED_OUTCOME_STATUSES`` below is for.
 DELIVERABLE_OUTCOME_EVENT_TYPES = frozenset({
     "report_contract_invalid",
     "task_complete",
     "subprocess_completion",
     "task_failed",
+})
+
+# Outcome statuses that actually DECIDE the deliverable — the only ones that
+# may be chosen as "the latest outcome receipt".
+#
+# Measured 07-09 on the live ledger (29.388 records): the plane filter above
+# refuses 6 of the 8 dispatch-ids that carried a contract_invalid receipt
+# before their merge. The remaining 2 share one chain shape:
+#
+#   20260830-140500-d6a2-kopie-erfde-de-violation
+#     task_complete  contract_invalid  effective 2026-08-30T12:11:42Z
+#     task_complete  unknown           effective 2026-08-30T12:12:59Z
+#   20260830-145100-d5-sync-main-na-1732 : identical, 12:44:47 → 12:46:05
+#
+# The ordering is right (``contract_invalid_effective_timestamp`` prefers
+# ``ingested_at``, and that ``unknown`` receipt really is later). The defect
+# is that "not the contract_invalid literal" was read as "resolved": an
+# ``unknown`` says nothing about the deliverable, and
+# ``event_outcome_semantics.classify_event_outcome("task_complete",
+# "unknown")`` agrees — it returns None, neither success nor failure. Only a
+# receipt that decides may overturn a governed refusal, so an undecided one
+# is SKIPPED at selection time, exactly as a gate-plane receipt already is.
+#
+# Status distribution over the 23.698 deliverable-outcome receipts in that
+# ledger: success 9130, failed 4279, unknown 3897, contract_invalid 3362,
+# done 2405, failure 352, empty 134, timeout 94, no_signal 35, complete 4,
+# blocked 2, completed 1, in_progress 1, and 2 free-text worker statuses
+# ("done — awaiting ci + t0 gate", "complete — push + pr created").
+#
+# This is an ALLOWLIST, not a blocklist of {unknown, no_signal, empty}: the
+# writers of this field are not a closed set (those last 6 records prove it),
+# and a status literal this module has never seen makes no statement about
+# the deliverable either. Under a blocklist any new literal would silently
+# heal a refused chain; under an allowlist it fails closed and the operator
+# still has ``--override-contract-invalid <reden>``. A contract_invalid
+# receipt is never skipped by this filter regardless of its status literal —
+# ``_is_decided_outcome`` short-circuits on ``_is_contract_invalid`` first,
+# so an old ``report_contract_invalid`` record with no status field cannot
+# drop out of its own check.
+DECIDED_OUTCOME_STATUSES = frozenset({
+    "success",
+    "done",
+    "complete",
+    "failed",
+    "failure",
+    "timeout",
+    CONTRACT_INVALID_STATUS,
 })
 
 _MIN_AWARE_DATETIME = datetime.min.replace(tzinfo=timezone.utc)
@@ -152,6 +198,22 @@ def _is_outcome_receipt(record: Dict[str, Any]) -> bool:
     """
     event_type = str(record.get("event_type") or record.get("event") or "").strip().lower()
     return event_type in DELIVERABLE_OUTCOME_EVENT_TYPES
+
+
+def _is_decided_outcome(record: Dict[str, Any]) -> bool:
+    """True when this outcome receipt DECIDES the deliverable one way or the
+    other (``DECIDED_OUTCOME_STATUSES``) — see that constant for the measured
+    reason and for why it is an allowlist.
+
+    A contract_invalid receipt is decided by definition and is checked first,
+    so it is never skipped over its status literal (an old
+    ``report_contract_invalid`` record carrying no status field at all still
+    counts).
+    """
+    if _is_contract_invalid(record):
+        return True
+    status = str(record.get("status") or "").strip().lower()
+    return status in DECIDED_OUTCOME_STATUSES
 
 
 def _read_receipts_strict(receipts_path: Path) -> List[Dict[str, Any]]:
@@ -345,26 +407,37 @@ def is_deliverable_acceptable(
     project_id: Optional[str] = None,
     strict: bool = True,
 ) -> Tuple[bool, str]:
-    """False while the latest DELIVERABLE-OUTCOME receipt on record for
-    ``dispatch_id`` is contract_invalid (OI-1638 gevolg 3) — a dispatch must
-    not be silently closed on the strength of a report that never satisfied
-    the report-body contract, even if an earlier attempt for the same
-    dispatch_id succeeded.
+    """False while the latest DECIDED DELIVERABLE-OUTCOME receipt on record
+    for ``dispatch_id`` is contract_invalid (OI-1638 gevolg 3) — a dispatch
+    must not be silently closed on the strength of a report that never
+    satisfied the report-body contract, even if an earlier attempt for the
+    same dispatch_id succeeded.
 
-    "Latest outcome receipt", not "latest receipt": every receipt plane
-    shares the dispatch_id, so the plain latest is usually a gate-plane
-    record. Measured 07-09 on the live ledger, all 8 dispatch-ids that
-    carried a contract_invalid receipt before their merge had a
-    ``review_gate_request`` written on the same dispatch_id in between — the
-    unfiltered version said GO on every one of them. Only
-    ``DELIVERABLE_OUTCOME_EVENT_TYPES`` is judged; see that constant for the
-    per-event-type counts behind it.
+    "Latest DECIDED OUTCOME receipt", not "latest receipt" — two narrowings,
+    both measured 07-09 on the live ledger over the 8 dispatch-ids that
+    carried a contract_invalid receipt before their merge:
 
-    A dispatch with no outcome receipt on record at all is NOT this
-    function's concern (fail-open, True): that is an absence, and per the
-    fleet's own precedent (OI-1624, "a gate outage is absence, never a
-    rejection") an absence must not read as a rejection. Callers needing "did
-    this dispatch even run" own that separate check themselves.
+      - Every receipt plane shares the dispatch_id, so the plain latest is
+        usually a gate-plane record: all 8 had a ``review_gate_request``
+        written on the same dispatch_id in between, and the unfiltered
+        version said GO on every one of them. Only
+        ``DELIVERABLE_OUTCOME_EVENT_TYPES`` is judged.
+      - An outcome receipt that decides nothing may not overturn a governed
+        refusal by being later: 2 of those 8 still passed on a
+        ``task_complete``/``unknown`` written a minute after the
+        contract_invalid. Only ``DECIDED_OUTCOME_STATUSES`` is judged.
+
+    See both constants for the counts behind them. An undecided outcome
+    receipt is skipped at selection time, exactly like a gate-plane one — not
+    treated as a refusal itself, which would turn the 3897 ``unknown``
+    records in that ledger into a merge blockade of their own.
+
+    Two distinct fail-open absences, kept distinguishable in the reason
+    string, per the fleet's own precedent (OI-1624, "a gate outage is
+    absence, never a rejection"): no outcome receipt at all ("geen
+    uitkomst-receipt"), and outcome receipts that are all undecided ("geen
+    besliste uitkomst"). Neither is this function's concern; callers needing
+    "did this dispatch even run" own that separate check themselves.
 
     ``strict`` (default True, this is a GATE function): an existing but
     unreadable ledger returns ``(False, "grootboek onleesbaar: ...")`` rather
@@ -382,29 +455,41 @@ def is_deliverable_acceptable(
         return False, f"grootboek onleesbaar: {exc}"
 
     records = _filter_project(records, project_id)
-    matching = [
+    outcomes = [
         r for r in records
         if str(r.get("dispatch_id") or "").strip() == did and _is_outcome_receipt(r)
     ]
-    if not matching:
+    if not outcomes:
         return True, (
             f"geen uitkomst-receipt op record voor {did} "
             f"(afwezigheid is geen weigering)"
         )
 
-    latest = sorted(matching, key=_sort_key)[-1]
+    decided = [r for r in outcomes if _is_decided_outcome(r)]
+    if not decided:
+        seen = sorted({
+            str(r.get("status") or "").strip().lower() or "<leeg>" for r in outcomes
+        })
+        return True, (
+            f"geen besliste uitkomst voor {did}: {len(outcomes)} uitkomst-receipt(s), "
+            f"alle onbeslist (status: {', '.join(seen)}) "
+            f"(afwezigheid is geen weigering)"
+        )
+
+    latest = sorted(decided, key=_sort_key)[-1]
     if _is_contract_invalid(latest):
         event_type = str(latest.get("event_type") or latest.get("event") or "")
         return False, (
-            f"latest outcome receipt for {did} is contract_invalid "
+            f"latest decided outcome receipt for {did} is contract_invalid "
             f"(event_type={event_type!r}, report_path={latest.get('report_path')!r})"
         )
-    return True, "latest outcome receipt is not contract_invalid"
+    return True, "latest decided outcome receipt is not contract_invalid"
 
 
 __all__ = [
     "CONTRACT_INVALID_STATUS",
     "CONTRACT_INVALID_EVENT_TYPE",
+    "DECIDED_OUTCOME_STATUSES",
     "DELIVERABLE_OUTCOME_EVENT_TYPES",
     "OPEN_LEDGER_FILENAME",
     "ReceiptsUnreadableError",

--- a/scripts/lib/contract_invalid_ledger.py
+++ b/scripts/lib/contract_invalid_ledger.py
@@ -22,8 +22,17 @@ at session start. This module is the missing read side:
     one open item per receipt (gevolg 2, "een lijst, geen vloed").
   - ``is_deliverable_acceptable``: the gate a closer must call before
     treating a dispatch's deliverable as done (gevolg 3, "niet stil
-    sluitbaar"). See this dispatch's report for the exact call site this
-    module does not own.
+    sluitbaar"). Its call site is the merge door (``pr_merge.py``'s
+    ``_run_contract_invalid_gate``).
+
+Which receipts that gate may judge is itself the thing that decides whether
+it fires at all. Every plane writes on the SAME dispatch_id — the worker's
+outcome, the review gate's request, state mutations — so "the latest
+receipt for this dispatch" is normally a gate-plane record, not the
+deliverable. Measured 07-09 over the live ledger: all 8 dispatch-ids with a
+contract_invalid receipt before their ``pr_merged`` had a
+``review_gate_request`` in between, so the unfiltered version passed all 8.
+``DELIVERABLE_OUTCOME_EVENT_TYPES`` is the fix and carries the counts.
 
 Staleness windowing is delegated to the existing
 ``contract_invalid_window.is_stale_contract_invalid`` / the effective
@@ -54,7 +63,55 @@ CONTRACT_INVALID_EVENT_TYPE = "report_contract_invalid"
 
 OPEN_LEDGER_FILENAME = "contract_invalid_open.json"
 
+# Receipts that carry a DELIVERABLE OUTCOME for a dispatch — the only ones
+# ``is_deliverable_acceptable`` may judge on.
+#
+# Measured 07-09 over the live ledger (29.386 records,
+# ~/.vnx-data/vnx-dev/state/t0_receipts.ndjson): the event types that ever
+# carry the contract_invalid literal are ``report_contract_invalid`` (3323),
+# ``task_complete`` (35) and ``subprocess_completion`` (4). ``task_failed``
+# is in this set as the fourth deliverable outcome (a governed failure
+# resolves a chain just as a governed success does) even though it never
+# carries the literal itself.
+#
+# Everything else on a dispatch_id belongs to the GATE or STATE plane and
+# says nothing about the deliverable: ``review_gate_request`` alone has 844
+# records and is written by gate_request_handler.py on the SAME dispatch_id
+# AFTER the worker's outcome receipt. Judging "the latest receipt" without
+# this filter therefore reads the gate request, not the deliverable. Measured
+# on the same ledger: of the 8 dispatch-ids that had a contract_invalid
+# receipt before their pr_merged, ALL 8 had a ``review_gate_request`` as
+# their last receipt before the merge — the gate would have said GO on every
+# single one.
+#
+# What this filter does NOT fix, measured on the same 8: it refuses 6. The
+# other 2 (20260830-140500-d6a2…, 20260830-145100-d5…) have a later
+# ``task_complete`` outcome with ``status: "unknown"``, which this module
+# accepts because it is not the contract_invalid literal — while
+# ``event_outcome_semantics.classify_event_outcome("task_complete",
+# "unknown")`` returns None, i.e. neither success nor failure. 3897 records
+# carry that status. Widening "not contract_invalid" to "a governed success"
+# is a separate policy change with a much larger blast radius (it would also
+# flip task_failed/timeout/no_signal chains) and is deliberately NOT made
+# here; it is reported as an open item for the operator to decide.
+DELIVERABLE_OUTCOME_EVENT_TYPES = frozenset({
+    "report_contract_invalid",
+    "task_complete",
+    "subprocess_completion",
+    "task_failed",
+})
+
 _MIN_AWARE_DATETIME = datetime.min.replace(tzinfo=timezone.utc)
+
+
+class ReceiptsUnreadableError(OSError):
+    """The receipts ledger exists but could not be read.
+
+    Raised by ``_read_receipts_strict`` and surfaced to the merge door so an
+    I/O failure becomes a refusal with its cause, never an empty read that
+    looks like "no receipt on record" (which fails OPEN). The advisory
+    readers keep the soft ``_read_receipts`` and never see this.
+    """
 
 
 def _parse_ts(value: Optional[Any]) -> Optional[datetime]:
@@ -86,19 +143,32 @@ def _is_contract_invalid(record: Dict[str, Any]) -> bool:
     return status == CONTRACT_INVALID_STATUS or event_type == CONTRACT_INVALID_EVENT_TYPE
 
 
-def _read_receipts(receipts_path: Path) -> List[Dict[str, Any]]:
-    """Read every well-formed JSON object line from an NDJSON receipts file.
+def _is_outcome_receipt(record: Dict[str, Any]) -> bool:
+    """True when this receipt reports a deliverable outcome for its dispatch.
 
-    Absence, an unreadable file, and malformed individual lines all degrade
-    to being skipped rather than raising — this is an advisory reader
-    (surfacing at SessionStart / a gate check), not a write path.
+    Decided on the event type alone (``DELIVERABLE_OUTCOME_EVENT_TYPES``), not
+    on the status: a gate-plane receipt is not a statement about the
+    deliverable regardless of what status it happens to carry.
+    """
+    event_type = str(record.get("event_type") or record.get("event") or "").strip().lower()
+    return event_type in DELIVERABLE_OUTCOME_EVENT_TYPES
+
+
+def _read_receipts_strict(receipts_path: Path) -> List[Dict[str, Any]]:
+    """Read every well-formed JSON object line from an NDJSON receipts file,
+    raising ``ReceiptsUnreadableError`` when the file exists but cannot be read.
+
+    A file that does not exist is a legitimate absence (a fresh store, an
+    isolated state dir) and yields ``[]`` here too — only a real I/O failure
+    on an existing path is an error. Malformed individual lines are still
+    skipped: one corrupt line must not blind the reader to the other 29.385.
     """
     if not receipts_path.exists():
         return []
     try:
         text = receipts_path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return []
+    except OSError as exc:
+        raise ReceiptsUnreadableError(f"{receipts_path}: {exc}") from exc
     records: List[Dict[str, Any]] = []
     for line in text.splitlines():
         line = line.strip()
@@ -111,6 +181,22 @@ def _read_receipts(receipts_path: Path) -> List[Dict[str, Any]]:
         if isinstance(rec, dict):
             records.append(rec)
     return records
+
+
+def _read_receipts(receipts_path: Path) -> List[Dict[str, Any]]:
+    """Soft read for the ADVISORY readers: absence, an unreadable file, and
+    malformed individual lines all degrade to being skipped rather than
+    raising — a SessionStart counter must not crash a session over a
+    permission bit.
+
+    The merge gate does NOT use this: see ``_read_receipts_strict`` /
+    ``is_deliverable_acceptable(strict=True)``, where the same I/O failure
+    must become a refusal instead of an empty read.
+    """
+    try:
+        return _read_receipts_strict(receipts_path)
+    except ReceiptsUnreadableError:
+        return []
 
 
 def _filter_project(records: List[Dict[str, Any]], project_id: Optional[str]) -> List[Dict[str, Any]]:
@@ -257,40 +343,71 @@ def is_deliverable_acceptable(
     receipts_path: Path,
     *,
     project_id: Optional[str] = None,
+    strict: bool = True,
 ) -> Tuple[bool, str]:
-    """False while the LATEST receipt on record for ``dispatch_id`` is
-    contract_invalid (OI-1638 gevolg 3) — a dispatch must not be silently
-    closed on the strength of a report that never satisfied the report-body
-    contract, even if an earlier attempt for the same dispatch_id succeeded.
+    """False while the latest DELIVERABLE-OUTCOME receipt on record for
+    ``dispatch_id`` is contract_invalid (OI-1638 gevolg 3) — a dispatch must
+    not be silently closed on the strength of a report that never satisfied
+    the report-body contract, even if an earlier attempt for the same
+    dispatch_id succeeded.
 
-    A dispatch with no receipt on record at all is NOT this function's
-    concern (fail-open, True): that is an absence, and per the fleet's own
-    precedent (OI-1624, "a gate outage is absence, never a rejection") an
-    absence must not read as a rejection. Callers needing "did this dispatch
-    even run" own that separate check themselves.
+    "Latest outcome receipt", not "latest receipt": every receipt plane
+    shares the dispatch_id, so the plain latest is usually a gate-plane
+    record. Measured 07-09 on the live ledger, all 8 dispatch-ids that
+    carried a contract_invalid receipt before their merge had a
+    ``review_gate_request`` written on the same dispatch_id in between — the
+    unfiltered version said GO on every one of them. Only
+    ``DELIVERABLE_OUTCOME_EVENT_TYPES`` is judged; see that constant for the
+    per-event-type counts behind it.
+
+    A dispatch with no outcome receipt on record at all is NOT this
+    function's concern (fail-open, True): that is an absence, and per the
+    fleet's own precedent (OI-1624, "a gate outage is absence, never a
+    rejection") an absence must not read as a rejection. Callers needing "did
+    this dispatch even run" own that separate check themselves.
+
+    ``strict`` (default True, this is a GATE function): an existing but
+    unreadable ledger returns ``(False, "grootboek onleesbaar: ...")`` rather
+    than degrading to an empty read that would look like that same
+    fail-open absence. ``strict=False`` restores the advisory soft read for a
+    caller that only wants a hint.
     """
     did = (dispatch_id or "").strip()
     if not did:
         return False, "empty dispatch_id"
 
-    records = _filter_project(_read_receipts(receipts_path), project_id)
-    matching = [r for r in records if str(r.get("dispatch_id") or "").strip() == did]
+    try:
+        records = _read_receipts_strict(receipts_path) if strict else _read_receipts(receipts_path)
+    except ReceiptsUnreadableError as exc:
+        return False, f"grootboek onleesbaar: {exc}"
+
+    records = _filter_project(records, project_id)
+    matching = [
+        r for r in records
+        if str(r.get("dispatch_id") or "").strip() == did and _is_outcome_receipt(r)
+    ]
     if not matching:
-        return True, "no receipt on record for dispatch_id (absence, not a rejection)"
+        return True, (
+            f"geen uitkomst-receipt op record voor {did} "
+            f"(afwezigheid is geen weigering)"
+        )
 
     latest = sorted(matching, key=_sort_key)[-1]
     if _is_contract_invalid(latest):
+        event_type = str(latest.get("event_type") or latest.get("event") or "")
         return False, (
-            f"latest receipt for {did} is contract_invalid "
-            f"(report_path={latest.get('report_path')!r})"
+            f"latest outcome receipt for {did} is contract_invalid "
+            f"(event_type={event_type!r}, report_path={latest.get('report_path')!r})"
         )
-    return True, "latest receipt is not contract_invalid"
+    return True, "latest outcome receipt is not contract_invalid"
 
 
 __all__ = [
     "CONTRACT_INVALID_STATUS",
     "CONTRACT_INVALID_EVENT_TYPE",
+    "DELIVERABLE_OUTCOME_EVENT_TYPES",
     "OPEN_LEDGER_FILENAME",
+    "ReceiptsUnreadableError",
     "build_contract_invalid_summary",
     "collect_contract_invalid_open",
     "write_contract_invalid_open_ledger",

--- a/scripts/lib/contract_invalid_ledger.py
+++ b/scripts/lib/contract_invalid_ledger.py
@@ -43,11 +43,14 @@ it fires at all, and it takes TWO filters to get there:
 
 Staleness windowing is delegated to the existing
 ``contract_invalid_window.is_stale_contract_invalid`` / the effective
-timestamp it defines — never reimplemented here. Both "open" and "acceptable"
-below are decided purely from the ``contract_invalid`` status/event_type
-literal on the latest receipt (``_is_contract_invalid``); no broader
-success/failure classification is needed for that, so this module does not
-delegate to ``event_outcome_semantics.classify_event_outcome``.
+timestamp it defines — never reimplemented here. The VERDICT itself, both
+for "open" and for "acceptable", is still read purely from the
+``contract_invalid`` status/event_type literal (``_is_contract_invalid``) —
+the two filters above only decide WHICH receipt that literal is read from.
+So no success/failure classification is needed, and this module does not
+delegate to ``event_outcome_semantics.classify_event_outcome``; where its
+judgment is relevant (``task_complete``/``unknown`` classifying as neither),
+it is cited as corroboration, never called.
 """
 
 from __future__ import annotations

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -47,6 +47,20 @@ Usage:
     python3 scripts/pr_merge.py --pr 123 --dry-run         # no merge, no write
     python3 scripts/pr_merge.py --pr 123 --override-reason 'gate flaked, re-verified'
 
+contract_invalid gate (Golf B, B7 / OI-1638 gevolg 3): a third fail-closed
+check runs after the review gate — the LATEST receipt on record for
+``--dispatch-id`` must not be ``contract_invalid`` (see
+``contract_invalid_ledger.is_deliverable_acceptable``): a dispatch whose
+deliverable never satisfied the report-body contract must not be silently
+closed by a merge. An empty ``--dispatch-id`` skips the check (existing
+behaviour — the door has no chain to check without one). The escape hatch is
+its own flag, ``--override-contract-invalid``, separate from
+``--override-reason``: accepting a contract_invalid deliverable anyway is a
+distinct judgment call from overriding a flaky CI run or an unrun review
+gate. A non-empty reason overrides visibly and is stamped onto the
+``pr_merged`` receipt as ``contract_invalid_override``; an empty reason is
+refused (no silent bypass).
+
 Receipt written to t0_receipts.ndjson:
     event_type  : "pr_merged"
     pr_number   : <int>
@@ -55,6 +69,10 @@ Receipt written to t0_receipts.ndjson:
     merge_method: "squash" | "merge" | "rebase"
     pr_title    : <from gh api>
     branch      : <from gh api>
+    contract_invalid_override: <dict, optional — {"flag", "reason"}, only
+                                 present when --override-contract-invalid
+                                 was used to bypass a contract_invalid latest
+                                 receipt>
 
 Register event written to dispatch_register.ndjson:
     event       : "pr_merged"
@@ -87,6 +105,7 @@ from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt
 from merge_preflight_ci_check import check_ci_run_for_head, _resolve_override_reason
 from merge_preflight_adr_check import check_adr_numbers_for_pr
+from contract_invalid_ledger import is_deliverable_acceptable
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -373,6 +392,86 @@ def _run_adr_gate(pr_number: int, *, pr_data: Optional[Dict[str, Any]] = None) -
     return check_adr_numbers_for_pr(pr_number, project_root=SCRIPT_DIR.parent, base_ref=base_ref)
 
 
+def _run_contract_invalid_gate(
+    dispatch_id: str,
+    *,
+    override_reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fail-closed merge gate (Golf B, B7): the LATEST receipt on record for
+    ``dispatch_id`` must not be ``contract_invalid`` (OI-1638 gevolg 3).
+
+    DISPATCH_RULES.md §14 gevolg 3 names ``is_deliverable_acceptable`` as the
+    gate a closer must call before treating a dispatch's deliverable as
+    done, and originally pointed at ``verify_pr_closure()`` as the intended
+    call site. That call site is wrong: the merge door is the one place that
+    sees the real ``main`` at the moment of merge, while the closure
+    verifier only reads afterwards and cannot stop a merge already in
+    flight. This is the corrected call site (see that doc section, corrected
+    alongside this dispatch).
+
+    Reads from the SAME receipts file ``emit_governance_receipt`` resolves to
+    when given no ``receipts_file`` (``ensure_env()``'s ``VNX_STATE_DIR`` /
+    ``t0_receipts.ndjson``) — the check and the write it gates must see the
+    same ledger.
+
+    An empty ``dispatch_id`` skips the check LOUDLY: ``pr_merge`` has never
+    required ``--dispatch-id`` (existing behaviour), so a dispatch-id-less
+    merge simply has no chain to check here — not a new hole this gate opens.
+
+    ``override_reason`` (``--override-contract-invalid``) is a SEPARATE
+    escape hatch from ``--override-reason`` (already wired to the CI and
+    review gates): accepting a contract_invalid deliverable anyway is a
+    distinct judgment call from overriding a flaky CI run or an unrun review
+    gate, so it gets its own flag rather than silently piggy-backing on
+    ``--override-reason``. Same resolution order as the other gates' escape
+    hatch (checked BEFORE running the read): non-empty reason overrides
+    visibly without touching the ledger read, empty is refused (no silent
+    bypass), ``None`` runs the normal check.
+    """
+    did = (dispatch_id or "").strip()
+    if not did:
+        return {
+            "verdict": "GO",
+            "message": "contract_invalid-check overgeslagen: geen dispatch-id",
+            "skipped": True,
+            "overridden": False,
+            "override_reason": None,
+        }
+
+    # ── Escape hatch (same resolution order as the CI/review gates) ───────
+    if override_reason is not None:
+        reason = override_reason.strip()
+        if not reason:
+            return {
+                "verdict": "NO-GO",
+                "message": (
+                    "override zonder reden geweigerd: --override-contract-invalid "
+                    "vereist een niet-lege reden (geen stille bypass)"
+                ),
+                "skipped": False,
+                "overridden": True,
+                "override_reason": reason,
+            }
+        return {
+            "verdict": "GO",
+            "message": f"contract_invalid-check overgeslagen voor {did} ({reason})",
+            "skipped": False,
+            "overridden": True,
+            "override_reason": reason,
+        }
+
+    paths = ensure_env()
+    receipts_path = Path(paths["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
+    acceptable, reason = is_deliverable_acceptable(did, receipts_path)
+    return {
+        "verdict": "GO" if acceptable else "NO-GO",
+        "message": reason,
+        "skipped": False,
+        "overridden": False,
+        "override_reason": None,
+    }
+
+
 _HEAD_MOVED_MARKERS = (
     "head branch is not up to date",
     "head branch was modified",
@@ -493,11 +592,17 @@ def _emit_receipt(
     pr_id: str = "",
     pr_id_resolution: str = "",
     receipts_file: Optional[str] = None,
+    contract_invalid_override: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Write pr_merged receipt to t0_receipts.ndjson with dual-scheme linkage.
 
     Dual-scheme: pr_number (GitHub numeric) + pr_id (internal PR-N/PR-LABEL).
     pr_id_resolution='unmatched' when no internal label could be derived.
+
+    ``contract_invalid_override`` (Golf B, B7): the audit field stamped onto
+    this receipt when ``--override-contract-invalid`` was used to bypass a
+    contract_invalid latest receipt — ``{"flag": "--override-contract-invalid",
+    "reason": <str>}``. ``None`` (the normal case) omits the field entirely.
     """
     kwargs: Dict[str, Any] = {
         "pr_number": pr_number,
@@ -512,6 +617,8 @@ def _emit_receipt(
         kwargs["pr_id_resolution"] = pr_id_resolution
     if dispatch_id:
         kwargs["dispatch_id"] = dispatch_id
+    if contract_invalid_override:
+        kwargs["contract_invalid_override"] = contract_invalid_override
     return emit_governance_receipt(
         "pr_merged",
         receipt_kind="state_mutation",
@@ -552,8 +659,15 @@ def merge_pr(
     receipts_file: Optional[str] = None,
     head_sha: str = "",
     pr_data: Optional[Dict[str, Any]] = None,
+    contract_invalid_override: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Merge a PR and emit audit trail.
+
+    ``contract_invalid_override`` (Golf B, B7): forwarded verbatim onto the
+    ``pr_merged`` receipt's ``contract_invalid_override`` field when set —
+    see ``_emit_receipt`` and ``_run_contract_invalid_gate``. ``None``
+    (default) omits the field, matching a merge whose contract_invalid gate
+    was never overridden.
 
     ``head_sha`` is the exact commit the gates approved; it is threaded into
     ``gh pr merge --match-head-commit`` so the merge refuses any other commit.
@@ -652,6 +766,7 @@ def merge_pr(
             pr_id=pr_id or "",
             pr_id_resolution="" if pr_id else "unmatched",
             receipts_file=receipts_file,
+            contract_invalid_override=contract_invalid_override,
         )
         append_status = (receipt or {}).get("append_status", "unknown")
         result["receipt_status"] = append_status
@@ -703,6 +818,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--override-reason", default=None,
         help="Escape hatch: skip the CI gate with this required reason (empty is refused). "
              "Also read from VNX_MERGE_OVERRIDE_REASON.",
+    )
+    parser.add_argument(
+        "--override-contract-invalid", default=None,
+        help="Escape hatch (golf B, B7): accept a dispatch whose latest receipt is "
+             "contract_invalid, with this required reason (empty is refused). Separate "
+             "from --override-reason.",
     )
     parser.add_argument("--json", action="store_true", help="Output result as JSON")
     args = parser.parse_args(argv)
@@ -757,9 +878,34 @@ def main(argv: Optional[list[str]] = None) -> int:
         return EXIT_ERROR
     print(f"ADR gate: {adr_gate['message']}")
 
+    # ── contract_invalid gate: the LATEST receipt for --dispatch-id must ────
+    # not be contract_invalid (Golf B, B7). No effect without --dispatch-id.
+    contract_gate = _run_contract_invalid_gate(
+        args.dispatch_id, override_reason=args.override_contract_invalid,
+    )
+    if contract_gate["verdict"] != "GO":
+        if args.json:
+            print(json.dumps({
+                "success": False, "pr_number": args.pr,
+                "error": contract_gate["message"],
+                "contract_invalid_gate": contract_gate,
+            }, indent=2))
+        else:
+            print(f"NO-GO: {contract_gate['message']}", file=sys.stderr)
+        return EXIT_ERROR
+    if contract_gate.get("overridden"):
+        print(f"OVERRIDE: {contract_gate['message']}")
+    else:
+        print(f"contract_invalid gate: {contract_gate['message']}")
+
     # The head SHA the gates approved is established once in _run_ci_gate; the
     # merge is pinned to it (--match-head-commit) so a post-gate push is refused.
     head_sha = (pr_data or {}).get("headRefOid") or ""
+
+    contract_invalid_override = (
+        {"flag": "--override-contract-invalid", "reason": contract_gate["override_reason"]}
+        if contract_gate.get("overridden") else None
+    )
 
     result = merge_pr(
         pr_number=args.pr,
@@ -768,6 +914,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         dry_run=args.dry_run,
         head_sha=head_sha,
         pr_data=pr_data,
+        contract_invalid_override=contract_invalid_override,
     )
 
     if args.json:

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -48,18 +48,28 @@ Usage:
     python3 scripts/pr_merge.py --pr 123 --override-reason 'gate flaked, re-verified'
 
 contract_invalid gate (Golf B, B7 / OI-1638 gevolg 3): a third fail-closed
-check runs after the review gate — the LATEST receipt on record for
-``--dispatch-id`` must not be ``contract_invalid`` (see
+check runs after the review gate — the latest DELIVERABLE-OUTCOME receipt on
+record for the dispatch must not be ``contract_invalid`` (see
 ``contract_invalid_ledger.is_deliverable_acceptable``): a dispatch whose
 deliverable never satisfied the report-body contract must not be silently
-closed by a merge. An empty ``--dispatch-id`` skips the check (existing
-behaviour — the door has no chain to check without one). The escape hatch is
-its own flag, ``--override-contract-invalid``, separate from
-``--override-reason``: accepting a contract_invalid deliverable anyway is a
-distinct judgment call from overriding a flaky CI run or an unrun review
-gate. A non-empty reason overrides visibly and is stamped onto the
-``pr_merged`` receipt as ``contract_invalid_override``; an empty reason is
-refused (no silent bypass).
+closed by a merge. "Outcome receipt", not "latest receipt": the review gate
+writes ``review_gate_request`` on the same dispatch_id between the worker's
+report and the merge, and judging the plain latest therefore read the gate
+request instead of the deliverable — measured 07-09, that masked all 8
+dispatch-ids in the live ledger that merged over a contract_invalid receipt.
+An unreadable ledger is a refusal with its cause, never an empty read.
+An empty ``--dispatch-id`` is resolved from the PR number first (the same
+lookup that stamps the receipt), so omitting the flag is not a bypass; only
+a PR with no dispatch_id in the register skips the check, loudly.
+
+The escape hatch is its own flag, ``--override-contract-invalid``, separate
+from ``--override-reason``: accepting a contract_invalid deliverable anyway
+is a distinct judgment call from overriding a flaky CI run or an unrun
+review gate. It is resolved AFTER the check: on a chain that is clean anyway
+the flag is reported as unnecessary and nothing is stamped, so
+``contract_invalid_override`` on a receipt always marks a real bypass. On a
+refused chain a non-empty reason overrides visibly and is stamped onto the
+``pr_merged`` receipt; an empty reason is refused (no silent bypass).
 
 Receipt written to t0_receipts.ndjson:
     event_type  : "pr_merged"
@@ -395,10 +405,12 @@ def _run_adr_gate(pr_number: int, *, pr_data: Optional[Dict[str, Any]] = None) -
 def _run_contract_invalid_gate(
     dispatch_id: str,
     *,
+    pr_number: Optional[int] = None,
     override_reason: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Fail-closed merge gate (Golf B, B7): the LATEST receipt on record for
-    ``dispatch_id`` must not be ``contract_invalid`` (OI-1638 gevolg 3).
+    """Fail-closed merge gate (Golf B, B7): the latest DELIVERABLE-OUTCOME
+    receipt on record for ``dispatch_id`` must not be ``contract_invalid``
+    (OI-1638 gevolg 3).
 
     DISPATCH_RULES.md §14 gevolg 3 names ``is_deliverable_acceptable`` as the
     gate a closer must call before treating a dispatch's deliverable as
@@ -414,62 +426,98 @@ def _run_contract_invalid_gate(
     ``t0_receipts.ndjson``) — the check and the write it gates must see the
     same ledger.
 
-    An empty ``dispatch_id`` skips the check LOUDLY: ``pr_merge`` has never
-    required ``--dispatch-id`` (existing behaviour), so a dispatch-id-less
-    merge simply has no chain to check here — not a new hole this gate opens.
+    An empty ``dispatch_id`` no longer walks straight past the gate: the door
+    resolves it from ``pr_number`` first, via the SAME
+    ``_lookup_dispatch_id_by_pr_number`` that ``merge_pr`` already uses to
+    stamp the ``pr_merged`` receipt. Omitting ``--dispatch-id`` therefore
+    stops being an escape hatch that needs no reason — the merge still gets
+    the receipt chain stamped on it either way, so the gate must judge that
+    same chain. Only when the register has no dispatch_id for this PR does
+    the check skip, LOUDLY (``pr_merge`` has never required ``--dispatch-id``
+    — an unresolvable PR genuinely has no chain to check).
 
     ``override_reason`` (``--override-contract-invalid``) is a SEPARATE
     escape hatch from ``--override-reason`` (already wired to the CI and
     review gates): accepting a contract_invalid deliverable anyway is a
     distinct judgment call from overriding a flaky CI run or an unrun review
     gate, so it gets its own flag rather than silently piggy-backing on
-    ``--override-reason``. Same resolution order as the other gates' escape
-    hatch (checked BEFORE running the read): non-empty reason overrides
-    visibly without touching the ledger read, empty is refused (no silent
-    bypass), ``None`` runs the normal check.
+    ``--override-reason``.
+
+    Unlike the other gates' hatch, this one is resolved AFTER the ledger read,
+    not before it. Checked before, the flag alone produced ``overridden:
+    True`` on a chain that was clean anyway, and ``main()`` then stamped
+    ``contract_invalid_override`` onto the ``pr_merged`` receipt — an audit
+    field claiming a bypass that never happened, which reads in the trail as
+    a governed failure someone waved through. So: run the check first, and
+    only let the flag matter when the verdict without it would have been
+    NO-GO. On a clean chain the flag is reported as unnecessary and nothing
+    is stamped; on a dirty chain a non-empty reason overrides visibly and an
+    empty one is refused (no silent bypass).
     """
     did = (dispatch_id or "").strip()
+    resolved_from_pr = False
+    if not did and pr_number is not None:
+        did = _lookup_dispatch_id_by_pr_number(pr_number).strip()
+        resolved_from_pr = bool(did)
+
     if not did:
+        suffix = f" (en niet af te leiden uit PR #{pr_number})" if pr_number is not None else ""
         return {
             "verdict": "GO",
-            "message": "contract_invalid-check overgeslagen: geen dispatch-id",
+            "message": f"contract_invalid-check overgeslagen: geen dispatch-id{suffix}",
             "skipped": True,
             "overridden": False,
             "override_reason": None,
-        }
-
-    # ── Escape hatch (same resolution order as the CI/review gates) ───────
-    if override_reason is not None:
-        reason = override_reason.strip()
-        if not reason:
-            return {
-                "verdict": "NO-GO",
-                "message": (
-                    "override zonder reden geweigerd: --override-contract-invalid "
-                    "vereist een niet-lege reden (geen stille bypass)"
-                ),
-                "skipped": False,
-                "overridden": True,
-                "override_reason": reason,
-            }
-        return {
-            "verdict": "GO",
-            "message": f"contract_invalid-check overgeslagen voor {did} ({reason})",
-            "skipped": False,
-            "overridden": True,
-            "override_reason": reason,
+            "override_unnecessary": False,
+            "resolved_from_pr": False,
         }
 
     paths = ensure_env()
     receipts_path = Path(paths["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
     acceptable, reason = is_deliverable_acceptable(did, receipts_path)
-    return {
+
+    origin = f" (dispatch-id afgeleid uit PR #{pr_number})" if resolved_from_pr else ""
+    result: Dict[str, Any] = {
         "verdict": "GO" if acceptable else "NO-GO",
-        "message": reason,
+        "message": f"{reason}{origin}",
         "skipped": False,
         "overridden": False,
         "override_reason": None,
+        "override_unnecessary": False,
+        "resolved_from_pr": resolved_from_pr,
     }
+
+    if override_reason is None:
+        return result
+
+    # ── Escape hatch, resolved against the verdict the check just produced ──
+    if acceptable:
+        result["message"] = (
+            f"{result['message']} — --override-contract-invalid was niet nodig "
+            f"(de keten is schoon); geen override op de receipt"
+        )
+        result["override_unnecessary"] = True
+        return result
+
+    reason_text = override_reason.strip()
+    if not reason_text:
+        result["verdict"] = "NO-GO"
+        result["message"] = (
+            "override zonder reden geweigerd: --override-contract-invalid "
+            "vereist een niet-lege reden (geen stille bypass)"
+        )
+        result["overridden"] = True
+        result["override_reason"] = reason_text
+        return result
+
+    result["verdict"] = "GO"
+    result["message"] = (
+        f"contract_invalid-check overgeslagen voor {did} ({reason_text}) — "
+        f"zonder de vlag was dit NO-GO: {reason}"
+    )
+    result["overridden"] = True
+    result["override_reason"] = reason_text
+    return result
 
 
 _HEAD_MOVED_MARKERS = (
@@ -878,10 +926,13 @@ def main(argv: Optional[list[str]] = None) -> int:
         return EXIT_ERROR
     print(f"ADR gate: {adr_gate['message']}")
 
-    # ── contract_invalid gate: the LATEST receipt for --dispatch-id must ────
-    # not be contract_invalid (Golf B, B7). No effect without --dispatch-id.
+    # ── contract_invalid gate: the latest OUTCOME receipt for the dispatch ──
+    # must not be contract_invalid (Golf B, B7). A missing --dispatch-id is
+    # resolved from the PR number first, so omitting the flag is not a bypass.
     contract_gate = _run_contract_invalid_gate(
-        args.dispatch_id, override_reason=args.override_contract_invalid,
+        args.dispatch_id,
+        pr_number=args.pr,
+        override_reason=args.override_contract_invalid,
     )
     if contract_gate["verdict"] != "GO":
         if args.json:

--- a/tests/test_contract_invalid_ledger.py
+++ b/tests/test_contract_invalid_ledger.py
@@ -374,6 +374,181 @@ def test_outcome_event_type_set_matches_measurement() -> None:
 
 
 # ---------------------------------------------------------------------------
+# is_deliverable_acceptable: only DECIDED outcomes are chosen
+#
+# The plane filter above still passed 2 of the 8 measured cases: both had a
+# ``task_complete``/``unknown`` written about a minute after the
+# contract_invalid, and "not the contract_invalid literal" was read as
+# "resolved". An undecided status decides nothing and must be skipped at
+# selection time, not counted as a resolution.
+# ---------------------------------------------------------------------------
+
+def _outcome_receipt(dispatch_id: str, status: str, timestamp: str, **overrides) -> dict:
+    """A deliverable-outcome receipt with an arbitrary status literal."""
+    rec = {
+        "dispatch_id": dispatch_id,
+        "provider": "claude",
+        "status": status,
+        "event_type": "task_complete",
+        "timestamp": timestamp,
+        "ingested_at": timestamp,
+    }
+    rec.update(overrides)
+    return rec
+
+
+def test_unknown_outcome_after_contract_invalid_is_still_no_go(tmp_path: Path) -> None:
+    """The measured case, field-for-field (20260830-140500-d6a2…): the
+    contract_invalid receipt has NO ``ingested_at`` and the later ``unknown``
+    one carries an EARLIER raw ``timestamp`` than its own ingest, so the
+    effective-timestamp ordering really does put the unknown last."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d6a2", "claude", "2026-08-30T12:11:42Z", ingested_at=None),
+        _outcome_receipt(
+            "d6a2", "unknown", "2026-08-30T12:11:42.852911+00:00",
+            ingested_at="2026-08-30T12:12:59Z",
+        ),
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d6a2", receipts)
+
+    assert ok is False
+    assert "contract_invalid" in reason
+    assert "d6a2" in reason
+
+
+def test_success_outcome_after_contract_invalid_is_go(tmp_path: Path) -> None:
+    """The same chain with a DECIDED last outcome resolves — the filter
+    narrows which receipts may be chosen, it does not freeze the verdict."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d-decided", "claude", "2026-08-30T12:11:42Z", ingested_at=None),
+        _outcome_receipt(
+            "d-decided", "success", "2026-08-30T12:11:42.852911+00:00",
+            ingested_at="2026-08-30T12:12:59Z",
+        ),
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d-decided", receipts)
+
+    assert ok is True
+    assert "not contract_invalid" in reason
+
+
+def test_only_undecided_outcomes_is_go_with_geen_besliste_uitkomst(tmp_path: Path) -> None:
+    """No decided outcome at all is an ABSENCE, not a refusal — and the
+    reason must name it as such, distinct from "no outcome receipt"."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _outcome_receipt("d-undecided", "unknown", "2026-09-06T10:00:00Z"),
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d-undecided", receipts)
+
+    assert ok is True
+    assert "geen besliste uitkomst" in reason
+    assert "unknown" in reason
+    assert "afwezigheid is geen weigering" in reason
+    assert "geen uitkomst-receipt" not in reason
+
+
+@pytest.mark.parametrize("status", ["unknown", "no_signal", "", "   "])
+def test_no_signal_and_empty_status_behave_like_unknown(tmp_path: Path, status: str) -> None:
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d-u", "claude", "2026-09-06T10:00:00Z"),
+        _outcome_receipt("d-u", status, "2026-09-06T10:05:00Z"),
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d-u", receipts)
+
+    assert ok is False, f"status {status!r} must not resolve a contract_invalid chain"
+    assert "contract_invalid" in reason
+
+
+def test_missing_status_field_behaves_like_undecided(tmp_path: Path) -> None:
+    """134 outcome receipts in the live ledger carry an empty status; a
+    receipt with no status KEY at all must read the same way, not crash."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d-nostatus", "claude", "2026-09-06T10:00:00Z"),
+        {"dispatch_id": "d-nostatus", "event_type": "task_complete",
+         "timestamp": "2026-09-06T10:05:00Z"},
+    ])
+
+    ok, _ = cil.is_deliverable_acceptable("d-nostatus", receipts)
+
+    assert ok is False
+
+
+@pytest.mark.parametrize("status", ["blocked", "completed", "in_progress",
+                                    "done — awaiting ci + t0 gate"])
+def test_unrecognized_status_does_not_heal_the_chain(tmp_path: Path, status: str) -> None:
+    """ALLOWLIST, not a blocklist of {unknown, no_signal, empty}: these four
+    literals all exist in the live ledger outside the enumerated set. A status
+    this module has never seen makes no statement about the deliverable, so it
+    must fail closed rather than silently unlock the merge."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d-novel", "claude", "2026-09-06T10:00:00Z"),
+        _outcome_receipt("d-novel", status, "2026-09-06T10:05:00Z"),
+    ])
+
+    ok, _ = cil.is_deliverable_acceptable("d-novel", receipts)
+
+    assert ok is False
+
+
+def test_contract_invalid_receipt_without_status_is_still_decided(tmp_path: Path) -> None:
+    """``_is_decided_outcome`` short-circuits on the contract_invalid literal
+    BEFORE the status allowlist, so an old ``report_contract_invalid`` record
+    carrying no status field cannot drop out of its own check."""
+    rec = {
+        "dispatch_id": "legacy-ci",
+        "event_type": "report_contract_invalid",
+        "timestamp": "2026-06-03T08:51:09Z",
+    }
+    assert cil._is_decided_outcome(rec) is True
+
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [rec])
+
+    ok, reason = cil.is_deliverable_acceptable("legacy-ci", receipts)
+
+    assert ok is False
+    assert "contract_invalid" in reason
+
+
+def test_decided_status_set_matches_measurement() -> None:
+    """Pin the allowlist: measured 07-09 over 23.698 deliverable-outcome
+    receipts in the live ledger. unknown (3897), no_signal (35) and the empty
+    status (134) are the enumerated undecided ones and must stay out."""
+    assert cil.DECIDED_OUTCOME_STATUSES == frozenset({
+        "success", "done", "complete", "failed", "failure", "timeout",
+        "contract_invalid",
+    })
+    for undecided in ("unknown", "no_signal", ""):
+        assert undecided not in cil.DECIDED_OUTCOME_STATUSES
+
+
+def test_undecided_receipts_do_not_block_a_dispatch_of_their_own(tmp_path: Path) -> None:
+    """Skipped, not refused: turning 3897 unknown records into refusals of
+    their own would be a merge blockade, not a fix."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _outcome_receipt("d-mixed", "unknown", "2026-09-06T10:00:00Z"),
+        _success_receipt("d-mixed", "claude", "2026-09-06T10:05:00Z"),
+        _outcome_receipt("d-mixed", "unknown", "2026-09-06T10:10:00Z"),
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d-mixed", receipts)
+
+    assert ok is True
+    assert "not contract_invalid" in reason
+
+
+# ---------------------------------------------------------------------------
 # is_deliverable_acceptable: an unreadable ledger fails CLOSED
 # ---------------------------------------------------------------------------
 

--- a/tests/test_contract_invalid_ledger.py
+++ b/tests/test_contract_invalid_ledger.py
@@ -22,6 +22,7 @@ fallback blocked).
 from __future__ import annotations
 
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -262,13 +263,172 @@ def test_is_deliverable_acceptable_true_for_absent_dispatch(tmp_path: Path) -> N
     ok, reason = cil.is_deliverable_acceptable("never-ran", receipts)
 
     assert ok is True
-    assert "no receipt" in reason
+    assert "geen uitkomst-receipt" in reason
+    assert "afwezigheid is geen weigering" in reason
 
 
 def test_is_deliverable_acceptable_false_for_empty_dispatch_id(tmp_path: Path) -> None:
     receipts = tmp_path / "t0_receipts.ndjson"
     ok, reason = cil.is_deliverable_acceptable("", receipts)
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# is_deliverable_acceptable: only DELIVERABLE-OUTCOME receipts are judged
+# ---------------------------------------------------------------------------
+
+def _gate_request_receipt(dispatch_id: str, timestamp: str, **overrides) -> dict:
+    """A review_gate_request receipt — the gate plane, on the SAME dispatch_id.
+
+    Shape mirrors what gate_request_handler.py emits (event_type
+    review_gate_request, status requested); 844 of these sit in the live
+    ledger and every one of the 8 measured masking cases had one as its last
+    receipt before the merge.
+    """
+    rec = {
+        "dispatch_id": dispatch_id,
+        "provider": "claude",
+        "status": "requested",
+        "event_type": "review_gate_request",
+        "receipt_kind": "review_gate",
+        "timestamp": timestamp,
+    }
+    rec.update(overrides)
+    return rec
+
+
+def test_gate_plane_receipt_does_not_mask_contract_invalid(tmp_path: Path) -> None:
+    """The measured masking case: worker outcome contract_invalid, then the
+    review gate writes on the same dispatch_id. The deliverable is still
+    unacceptable — a gate request says nothing about the report body."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d-masked", "kimi", "2026-09-06T11:36:00Z"),
+        _gate_request_receipt("d-masked", "2026-09-06T11:50:54Z"),
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d-masked", receipts)
+
+    assert ok is False
+    assert "contract_invalid" in reason
+
+
+def test_only_gate_plane_receipts_reads_as_no_outcome(tmp_path: Path) -> None:
+    """Gate/state-plane receipts alone are not an outcome — absence, so no
+    rejection, but the reason must say WHY it is an absence."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _gate_request_receipt("d-gate-only", "2026-09-06T11:50:54Z"),
+        {"dispatch_id": "d-gate-only", "event_type": "state_mutation",
+         "status": "success", "timestamp": "2026-09-06T11:55:00Z"},
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d-gate-only", receipts)
+
+    assert ok is True
+    assert "geen uitkomst-receipt" in reason
+
+
+def test_real_outcome_success_after_gate_receipt_resolves(tmp_path: Path) -> None:
+    """A LATER genuine outcome still resolves the chain — the filter narrows
+    which receipts count, it does not freeze the first verdict."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d-really-healed", "kimi", "2026-09-06T11:36:00Z"),
+        _gate_request_receipt("d-really-healed", "2026-09-06T11:50:54Z"),
+        _success_receipt("d-really-healed", "kimi", "2026-09-06T12:05:00Z"),
+    ])
+
+    ok, reason = cil.is_deliverable_acceptable("d-really-healed", receipts)
+
+    assert ok is True
+    assert "not contract_invalid" in reason
+
+
+def test_subprocess_completion_counts_as_outcome(tmp_path: Path) -> None:
+    """subprocess_completion carries the literal 4x in the live ledger, so it
+    is in DELIVERABLE_OUTCOME_EVENT_TYPES and must be judged."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [
+        _ci_receipt("d-sub", "kimi", "2026-09-06T10:00:00Z",
+                    event_type="subprocess_completion"),
+        _gate_request_receipt("d-sub", "2026-09-06T10:30:00Z"),
+    ])
+
+    ok, _ = cil.is_deliverable_acceptable("d-sub", receipts)
+    assert ok is False
+
+
+def test_outcome_event_type_set_matches_measurement() -> None:
+    """Pin the set: measured 07-09 over 29.386 live records, the event types
+    that ever carry the contract_invalid literal are report_contract_invalid,
+    task_complete and subprocess_completion; task_failed is the fourth
+    deliverable outcome. review_gate_request must never be in here."""
+    assert cil.DELIVERABLE_OUTCOME_EVENT_TYPES == frozenset({
+        "report_contract_invalid",
+        "task_complete",
+        "subprocess_completion",
+        "task_failed",
+    })
+    assert "review_gate_request" not in cil.DELIVERABLE_OUTCOME_EVENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# is_deliverable_acceptable: an unreadable ledger fails CLOSED
+# ---------------------------------------------------------------------------
+
+def test_unreadable_ledger_is_a_refusal_not_an_absence(tmp_path: Path) -> None:
+    """A directory where the ledger should be: read raises, and the gate must
+    refuse with the cause instead of degrading to an empty read (which reads
+    as "no outcome receipt" and fails OPEN)."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    receipts.mkdir(parents=True)
+
+    ok, reason = cil.is_deliverable_acceptable("d-any", receipts)
+
+    assert ok is False
+    assert "grootboek onleesbaar" in reason
+    assert "afwezigheid" not in reason
+
+
+def test_unreadable_ledger_permission_bit_is_a_refusal(tmp_path: Path) -> None:
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [_ci_receipt("d-any", "kimi", "2026-09-06T10:00:00Z")])
+    receipts.chmod(0o000)
+    try:
+        if os.access(receipts, os.R_OK):  # running as root: chmod cannot deny
+            pytest.skip("read permission not enforceable for this user")
+        ok, reason = cil.is_deliverable_acceptable("d-any", receipts)
+    finally:
+        receipts.chmod(0o644)
+
+    assert ok is False
+    assert "grootboek onleesbaar" in reason
+
+
+def test_strict_false_keeps_the_soft_read(tmp_path: Path) -> None:
+    """The advisory contract is still available explicitly — strict=False
+    degrades an unreadable ledger to an empty read, as before."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    receipts.mkdir(parents=True)
+
+    ok, reason = cil.is_deliverable_acceptable("d-any", receipts, strict=False)
+
+    assert ok is True
+    assert "geen uitkomst-receipt" in reason
+
+
+def test_advisory_readers_keep_soft_behaviour_on_unreadable_ledger(tmp_path: Path) -> None:
+    """build_contract_invalid_summary / collect_contract_invalid_open surface
+    at SessionStart — an I/O failure there must not crash a session."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    receipts.mkdir(parents=True)
+
+    summary = cil.build_contract_invalid_summary(receipts)
+    open_items = cil.collect_contract_invalid_open(receipts)
+
+    assert summary["total"] == 0
+    assert open_items == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_merge_contract_invalid.py
+++ b/tests/test_pr_merge_contract_invalid.py
@@ -83,6 +83,39 @@ def _load_receipts(path: Path) -> List[Dict[str, Any]]:
     return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
 
 
+def _outcome_ci(dispatch_id: str, timestamp: str, **overrides) -> Dict[str, Any]:
+    """A worker outcome receipt that failed the report-body contract."""
+    rec = {
+        "timestamp": timestamp, "event_type": "task_complete",
+        "status": "contract_invalid", "dispatch_id": dispatch_id,
+        "report_path": f"/reports/{dispatch_id}.md",
+    }
+    rec.update(overrides)
+    return rec
+
+
+def _outcome_success(dispatch_id: str, timestamp: str, **overrides) -> Dict[str, Any]:
+    rec = {
+        "timestamp": timestamp, "event_type": "task_complete",
+        "status": "success", "dispatch_id": dispatch_id,
+    }
+    rec.update(overrides)
+    return rec
+
+
+def _gate_request(dispatch_id: str, timestamp: str, **overrides) -> Dict[str, Any]:
+    """The gate-plane receipt gate_request_handler.py writes on the SAME
+    dispatch_id after the worker's outcome — the receipt that masked the
+    check on all 8 measured cases."""
+    rec = {
+        "timestamp": timestamp, "event_type": "review_gate_request",
+        "receipt_kind": "review_gate", "status": "requested",
+        "dispatch_id": dispatch_id, "pr_number": 1,
+    }
+    rec.update(overrides)
+    return rec
+
+
 def _go_gate(**kw):
     gate = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
     gate.update(kw)
@@ -297,3 +330,232 @@ class TestMainContractInvalidGateWiring:
         out = json.loads(stdout[stdout.index("{"):])
         assert out["success"] is False
         assert did in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# The gate must fire on the GOVERNED path, not just on a synthetic one-receipt
+# chain (07-09 fix-forward). Every case below is measured against the live
+# ledger: 8 dispatch-ids merged over a contract_invalid receipt and the gate
+# as shipped would have said GO on all 8.
+# ---------------------------------------------------------------------------
+
+class TestOutcomeReceiptFiltering:
+    def test_gate_request_after_contract_invalid_still_no_go(self, vnx_env):
+        """The realistic chain (#1786-shaped): outcome contract_invalid, then
+        the review gate writes review_gate_request on the SAME dispatch_id.
+        Judging "the latest receipt" reads the gate request and passes."""
+        did = "20260906-oi1641-overlap-scan"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T11:36:00Z"),
+            _gate_request(did, "2026-09-06T11:50:54Z"),
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(did)
+
+        assert gate["verdict"] == "NO-GO"
+        assert did in gate["message"]
+        assert "contract_invalid" in gate["message"]
+
+    def test_real_outcome_success_after_gate_request_is_go(self, vnx_env):
+        did = "20260906-healed-for-real"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T11:36:00Z"),
+            _gate_request(did, "2026-09-06T11:50:54Z"),
+            _outcome_success(did, "2026-09-06T12:05:00Z"),
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(did)
+
+        assert gate["verdict"] == "GO"
+
+    def test_only_gate_plane_receipts_is_go_with_no_outcome_reason(self, vnx_env):
+        did = "20260906-gate-plane-only"
+        _write_receipts(vnx_env["receipts_path"], [
+            _gate_request(did, "2026-09-06T11:50:54Z"),
+            {"timestamp": "2026-09-06T11:55:00Z", "event_type": "state_mutation",
+             "status": "success", "dispatch_id": did},
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(did)
+
+        assert gate["verdict"] == "GO"
+        assert "geen uitkomst-receipt" in gate["message"]
+
+    def test_main_refuses_the_realistic_chain_before_merging(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        did = "20260906-a1-diff-sandwich"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T17:20:00Z"),
+            _gate_request(did, "2026-09-06T17:32:33Z"),
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls, "a gate-plane receipt must not unlock the merge"
+        assert did in capsys.readouterr().err
+
+
+class TestUnreadableLedgerFailsClosed:
+    def test_unreadable_ledger_is_no_go_with_the_cause(self, vnx_env):
+        """A directory where t0_receipts.ndjson should be — the read raises,
+        and an I/O failure must never read as "absence, not a rejection"."""
+        vnx_env["receipts_path"].mkdir(parents=True)
+
+        gate = pr_merge._run_contract_invalid_gate("d-any")
+
+        assert gate["verdict"] == "NO-GO"
+        assert "grootboek onleesbaar" in gate["message"]
+        assert "afwezigheid" not in gate["message"]
+
+    def test_main_refuses_on_unreadable_ledger(self, vnx_env, monkeypatch, capsys):
+        vnx_env["receipts_path"].mkdir(parents=True)
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", "d-any"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls
+        assert "grootboek onleesbaar" in capsys.readouterr().err
+
+
+class TestDispatchIdResolvedFromPrNumber:
+    """A missing --dispatch-id was a reasonless escape hatch: merge_pr itself
+    resolves the id from the PR number to stamp the receipt (pr_merge.py's
+    _lookup_dispatch_id_by_pr_number), so the gate can resolve the same chain.
+    The real lookup runs here against a real register file in the tmp state
+    dir — only the register content is a fixture, not the lookup."""
+
+    PR = 424242
+
+    def _write_register(self, vnx_env, dispatch_id: str, pr_number: int) -> None:
+        (vnx_env["state_dir"] / "dispatch_register.ndjson").write_text(
+            json.dumps({
+                "timestamp": "2026-09-06T11:00:00Z", "event": "dispatch_completed",
+                "dispatch_id": dispatch_id, "pr_number": pr_number, "terminal": "T0",
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_gate_runs_and_refuses_on_resolved_dispatch_id(self, vnx_env, monkeypatch):
+        monkeypatch.setenv("VNX_PROJECT_ID", "")  # no central merge-read
+        did = "20260907-b7-resolved-from-pr"
+        self._write_register(vnx_env, did, self.PR)
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T11:36:00Z"),
+            _gate_request(did, "2026-09-06T11:50:54Z"),
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate("", pr_number=self.PR)
+
+        assert gate["verdict"] == "NO-GO"
+        assert gate["resolved_from_pr"] is True
+        assert gate["skipped"] is False
+        assert did in gate["message"]
+
+    def test_main_refuses_without_dispatch_id_flag(self, vnx_env, monkeypatch, capsys):
+        monkeypatch.setenv("VNX_PROJECT_ID", "")
+        did = "20260907-b7-resolved-main"
+        self._write_register(vnx_env, did, self.PR)
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T11:36:00Z"),
+            _gate_request(did, "2026-09-06T11:50:54Z"),
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", str(self.PR)])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls, "omitting --dispatch-id must not bypass the gate"
+        assert did in capsys.readouterr().err
+
+    def test_unresolvable_pr_still_skips_loudly(self, vnx_env, monkeypatch):
+        monkeypatch.setenv("VNX_PROJECT_ID", "")
+
+        gate = pr_merge._run_contract_invalid_gate("", pr_number=self.PR)
+
+        assert gate["verdict"] == "GO"
+        assert gate["skipped"] is True
+        assert "geen dispatch-id" in gate["message"]
+        assert str(self.PR) in gate["message"]
+
+
+class TestOverrideOnlyStampsARealBypass:
+    """--override-contract-invalid short-circuited BEFORE the ledger read, so
+    the flag alone produced overridden=True on a clean chain and main()
+    stamped contract_invalid_override onto the receipt — an audit field
+    claiming a bypass that never happened."""
+
+    def test_clean_chain_reports_the_flag_as_unnecessary(self, vnx_env):
+        did = "20260907-b7-clean-chain"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_success(did, "2026-09-06T11:36:00Z"),
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(did, override_reason="voor de zekerheid")
+
+        assert gate["verdict"] == "GO"
+        assert gate["overridden"] is False
+        assert gate["override_unnecessary"] is True
+        assert gate["override_reason"] is None
+        assert "niet nodig" in gate["message"]
+
+    def test_clean_chain_leaves_no_audit_field_on_the_receipt(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        did = "20260907-b7-clean-chain-main"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_success(did, "2026-09-06T11:36:00Z"),
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", did,
+            "--override-contract-invalid", "voor de zekerheid",
+        ])
+
+        assert rc == pr_merge.EXIT_OK
+        assert do_merge_calls
+        assert "niet nodig" in capsys.readouterr().out
+
+        merged = [
+            r for r in _load_receipts(vnx_env["receipts_path"])
+            if r.get("event_type") == "pr_merged" and r.get("dispatch_id") == did
+        ]
+        assert len(merged) == 1
+        assert "contract_invalid_override" not in merged[0], (
+            "an override field on a clean chain reads in the trail as a "
+            "governed failure someone waved through"
+        )
+
+    def test_dirty_chain_still_merges_and_stamps(self, vnx_env, monkeypatch):
+        did = "20260907-b7-dirty-chain"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T11:36:00Z"),
+            _gate_request(did, "2026-09-06T11:50:54Z"),
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", did,
+            "--override-contract-invalid", "handmatig geverifieerd",
+        ])
+
+        assert rc == pr_merge.EXIT_OK
+        assert do_merge_calls
+        merged = [
+            r for r in _load_receipts(vnx_env["receipts_path"])
+            if r.get("event_type") == "pr_merged" and r.get("dispatch_id") == did
+        ]
+        assert len(merged) == 1
+        assert merged[0]["contract_invalid_override"] == {
+            "flag": "--override-contract-invalid",
+            "reason": "handmatig geverifieerd",
+        }

--- a/tests/test_pr_merge_contract_invalid.py
+++ b/tests/test_pr_merge_contract_invalid.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Tests for the contract_invalid merge gate wired into pr_merge.py
+(Golf B, B7 / OI-1638 gevolg 3).
+
+``contract_invalid_ledger.is_deliverable_acceptable`` existed with zero
+callers outside its own module before this gate: OI-1638 gevolg 3 (see
+DISPATCH_RULES.md §14) wrote the read side but never wired a call site.
+This is that call site — the merge door (``pr_merge.py::main()``), after the
+CI gate, the review gate, and the ADR-number preflight (golf B, B6), before
+the merge itself.
+
+Only ``gh`` (via ``_run_ci_gate``/``_run_review_gate``/``_run_adr_gate`` and
+``_do_merge``) and the receipts path (via the isolated ``VNX_STATE_DIR``)
+are mocked — ``is_deliverable_acceptable``/``_run_contract_invalid_gate``
+run for real against a real (tmp) NDJSON receipts file, exercising the
+actual read+decision path this gate depends on.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+
+
+SHA = "b" * 40
+
+PR_DATA = {
+    "number": 1,
+    "title": "test PR",
+    "state": "OPEN",
+    "headRefName": "feature/x",
+    "baseRefName": "main",
+    "headRefOid": SHA,
+}
+
+
+@pytest.fixture()
+def vnx_env(tmp_path, monkeypatch):
+    """Isolated VNX state dir — contract_invalid receipts never touch the real store."""
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    (data_dir / "dispatches").mkdir(parents=True, exist_ok=True)
+    return {
+        "state_dir": state_dir,
+        "data_dir": data_dir,
+        "receipts_path": state_dir / "t0_receipts.ndjson",
+    }
+
+
+def _write_receipts(path: Path, records: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _load_receipts(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _go_gate(**kw):
+    gate = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+    gate.update(kw)
+    return gate
+
+
+def _bypass_upstream_gates(monkeypatch):
+    """CI/review/ADR gates are GO — out of scope for this dispatch (golf B, B4/B6)."""
+    monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (_go_gate(), dict(PR_DATA)))
+    monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (_go_gate(), dict(PR_DATA)))
+    monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr, **k: {"verdict": "GO", "message": "ok"})
+    monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **k: True)
+
+
+def _track_do_merge(monkeypatch):
+    calls: List[Any] = []
+    monkeypatch.setattr(
+        pr_merge, "_do_merge",
+        lambda n, m, h="": calls.append((n, m, h)) or (True, ""),
+    )
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _run_contract_invalid_gate
+# ---------------------------------------------------------------------------
+
+class TestRunContractInvalidGate:
+    def test_empty_dispatch_id_skips_go(self, vnx_env):
+        gate = pr_merge._run_contract_invalid_gate("")
+        assert gate["verdict"] == "GO"
+        assert gate["skipped"] is True
+        assert "geen dispatch-id" in gate["message"]
+
+    def test_no_receipt_on_record_is_acceptable(self, vnx_env):
+        """Absence is not a rejection (OI-1624 precedent) — nul is een meetfout, so a case
+        that DOES have receipts on record is covered separately below."""
+        gate = pr_merge._run_contract_invalid_gate(
+            "never-ran-dispatch", override_reason=None,
+        )
+        assert gate["verdict"] == "GO"
+        assert gate["overridden"] is False
+
+    def test_latest_contract_invalid_is_no_go(self, vnx_env):
+        did = "d-open"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        gate = pr_merge._run_contract_invalid_gate(did)
+        assert gate["verdict"] == "NO-GO"
+        assert did in gate["message"]
+        assert "contract_invalid" in gate["message"]
+
+    def test_latest_success_after_earlier_contract_invalid_is_go(self, vnx_env):
+        did = "d-healed"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+            {"timestamp": "2026-09-06T11:00:00Z", "event_type": "task_complete",
+             "status": "success", "dispatch_id": did},
+        ])
+        gate = pr_merge._run_contract_invalid_gate(did)
+        assert gate["verdict"] == "GO"
+
+    def test_override_empty_reason_refused(self, vnx_env):
+        did = "d-open"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        gate = pr_merge._run_contract_invalid_gate(did, override_reason="   ")
+        assert gate["verdict"] == "NO-GO"
+        assert gate["overridden"] is True
+        assert "niet-lege reden" in gate["message"]
+
+    def test_override_nonempty_reason_grants_go(self, vnx_env):
+        did = "d-open"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        gate = pr_merge._run_contract_invalid_gate(did, override_reason="geverifieerd")
+        assert gate["verdict"] == "GO"
+        assert gate["overridden"] is True
+        assert gate["override_reason"] == "geverifieerd"
+
+
+# ---------------------------------------------------------------------------
+# main() wiring
+# ---------------------------------------------------------------------------
+
+class TestMainContractInvalidGateWiring:
+    def test_refuses_before_merge_when_latest_receipt_is_contract_invalid(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        did = "20260907-b7-fixture-nogo"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_ERROR
+        err = capsys.readouterr().err
+        assert did in err
+        assert "contract_invalid" in err
+        assert not do_merge_calls, "merge must not run when the contract_invalid gate is NO-GO"
+
+    def test_override_with_reason_allows_merge_and_stamps_receipt(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        did = "20260907-b7-fixture-override"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", did,
+            "--override-contract-invalid", "handmatig geverifieerd",
+        ])
+
+        assert rc == pr_merge.EXIT_OK
+        assert do_merge_calls, "merge must run once the gate is overridden"
+        out = capsys.readouterr().out
+        assert "OVERRIDE" in out
+
+        receipts = _load_receipts(vnx_env["receipts_path"])
+        merged = [
+            r for r in receipts
+            if r.get("event_type") == "pr_merged" and r.get("dispatch_id") == did
+        ]
+        assert len(merged) == 1
+        audit = merged[0].get("contract_invalid_override")
+        assert audit is not None, "pr_merged receipt must carry the contract_invalid_override audit field"
+        assert audit["reason"] == "handmatig geverifieerd"
+        assert audit["flag"] == "--override-contract-invalid"
+
+    def test_override_with_empty_reason_is_refused(self, vnx_env, monkeypatch, capsys):
+        did = "20260907-b7-fixture-empty-override"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", did, "--override-contract-invalid", "",
+        ])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls
+        err = capsys.readouterr().err
+        assert "niet-lege reden" in err
+
+        receipts = _load_receipts(vnx_env["receipts_path"])
+        assert not any(r.get("event_type") == "pr_merged" for r in receipts)
+
+    def test_no_refusal_when_latest_receipt_is_governed_success(
+        self, vnx_env, monkeypatch,
+    ):
+        did = "20260907-b7-fixture-healed"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+            {"timestamp": "2026-09-06T11:00:00Z", "event_type": "task_complete",
+             "status": "success", "dispatch_id": did},
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_OK
+        assert do_merge_calls, "merge must run once the dispatch has healed past contract_invalid"
+
+    def test_no_dispatch_id_skips_check_loudly(self, vnx_env, monkeypatch, capsys):
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert do_merge_calls, "a dispatch-id-less merge is not itself refused"
+        out = capsys.readouterr().out
+        assert "contract_invalid-check overgeslagen: geen dispatch-id" in out
+
+    def test_json_no_go_outputs_json(self, vnx_env, monkeypatch, capsys):
+        did = "20260907-b7-fixture-json"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did, "--json"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        # The upstream (bypassed-as-GO) CI/review/ADR gates print their own
+        # plain-text "ok" lines unconditionally before this gate's JSON block
+        # (existing behaviour, unrelated to this dispatch) — extract just the
+        # JSON object this gate emits.
+        stdout = capsys.readouterr().out
+        out = json.loads(stdout[stdout.index("{"):])
+        assert out["success"] is False
+        assert did in out["error"]

--- a/tests/test_pr_merge_contract_invalid.py
+++ b/tests/test_pr_merge_contract_invalid.py
@@ -399,6 +399,100 @@ class TestOutcomeReceiptFiltering:
         assert did in capsys.readouterr().err
 
 
+class TestUndecidedOutcomeDoesNotLiftTheRefusal:
+    """The plane filter alone still passed 2 of the 8 measured cases. Both had
+    a ``task_complete``/``unknown`` written about a minute after the
+    contract_invalid, and an ``unknown`` was read as "resolved". Chains below
+    reproduce those two field-for-field: the contract_invalid receipt has no
+    ``ingested_at`` at all, and the ``unknown`` one carries a raw
+    ``timestamp`` EARLIER than the contract_invalid's while its ``ingested_at``
+    is later — so it genuinely is the last outcome receipt."""
+
+    D6A2 = [
+        {"timestamp": "2026-08-30T12:11:42Z", "event_type": "task_complete",
+         "status": "contract_invalid", "dispatch_id": "20260830-140500-d6a2",
+         "report_path": "/reports/20260830-140500-d6a2.md"},
+        {"timestamp": "2026-08-30T12:11:42.852911+00:00", "ingested_at": "2026-08-30T12:12:59Z",
+         "event_type": "task_complete", "status": "unknown",
+         "dispatch_id": "20260830-140500-d6a2"},
+    ]
+
+    def test_unknown_outcome_after_contract_invalid_is_no_go(self, vnx_env):
+        _write_receipts(vnx_env["receipts_path"], self.D6A2)
+
+        gate = pr_merge._run_contract_invalid_gate("20260830-140500-d6a2")
+
+        assert gate["verdict"] == "NO-GO"
+        assert "contract_invalid" in gate["message"]
+        assert "20260830-140500-d6a2" in gate["message"]
+
+    def test_main_refuses_the_unknown_masked_chain(self, vnx_env, monkeypatch, capsys):
+        _write_receipts(vnx_env["receipts_path"], self.D6A2)
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", "20260830-140500-d6a2"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls, "an undecided outcome must not unlock the merge"
+        assert "20260830-140500-d6a2" in capsys.readouterr().err
+
+    def test_success_after_contract_invalid_still_merges(self, vnx_env, monkeypatch):
+        """Same chain, decided last outcome: the merge goes through. The filter
+        narrows which receipts may be chosen, it does not freeze the verdict."""
+        did = "20260830-140500-d6a2-really-healed"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-08-30T12:11:42Z"),
+            {"timestamp": "2026-08-30T12:11:42.852911+00:00",
+             "ingested_at": "2026-08-30T12:12:59Z", "event_type": "task_complete",
+             "status": "success", "dispatch_id": did},
+        ])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_OK
+        assert do_merge_calls
+
+    def test_only_undecided_outcomes_is_go_with_its_own_reason(self, vnx_env):
+        """3897 unknown records live in that ledger. Skipped, not refused —
+        refusing on them would be a merge blockade, not a fix. The reason must
+        say WHY it passed, distinct from "no outcome receipt at all"."""
+        did = "20260907-only-unknown"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-06T10:00:00Z", "event_type": "task_complete",
+             "status": "unknown", "dispatch_id": did},
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(did)
+
+        assert gate["verdict"] == "GO"
+        assert "geen besliste uitkomst" in gate["message"]
+        assert "geen uitkomst-receipt" not in gate["message"]
+
+    def test_override_still_forces_the_masked_chain_through(self, vnx_env, monkeypatch):
+        """The escape hatch keeps working on the newly-refused chain, and the
+        bypass is stamped on the receipt — it is a real bypass now."""
+        _write_receipts(vnx_env["receipts_path"], self.D6A2)
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", "20260830-140500-d6a2",
+            "--override-contract-invalid", "rapport handmatig nagelezen",
+        ])
+
+        assert rc == pr_merge.EXIT_OK
+        assert do_merge_calls
+        merged = [
+            r for r in _load_receipts(vnx_env["receipts_path"])
+            if r.get("event_type") == "pr_merged"
+        ]
+        assert len(merged) == 1
+        assert merged[0]["contract_invalid_override"]["reason"] == "rapport handmatig nagelezen"
+
+
 class TestUnreadableLedgerFailsClosed:
     def test_unreadable_ledger_is_no_go_with_the_cause(self, vnx_env):
         """A directory where t0_receipts.ndjson should be — the read raises,


### PR DESCRIPTION
## Summary

`contract_invalid_ledger.is_deliverable_acceptable()` (OI-1638 gevolg 3) had nul aanroepers buiten de eigen module: de leeskant bestond, het gevolg niet. Dit PR wiert de merge-deur (`pr_merge.py::main()`, na de CI-gate, de review-gate en de ADR-preflight uit golf B/B6, vóór de merge) als een derde fail-closed check.

## Changes

- `scripts/pr_merge.py`:
  - Nieuwe `_run_contract_invalid_gate(dispatch_id, *, override_reason=None)`: roept `is_deliverable_acceptable` aan tegen dezelfde receipts-resolutie als `emit_governance_receipt` (`ensure_env()`'s `VNX_STATE_DIR`/`t0_receipts.ndjson`). Een lege `--dispatch-id` slaat de check luid over (bestaand gedrag, geen nieuwe klep).
  - Nieuwe vlag `--override-contract-invalid "<reden>"`, los van `--override-reason`. Lege reden geweigerd; niet-lege reden overrides zichtbaar en wordt gestempeld op de geschreven `pr_merged`-receipt als `contract_invalid_override: {"flag", "reason"}`.
  - `_emit_receipt`/`merge_pr` threaden `contract_invalid_override` door naar de receipt.
  - Aanroepblok in `main()` na het ADR-blok (B6), vóór `merge_pr()`.
- `docs/core/DISPATCH_RULES.md` §14 gevolg 3: gecorrigeerd van de oorspronkelijk bedoelde aanroepplek `verify_pr_closure()` naar de merge-deur — de closure-verifier leest alleen achteraf en kan een merge in uitvoering niet stoppen; de deur ziet de echte `main` op merge-moment.
- `tests/test_pr_merge_contract_invalid.py` (nieuw): 12 tests, unit-niveau op `_run_contract_invalid_gate` en wiring-niveau op `main()` (NO-GO weigert vóór merge, override met/zonder reden, healed dispatch, lege `--dispatch-id`, `--json`).

## Verification

- `pytest tests/test_pr_merge_contract_invalid.py -v`: rood op de ongewijzigde `origin/main`-versie van `pr_merge.py` (11 van 12 falend — de enige geslaagde is het "geen weigering na healed dispatch"-geval, dat sowieso al klopte zonder de gate), groen na de wijziging (12/12).
- `pytest tests/test_pr_merge_ci_gate.py tests/test_pr_merge_dual_scheme.py tests/test_pr_merge_match_head.py tests/test_pr_merge_outcome_exitcode.py tests/test_pr_merge_receipt.py tests/test_pr_merge_review_gate.py tests/test_pr_merge_contract_invalid.py`: 98/98 groen, geen regressies.
- `pytest tests/test_contract_invalid_ledger.py`: 16/16 groen (alleen-lezen bestandsgrens, geen wijziging, gecontroleerd als buur).
- `git diff HEAD` leeg + `git show HEAD:scripts/pr_merge.py` teruggelezen op het aanroepblok en de vlag (zie rapport).

## Gemeten afwijking van de dispatch-aanname

De dispatch stelt dat #1786 en #1789 op 06-09 gemerged zijn "terwijl hun laatste receipt contract_invalid was". Gemeten in `t0_receipts.ndjson`: voor #1786 (dispatch_id `20260906-oi1641-overlap-scan`) was de laatste receipt vóór de merge een `review_gate_request` met status `requested` — niet meer `contract_invalid` op het moment van mergen. Voor #1789 gebruikte de merge dispatch_id `20260906-oi1643-subagent-hook-r2` (een retry), waarvan de eigen laatste receipt altijd `success` was; de `contract_invalid`-receipt hoorde bij een ANDER (basis) dispatch_id (`20260906-oi1643-subagent-hook`, zonder `-r2`). Deze nieuwe gate — die exact matcht op de `--dispatch-id` string, zoals `is_deliverable_acceptable`'s contract voorschrijft — zou dus geen van beide historische merges hebben tegengehouden. Zie het volledige rapport voor de gemeten tijdlijnen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)