### PR TITLE
feat(forge): branch-protection als YAML met apply, drift-preflight en doctor-check (golf B, B1)

### DIFF
--- a/scripts/forge/apply_branch_protection.py
+++ b/scripts/forge/apply_branch_protection.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Apply scripts/forge/branch_protection.yaml to a branch's live protection
+(Golf B, B1).
+
+Reads the local YAML (default ``scripts/forge/branch_protection.yaml``),
+fetches live state via ``forge_protection_drift.fetch_live_protection``, and
+writes only what differs:
+
+  - any diff among the fields the branch-protection PUT endpoint owns ->
+    a single PUT with the FULL object built from the YAML (see
+    ``build_put_payload`` — the PUT replaces the whole object, so a partial
+    send would reset every untouched field to its GitHub default).
+  - a ``required_signatures`` diff -> POST (enable) or DELETE (disable) on
+    its own endpoint (not part of the PUT body at all).
+  - a ``repo.allow_auto_merge`` diff -> PATCH on the repo object.
+  - a ``rulesets`` diff -> never written. Checked only (see
+    ``forge_protection_drift.py``'s module docstring).
+
+No diffs at all is a no-op: idempotent, zero API writes on a second run.
+
+Verzwak-weigering (weaken-refusal): before writing, ``is_weakening(live,
+yaml)`` asks whether the YAML describes a WEAKER state than what is live
+right now. A weakening apply is refused unless ``--allow-weaken "<reason>"``
+is given with a non-empty reason (an empty reason is refused, never a silent
+bypass) — this is the same judgment ``pr_merge.py``'s merge-door preflight
+makes for a PR's own YAML edit, applied here at write time instead of at
+merge time. ``--dry-run`` never writes regardless, so it is not gated by
+this refusal: it always prints the built object.
+
+Every non-dry-run invocation writes a receipt (before/after normalized
+state, the weaken reason if one was used) via ``governance_receipts`` — see
+``_emit_apply_receipt``.
+
+The FIRST apply against the real repo is an operator step, not something
+this dispatch runs automatically (see the dispatch report's Open Items):
+
+    python3 scripts/forge/apply_branch_protection.py
+
+BILLING SAFETY: No Anthropic SDK. No direct API calls to api.anthropic.com.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent  # scripts/forge
+SCRIPTS_DIR = SCRIPT_DIR.parent  # scripts/
+LIB_DIR = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from forge_protection_drift import (  # noqa: E402
+    ProtectionConfig,
+    ProtectionConfigError,
+    ProtectionDriftError,
+    compare,
+    fetch_live_protection,
+    is_weakening,
+    load_protection_config,
+    to_normalized_dict,
+)
+from governance_receipts import emit_governance_receipt  # noqa: E402
+
+DEFAULT_BRANCH = "main"
+DEFAULT_YAML_PATH = SCRIPT_DIR / "branch_protection.yaml"
+
+
+def build_put_payload(config: ProtectionConfig) -> Dict[str, Any]:
+    """The exact body for ``PUT /repos/{owner}/{repo}/branches/{branch}/protection``.
+
+    Complete on purpose (see module docstring): the endpoint replaces the
+    whole object, so every field the YAML tracks is always sent, not just
+    the ones that changed.
+    """
+    return {
+        "required_status_checks": {
+            "strict": config.strict,
+            "checks": [{"context": c.context, "app_id": c.app_id} for c in config.checks],
+        },
+        "enforce_admins": config.enforce_admins,
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": config.dismiss_stale_reviews,
+            "require_code_owner_reviews": config.require_code_owner_reviews,
+            "require_last_push_approval": config.require_last_push_approval,
+            "required_approving_review_count": config.required_approving_review_count,
+        },
+        "restrictions": None,
+        "required_linear_history": config.required_linear_history,
+        "allow_force_pushes": config.allow_force_pushes,
+        "allow_deletions": config.allow_deletions,
+        "block_creations": config.block_creations,
+        "required_conversation_resolution": config.required_conversation_resolution,
+        "lock_branch": config.lock_branch,
+        "allow_fork_syncing": config.allow_fork_syncing,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Write calls — isolated so tests can monkeypatch each independently without
+# touching the network.
+# ---------------------------------------------------------------------------
+
+
+def _put_protection(
+    project_root: Path, branch: str, payload: Dict[str, Any], *, gh_bin: str = "gh", timeout: int = 30,
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        [
+            gh_bin, "api", f"repos/{{owner}}/{{repo}}/branches/{branch}/protection",
+            "--method", "PUT", "--input", "-",
+        ],
+        cwd=str(project_root), input=json.dumps(payload), capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def _patch_required_signatures(
+    project_root: Path, branch: str, enabled: bool, *, gh_bin: str = "gh", timeout: int = 30,
+) -> "subprocess.CompletedProcess[str]":
+    method = "POST" if enabled else "DELETE"
+    return subprocess.run(
+        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/branches/{branch}/protection/required_signatures",
+         "--method", method],
+        cwd=str(project_root), capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def _patch_repo_auto_merge(
+    project_root: Path, allow: bool, *, gh_bin: str = "gh", timeout: int = 30,
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        [gh_bin, "api", "repos/{owner}/{repo}", "--method", "PATCH",
+         "-F", f"allow_auto_merge={'true' if allow else 'false'}"],
+        cwd=str(project_root), capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def _diff_buckets(diffs: List[Dict[str, Any]]) -> Dict[str, bool]:
+    """Which of the three independent write surfaces a diff list touches."""
+    buckets = {"protection": False, "required_signatures": False, "repo.allow_auto_merge": False}
+    for d in diffs:
+        field = d["field"]
+        if field == "required_signatures":
+            buckets["required_signatures"] = True
+        elif field == "repo.allow_auto_merge":
+            buckets["repo.allow_auto_merge"] = True
+        elif field == "rulesets":
+            continue  # checked, never written — see module docstring
+        else:
+            buckets["protection"] = True
+    return buckets
+
+
+def _emit_apply_receipt(
+    *, before: Dict[str, Any], after: Dict[str, Any], reason: Optional[str], applied: bool,
+    receipts_file: Optional[str] = None,
+) -> Dict[str, Any]:
+    return emit_governance_receipt(
+        "branch_protection_applied",
+        receipt_kind="state_mutation",
+        status="success",
+        terminal="T0",
+        source="apply_branch_protection",
+        receipts_file=receipts_file,
+        before=before,
+        after=after,
+        applied=applied,
+        weaken_reason=reason,
+    )
+
+
+def run_apply(
+    *,
+    yaml_path: Path,
+    project_root: Path,
+    branch: str = DEFAULT_BRANCH,
+    dry_run: bool = False,
+    allow_weaken_reason: Optional[str] = None,
+    gh_bin: str = "gh",
+    receipts_file: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Apply ``yaml_path`` to ``branch``'s live protection. Returns a result
+    dict with at minimum ``verdict`` (``"OK"``, ``"DRY-RUN"``, ``"REFUSED"``,
+    or ``"ERROR"``) and ``diffs``.
+    """
+    config = load_protection_config(yaml_path)
+    yaml_norm = to_normalized_dict(config)
+    live_norm = fetch_live_protection(project_root, branch=branch, gh_bin=gh_bin)
+    diffs = compare(live_norm, yaml_norm)
+    weakening, weak_fields = is_weakening(live_norm, yaml_norm) if diffs else (False, [])
+    payload = build_put_payload(config)
+
+    if dry_run:
+        return {
+            "verdict": "DRY-RUN", "applied": False, "changed": bool(diffs),
+            "payload": payload, "diffs": diffs, "weak_fields": weak_fields,
+        }
+
+    if not diffs:
+        _emit_apply_receipt(
+            before=live_norm, after=live_norm, reason=None, applied=False, receipts_file=receipts_file,
+        )
+        return {
+            "verdict": "OK", "applied": False, "changed": False,
+            "message": "nul wijzigingen: live branch-protection komt al overeen met de YAML",
+            "diffs": [],
+        }
+
+    reason: Optional[str] = None
+    if weakening:
+        reason = (allow_weaken_reason or "").strip()
+        if not reason:
+            return {
+                "verdict": "REFUSED", "applied": False, "changed": True,
+                "message": "verzwakking geweigerd zonder --allow-weaken: " + ", ".join(weak_fields),
+                "diffs": diffs, "weak_fields": weak_fields,
+            }
+
+    buckets = _diff_buckets(diffs)
+    calls: List[str] = []
+
+    if buckets["protection"]:
+        proc = _put_protection(project_root, branch, payload, gh_bin=gh_bin)
+        if proc.returncode != 0:
+            return {
+                "verdict": "ERROR", "applied": False, "diffs": diffs,
+                "message": f"PUT protection faalde: {(proc.stderr or '').strip()[:300]}",
+            }
+        calls.append("protection")
+
+    if buckets["required_signatures"]:
+        proc = _patch_required_signatures(project_root, branch, config.required_signatures, gh_bin=gh_bin)
+        if proc.returncode != 0:
+            return {
+                "verdict": "ERROR", "applied": bool(calls), "diffs": diffs,
+                "message": f"required_signatures faalde: {(proc.stderr or '').strip()[:300]}",
+            }
+        calls.append("required_signatures")
+
+    if buckets["repo.allow_auto_merge"]:
+        proc = _patch_repo_auto_merge(project_root, config.allow_auto_merge, gh_bin=gh_bin)
+        if proc.returncode != 0:
+            return {
+                "verdict": "ERROR", "applied": bool(calls), "diffs": diffs,
+                "message": f"repo.allow_auto_merge faalde: {(proc.stderr or '').strip()[:300]}",
+            }
+        calls.append("repo.allow_auto_merge")
+
+    _emit_apply_receipt(before=live_norm, after=yaml_norm, reason=reason, applied=True, receipts_file=receipts_file)
+
+    message = f"toegepast: {', '.join(calls) if calls else 'geen schrijfacties'}"
+    if reason:
+        message += f" (OVERRIDE: {reason})"
+    return {
+        "verdict": "OK", "applied": True, "changed": True, "message": message,
+        "diffs": diffs, "weak_fields": weak_fields, "calls": calls,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="apply_branch_protection",
+        description="Apply scripts/forge/branch_protection.yaml to a branch's live protection",
+    )
+    parser.add_argument("--yaml-path", default=str(DEFAULT_YAML_PATH))
+    parser.add_argument("--project-root", default=str(SCRIPTS_DIR.parent))
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--allow-weaken", default=None,
+        help="Accept an apply that weakens live protection, with this required reason "
+             "(empty is refused).",
+    )
+    parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        result = run_apply(
+            yaml_path=Path(args.yaml_path),
+            project_root=Path(args.project_root),
+            branch=args.branch,
+            dry_run=args.dry_run,
+            allow_weaken_reason=args.allow_weaken,
+            gh_bin=args.gh_bin,
+        )
+    except (ProtectionConfigError, ProtectionDriftError) as exc:
+        print(f"FOUT: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    elif result["verdict"] == "DRY-RUN":
+        print(json.dumps(result["payload"], indent=2))
+        if result["weak_fields"]:
+            print(f"[dry-run] zou een verzwakking zijn zonder --allow-weaken: {', '.join(result['weak_fields'])}", file=sys.stderr)
+    else:
+        print(result.get("message", result["verdict"]))
+
+    return 0 if result["verdict"] in ("OK", "DRY-RUN") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forge/apply_branch_protection.py
+++ b/scripts/forge/apply_branch_protection.py
@@ -27,9 +27,13 @@ makes for a PR's own YAML edit, applied here at write time instead of at
 merge time. ``--dry-run`` never writes regardless, so it is not gated by
 this refusal: it always prints the built object.
 
-Every non-dry-run invocation writes a receipt (before/after normalized
-state, the weaken reason if one was used) via ``governance_receipts`` — see
-``_emit_apply_receipt``.
+Every non-dry-run invocation writes a receipt via ``governance_receipts``
+from a ``finally``, not from the success path: the runs that most need a
+trace are the ones that do NOT reach the end — a PUT that lands followed by
+a ``required_signatures`` call that fails leaves main mutated, and a refused
+weakening is the record of someone trying. The receipt carries the calls
+that actually ran, the ones that never did, the verdict, the diffed fields
+and the weaken reason. See ``_emit_apply_receipt``.
 
 The FIRST apply against the real repo is an operator step, not something
 this dispatch runs automatically (see the dispatch report's Open Items):
@@ -58,6 +62,7 @@ from forge_protection_drift import (  # noqa: E402
     ProtectionConfig,
     ProtectionConfigError,
     ProtectionDriftError,
+    bypass_allowances_to_api_object,
     compare,
     fetch_live_protection,
     is_weakening,
@@ -77,18 +82,28 @@ def build_put_payload(config: ProtectionConfig) -> Dict[str, Any]:
     whole object, so every field the YAML tracks is always sent, not just
     the ones that changed.
     """
+    reviews: Optional[Dict[str, Any]] = None
+    if config.required_pull_request_reviews_present:
+        reviews = {
+            "dismiss_stale_reviews": config.dismiss_stale_reviews,
+            "require_code_owner_reviews": config.require_code_owner_reviews,
+            "require_last_push_approval": config.require_last_push_approval,
+            "required_approving_review_count": config.required_approving_review_count,
+        }
+        # Only sent when the YAML grants one. The PUT replaces the whole
+        # object, so an omitted key clears any grant living on the branch —
+        # which is exactly what a YAML that stays silent about bypasses means.
+        if config.bypass_pull_request_allowances:
+            reviews["bypass_pull_request_allowances"] = bypass_allowances_to_api_object(
+                config.bypass_pull_request_allowances
+            )
     return {
         "required_status_checks": {
             "strict": config.strict,
             "checks": [{"context": c.context, "app_id": c.app_id} for c in config.checks],
         },
         "enforce_admins": config.enforce_admins,
-        "required_pull_request_reviews": {
-            "dismiss_stale_reviews": config.dismiss_stale_reviews,
-            "require_code_owner_reviews": config.require_code_owner_reviews,
-            "require_last_push_approval": config.require_last_push_approval,
-            "required_approving_review_count": config.required_approving_review_count,
-        },
+        "required_pull_request_reviews": reviews,
         "restrictions": None,
         "required_linear_history": config.required_linear_history,
         "allow_force_pushes": config.allow_force_pushes,
@@ -155,20 +170,46 @@ def _diff_buckets(diffs: List[Dict[str, Any]]) -> Dict[str, bool]:
     return buckets
 
 
+#: The three write surfaces, in the order ``run_apply`` fires them. Used to
+#: report which ones a half-finished apply never reached.
+_WRITE_SURFACES = ("protection", "required_signatures", "repo.allow_auto_merge")
+
+_RECEIPT_STATUS_BY_VERDICT = {"OK": "success", "REFUSED": "blocked"}
+
+
 def _emit_apply_receipt(
-    *, before: Dict[str, Any], after: Dict[str, Any], reason: Optional[str], applied: bool,
-    receipts_file: Optional[str] = None,
+    *, before: Dict[str, Any], after: Optional[Dict[str, Any]], reason: Optional[str],
+    applied: bool, verdict: str, calls: List[str], pending_calls: List[str],
+    diffs: List[Dict[str, Any]], weak_fields: List[str], receipts_file: Optional[str] = None,
 ) -> Dict[str, Any]:
+    """The trace for ONE apply attempt, whatever became of it.
+
+    ``after`` is the resulting state only where that is a claim this function
+    can stand behind: the YAML on a completed apply, the untouched live state
+    on a no-op or a refusal, and ``None`` on anything partial or failed —
+    a half-applied branch is in a state nobody has read back, and saying
+    "after = the YAML" there would put a mutation in the ledger that never
+    happened.
+    """
     return emit_governance_receipt(
         "branch_protection_applied",
         receipt_kind="state_mutation",
-        status="success",
+        status=_RECEIPT_STATUS_BY_VERDICT.get(verdict, "failure"),
         terminal="T0",
         source="apply_branch_protection",
         receipts_file=receipts_file,
         before=before,
         after=after,
         applied=applied,
+        partial=applied and verdict != "OK",
+        # NOT "verdict": append_receipt enriches every receipt with its own
+        # `verdict` object (decision/reason), which would silently overwrite
+        # ours -- measured on this file's own tests.
+        apply_verdict=verdict,
+        calls=calls,
+        pending_calls=pending_calls,
+        diff_fields=sorted({d["field"] for d in diffs}),
+        weak_fields=weak_fields,
         weaken_reason=reason,
     )
 
@@ -200,65 +241,94 @@ def run_apply(
             "payload": payload, "diffs": diffs, "weak_fields": weak_fields,
         }
 
-    if not diffs:
-        _emit_apply_receipt(
-            before=live_norm, after=live_norm, reason=None, applied=False, receipts_file=receipts_file,
-        )
-        return {
-            "verdict": "OK", "applied": False, "changed": False,
-            "message": "nul wijzigingen: live branch-protection komt al overeen met de YAML",
-            "diffs": [],
-        }
-
-    reason: Optional[str] = None
-    if weakening:
-        reason = (allow_weaken_reason or "").strip()
-        if not reason:
-            return {
-                "verdict": "REFUSED", "applied": False, "changed": True,
-                "message": "verzwakking geweigerd zonder --allow-weaken: " + ", ".join(weak_fields),
-                "diffs": diffs, "weak_fields": weak_fields,
-            }
-
-    buckets = _diff_buckets(diffs)
+    # Everything from here on can mutate live protection, so everything from
+    # here on is inside the try: the receipt is written in the finally, from
+    # the calls that actually ran. Returning before writing it — which is
+    # what a failing second call used to do — leaves a mutated branch and a
+    # ledger that never heard about it.
     calls: List[str] = []
-
-    if buckets["protection"]:
-        proc = _put_protection(project_root, branch, payload, gh_bin=gh_bin)
-        if proc.returncode != 0:
-            return {
-                "verdict": "ERROR", "applied": False, "diffs": diffs,
-                "message": f"PUT protection faalde: {(proc.stderr or '').strip()[:300]}",
+    pending: List[str] = []
+    reason: Optional[str] = None
+    outcome: Dict[str, Any] = {}
+    try:
+        if not diffs:
+            outcome = {
+                "verdict": "OK", "applied": False, "changed": False,
+                "message": "nul wijzigingen: live branch-protection komt al overeen met de YAML",
+                "diffs": [],
             }
-        calls.append("protection")
+            return outcome
 
-    if buckets["required_signatures"]:
-        proc = _patch_required_signatures(project_root, branch, config.required_signatures, gh_bin=gh_bin)
-        if proc.returncode != 0:
-            return {
-                "verdict": "ERROR", "applied": bool(calls), "diffs": diffs,
-                "message": f"required_signatures faalde: {(proc.stderr or '').strip()[:300]}",
-            }
-        calls.append("required_signatures")
+        if weakening:
+            reason = (allow_weaken_reason or "").strip()
+            if not reason:
+                outcome = {
+                    "verdict": "REFUSED", "applied": False, "changed": True,
+                    "message": "verzwakking geweigerd zonder --allow-weaken: " + ", ".join(weak_fields),
+                    "diffs": diffs, "weak_fields": weak_fields,
+                }
+                return outcome
 
-    if buckets["repo.allow_auto_merge"]:
-        proc = _patch_repo_auto_merge(project_root, config.allow_auto_merge, gh_bin=gh_bin)
-        if proc.returncode != 0:
-            return {
-                "verdict": "ERROR", "applied": bool(calls), "diffs": diffs,
-                "message": f"repo.allow_auto_merge faalde: {(proc.stderr or '').strip()[:300]}",
-            }
-        calls.append("repo.allow_auto_merge")
+        buckets = _diff_buckets(diffs)
+        pending = [surface for surface in _WRITE_SURFACES if buckets[surface]]
 
-    _emit_apply_receipt(before=live_norm, after=yaml_norm, reason=reason, applied=True, receipts_file=receipts_file)
+        if buckets["protection"]:
+            proc = _put_protection(project_root, branch, payload, gh_bin=gh_bin)
+            if proc.returncode != 0:
+                outcome = {
+                    "verdict": "ERROR", "applied": False, "diffs": diffs,
+                    "message": f"PUT protection faalde: {(proc.stderr or '').strip()[:300]}",
+                }
+                return outcome
+            calls.append("protection")
+            pending.remove("protection")
 
-    message = f"toegepast: {', '.join(calls) if calls else 'geen schrijfacties'}"
-    if reason:
-        message += f" (OVERRIDE: {reason})"
-    return {
-        "verdict": "OK", "applied": True, "changed": True, "message": message,
-        "diffs": diffs, "weak_fields": weak_fields, "calls": calls,
-    }
+        if buckets["required_signatures"]:
+            proc = _patch_required_signatures(project_root, branch, config.required_signatures, gh_bin=gh_bin)
+            if proc.returncode != 0:
+                outcome = {
+                    "verdict": "ERROR", "applied": bool(calls), "diffs": diffs,
+                    "message": f"required_signatures faalde: {(proc.stderr or '').strip()[:300]}",
+                }
+                return outcome
+            calls.append("required_signatures")
+            pending.remove("required_signatures")
+
+        if buckets["repo.allow_auto_merge"]:
+            proc = _patch_repo_auto_merge(project_root, config.allow_auto_merge, gh_bin=gh_bin)
+            if proc.returncode != 0:
+                outcome = {
+                    "verdict": "ERROR", "applied": bool(calls), "diffs": diffs,
+                    "message": f"repo.allow_auto_merge faalde: {(proc.stderr or '').strip()[:300]}",
+                }
+                return outcome
+            calls.append("repo.allow_auto_merge")
+            pending.remove("repo.allow_auto_merge")
+
+        message = f"toegepast: {', '.join(calls) if calls else 'geen schrijfacties'}"
+        if reason:
+            message += f" (OVERRIDE: {reason})"
+        outcome = {
+            "verdict": "OK", "applied": True, "changed": True, "message": message,
+            "diffs": diffs, "weak_fields": weak_fields, "calls": calls,
+        }
+        return outcome
+    finally:
+        verdict = str(outcome.get("verdict") or "EXCEPTION")
+        if verdict == "OK":
+            after: Optional[Dict[str, Any]] = yaml_norm if calls else live_norm
+        elif verdict == "REFUSED":
+            after = live_norm
+        else:
+            after = None
+        try:
+            _emit_apply_receipt(
+                before=live_norm, after=after, reason=reason, applied=bool(calls),
+                verdict=verdict, calls=list(calls), pending_calls=list(pending),
+                diffs=diffs, weak_fields=list(weak_fields), receipts_file=receipts_file,
+            )
+        except Exception as exc:  # receipt failure must not mask the outcome
+            print(f"WAARSCHUWING: apply-receipt niet geschreven: {exc}", file=sys.stderr)
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/scripts/forge/branch_protection.yaml
+++ b/scripts/forge/branch_protection.yaml
@@ -1,0 +1,72 @@
+# Golf B, B1: canonical branch-protection configuration for `main`.
+#
+# Applied via `python3 scripts/forge/apply_branch_protection.py` (the first
+# apply is an operator step — see that script's docstring). Drift-checked by
+# `scripts/pr_merge.py`'s merge preflight and by `vnx doctor`
+# (`check_branch_protection_drift` in scripts/vnx_doctor.py). Measured live
+# via `gh api repos/{owner}/{repo}/branches/main/protection` (+
+# `.../required_signatures`, `repos/{owner}/{repo}`, `.../rulesets`) on
+# 2026-09-07 — see the dispatch report for the exact commands and output.
+#
+# Do not hand-edit the checks[] list without also updating the workflow that
+# produces the matching context name in .github/workflows/ — this file and
+# the workflow must describe the same context names, or CI and branch
+# protection silently diverge (see scripts/lib/ci_contexts.py's docstring
+# for what that divergence looks like in practice: PR #1691).
+branch: main
+
+required_status_checks:
+  strict: false
+  checks:
+    - {context: "Profile A (doctor + core tests)", app_id: 15368}
+    - {context: "Profile B (snapshot integration)", app_id: 15368}
+    - {context: "Profile C (adoption smoke tests)", app_id: 15368}
+    - {context: "Profile D (pip install smoke)", app_id: 15368}
+    - {context: "ADR-003: No Anthropic SDK Imports", app_id: 15368}
+    - {context: "Anchor Immutability Check", app_id: 15368}
+    - {context: "Dashboard TS Lint (fixture-gate + typecheck)", app_id: 15368}
+    - {context: "Dispatch-ID Slug-Match Gate", app_id: 15368}
+    - {context: "docs/core/SUBSYSTEMS.md matches the live registry", app_id: 15368}
+    - {context: "Lint Patterns (silent-except + atomic-write)", app_id: 15368}
+    - {context: "Repo-local state-pin gate (#1043 footgun)", app_id: 15368}
+    - {context: "Trace Token Validation", app_id: 15368}
+    - {context: "secret scan (gitleaks)", app_id: 15368}
+    - {context: "vnx doctor smoke", app_id: 15368}
+
+# B3 will add "vnx-gate/review" here once the review-gate GitHub App exists.
+# Ignored by both apply_branch_protection.py and forge_protection_drift.py —
+# an entry here is a future obligation, not a current requirement. The schema
+# still refuses a vnx-gate/* entry placed directly in checks[] above without a
+# bound app_id (null or the GitHub "any app" sentinel -1): an unbound
+# vnx-gate/* check would let any app satisfy it.
+pending_checks: []
+
+required_pull_request_reviews:
+  required_approving_review_count: 0
+  dismiss_stale_reviews: false
+  require_code_owner_reviews: false
+  require_last_push_approval: false
+
+enforce_admins: true
+required_signatures: false
+required_linear_history: false
+allow_force_pushes: false
+allow_deletions: false
+allow_fork_syncing: false
+block_creations: false
+lock_branch: false
+required_conversation_resolution: false
+
+# GitHub omits this key entirely from a GET when there is no restriction
+# object; the PUT endpoint requires it as an explicit `null` to mean "no
+# push restrictions". Kept as a required field (not optional) so a future
+# editor cannot drop it silently — apply_branch_protection.py never writes
+# anything else here.
+restrictions: null
+
+repo:
+  allow_auto_merge: false
+
+# Checked, never applied — apply_branch_protection.py never writes rulesets.
+# GET /repos/{owner}/{repo}/rulesets returned [] when this was measured.
+rulesets: []

--- a/scripts/lib/forge_protection_drift.py
+++ b/scripts/lib/forge_protection_drift.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""Branch-protection config parsing, live-state fetch, and drift/weaken comparison
+(Golf B, B1).
+
+``PUT /repos/{owner}/{repo}/branches/{branch}/protection`` replaces the WHOLE
+protection object: any field the caller omits falls back to its GitHub
+default, silently. Anything this repo does not track in
+``scripts/forge/branch_protection.yaml`` and re-apply explicitly can
+therefore be reset by an unrelated apply. So the YAML is a complete
+declaration, not a patch, and every write in ``apply_branch_protection.py``
+sends the full built object rather than a partial one.
+
+Two orthogonal comparisons live here, both built on the SAME field-level
+diff engine (:func:`compare`) so they can never drift apart from each other:
+
+  ``compare(a, b)``     lists every field where ``a`` and ``b`` disagree.
+                         Direction-agnostic — used both for "is live drifted
+                         from the YAML" (doctor, the merge-door's main-vs-live
+                         check) and as the diff source :func:`is_weakening`
+                         classifies.
+  ``is_weakening(old, new)``
+                         Classifies each ``compare(old, new)`` diff by field
+                         polarity (a missing check, a protective boolean
+                         flipped off, a review count lowered, auto-merge
+                         turned on, ...) and reports which of those diffs
+                         make ``new`` a WEAKER configuration than ``old``.
+                         Used by ``apply_branch_protection.py`` (old=live,
+                         new=YAML) and by ``pr_merge.py``'s preflight
+                         (old=main's YAML, new=the PR's YAML).
+
+Fail-closed throughout: an unreadable/unparseable live-state read raises
+:class:`ProtectionDriftError`, and a YAML that violates the schema raises
+:class:`ProtectionConfigError`. Neither degrades to "nothing required" — a
+caller that cannot read the state must refuse, not pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+import yaml
+
+from ci_contexts import ANY_APP_ID, RequiredCheck
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Repo-relative path to the canonical config, used both as the default local
+#: path and as the path queried through the GitHub contents API.
+PROTECTION_YAML_RELATIVE_PATH = "scripts/forge/branch_protection.yaml"
+
+VNX_GATE_PREFIX = "vnx-gate/"
+
+_KNOWN_TOP_LEVEL_FIELDS = frozenset({
+    "branch", "required_status_checks", "pending_checks",
+    "required_pull_request_reviews", "enforce_admins", "required_signatures",
+    "required_linear_history", "allow_force_pushes", "allow_deletions",
+    "allow_fork_syncing", "block_creations", "lock_branch",
+    "required_conversation_resolution", "restrictions", "repo", "rulesets",
+})
+_KNOWN_RSC_FIELDS = frozenset({"strict", "checks"})
+_KNOWN_CHECK_FIELDS = frozenset({"context", "app_id"})
+_KNOWN_PPR_FIELDS = frozenset({
+    "required_approving_review_count", "dismiss_stale_reviews",
+    "require_code_owner_reviews", "require_last_push_approval",
+})
+_KNOWN_REPO_FIELDS = frozenset({"allow_auto_merge"})
+
+_BOOL_TOP_LEVEL_FIELDS = (
+    "enforce_admins", "required_signatures", "required_linear_history",
+    "allow_force_pushes", "allow_deletions", "allow_fork_syncing",
+    "block_creations", "lock_branch", "required_conversation_resolution",
+)
+
+
+class ProtectionConfigError(ValueError):
+    """``branch_protection.yaml`` (or a ref's copy of it) violates the schema.
+
+    Raised, never degraded to a partial read: an under-specified or
+    malformed protection config must never be treated as "nothing required".
+    """
+
+
+class ProtectionDriftError(RuntimeError):
+    """Live branch-protection state could not be read. Raised, never
+    swallowed into an empty/default result — an unreadable live state must
+    block, not pass as "no drift found"."""
+
+
+# ---------------------------------------------------------------------------
+# Config model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProtectionConfig:
+    branch: str
+    strict: bool
+    checks: Tuple[RequiredCheck, ...]
+    pending_checks: Tuple[str, ...]
+    required_approving_review_count: int
+    dismiss_stale_reviews: bool
+    require_code_owner_reviews: bool
+    require_last_push_approval: bool
+    enforce_admins: bool
+    required_signatures: bool
+    required_linear_history: bool
+    allow_force_pushes: bool
+    allow_deletions: bool
+    allow_fork_syncing: bool
+    block_creations: bool
+    lock_branch: bool
+    required_conversation_resolution: bool
+    allow_auto_merge: bool
+    rulesets: Tuple[str, ...]
+
+
+def _require_object_fields(obj: Any, known: frozenset, where: str) -> None:
+    if not isinstance(obj, dict):
+        raise ProtectionConfigError(f"{where} moet een object zijn, kreeg {type(obj).__name__}")
+    missing = known - set(obj)
+    if missing:
+        raise ProtectionConfigError(f"{where} mist verplichte velden: {sorted(missing)}")
+    unknown = set(obj) - known
+    if unknown:
+        raise ProtectionConfigError(f"{where} heeft onbekende velden: {sorted(unknown)}")
+
+
+def _require_bool(obj: Dict[str, Any], field: str, where: str) -> bool:
+    value = obj[field]
+    if not isinstance(value, bool):
+        raise ProtectionConfigError(f"{where}.{field} moet een boolean zijn, kreeg {type(value).__name__}")
+    return value
+
+
+def parse_protection_config(raw_text: str) -> ProtectionConfig:
+    """Parse + validate ``branch_protection.yaml`` text. Raises
+    :class:`ProtectionConfigError` on any schema violation — see module
+    docstring: an unreadable config must never be treated as "nothing
+    required"."""
+    try:
+        doc = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise ProtectionConfigError(f"branch_protection.yaml is geen geldige YAML: {exc}") from exc
+    _require_object_fields(doc, _KNOWN_TOP_LEVEL_FIELDS, "branch_protection.yaml")
+
+    if not isinstance(doc["branch"], str) or not doc["branch"]:
+        raise ProtectionConfigError("branch moet een niet-lege string zijn")
+
+    rsc = doc["required_status_checks"]
+    _require_object_fields(rsc, _KNOWN_RSC_FIELDS, "required_status_checks")
+    strict = _require_bool(rsc, "strict", "required_status_checks")
+
+    raw_checks = rsc["checks"]
+    if not isinstance(raw_checks, list) or not raw_checks:
+        raise ProtectionConfigError("required_status_checks.checks moet een niet-lege lijst zijn")
+
+    checks: List[RequiredCheck] = []
+    seen_names: set = set()
+    for index, entry in enumerate(raw_checks):
+        where = f"required_status_checks.checks[{index}]"
+        _require_object_fields(entry, _KNOWN_CHECK_FIELDS, where)
+        context = entry["context"]
+        if not isinstance(context, str) or not context:
+            raise ProtectionConfigError(f"{where}.context moet een niet-lege string zijn")
+        if context in seen_names:
+            raise ProtectionConfigError(f"required_status_checks.checks bevat '{context}' dubbel")
+        seen_names.add(context)
+        app_id = entry["app_id"]
+        if app_id is not None and not isinstance(app_id, int):
+            raise ProtectionConfigError(f"{where}.app_id moet een integer of null zijn")
+        if context.startswith(VNX_GATE_PREFIX) and (app_id is None or app_id == ANY_APP_ID):
+            raise ProtectionConfigError(
+                f"{where} ('{context}') is een vnx-gate/*-check zonder gebonden app_id "
+                "(null of de 'elke app'-sentinel -1): dat zou elke app deze status laten zetten"
+            )
+        checks.append(RequiredCheck(context, None if app_id == ANY_APP_ID else app_id))
+
+    pending_raw = doc["pending_checks"]
+    if not isinstance(pending_raw, list) or not all(isinstance(p, str) for p in pending_raw):
+        raise ProtectionConfigError("pending_checks moet een lijst van strings zijn")
+
+    ppr = doc["required_pull_request_reviews"]
+    _require_object_fields(ppr, _KNOWN_PPR_FIELDS, "required_pull_request_reviews")
+    review_count = ppr["required_approving_review_count"]
+    if not isinstance(review_count, int) or isinstance(review_count, bool) or review_count < 0:
+        raise ProtectionConfigError(
+            "required_pull_request_reviews.required_approving_review_count moet een niet-negatieve integer zijn"
+        )
+    dismiss_stale = _require_bool(ppr, "dismiss_stale_reviews", "required_pull_request_reviews")
+    require_code_owner = _require_bool(ppr, "require_code_owner_reviews", "required_pull_request_reviews")
+    require_last_push = _require_bool(ppr, "require_last_push_approval", "required_pull_request_reviews")
+
+    bool_values = {f: _require_bool(doc, f, "branch_protection.yaml") for f in _BOOL_TOP_LEVEL_FIELDS}
+
+    if doc["restrictions"] is not None:
+        raise ProtectionConfigError("restrictions moet null zijn (push-restricties worden hier niet gemodelleerd)")
+
+    repo_obj = doc["repo"]
+    _require_object_fields(repo_obj, _KNOWN_REPO_FIELDS, "repo")
+    allow_auto_merge = _require_bool(repo_obj, "allow_auto_merge", "repo")
+
+    rulesets_raw = doc["rulesets"]
+    if not isinstance(rulesets_raw, list) or not all(isinstance(r, str) for r in rulesets_raw):
+        raise ProtectionConfigError("rulesets moet een lijst van strings zijn")
+
+    return ProtectionConfig(
+        branch=doc["branch"],
+        strict=strict,
+        checks=tuple(checks),
+        pending_checks=tuple(pending_raw),
+        required_approving_review_count=review_count,
+        dismiss_stale_reviews=dismiss_stale,
+        require_code_owner_reviews=require_code_owner,
+        require_last_push_approval=require_last_push,
+        enforce_admins=bool_values["enforce_admins"],
+        required_signatures=bool_values["required_signatures"],
+        required_linear_history=bool_values["required_linear_history"],
+        allow_force_pushes=bool_values["allow_force_pushes"],
+        allow_deletions=bool_values["allow_deletions"],
+        allow_fork_syncing=bool_values["allow_fork_syncing"],
+        block_creations=bool_values["block_creations"],
+        lock_branch=bool_values["lock_branch"],
+        required_conversation_resolution=bool_values["required_conversation_resolution"],
+        allow_auto_merge=allow_auto_merge,
+        rulesets=tuple(rulesets_raw),
+    )
+
+
+def load_protection_config(path: Path) -> ProtectionConfig:
+    return parse_protection_config(Path(path).read_text(encoding="utf-8"))
+
+
+def to_normalized_dict(config: ProtectionConfig) -> Dict[str, Any]:
+    """The same JSON-comparable shape :func:`fetch_live_protection` returns,
+    so :func:`compare` can diff a parsed YAML against live state (or another
+    parsed YAML) without caring which side is which."""
+    return {
+        "required_status_checks": {
+            "strict": config.strict,
+            "checks": [{"context": c.context, "app_id": c.app_id} for c in config.checks],
+        },
+        "required_pull_request_reviews": {
+            "required_approving_review_count": config.required_approving_review_count,
+            "dismiss_stale_reviews": config.dismiss_stale_reviews,
+            "require_code_owner_reviews": config.require_code_owner_reviews,
+            "require_last_push_approval": config.require_last_push_approval,
+        },
+        "enforce_admins": config.enforce_admins,
+        "required_signatures": config.required_signatures,
+        "required_linear_history": config.required_linear_history,
+        "allow_force_pushes": config.allow_force_pushes,
+        "allow_deletions": config.allow_deletions,
+        "allow_fork_syncing": config.allow_fork_syncing,
+        "block_creations": config.block_creations,
+        "lock_branch": config.lock_branch,
+        "required_conversation_resolution": config.required_conversation_resolution,
+        "restrictions": None,
+        "repo": {"allow_auto_merge": config.allow_auto_merge},
+        "rulesets": sorted(config.rulesets),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live-state fetch (gh api)
+# ---------------------------------------------------------------------------
+
+
+def _gh_json(argv: List[str], project_root: Path, timeout: int) -> Any:
+    try:
+        proc = subprocess.run(
+            argv, cwd=str(project_root), capture_output=True, text=True, timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise ProtectionDriftError(f"gh CLI niet beschikbaar: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ProtectionDriftError(f"{' '.join(argv)} liep vast na {timeout}s") from exc
+    if proc.returncode != 0:
+        raise ProtectionDriftError(
+            f"{' '.join(argv)} faalde (rc={proc.returncode}): {(proc.stderr or '').strip()[:200]}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ProtectionDriftError(f"{' '.join(argv)} gaf onparseerbare JSON: {exc}") from exc
+
+
+def fetch_live_protection(
+    project_root: Path, *, branch: str = "main", gh_bin: str = "gh", timeout: int = 20,
+) -> Dict[str, Any]:
+    """The live branch-protection + repo + rulesets state, normalized to the
+    same shape :func:`to_normalized_dict` produces from the YAML.
+
+    Three ``gh api`` calls: the branch protection object itself (which also
+    carries ``required_signatures.enabled`` inline — no separate read is
+    needed for that, only the WRITE side uses its own endpoint, see
+    ``apply_branch_protection.py``), the repo object (for
+    ``allow_auto_merge``), and the rulesets list. Raises
+    :class:`ProtectionDriftError` on any unreadable/unparseable response —
+    never returns a partial or default-filled result.
+    """
+    protection = _gh_json(
+        [gh_bin, "api", f"repos/{{owner}}/{{repo}}/branches/{branch}/protection"], project_root, timeout,
+    )
+    if not isinstance(protection, dict):
+        raise ProtectionDriftError(f"protection-antwoord is {type(protection).__name__}, verwacht een object")
+
+    repo_obj = _gh_json([gh_bin, "api", "repos/{owner}/{repo}"], project_root, timeout)
+    if not isinstance(repo_obj, dict):
+        raise ProtectionDriftError(f"repo-antwoord is {type(repo_obj).__name__}, verwacht een object")
+
+    rulesets = _gh_json([gh_bin, "api", "repos/{owner}/{repo}/rulesets"], project_root, timeout)
+    if not isinstance(rulesets, list):
+        raise ProtectionDriftError(f"rulesets-antwoord is {type(rulesets).__name__}, verwacht een lijst")
+
+    rsc = protection.get("required_status_checks") or {}
+    checks: List[Dict[str, Any]] = []
+    for entry in rsc.get("checks") or []:
+        if not isinstance(entry, dict):
+            continue
+        context = entry.get("context")
+        if not isinstance(context, str) or not context:
+            continue
+        app_id = entry.get("app_id")
+        checks.append({
+            "context": context,
+            "app_id": app_id if isinstance(app_id, int) and app_id != ANY_APP_ID else None,
+        })
+
+    ppr = protection.get("required_pull_request_reviews") or {}
+
+    def _enabled(field: str) -> bool:
+        block = protection.get(field)
+        return bool(block.get("enabled", False)) if isinstance(block, dict) else False
+
+    return {
+        "required_status_checks": {"strict": bool(rsc.get("strict", False)), "checks": checks},
+        "required_pull_request_reviews": {
+            "required_approving_review_count": int(ppr.get("required_approving_review_count", 0)),
+            "dismiss_stale_reviews": bool(ppr.get("dismiss_stale_reviews", False)),
+            "require_code_owner_reviews": bool(ppr.get("require_code_owner_reviews", False)),
+            "require_last_push_approval": bool(ppr.get("require_last_push_approval", False)),
+        },
+        "enforce_admins": _enabled("enforce_admins"),
+        "required_signatures": _enabled("required_signatures"),
+        "required_linear_history": _enabled("required_linear_history"),
+        "allow_force_pushes": _enabled("allow_force_pushes"),
+        "allow_deletions": _enabled("allow_deletions"),
+        "allow_fork_syncing": _enabled("allow_fork_syncing"),
+        "block_creations": _enabled("block_creations"),
+        "lock_branch": _enabled("lock_branch"),
+        "required_conversation_resolution": _enabled("required_conversation_resolution"),
+        "restrictions": protection.get("restrictions"),
+        "repo": {"allow_auto_merge": bool(repo_obj.get("allow_auto_merge", False))},
+        "rulesets": sorted(
+            r.get("name") for r in rulesets if isinstance(r, dict) and isinstance(r.get("name"), str)
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fetching a copy of the YAML at an arbitrary ref (contents API)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class YamlFetchResult:
+    """The result of fetching ``branch_protection.yaml`` at one git ref.
+
+    ``not_found`` is a NAMED case, distinct from ``error``: a 404 on exactly
+    the queried path means "this ref has no such file" (the bootstrap case
+    when queried against main, or "this PR deletes the file" when queried
+    against a PR head) — never conflated with an unreadable/unparseable
+    response, which is a fail-closed ``error`` instead.
+    """
+
+    text: Optional[str]
+    not_found: bool
+    error: Optional[str]
+
+
+_HTTP_404_MARKERS = ("HTTP 404", "Not Found (HTTP 404)")
+
+
+def fetch_yaml_from_ref(
+    project_root: Path,
+    ref: str,
+    path: str = PROTECTION_YAML_RELATIVE_PATH,
+    *,
+    gh_bin: str = "gh",
+    timeout: int = 20,
+) -> YamlFetchResult:
+    """Fetch ``path`` at ``ref`` via the GitHub contents API — never a local
+    ref (see ``merge_preflight_adr_check.py``'s docstring for why the door
+    never trusts a local ``origin/<ref>``: it is only as fresh as the last
+    incidental fetch, and the door itself never fetches).
+    """
+    encoded_ref = quote(ref, safe="")
+    try:
+        proc = subprocess.run(
+            [gh_bin, "api", f"repos/{{owner}}/{{repo}}/contents/{path}?ref={encoded_ref}"],
+            cwd=str(project_root), capture_output=True, text=True, timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        return YamlFetchResult(text=None, not_found=False, error=f"gh CLI niet beschikbaar: {exc}")
+    except subprocess.TimeoutExpired:
+        return YamlFetchResult(
+            text=None, not_found=False,
+            error=f"gh api contents/{path}?ref={ref} liep vast na {timeout}s",
+        )
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        if any(marker in stderr for marker in _HTTP_404_MARKERS):
+            return YamlFetchResult(text=None, not_found=True, error=None)
+        return YamlFetchResult(
+            text=None, not_found=False,
+            error=f"gh api contents/{path}?ref={ref} faalde (rc={proc.returncode}): {stderr[:200]}",
+        )
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return YamlFetchResult(text=None, not_found=False, error=f"onparseerbare JSON van contents-API: {exc}")
+
+    if not isinstance(payload, dict):
+        return YamlFetchResult(
+            text=None, not_found=False,
+            error=f"contents-antwoord is {type(payload).__name__}, verwacht een object",
+        )
+    content_b64 = payload.get("content")
+    if not isinstance(content_b64, str):
+        return YamlFetchResult(text=None, not_found=False, error="contents-antwoord mist 'content'-veld")
+    try:
+        text = base64.b64decode(content_b64).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        return YamlFetchResult(text=None, not_found=False, error=f"content niet te decoderen: {exc}")
+    return YamlFetchResult(text=text, not_found=False, error=None)
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+_ABSENT = object()
+
+#: Fields where True is the MORE-protective value: a diff going True -> False
+#: is a weakening. "strict uit" (required_status_checks.strict) is the one
+#: explicitly named in the dispatch alongside the general "a boolean going
+#: true to false" rule.
+_TRUE_IS_STRONGER = frozenset({
+    "required_status_checks.strict",
+    "enforce_admins",
+    "required_linear_history",
+    "required_conversation_resolution",
+    "required_signatures",
+    "block_creations",
+    "lock_branch",
+    "required_pull_request_reviews.dismiss_stale_reviews",
+    "required_pull_request_reviews.require_code_owner_reviews",
+    "required_pull_request_reviews.require_last_push_approval",
+})
+
+#: Fields where False is the MORE-protective value: a diff going False -> True
+#: is a weakening ("auto-merge aan" is the one explicitly named — it runs the
+#: opposite direction from the general true-to-false rule above).
+_FALSE_IS_STRONGER = frozenset({
+    "allow_force_pushes",
+    "allow_deletions",
+    "allow_fork_syncing",
+    "repo.allow_auto_merge",
+})
+
+
+def compare(a: Dict[str, Any], b: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """List every field where normalized states ``a`` and ``b`` disagree.
+
+    Direction-agnostic: this only reports WHAT differs, not whether ``b`` is
+    weaker or stronger than ``a`` — see :func:`is_weakening` for that
+    judgment, built on top of this same diff list (one function, two
+    callers: a direct drift check, and ``is_weakening``'s classifier).
+
+    Each diff is ``{"field": <dotted path>, "a": <value in a>, "b": <value in
+    b>}``; a ``required_status_checks.checks[<name>]`` diff additionally
+    carries ``a_present``/``b_present`` so a name-only add/remove (no app_id
+    on either side to compare) is still fully described.
+    """
+    diffs: List[Dict[str, Any]] = []
+
+    def scalar(field: str, av: Any, bv: Any) -> None:
+        if av != bv:
+            diffs.append({"field": field, "a": av, "b": bv})
+
+    a_rsc = a.get("required_status_checks") or {}
+    b_rsc = b.get("required_status_checks") or {}
+    scalar("required_status_checks.strict", a_rsc.get("strict"), b_rsc.get("strict"))
+
+    a_checks = {c["context"]: c.get("app_id") for c in (a_rsc.get("checks") or [])}
+    b_checks = {c["context"]: c.get("app_id") for c in (b_rsc.get("checks") or [])}
+    for name in sorted(set(a_checks) | set(b_checks)):
+        av = a_checks.get(name, _ABSENT)
+        bv = b_checks.get(name, _ABSENT)
+        if av != bv:
+            diffs.append({
+                "field": f"required_status_checks.checks[{name}]",
+                "a": None if av is _ABSENT else av,
+                "b": None if bv is _ABSENT else bv,
+                "a_present": av is not _ABSENT,
+                "b_present": bv is not _ABSENT,
+            })
+
+    a_ppr = a.get("required_pull_request_reviews") or {}
+    b_ppr = b.get("required_pull_request_reviews") or {}
+    for f in ("required_approving_review_count", "dismiss_stale_reviews",
+              "require_code_owner_reviews", "require_last_push_approval"):
+        scalar(f"required_pull_request_reviews.{f}", a_ppr.get(f), b_ppr.get(f))
+
+    for f in _BOOL_TOP_LEVEL_FIELDS:
+        scalar(f, a.get(f), b.get(f))
+    scalar("restrictions", a.get("restrictions"), b.get("restrictions"))
+
+    scalar(
+        "repo.allow_auto_merge",
+        (a.get("repo") or {}).get("allow_auto_merge"),
+        (b.get("repo") or {}).get("allow_auto_merge"),
+    )
+
+    a_rulesets = sorted(a.get("rulesets") or [])
+    b_rulesets = sorted(b.get("rulesets") or [])
+    if a_rulesets != b_rulesets:
+        diffs.append({"field": "rulesets", "a": a_rulesets, "b": b_rulesets})
+
+    return diffs
+
+
+def is_weakening(old: Dict[str, Any], new: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    """Is ``new`` a WEAKER branch-protection configuration than ``old``?
+
+    Built on :func:`compare`'s diff list (old=a, new=b), classified per
+    field: a required check present in ``old`` but missing from ``new``, a
+    protective boolean flipped off, the required review count lowered, or
+    ``allow_auto_merge`` turned on. Fields outside this vocabulary (e.g.
+    ``rulesets``, which this repo only ever checks and never writes) never
+    trigger a weakening verdict — see the module docstring's list of the
+    exact cases this covers.
+    """
+    weak_fields: List[str] = []
+    for diff in compare(old, new):
+        field = diff["field"]
+        if field.startswith("required_status_checks.checks["):
+            if diff["a_present"] and not diff["b_present"]:
+                weak_fields.append(field)
+            continue
+        if field == "required_pull_request_reviews.required_approving_review_count":
+            if diff["b"] < diff["a"]:
+                weak_fields.append(field)
+            continue
+        if field in _TRUE_IS_STRONGER and diff["a"] is True and diff["b"] is False:
+            weak_fields.append(field)
+            continue
+        if field in _FALSE_IS_STRONGER and diff["a"] is False and diff["b"] is True:
+            weak_fields.append(field)
+            continue
+    return (len(weak_fields) > 0, weak_fields)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _default_yaml_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "forge" / "branch_protection.yaml"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="forge_protection_drift",
+        description="Compare live branch protection to scripts/forge/branch_protection.yaml",
+    )
+    parser.add_argument("--yaml-path", default=str(_default_yaml_path()))
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_protection_config(Path(args.yaml_path))
+    except (ProtectionConfigError, OSError) as exc:
+        print(f"FOUT: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        live = fetch_live_protection(Path(args.project_root), branch=args.branch, gh_bin=args.gh_bin)
+    except ProtectionDriftError as exc:
+        print(f"FOUT: {exc}", file=sys.stderr)
+        return 1
+
+    diffs = compare(to_normalized_dict(config), live)
+    if args.json:
+        print(json.dumps(diffs, indent=2, default=str))
+    elif not diffs:
+        print(f"geen verschillen: branch-protection op {args.branch} komt overeen met {args.yaml_path}")
+    else:
+        for d in diffs:
+            print(f"DRIFT {d['field']}: yaml={d['a']!r} live={d['b']!r}")
+    return 0 if not diffs else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/forge_protection_drift.py
+++ b/scripts/lib/forge_protection_drift.py
@@ -72,7 +72,17 @@ _KNOWN_PPR_FIELDS = frozenset({
     "required_approving_review_count", "dismiss_stale_reviews",
     "require_code_owner_reviews", "require_last_push_approval",
 })
+#: Present in the PUT body and in a GET only once configured. Optional in the
+#: YAML (an absent key means "no bypass granted"), so a config written before
+#: this field was modelled keeps parsing — but it is COMPARED either way, so
+#: a grant appearing on live is drift against a YAML that stays silent.
+_OPTIONAL_PPR_FIELDS = frozenset({"bypass_pull_request_allowances"})
 _KNOWN_REPO_FIELDS = frozenset({"allow_auto_merge"})
+
+#: The three actor kinds a bypass allowance can name. Flattened to sorted
+#: ``"<kind>:<name>"`` strings so the live shape (objects carrying
+#: ``login``/``slug``) and the YAML shape (plain names) compare as equals.
+_BYPASS_KINDS = ("users", "teams", "apps")
 
 _BOOL_TOP_LEVEL_FIELDS = (
     "enforce_admins", "required_signatures", "required_linear_history",
@@ -106,10 +116,18 @@ class ProtectionConfig:
     strict: bool
     checks: Tuple[RequiredCheck, ...]
     pending_checks: Tuple[str, ...]
+    #: False when the YAML declares ``required_pull_request_reviews: null``,
+    #: i.e. "no pull-request requirement at all". Distinct from a present
+    #: block asking for zero approvals: GitHub OMITS the whole subobject from
+    #: a GET when the requirement is off (the same way it omits
+    #: ``restrictions`` when unset), so without this flag the strongest
+    #: setting in the object and its complete absence normalize identically.
+    required_pull_request_reviews_present: bool
     required_approving_review_count: int
     dismiss_stale_reviews: bool
     require_code_owner_reviews: bool
     require_last_push_approval: bool
+    bypass_pull_request_allowances: Tuple[str, ...]
     enforce_admins: bool
     required_signatures: bool
     required_linear_history: bool
@@ -123,13 +141,15 @@ class ProtectionConfig:
     rulesets: Tuple[str, ...]
 
 
-def _require_object_fields(obj: Any, known: frozenset, where: str) -> None:
+def _require_object_fields(
+    obj: Any, known: frozenset, where: str, *, optional: frozenset = frozenset(),
+) -> None:
     if not isinstance(obj, dict):
         raise ProtectionConfigError(f"{where} moet een object zijn, kreeg {type(obj).__name__}")
     missing = known - set(obj)
     if missing:
         raise ProtectionConfigError(f"{where} mist verplichte velden: {sorted(missing)}")
-    unknown = set(obj) - known
+    unknown = set(obj) - known - optional
     if unknown:
         raise ProtectionConfigError(f"{where} heeft onbekende velden: {sorted(unknown)}")
 
@@ -139,6 +159,63 @@ def _require_bool(obj: Dict[str, Any], field: str, where: str) -> bool:
     if not isinstance(value, bool):
         raise ProtectionConfigError(f"{where}.{field} moet een boolean zijn, kreeg {type(value).__name__}")
     return value
+
+
+def normalize_bypass_allowances(raw: Any) -> List[str]:
+    """A ``bypass_pull_request_allowances`` object flattened to sorted
+    ``"<kind>:<name>"`` strings.
+
+    Accepts both shapes it is fed: the live GET's objects (``{"users":
+    [{"login": "x"}]}``) and the YAML's plain names (``{"users": ["x"]}``).
+    Anything unrecognizable normalizes away rather than raising — the strict
+    side is :func:`_parse_bypass_allowances`, which validates the YAML at
+    parse time; a live response is not this repo's to validate, only to
+    compare.
+    """
+    if not isinstance(raw, dict):
+        return []
+    names: List[str] = []
+    for kind in _BYPASS_KINDS:
+        for entry in raw.get(kind) or []:
+            name: Any = entry
+            if isinstance(entry, dict):
+                name = entry.get("login") or entry.get("slug") or entry.get("name")
+            if isinstance(name, str) and name:
+                names.append(f"{kind}:{name}")
+    return sorted(set(names))
+
+
+def bypass_allowances_to_api_object(entries: Tuple[str, ...]) -> Dict[str, List[str]]:
+    """The inverse of :func:`normalize_bypass_allowances` for the PUT body."""
+    obj: Dict[str, List[str]] = {kind: [] for kind in _BYPASS_KINDS}
+    for entry in entries:
+        kind, _, name = entry.partition(":")
+        if kind in obj and name:
+            obj[kind].append(name)
+    return {kind: sorted(values) for kind, values in obj.items()}
+
+
+def _parse_bypass_allowances(raw: Any, where: str) -> Tuple[str, ...]:
+    """Strict YAML-side parse. Absent/null means "no bypass granted"."""
+    field = f"{where}.bypass_pull_request_allowances"
+    if raw is None:
+        return ()
+    if not isinstance(raw, dict):
+        raise ProtectionConfigError(
+            f"{field} moet een object zijn met users/teams/apps, kreeg {type(raw).__name__}"
+        )
+    unknown = set(raw) - set(_BYPASS_KINDS)
+    if unknown:
+        raise ProtectionConfigError(f"{field} heeft onbekende velden: {sorted(unknown)}")
+    names: List[str] = []
+    for kind in _BYPASS_KINDS:
+        values = raw.get(kind)
+        if values is None:
+            continue
+        if not isinstance(values, list) or not all(isinstance(v, str) and v for v in values):
+            raise ProtectionConfigError(f"{field}.{kind} moet een lijst van niet-lege strings zijn")
+        names.extend(f"{kind}:{v}" for v in values)
+    return tuple(sorted(set(names)))
 
 
 def parse_protection_config(raw_text: str) -> ProtectionConfig:
@@ -188,16 +265,31 @@ def parse_protection_config(raw_text: str) -> ProtectionConfig:
     if not isinstance(pending_raw, list) or not all(isinstance(p, str) for p in pending_raw):
         raise ProtectionConfigError("pending_checks moet een lijst van strings zijn")
 
+    # An explicit `null` here declares "no pull-request requirement at all",
+    # which is what GitHub reports by omitting the subobject entirely. The
+    # values below are then unused (to_normalized_dict emits None for the
+    # whole block, build_put_payload sends null) — they are not a default
+    # standing in for a missing declaration.
     ppr = doc["required_pull_request_reviews"]
-    _require_object_fields(ppr, _KNOWN_PPR_FIELDS, "required_pull_request_reviews")
-    review_count = ppr["required_approving_review_count"]
-    if not isinstance(review_count, int) or isinstance(review_count, bool) or review_count < 0:
-        raise ProtectionConfigError(
-            "required_pull_request_reviews.required_approving_review_count moet een niet-negatieve integer zijn"
+    ppr_present = ppr is not None
+    review_count = 0
+    dismiss_stale = require_code_owner = require_last_push = False
+    bypass_allowances: Tuple[str, ...] = ()
+    if ppr_present:
+        _require_object_fields(
+            ppr, _KNOWN_PPR_FIELDS, "required_pull_request_reviews", optional=_OPTIONAL_PPR_FIELDS,
         )
-    dismiss_stale = _require_bool(ppr, "dismiss_stale_reviews", "required_pull_request_reviews")
-    require_code_owner = _require_bool(ppr, "require_code_owner_reviews", "required_pull_request_reviews")
-    require_last_push = _require_bool(ppr, "require_last_push_approval", "required_pull_request_reviews")
+        review_count = ppr["required_approving_review_count"]
+        if not isinstance(review_count, int) or isinstance(review_count, bool) or review_count < 0:
+            raise ProtectionConfigError(
+                "required_pull_request_reviews.required_approving_review_count moet een niet-negatieve integer zijn"
+            )
+        dismiss_stale = _require_bool(ppr, "dismiss_stale_reviews", "required_pull_request_reviews")
+        require_code_owner = _require_bool(ppr, "require_code_owner_reviews", "required_pull_request_reviews")
+        require_last_push = _require_bool(ppr, "require_last_push_approval", "required_pull_request_reviews")
+        bypass_allowances = _parse_bypass_allowances(
+            ppr.get("bypass_pull_request_allowances"), "required_pull_request_reviews",
+        )
 
     bool_values = {f: _require_bool(doc, f, "branch_protection.yaml") for f in _BOOL_TOP_LEVEL_FIELDS}
 
@@ -217,10 +309,12 @@ def parse_protection_config(raw_text: str) -> ProtectionConfig:
         strict=strict,
         checks=tuple(checks),
         pending_checks=tuple(pending_raw),
+        required_pull_request_reviews_present=ppr_present,
         required_approving_review_count=review_count,
         dismiss_stale_reviews=dismiss_stale,
         require_code_owner_reviews=require_code_owner,
         require_last_push_approval=require_last_push,
+        bypass_pull_request_allowances=bypass_allowances,
         enforce_admins=bool_values["enforce_admins"],
         required_signatures=bool_values["required_signatures"],
         required_linear_history=bool_values["required_linear_history"],
@@ -248,12 +342,15 @@ def to_normalized_dict(config: ProtectionConfig) -> Dict[str, Any]:
             "strict": config.strict,
             "checks": [{"context": c.context, "app_id": c.app_id} for c in config.checks],
         },
-        "required_pull_request_reviews": {
+        # None, not a zero-filled object, when the YAML declares no
+        # pull-request requirement — see ProtectionConfig's field comment.
+        "required_pull_request_reviews": ({
             "required_approving_review_count": config.required_approving_review_count,
             "dismiss_stale_reviews": config.dismiss_stale_reviews,
             "require_code_owner_reviews": config.require_code_owner_reviews,
             "require_last_push_approval": config.require_last_push_approval,
-        },
+            "bypass_pull_request_allowances": list(config.bypass_pull_request_allowances),
+        } if config.required_pull_request_reviews_present else None),
         "enforce_admins": config.enforce_admins,
         "required_signatures": config.required_signatures,
         "required_linear_history": config.required_linear_history,
@@ -335,7 +432,22 @@ def fetch_live_protection(
             "app_id": app_id if isinstance(app_id, int) and app_id != ANY_APP_ID else None,
         })
 
-    ppr = protection.get("required_pull_request_reviews") or {}
+    # GitHub omits this subobject entirely when "Require a pull request
+    # before merging" is off — the same omission it makes for `restrictions`.
+    # Normalizing that absence into zeroes would make turning the PR
+    # requirement off produce no drift and no weakening at all.
+    raw_ppr = protection.get("required_pull_request_reviews")
+    ppr_norm: Optional[Dict[str, Any]] = None
+    if isinstance(raw_ppr, dict):
+        ppr_norm = {
+            "required_approving_review_count": int(raw_ppr.get("required_approving_review_count", 0)),
+            "dismiss_stale_reviews": bool(raw_ppr.get("dismiss_stale_reviews", False)),
+            "require_code_owner_reviews": bool(raw_ppr.get("require_code_owner_reviews", False)),
+            "require_last_push_approval": bool(raw_ppr.get("require_last_push_approval", False)),
+            "bypass_pull_request_allowances": normalize_bypass_allowances(
+                raw_ppr.get("bypass_pull_request_allowances")
+            ),
+        }
 
     def _enabled(field: str) -> bool:
         block = protection.get(field)
@@ -343,12 +455,7 @@ def fetch_live_protection(
 
     return {
         "required_status_checks": {"strict": bool(rsc.get("strict", False)), "checks": checks},
-        "required_pull_request_reviews": {
-            "required_approving_review_count": int(ppr.get("required_approving_review_count", 0)),
-            "dismiss_stale_reviews": bool(ppr.get("dismiss_stale_reviews", False)),
-            "require_code_owner_reviews": bool(ppr.get("require_code_owner_reviews", False)),
-            "require_last_push_approval": bool(ppr.get("require_last_push_approval", False)),
-        },
+        "required_pull_request_reviews": ppr_norm,
         "enforce_admins": _enabled("enforce_admins"),
         "required_signatures": _enabled("required_signatures"),
         "required_linear_history": _enabled("required_linear_history"),
@@ -376,10 +483,13 @@ class YamlFetchResult:
     """The result of fetching ``branch_protection.yaml`` at one git ref.
 
     ``not_found`` is a NAMED case, distinct from ``error``: a 404 on exactly
-    the queried path means "this ref has no such file" (the bootstrap case
-    when queried against main, or "this PR deletes the file" when queried
-    against a PR head) — never conflated with an unreadable/unparseable
-    response, which is a fail-closed ``error`` instead.
+    the queried path AT A REF THAT EXISTS means "this ref has no such file"
+    (the bootstrap case when queried against main, or "this PR deletes the
+    file" when queried against a PR head) — never conflated with an
+    unreadable/unparseable response, which is a fail-closed ``error``
+    instead. The "at a ref that exists" half is not free: it costs the
+    second call in :func:`_confirm_ref_exists`, because ``gh``'s 404 text is
+    identical for an unknown ref, an unresolvable repo, and a missing path.
     """
 
     text: Optional[str]
@@ -388,6 +498,38 @@ class YamlFetchResult:
 
 
 _HTTP_404_MARKERS = ("HTTP 404", "Not Found (HTTP 404)")
+
+
+def _confirm_ref_exists(
+    project_root: Path, ref: str, *, gh_bin: str, timeout: int,
+) -> Optional[str]:
+    """``None`` when ``ref`` demonstrably exists in this repo, otherwise the
+    reason it could not be confirmed.
+
+    A 404 from the contents API says nothing about WHICH part of the request
+    was not found. ``gh`` reports "Not Found (HTTP 404)" for an unresolvable
+    repo, "No commit found for the ref ... (HTTP 404)" for an unknown ref,
+    and the very same text for the one case the caller wants to act on: this
+    ref exists, that path does not. The merge door turns that case into a GO
+    that skips every remaining check, so an unconfirmed ref must not reach
+    it — this second call is what separates the three.
+    """
+    argv = [
+        gh_bin, "api", f"repos/{{owner}}/{{repo}}/commits/{quote(ref, safe='/')}", "--jq", ".sha",
+    ]
+    try:
+        proc = subprocess.run(
+            argv, cwd=str(project_root), capture_output=True, text=True, timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        return f"gh CLI niet beschikbaar: {exc}"
+    except subprocess.TimeoutExpired:
+        return f"gh api commits/{ref} liep vast na {timeout}s"
+    if proc.returncode != 0:
+        return f"gh api commits/{ref} faalde (rc={proc.returncode}): {(proc.stderr or '').strip()[:200]}"
+    if not (proc.stdout or "").strip().strip('"'):
+        return f"gh api commits/{ref} gaf geen sha terug"
+    return None
 
 
 def fetch_yaml_from_ref(
@@ -420,7 +562,17 @@ def fetch_yaml_from_ref(
     if proc.returncode != 0:
         stderr = (proc.stderr or "").strip()
         if any(marker in stderr for marker in _HTTP_404_MARKERS):
-            return YamlFetchResult(text=None, not_found=True, error=None)
+            unconfirmed = _confirm_ref_exists(project_root, ref, gh_bin=gh_bin, timeout=timeout)
+            if unconfirmed is None:
+                return YamlFetchResult(text=None, not_found=True, error=None)
+            return YamlFetchResult(
+                text=None, not_found=False,
+                error=(
+                    f"404 op contents/{path}?ref={ref}, maar ref '{ref}' is zelf niet bevestigd "
+                    f"({unconfirmed}): niet te onderscheiden van een onbekende ref of een "
+                    "onbereikbare repo"
+                ),
+            )
         return YamlFetchResult(
             text=None, not_found=False,
             error=f"gh api contents/{path}?ref={ref} faalde (rc={proc.returncode}): {stderr[:200]}",
@@ -517,11 +669,29 @@ def compare(a: Dict[str, Any], b: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "b_present": bv is not _ABSENT,
             })
 
-    a_ppr = a.get("required_pull_request_reviews") or {}
-    b_ppr = b.get("required_pull_request_reviews") or {}
-    for f in ("required_approving_review_count", "dismiss_stale_reviews",
-              "require_code_owner_reviews", "require_last_push_approval"):
-        scalar(f"required_pull_request_reviews.{f}", a_ppr.get(f), b_ppr.get(f))
+    # Presence first, fields second: an absent block and a present block
+    # asking for zero approvals are DIFFERENT states (see
+    # ProtectionConfig.required_pull_request_reviews_present). Comparing
+    # field-by-field across that boundary would report them as equal.
+    a_ppr = a.get("required_pull_request_reviews")
+    b_ppr = b.get("required_pull_request_reviews")
+    a_ppr_present = isinstance(a_ppr, dict)
+    b_ppr_present = isinstance(b_ppr, dict)
+    if a_ppr_present != b_ppr_present:
+        diffs.append({
+            "field": "required_pull_request_reviews",
+            "a": a_ppr, "b": b_ppr,
+            "a_present": a_ppr_present, "b_present": b_ppr_present,
+        })
+    elif a_ppr_present:
+        for f in ("required_approving_review_count", "dismiss_stale_reviews",
+                  "require_code_owner_reviews", "require_last_push_approval"):
+            scalar(f"required_pull_request_reviews.{f}", a_ppr.get(f), b_ppr.get(f))
+        scalar(
+            "required_pull_request_reviews.bypass_pull_request_allowances",
+            sorted(a_ppr.get("bypass_pull_request_allowances") or []),
+            sorted(b_ppr.get("bypass_pull_request_allowances") or []),
+        )
 
     for f in _BOOL_TOP_LEVEL_FIELDS:
         scalar(f, a.get(f), b.get(f))
@@ -557,6 +727,18 @@ def is_weakening(old: Dict[str, Any], new: Dict[str, Any]) -> Tuple[bool, List[s
         field = diff["field"]
         if field.startswith("required_status_checks.checks["):
             if diff["a_present"] and not diff["b_present"]:
+                weak_fields.append(field)
+            continue
+        if field == "required_pull_request_reviews":
+            # The whole pull-request requirement dropped: the single most
+            # consequential weakening the object can express.
+            if diff["a_present"] and not diff["b_present"]:
+                weak_fields.append(field)
+            continue
+        if field == "required_pull_request_reviews.bypass_pull_request_allowances":
+            # Any actor granted a bypass that did not have one merges around
+            # the requirement, however strong the rest of the block reads.
+            if set(diff["b"] or []) - set(diff["a"] or []):
                 weak_fields.append(field)
             continue
         if field == "required_pull_request_reviews.required_approving_review_count":

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -546,46 +546,68 @@ def _no_go_protection(message: str) -> Dict[str, Any]:
     return {"verdict": "NO-GO", "message": message, "overridden": False, "override_reason": None}
 
 
-def _door_blob_hash_gate(project_root: Path) -> Dict[str, Any]:
-    """Golf B, B1: the merge door only runs any of the branch-protection
-    preflight checks above from the checkout ON main — a fix-forward pushed
-    straight to a feature branch (bypassing review of pr_merge.py itself)
-    must not be able to weaken what this door enforces just by running from
-    a stale or edited local checkout. Compares the git blob hash of the
-    RUNNING ``scripts/pr_merge.py`` (``git hash-object``, computed locally)
-    against the sha GitHub reports for that same path on ``main`` (the
-    contents API's ``sha`` field IS a git blob hash — measured equal on this
-    repo's own ``scripts/pr_merge.py`` on 2026-09-07). Any mismatch refuses;
-    an unreadable local or remote hash refuses too (fail-closed).
-    """
-    local = subprocess.run(
-        ["git", "hash-object", "scripts/pr_merge.py"],
-        cwd=str(project_root), capture_output=True, text=True, timeout=15,
-    )
-    if local.returncode != 0:
-        return _no_go_protection(
-            "git hash-object op scripts/pr_merge.py faalde: deur-integriteit niet toetsbaar "
-            f"({(local.stderr or '').strip()[:200]})"
-        )
-    local_hash = (local.stdout or "").strip()
+#: Every file whose CONTENT decides what this door refuses. Hashing only the
+#: entry point was not enough: the entry point delegates its actual judgment
+#: to these libraries, so a one-line edit to ``is_weakening`` neutralizes the
+#: branch-protection preflight while ``scripts/pr_merge.py`` stays
+#: byte-identical to main and the integrity check reports GO (measured by the
+#: B1 read-seat on 2026-09-07 — that exact mutation passed unseen while 14
+#: tests went red on it).
+_DOOR_INTEGRITY_PATHS = (
+    "scripts/pr_merge.py",
+    "scripts/lib/forge_protection_drift.py",
+    "scripts/lib/merge_preflight_adr_check.py",
+    "scripts/lib/merge_preflight_ci_check.py",
+    "scripts/lib/contract_invalid_ledger.py",
+)
 
-    remote = _gh([
-        "api", "repos/{owner}/{repo}/contents/scripts/pr_merge.py?ref=main",
-        "--jq", ".sha",
-    ])
-    if remote.returncode != 0:
-        return _no_go_protection(
-            "sha van scripts/pr_merge.py op main kon niet worden opgevraagd: deur-integriteit "
-            f"niet toetsbaar ({(remote.stderr or '').strip()[:200]})"
+
+def _door_blob_hash_gate(project_root: Path) -> Dict[str, Any]:
+    """Golf B, B1: the merge door only runs its preflight checks from the
+    checkout ON main — a fix-forward pushed straight to a feature branch
+    (bypassing review of the door's own code) must not be able to weaken
+    what this door enforces just by running from a stale or edited local
+    checkout. Compares the git blob hash of every file in
+    ``_DOOR_INTEGRITY_PATHS`` (``git hash-object``, computed locally) against
+    the sha GitHub reports for that same path on ``main`` (the contents API's
+    ``sha`` field IS a git blob hash — measured equal on this repo's own
+    ``scripts/pr_merge.py`` on 2026-09-07). Any mismatch refuses, naming the
+    files that differ; an unreadable local or remote hash refuses too
+    (fail-closed).
+    """
+    mismatched: list[str] = []
+    for path in _DOOR_INTEGRITY_PATHS:
+        local = subprocess.run(
+            ["git", "hash-object", path],
+            cwd=str(project_root), capture_output=True, text=True, timeout=15,
         )
-    remote_hash = (remote.stdout or "").strip()
-    if not remote_hash or local_hash != remote_hash:
+        if local.returncode != 0:
+            return _no_go_protection(
+                f"git hash-object op {path} faalde: deur-integriteit niet toetsbaar "
+                f"({(local.stderr or '').strip()[:200]})"
+            )
+        local_hash = (local.stdout or "").strip()
+
+        remote = _gh([
+            "api", f"repos/{{owner}}/{{repo}}/contents/{path}?ref=main", "--jq", ".sha",
+        ])
+        if remote.returncode != 0:
+            return _no_go_protection(
+                f"sha van {path} op main kon niet worden opgevraagd: deur-integriteit "
+                f"niet toetsbaar ({(remote.stderr or '').strip()[:200]})"
+            )
+        remote_hash = (remote.stdout or "").strip()
+        if not remote_hash or local_hash != remote_hash:
+            mismatched.append(path)
+
+    if mismatched:
         return _no_go_protection(
-            "de draaiende scripts/pr_merge.py wijkt af van de versie op main: de deur draait "
-            "alleen uit de hoofd-checkout op main"
+            "de draaiende deur wijkt af van de versie op main (" + ", ".join(mismatched)
+            + "): de deur draait alleen uit de hoofd-checkout op main"
         )
     return {
-        "verdict": "GO", "message": "deur-integriteit: pr_merge.py identiek aan main",
+        "verdict": "GO",
+        "message": f"deur-integriteit: {len(_DOOR_INTEGRITY_PATHS)} deurbestanden identiek aan main",
         "overridden": False, "override_reason": None,
     }
 
@@ -602,27 +624,38 @@ def _run_branch_protection_gate(
 
     Four checks, in order, each a refusal on its own:
 
-    (a) Read main's YAML via the contents API (never a local ref — the door
-        never fetches). A 404 on EXACTLY that path is the bootstrap case (no
-        PR has ever applied a branch_protection.yaml to main yet): a no-op
-        GO, loudly. Any other read/parse failure blocks.
-    (b) Live protection on main must match main's own declared YAML — any
+    (a) The RUNNING door must be byte-identical to main's copy
+        (``_door_blob_hash_gate`` over ``_DOOR_INTEGRITY_PATHS``) — the door
+        only runs any of the checks below from the main checkout. FIRST, not
+        last: every step after this one has a branch that returns early, and
+        a check that proves the door is unedited is worthless when the
+        edited door can route around it. The bootstrap no-op in (b) did
+        exactly that.
+    (b) Read main's YAML via the contents API (never a local ref — the door
+        never fetches). A 404 on EXACTLY that path, at a ref confirmed to
+        exist, is the bootstrap case (no PR has ever applied a
+        branch_protection.yaml to main yet): a no-op GO, loudly. Any other
+        read/parse failure blocks — including a 404 whose ref cannot be
+        confirmed, which is indistinguishable from an unknown ref or an
+        unresolvable repo (see ``forge_protection_drift._confirm_ref_exists``).
+    (c) Live protection on main must match main's own declared YAML — any
         drift blocks, with the differing fields named. No override: a drift
         here means ``apply_branch_protection.py`` must be run first, not
         that this merge should be waved through.
-    (c) This PR's own version of the YAML (read at the PR's head sha, same
+    (d) This PR's own version of the YAML (read at the PR's head sha, same
         contents API) must not weaken main's version
         (``forge_protection_drift.is_weakening``). Deleting the file counts
         as the ultimate weakening. Blocks without ``--allow-weaken
         "<reason>"`` (empty reason refused, no silent bypass).
-    (d) The RUNNING ``scripts/pr_merge.py`` must be byte-identical to main's
-        (``_door_blob_hash_gate``) — the door only runs any of the above
-        from the main checkout.
 
-    No override besides ``--allow-weaken`` — a drift found in (b) or an
+    No override besides ``--allow-weaken`` — a drift found in (c) or an
     unreadable/unparseable state anywhere has no escape hatch.
     """
     project_root = SCRIPT_DIR.parent
+
+    door_check = _door_blob_hash_gate(project_root)
+    if door_check["verdict"] != "GO":
+        return door_check
 
     main_yaml = fetch_yaml_from_ref(project_root, "main", PROTECTION_YAML_RELATIVE_PATH)
     if main_yaml.not_found:
@@ -687,10 +720,6 @@ def _run_branch_protection_gate(
                 "overridden": True,
                 "override_reason": reason,
             }
-
-    door_check = _door_blob_hash_gate(project_root)
-    if door_check["verdict"] != "GO":
-        return door_check
 
     if weakening:
         return {

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -90,6 +90,18 @@ Register event written to dispatch_register.ndjson:
     dispatch_id : <str, optional>
     terminal    : "T0"
 
+Branch-protection preflight (Golf B, B1): a fourth fail-closed gate after
+contract_invalid — live branch protection on main must match
+``scripts/forge/branch_protection.yaml`` as committed on main, and this PR's
+own copy of that YAML must not weaken main's (see
+``_run_branch_protection_gate`` and ``scripts/lib/forge_protection_drift.py``
+for the full four-step check). A 404 on that exact path when reading main's
+YAML is the bootstrap case (no PR has ever applied one yet) and is a loud
+no-op, not a refusal. The only override is ``--allow-weaken "<reason>"``,
+which accepts ONLY a weakening the PR's own YAML edit introduces relative to
+main — a drift between live state and main's own declared YAML has no
+override at all (run ``apply_branch_protection.py`` first).
+
 BILLING SAFETY: No Anthropic SDK. No direct API calls.
 """
 
@@ -116,6 +128,16 @@ from governance_receipts import emit_governance_receipt
 from merge_preflight_ci_check import check_ci_run_for_head, _resolve_override_reason
 from merge_preflight_adr_check import check_adr_numbers_for_pr
 from contract_invalid_ledger import is_deliverable_acceptable
+from forge_protection_drift import (
+    PROTECTION_YAML_RELATIVE_PATH,
+    ProtectionConfigError,
+    compare as compare_protection_state,
+    fetch_live_protection,
+    fetch_yaml_from_ref,
+    is_weakening as protection_is_weakening,
+    parse_protection_config,
+    to_normalized_dict as protection_to_normalized_dict,
+)
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -520,6 +542,174 @@ def _run_contract_invalid_gate(
     return result
 
 
+def _no_go_protection(message: str) -> Dict[str, Any]:
+    return {"verdict": "NO-GO", "message": message, "overridden": False, "override_reason": None}
+
+
+def _door_blob_hash_gate(project_root: Path) -> Dict[str, Any]:
+    """Golf B, B1: the merge door only runs any of the branch-protection
+    preflight checks above from the checkout ON main — a fix-forward pushed
+    straight to a feature branch (bypassing review of pr_merge.py itself)
+    must not be able to weaken what this door enforces just by running from
+    a stale or edited local checkout. Compares the git blob hash of the
+    RUNNING ``scripts/pr_merge.py`` (``git hash-object``, computed locally)
+    against the sha GitHub reports for that same path on ``main`` (the
+    contents API's ``sha`` field IS a git blob hash — measured equal on this
+    repo's own ``scripts/pr_merge.py`` on 2026-09-07). Any mismatch refuses;
+    an unreadable local or remote hash refuses too (fail-closed).
+    """
+    local = subprocess.run(
+        ["git", "hash-object", "scripts/pr_merge.py"],
+        cwd=str(project_root), capture_output=True, text=True, timeout=15,
+    )
+    if local.returncode != 0:
+        return _no_go_protection(
+            "git hash-object op scripts/pr_merge.py faalde: deur-integriteit niet toetsbaar "
+            f"({(local.stderr or '').strip()[:200]})"
+        )
+    local_hash = (local.stdout or "").strip()
+
+    remote = _gh([
+        "api", "repos/{owner}/{repo}/contents/scripts/pr_merge.py?ref=main",
+        "--jq", ".sha",
+    ])
+    if remote.returncode != 0:
+        return _no_go_protection(
+            "sha van scripts/pr_merge.py op main kon niet worden opgevraagd: deur-integriteit "
+            f"niet toetsbaar ({(remote.stderr or '').strip()[:200]})"
+        )
+    remote_hash = (remote.stdout or "").strip()
+    if not remote_hash or local_hash != remote_hash:
+        return _no_go_protection(
+            "de draaiende scripts/pr_merge.py wijkt af van de versie op main: de deur draait "
+            "alleen uit de hoofd-checkout op main"
+        )
+    return {
+        "verdict": "GO", "message": "deur-integriteit: pr_merge.py identiek aan main",
+        "overridden": False, "override_reason": None,
+    }
+
+
+def _run_branch_protection_gate(
+    pr_number: int,
+    *,
+    pr_data: Optional[Dict[str, Any]] = None,
+    allow_weaken_reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fail-closed merge gate (Golf B, B1): live branch protection on main
+    must match ``scripts/forge/branch_protection.yaml`` as committed on
+    main, and this PR's own copy of that YAML must not weaken main's.
+
+    Four checks, in order, each a refusal on its own:
+
+    (a) Read main's YAML via the contents API (never a local ref — the door
+        never fetches). A 404 on EXACTLY that path is the bootstrap case (no
+        PR has ever applied a branch_protection.yaml to main yet): a no-op
+        GO, loudly. Any other read/parse failure blocks.
+    (b) Live protection on main must match main's own declared YAML — any
+        drift blocks, with the differing fields named. No override: a drift
+        here means ``apply_branch_protection.py`` must be run first, not
+        that this merge should be waved through.
+    (c) This PR's own version of the YAML (read at the PR's head sha, same
+        contents API) must not weaken main's version
+        (``forge_protection_drift.is_weakening``). Deleting the file counts
+        as the ultimate weakening. Blocks without ``--allow-weaken
+        "<reason>"`` (empty reason refused, no silent bypass).
+    (d) The RUNNING ``scripts/pr_merge.py`` must be byte-identical to main's
+        (``_door_blob_hash_gate``) — the door only runs any of the above
+        from the main checkout.
+
+    No override besides ``--allow-weaken`` — a drift found in (b) or an
+    unreadable/unparseable state anywhere has no escape hatch.
+    """
+    project_root = SCRIPT_DIR.parent
+
+    main_yaml = fetch_yaml_from_ref(project_root, "main", PROTECTION_YAML_RELATIVE_PATH)
+    if main_yaml.not_found:
+        return {
+            "verdict": "GO",
+            "message": "branch-protection-drift: geen YAML op main, preflight overgeslagen",
+            "bootstrap": True,
+            "overridden": False,
+            "override_reason": None,
+        }
+    if main_yaml.error:
+        return _no_go_protection(f"branch-protection-YAML op main niet leesbaar: {main_yaml.error}")
+    try:
+        main_config = parse_protection_config(main_yaml.text or "")
+    except ProtectionConfigError as exc:
+        return _no_go_protection(f"branch-protection-YAML op main ongeldig: {exc}")
+    main_norm = protection_to_normalized_dict(main_config)
+
+    try:
+        live_norm = fetch_live_protection(project_root, branch="main")
+    except Exception as exc:  # noqa: BLE001 — any unreadable live state blocks
+        return _no_go_protection(f"live branch-protection niet leesbaar: {exc}")
+    diffs = compare_protection_state(main_norm, live_norm)
+    if diffs:
+        fields = ", ".join(sorted({d["field"] for d in diffs}))
+        return _no_go_protection(
+            f"branch-protection wijkt af van scripts/forge/branch_protection.yaml op main: {fields}"
+        )
+
+    head_sha = (pr_data or {}).get("headRefOid") or ""
+    if not head_sha:
+        return _no_go_protection(
+            f"PR-head kon niet worden bepaald voor #{pr_number}: branch-protection-preflight niet toetsbaar"
+        )
+    pr_yaml = fetch_yaml_from_ref(project_root, head_sha, PROTECTION_YAML_RELATIVE_PATH)
+    if pr_yaml.not_found:
+        return _no_go_protection(
+            f"deze PR verwijdert {PROTECTION_YAML_RELATIVE_PATH}: branch-protection kan niet "
+            "meer worden gehandhaafd"
+        )
+    if pr_yaml.error:
+        return _no_go_protection(f"branch-protection-YAML op de PR-head niet leesbaar: {pr_yaml.error}")
+    try:
+        pr_config = parse_protection_config(pr_yaml.text or "")
+    except ProtectionConfigError as exc:
+        return _no_go_protection(f"branch-protection-YAML op de PR-head ongeldig: {exc}")
+    pr_norm = protection_to_normalized_dict(pr_config)
+
+    weakening, weak_fields = protection_is_weakening(main_norm, pr_norm)
+    reason = None
+    if weakening:
+        reason = (allow_weaken_reason or "").strip()
+        if allow_weaken_reason is None:
+            return _no_go_protection(
+                "deze PR verzwakt branch-protection t.o.v. main zonder --allow-weaken: "
+                + ", ".join(weak_fields)
+            )
+        if not reason:
+            return {
+                "verdict": "NO-GO",
+                "message": "override zonder reden geweigerd: --allow-weaken vereist een niet-lege reden",
+                "overridden": True,
+                "override_reason": reason,
+            }
+
+    door_check = _door_blob_hash_gate(project_root)
+    if door_check["verdict"] != "GO":
+        return door_check
+
+    if weakening:
+        return {
+            "verdict": "GO",
+            "message": (
+                f"OVERRIDE: branch-protection-verzwakking geaccepteerd ({reason}): "
+                + ", ".join(weak_fields)
+            ),
+            "overridden": True,
+            "override_reason": reason,
+        }
+    return {
+        "verdict": "GO",
+        "message": "branch-protection: geen drift, PR verzwakt niets",
+        "overridden": False,
+        "override_reason": None,
+    }
+
+
 _HEAD_MOVED_MARKERS = (
     "head branch is not up to date",
     "head branch was modified",
@@ -873,6 +1063,12 @@ def main(argv: Optional[list[str]] = None) -> int:
              "contract_invalid, with this required reason (empty is refused). Separate "
              "from --override-reason.",
     )
+    parser.add_argument(
+        "--allow-weaken", default=None,
+        help="Escape hatch (golf B, B1): accept a PR that weakens "
+             "scripts/forge/branch_protection.yaml relative to main, with this required "
+             "reason (empty is refused). No other override applies to this gate.",
+    )
     parser.add_argument("--json", action="store_true", help="Output result as JSON")
     args = parser.parse_args(argv)
 
@@ -948,6 +1144,28 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"OVERRIDE: {contract_gate['message']}")
     else:
         print(f"contract_invalid gate: {contract_gate['message']}")
+
+    # ── Branch-protection preflight (Golf B, B1): main's live protection ───
+    # must match scripts/forge/branch_protection.yaml, and this PR must not
+    # weaken that YAML relative to main. Only --allow-weaken overrides a
+    # weakening; drift between live and main's own YAML has no override.
+    protection_gate = _run_branch_protection_gate(
+        args.pr, pr_data=pr_data, allow_weaken_reason=args.allow_weaken,
+    )
+    if protection_gate["verdict"] != "GO":
+        if args.json:
+            print(json.dumps({
+                "success": False, "pr_number": args.pr,
+                "error": protection_gate["message"],
+                "branch_protection_gate": protection_gate,
+            }, indent=2))
+        else:
+            print(f"NO-GO: {protection_gate['message']}", file=sys.stderr)
+        return EXIT_ERROR
+    if protection_gate.get("overridden"):
+        print(f"OVERRIDE: {protection_gate['message']}")
+    else:
+        print(f"Branch-protection gate: {protection_gate['message']}")
 
     # The head SHA the gates approved is established once in _run_ci_gate; the
     # merge is pinned to it (--match-head-commit) so a post-gate push is refused.

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -937,6 +937,83 @@ def check_t0_state_freshness(paths: Dict[str, str]) -> List[CheckResult]:
 
 
 # ---------------------------------------------------------------------------
+# Branch-protection drift (Golf B, B1)
+# ---------------------------------------------------------------------------
+
+def check_branch_protection_drift(paths: Dict[str, str]) -> List[CheckResult]:
+    """Live branch protection on main must match
+    ``scripts/forge/branch_protection.yaml`` — the same comparison
+    ``pr_merge.py``'s merge preflight and ``apply_branch_protection.py`` use
+    (``forge_protection_drift.compare``), so this can never disagree with
+    what the door itself would refuse on.
+
+    Read-only: this check never writes. A missing YAML on disk (not yet
+    added, or a repo checked out before this dispatch landed) and an
+    unreachable/unparseable live-state read both degrade to WARN, not FAIL —
+    neither is evidence of drift, only of "this check could not run" (a
+    fresh clone with no ``gh`` auth must not report a FAIL it never actually
+    verified). An invalid YAML, or a genuine diff between live and the YAML,
+    is a FAIL.
+    """
+    vnx_home = Path(paths["VNX_HOME"])
+    yaml_path = vnx_home / "scripts" / "forge" / "branch_protection.yaml"
+
+    try:
+        from forge_protection_drift import (
+            ProtectionConfigError,
+            ProtectionDriftError,
+            compare as compare_protection_state,
+            fetch_live_protection,
+            load_protection_config,
+            to_normalized_dict as protection_to_normalized_dict,
+        )
+    except ImportError as exc:
+        return [CheckResult(
+            "branch_protection_drift", WARN,
+            f"forge_protection_drift niet importeerbaar: {exc}",
+        )]
+
+    if not yaml_path.exists():
+        return [CheckResult(
+            "branch_protection_drift", WARN,
+            "scripts/forge/branch_protection.yaml ontbreekt: drift niet toetsbaar",
+            remediation="voeg scripts/forge/branch_protection.yaml toe (golf B, B1)",
+        )]
+
+    try:
+        config = load_protection_config(yaml_path)
+    except ProtectionConfigError as exc:
+        return [CheckResult(
+            "branch_protection_drift", FAIL, f"branch_protection.yaml ongeldig: {exc}",
+            remediation="corrigeer scripts/forge/branch_protection.yaml",
+        )]
+
+    try:
+        live_norm = fetch_live_protection(vnx_home, branch="main")
+    except ProtectionDriftError as exc:
+        return [CheckResult(
+            "branch_protection_drift", WARN,
+            f"live branch-protection niet leesbaar: {exc}",
+            remediation="controleer gh-authenticatie en netwerktoegang",
+        )]
+
+    diffs = compare_protection_state(protection_to_normalized_dict(config), live_norm)
+    if not diffs:
+        return [CheckResult(
+            "branch_protection_drift", PASS,
+            "branch-protection op main komt overeen met scripts/forge/branch_protection.yaml",
+        )]
+
+    fields = sorted({d["field"] for d in diffs})
+    return [CheckResult(
+        "branch_protection_drift", FAIL,
+        f"branch-protection wijkt af van de YAML: {', '.join(fields)}",
+        remediation="python3 scripts/forge/apply_branch_protection.py (of --dry-run om te bekijken)",
+        details=fields,
+    )]
+
+
+# ---------------------------------------------------------------------------
 # Runtime checks (delegates to vnx_doctor_runtime.py)
 # ---------------------------------------------------------------------------
 
@@ -1000,6 +1077,7 @@ def run_doctor(paths: Dict[str, str], *,
     results.extend(check_state_root_location(paths))
     results.extend(check_dream_cycle(paths))
     results.extend(check_t0_state_freshness(paths))
+    results.extend(check_branch_protection_drift(paths))
 
     if package_check:
         vnx_home = Path(paths["VNX_HOME"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,12 +343,22 @@ def _stub_branch_protection_gate_gh_calls(monkeypatch: pytest.MonkeyPatch) -> No
     ``GH_TOKEN``), fail closed the same way the ADR-gate stub above
     (``_stub_adr_gate_gh_calls``) was added to prevent.
 
-    Stubs the NETWORK CALL (``pr_merge.fetch_yaml_from_ref``, the name
-    ``_run_branch_protection_gate`` calls first), not the gate function
-    itself — mirrors the ADR-gate stub's own reasoning. Tests that
-    specifically exercise this gate override ``pr_merge.fetch_yaml_from_ref``
-    / ``pr_merge.fetch_live_protection`` (or ``_run_branch_protection_gate``
-    wholesale) in the test body — same monkeypatch instance, later call wins.
+    Stubs the two OFFLINE-BREAKING steps, not the gate function itself —
+    mirrors the ADR-gate stub's own reasoning:
+
+    - ``pr_merge._door_blob_hash_gate``, the gate's FIRST step since the B1
+      fix-forward, which shells out to ``git hash-object`` plus one ``gh api
+      contents/...`` read per door file. It used to sit last, behind the
+      bootstrap branch below, so this fixture never had to account for it.
+    - ``pr_merge.fetch_yaml_from_ref``, the contents read of main's
+      ``scripts/forge/branch_protection.yaml``.
+
+    Tests that specifically exercise this gate override these names (or
+    ``_run_branch_protection_gate`` wholesale) in the test body — same
+    monkeypatch instance, later call wins. The door-integrity check has its
+    own direct coverage in tests/test_pr_merge_branch_protection.py
+    (``TestDoorBlobHashGate``, ``TestDoorBlobHashCoversTheWholeDoor``), so
+    defaulting it to GO here hides nothing.
     """
     try:
         import pr_merge
@@ -356,6 +366,13 @@ def _stub_branch_protection_gate_gh_calls(monkeypatch: pytest.MonkeyPatch) -> No
         return
     from forge_protection_drift import YamlFetchResult
 
+    monkeypatch.setattr(
+        pr_merge, "_door_blob_hash_gate",
+        lambda project_root: {
+            "verdict": "GO", "message": "deur-integriteit: gestubd in de testsuite",
+            "overridden": False, "override_reason": None,
+        },
+    )
     monkeypatch.setattr(
         pr_merge, "fetch_yaml_from_ref",
         lambda *a, **k: YamlFetchResult(text=None, not_found=True, error=None),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,6 +327,41 @@ def _stub_adr_gate_gh_calls(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_branch_protection_gate_gh_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Golf B, B1: keep pr_merge's branch-protection preflight offline + a
+    no-op by default for every test that doesn't specifically exercise it.
+
+    ``pr_merge.main()`` runs a fourth gate, ``_run_branch_protection_gate``,
+    whose first step is a live ``gh api contents/...`` read of main's
+    ``scripts/forge/branch_protection.yaml``. Stubbing that call to "not
+    found" is not just a convenient offline default: it is the ACTUAL
+    production state as of this dispatch (main has no such file yet — this
+    PR is the one that adds it), which is exactly the gate's own bootstrap
+    no-op. Every other test that drives ``pr_merge.main()`` through the
+    upstream gates would otherwise also hit this live call and, in CI (no
+    ``GH_TOKEN``), fail closed the same way the ADR-gate stub above
+    (``_stub_adr_gate_gh_calls``) was added to prevent.
+
+    Stubs the NETWORK CALL (``pr_merge.fetch_yaml_from_ref``, the name
+    ``_run_branch_protection_gate`` calls first), not the gate function
+    itself — mirrors the ADR-gate stub's own reasoning. Tests that
+    specifically exercise this gate override ``pr_merge.fetch_yaml_from_ref``
+    / ``pr_merge.fetch_live_protection`` (or ``_run_branch_protection_gate``
+    wholesale) in the test body — same monkeypatch instance, later call wins.
+    """
+    try:
+        import pr_merge
+    except ImportError:
+        return
+    from forge_protection_drift import YamlFetchResult
+
+    monkeypatch.setattr(
+        pr_merge, "fetch_yaml_from_ref",
+        lambda *a, **k: YamlFetchResult(text=None, not_found=True, error=None),
+    )
+
+
 # ---------------------------------------------------------------------------
 # DB / registry fixtures  (shared with test_burnin_certification)
 # ---------------------------------------------------------------------------

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -134,7 +134,19 @@ class TestWeakenRefusal:
         assert result["verdict"] == "REFUSED"
         assert not put_calls
         assert any("checks[" in f for f in result["weak_fields"])
-        assert _load_receipts(receipts_path) == []
+
+        # Fix-forward punt 3: a refusal is a governance event too -- it is the
+        # moment someone tried to weaken live protection. Silence here means
+        # the attempt only ever existed in one terminal's scrollback.
+        applied = [
+            r for r in _load_receipts(receipts_path)
+            if r.get("event_type") == "branch_protection_applied"
+        ]
+        assert len(applied) == 1
+        assert applied[0]["apply_verdict"] == "REFUSED"
+        assert applied[0]["applied"] is False
+        assert applied[0]["calls"] == []
+        assert any("checks[" in f for f in applied[0]["weak_fields"])
 
     def test_empty_reason_is_refused(self, monkeypatch, receipts_path):
         live = self._live_with_an_extra_check()
@@ -238,3 +250,120 @@ class TestWriteBucketing:
 
         assert result["verdict"] == "ERROR"
         assert "422" in result["message"]
+
+
+class TestEveryOutcomeLeavesATrace:
+    """Fix-forward punt 3: ``_emit_apply_receipt`` sat after the three write
+    blocks, so exactly the runs that need a trace most -- a PUT that lands
+    followed by a second call that fails -- returned without writing one.
+    The mutation is real; the ledger did not know about it.
+    """
+
+    def _yaml_wanting_signatures_on(self, tmp_path: Path) -> Path:
+        """A YAML whose only extra demand over live is required_signatures:
+        true. Turning signatures ON is a STRENGTHENING, so nothing is refused
+        and both write buckets fire."""
+        text = YAML_PATH.read_text(encoding="utf-8")
+        assert "required_signatures: false" in text
+        patched = text.replace("required_signatures: false", "required_signatures: true")
+        path = tmp_path / "branch_protection.yaml"
+        path.write_text(patched, encoding="utf-8")
+        return path
+
+    def _live_needing_both_buckets(self) -> Dict[str, Any]:
+        live = _real_norm()
+        live["allow_force_pushes"] = True  # yaml says false -> protection PUT
+        live["required_signatures"] = False  # yaml says true -> signatures POST
+        return live
+
+    def test_a_half_applied_run_still_writes_a_receipt(self, monkeypatch, tmp_path, receipts_path):
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: self._live_needing_both_buckets())
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+        monkeypatch.setattr(
+            abp, "_patch_required_signatures", lambda *a, **k: _ok(1, stderr="API rate limit exceeded"),
+        )
+
+        result = abp.run_apply(
+            yaml_path=self._yaml_wanting_signatures_on(tmp_path), project_root=VNX_ROOT,
+        )
+
+        assert result["verdict"] == "ERROR"
+        assert result["applied"] is True
+        assert put_calls, "the PUT landed -- live protection was mutated"
+
+        applied = [
+            r for r in _load_receipts(receipts_path)
+            if r.get("event_type") == "branch_protection_applied"
+        ]
+        assert len(applied) == 1
+        receipt = applied[0]
+        assert receipt["apply_verdict"] == "ERROR"
+        assert receipt["applied"] is True
+        assert receipt["calls"] == ["protection"]
+        assert receipt["pending_calls"] == ["required_signatures"]
+        assert receipt["partial"] is True
+        assert receipt["after"] is None, "a partial mutation must not claim the YAML's state"
+        assert receipt["before"]["allow_force_pushes"] is True
+        assert receipt["status"] == "failure"
+
+    def test_a_failing_first_call_writes_a_receipt_with_nothing_applied(
+        self, monkeypatch, receipts_path,
+    ):
+        live = _real_norm()
+        live["allow_force_pushes"] = True
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: _ok(1, stderr="422 nope"))
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "ERROR"
+        applied = [
+            r for r in _load_receipts(receipts_path)
+            if r.get("event_type") == "branch_protection_applied"
+        ]
+        assert len(applied) == 1
+        assert applied[0]["applied"] is False
+        assert applied[0]["calls"] == []
+        assert applied[0]["after"] is None
+
+    def test_a_full_apply_records_the_yaml_as_the_after_state(self, monkeypatch, receipts_path):
+        live = _real_norm()
+        live["allow_force_pushes"] = True
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: _ok())
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "OK"
+        applied = [
+            r for r in _load_receipts(receipts_path)
+            if r.get("event_type") == "branch_protection_applied"
+        ]
+        assert len(applied) == 1
+        assert applied[0]["partial"] is False
+        assert applied[0]["after"]["allow_force_pushes"] is False
+        assert applied[0]["status"] == "success"
+
+    def test_an_exception_mid_apply_still_writes_a_receipt(self, monkeypatch, receipts_path):
+        """A timeout inside a write call is not a returned verdict at all --
+        the trace has to survive the exception on its way out."""
+        live = _real_norm()
+        live["allow_force_pushes"] = True
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
+
+        monkeypatch.setattr(abp, "_put_protection", boom)
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        applied = [
+            r for r in _load_receipts(receipts_path)
+            if r.get("event_type") == "branch_protection_applied"
+        ]
+        assert len(applied) == 1
+        assert applied[0]["apply_verdict"] == "EXCEPTION"
+        assert applied[0]["applied"] is False

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Tests for scripts/forge/apply_branch_protection.py (Golf B, B1).
+
+``fetch_live_protection`` and the actual gh write calls (``_put_protection``
+etc.) are monkeypatched per test -- the planning logic (diff, weaken-check,
+which write buckets fire) runs for real, exercising the same
+``forge_protection_drift.compare``/``is_weakening`` used by the merge-door
+preflight and ``vnx doctor``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "forge"))
+
+import apply_branch_protection as abp
+from forge_protection_drift import load_protection_config, to_normalized_dict
+
+
+YAML_PATH = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
+
+
+def _real_config():
+    return load_protection_config(YAML_PATH)
+
+
+def _real_norm() -> Dict[str, Any]:
+    return to_normalized_dict(_real_config())
+
+
+def _ok(returncode: int = 0, stderr: str = "") -> "subprocess.CompletedProcess[str]":
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+
+
+def _load_receipts(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.fixture()
+def receipts_path() -> Path:
+    return Path(os.environ["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
+
+
+class TestIdempotency:
+    """(g) apply idempotent: a second run with identical live state reports
+    zero changes and performs zero write calls."""
+
+    def test_no_diffs_makes_zero_write_calls(self, monkeypatch, receipts_path):
+        live = _real_norm()
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+        sig_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_patch_required_signatures", lambda *a, **k: sig_calls.append(a) or _ok())
+        auto_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_patch_repo_auto_merge", lambda *a, **k: auto_calls.append(a) or _ok())
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "OK"
+        assert result["applied"] is False
+        assert result["diffs"] == []
+        assert not put_calls and not sig_calls and not auto_calls
+
+        receipts = _load_receipts(receipts_path)
+        applied_receipts = [r for r in receipts if r.get("event_type") == "branch_protection_applied"]
+        assert len(applied_receipts) == 1
+        assert applied_receipts[0]["applied"] is False
+
+
+class TestDryRun:
+    def test_dry_run_never_calls_gh_writes_and_prints_the_full_payload(self, monkeypatch, capsys):
+        live = _real_norm()
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+
+        rc = abp.main(["--yaml-path", str(YAML_PATH), "--project-root", str(VNX_ROOT), "--dry-run"])
+
+        assert rc == 0
+        assert not put_calls
+        out = json.loads(capsys.readouterr().out)
+        assert out["required_status_checks"]["strict"] is False
+        assert len(out["required_status_checks"]["checks"]) == 14
+        assert out["restrictions"] is None
+
+    def test_dry_run_prints_payload_even_when_state_matches_exactly(self, monkeypatch, capsys):
+        """--dry-run always prints the built object, drift or not (it never writes)."""
+        live = _real_norm()
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT, dry_run=True)
+
+        assert result["verdict"] == "DRY-RUN"
+        assert result["changed"] is False
+        assert result["payload"]["enforce_admins"] is True
+
+
+class TestWeakenRefusal:
+    """(d) apply with a check less, or a weakened boolean, without
+    --allow-weaken: refused. With the flag and a reason: goes through, and
+    the receipt carries the reason."""
+
+    def _live_with_an_extra_check(self) -> Dict[str, Any]:
+        """Live currently requires one MORE check than the YAML declares --
+        applying the YAML would DROP that check ("a check minder")."""
+        live = _real_norm()
+        live["required_status_checks"] = dict(live["required_status_checks"])
+        live["required_status_checks"]["checks"] = list(live["required_status_checks"]["checks"]) + [
+            {"context": "Extra Check Not In YAML", "app_id": 1},
+        ]
+        return live
+
+    def test_refused_without_allow_weaken(self, monkeypatch, receipts_path):
+        live = self._live_with_an_extra_check()
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "REFUSED"
+        assert not put_calls
+        assert any("checks[" in f for f in result["weak_fields"])
+        assert _load_receipts(receipts_path) == []
+
+    def test_empty_reason_is_refused(self, monkeypatch, receipts_path):
+        live = self._live_with_an_extra_check()
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT, allow_weaken_reason="   ")
+
+        assert result["verdict"] == "REFUSED"
+        assert not put_calls
+
+    def test_allowed_with_reason_proceeds_and_receipt_carries_it(self, monkeypatch, receipts_path):
+        live = self._live_with_an_extra_check()
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+
+        result = abp.run_apply(
+            yaml_path=YAML_PATH, project_root=VNX_ROOT, allow_weaken_reason="operator-goedgekeurd",
+        )
+
+        assert result["verdict"] == "OK"
+        assert put_calls, "the protection PUT must fire once the weakening is accepted"
+
+        receipts = _load_receipts(receipts_path)
+        applied = [r for r in receipts if r.get("event_type") == "branch_protection_applied"]
+        assert len(applied) == 1
+        assert applied[0]["weaken_reason"] == "operator-goedgekeurd"
+        assert applied[0]["applied"] is True
+
+    def test_a_weakened_boolean_without_a_missing_check_is_also_refused(self, monkeypatch):
+        """Live currently has strict=True (stronger); the YAML wants
+        strict=False -- applying the YAML would weaken this one field, with
+        no check removed at all."""
+        live = _real_norm()
+        live["required_status_checks"] = dict(live["required_status_checks"])
+        live["required_status_checks"]["strict"] = True
+
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "REFUSED"
+        assert "required_status_checks.strict" in result["weak_fields"]
+        assert not put_calls
+
+
+class TestPendingChecksIgnored:
+    """(h) pending_checks with an entry: apply ignores it entirely."""
+
+    def test_pending_checks_entry_never_reaches_the_put_payload_or_the_diff(self, monkeypatch, tmp_path):
+        doc_text = YAML_PATH.read_text(encoding="utf-8")
+        assert "pending_checks: []" in doc_text
+        patched = doc_text.replace("pending_checks: []", "pending_checks: [\"vnx-gate/review\"]")
+        custom_yaml = tmp_path / "branch_protection.yaml"
+        custom_yaml.write_text(patched, encoding="utf-8")
+
+        live = _real_norm()
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+
+        result = abp.run_apply(yaml_path=custom_yaml, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "OK"
+        assert result["diffs"] == []
+        assert "vnx-gate/review" not in json.dumps(result)
+
+
+class TestWriteBucketing:
+    """A diff confined to required_signatures or repo.allow_auto_merge fires
+    only that endpoint, never the full protection PUT."""
+
+    def test_auto_merge_only_diff_skips_the_protection_put(self, monkeypatch):
+        """Live has allow_auto_merge=True (weaker/more-permissive); the YAML
+        wants False (stronger) -- a real diff, but NOT a weakening (turning
+        auto-merge OFF needs no --allow-weaken), so it applies directly and
+        touches only the repo-patch endpoint."""
+        live = _real_norm()
+        live["repo"] = {"allow_auto_merge": True}
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        put_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: put_calls.append(a) or _ok())
+        auto_calls: List[Any] = []
+        monkeypatch.setattr(abp, "_patch_repo_auto_merge", lambda *a, **k: auto_calls.append(a) or _ok())
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "OK"
+        assert not put_calls
+        assert auto_calls
+
+    def test_write_failure_is_reported_as_error(self, monkeypatch):
+        live = _real_norm()
+        live["allow_force_pushes"] = True
+        monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+        monkeypatch.setattr(abp, "_put_protection", lambda *a, **k: _ok(1, stderr="422 nope"))
+
+        result = abp.run_apply(yaml_path=YAML_PATH, project_root=VNX_ROOT)
+
+        assert result["verdict"] == "ERROR"
+        assert "422" in result["message"]

--- a/tests/test_forge_protection_drift.py
+++ b/tests/test_forge_protection_drift.py
@@ -415,11 +415,33 @@ class TestFetchLiveProtection:
 # fetch_yaml_from_ref() — 404 vs other failures (i)
 # ---------------------------------------------------------------------------
 
+def _contents_and_commits(
+    *, contents: "subprocess.CompletedProcess[str]", commits: "subprocess.CompletedProcess[str]",
+):
+    """A gh stub that answers the contents read and the ref-confirmation read
+    separately -- ``fetch_yaml_from_ref`` makes the second call only after a
+    404 on the first (see ``_confirm_ref_exists``)."""
+
+    def fake_run(argv, **kwargs):
+        joined = " ".join(argv)
+        if "/contents/" in joined:
+            return contents
+        if "/commits/" in joined:
+            return commits
+        raise AssertionError(f"unexpected gh call: {joined}")
+
+    return fake_run
+
+
 class TestFetchYamlFromRef:
     def test_404_is_not_found_not_error(self, monkeypatch, tmp_path):
+        """A 404 on the path AT A REF THAT EXISTS is the named not-found case."""
         monkeypatch.setattr(
             fpd.subprocess, "run",
-            lambda argv, **k: _err("gh: Not Found (HTTP 404)", 1),
+            _contents_and_commits(
+                contents=_err("gh: Not Found (HTTP 404)", 1),
+                commits=_ok("d" * 40),
+            ),
         )
         result = fpd.fetch_yaml_from_ref(tmp_path, "main")
         assert result.not_found is True
@@ -473,3 +495,228 @@ class TestFetchYamlFromRef:
         result = fpd.fetch_yaml_from_ref(tmp_path, "main")
         assert result.not_found is False
         assert result.error is not None
+
+
+class TestNotFoundRequiresAConfirmedRef:
+    """Fix-forward punt 2: a 404 is only "this ref has no such file" once the
+    ref itself is confirmed to exist. ``gh`` returns the same ``HTTP 404``
+    marker for an unknown ref and for an unresolvable repo, and the merge
+    door turns exactly that marker into a GO that skips every remaining
+    check -- so an unconfirmed ref must be a fail-closed error instead.
+    """
+
+    def test_404_on_an_unknown_ref_is_an_error_not_not_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            fpd.subprocess, "run",
+            _contents_and_commits(
+                contents=_err("gh: No commit found for the ref refs/heads/does-not-exist-xyz (HTTP 404)", 1),
+                commits=_err("gh: No commit found for the ref refs/heads/does-not-exist-xyz (HTTP 404)", 1),
+            ),
+        )
+        result = fpd.fetch_yaml_from_ref(tmp_path, "does-not-exist-xyz")
+        assert result.not_found is False
+        assert result.error is not None
+        assert "does-not-exist-xyz" in result.error
+
+    def test_404_on_an_unresolvable_repo_is_an_error_not_not_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            fpd.subprocess, "run",
+            _contents_and_commits(
+                contents=_err("gh: Not Found (HTTP 404)", 1),
+                commits=_err("gh: Not Found (HTTP 404)", 1),
+            ),
+        )
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None
+
+    def test_an_empty_sha_from_the_confirmation_is_an_error(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            fpd.subprocess, "run",
+            _contents_and_commits(
+                contents=_err("gh: Not Found (HTTP 404)", 1),
+                commits=_ok(""),
+            ),
+        )
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None
+
+    def test_a_missing_gh_during_confirmation_is_an_error(self, monkeypatch, tmp_path):
+        def fake_run(argv, **kwargs):
+            if "/contents/" in " ".join(argv):
+                return _err("gh: Not Found (HTTP 404)", 1)
+            raise FileNotFoundError("gh not found")
+
+        monkeypatch.setattr(fpd.subprocess, "run", fake_run)
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None
+
+    def test_a_confirmed_head_sha_still_yields_not_found(self, monkeypatch, tmp_path):
+        """The PR-side use: the head sha exists, the file does not."""
+        head = "e" * 40
+        monkeypatch.setattr(
+            fpd.subprocess, "run",
+            _contents_and_commits(contents=_err("gh: Not Found (HTTP 404)", 1), commits=_ok(head)),
+        )
+        result = fpd.fetch_yaml_from_ref(tmp_path, head)
+        assert result.not_found is True
+        assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# An ABSENT required_pull_request_reviews block (fix-forward punt 1)
+# ---------------------------------------------------------------------------
+
+def _gh_live_stub(protection_payload: Dict[str, Any], *, allow_auto_merge: bool = False):
+    def fake_run(argv, **kwargs):
+        joined = " ".join(argv)
+        if "branches/main/protection" in joined:
+            return _ok(protection_payload)
+        if "rulesets" in joined:
+            return _ok([])
+        if argv[-1] == "repos/{owner}/{repo}":
+            return _ok({"allow_auto_merge": allow_auto_merge})
+        raise AssertionError(f"unexpected gh call: {joined}")
+
+    return fake_run
+
+
+def _single_check_yaml_norm(**overrides: Any) -> Dict[str, Any]:
+    """A YAML normalization whose checks[] matches ``_PROTECTION_PAYLOAD``'s
+    single entry, so a comparison against that payload isolates the field
+    under test instead of drowning it in check diffs."""
+    doc = _base_config_dict(**overrides)
+    doc["required_status_checks"]["checks"] = [{"context": "Profile A", "app_id": 15368}]
+    return fpd.to_normalized_dict(fpd.parse_protection_config(yaml.safe_dump(doc)))
+
+
+class TestAbsentPullRequestReviewsBlock:
+    """Fix-forward punt 1: GitHub OMITS ``required_pull_request_reviews``
+    from the GET when "Require a pull request before merging" is off --
+    exactly as it omits ``restrictions`` when unset. Normalizing an absent
+    block into the same zero/false object the YAML declares makes the most
+    consequential setting of the whole object invisible to both watchers.
+    """
+
+    def _live_without_the_block(self, monkeypatch, tmp_path) -> Dict[str, Any]:
+        payload = dict(_PROTECTION_PAYLOAD)
+        payload.pop("required_pull_request_reviews")
+        monkeypatch.setattr(fpd.subprocess, "run", _gh_live_stub(payload))
+        return fpd.fetch_live_protection(tmp_path, branch="main")
+
+    def test_control_the_block_present_gives_zero_drift(self, monkeypatch, tmp_path):
+        """The baseline that makes a zero below a measurement, not a bug."""
+        monkeypatch.setattr(fpd.subprocess, "run", _gh_live_stub(_PROTECTION_PAYLOAD))
+        live = fpd.fetch_live_protection(tmp_path, branch="main")
+        assert fpd.compare(_single_check_yaml_norm(), live) == []
+
+    def test_absent_block_normalizes_to_none_not_to_zeroes(self, monkeypatch, tmp_path):
+        live = self._live_without_the_block(monkeypatch, tmp_path)
+        assert live["required_pull_request_reviews"] is None
+
+    def test_absent_block_is_drift_against_a_yaml_that_declares_one(self, monkeypatch, tmp_path):
+        live = self._live_without_the_block(monkeypatch, tmp_path)
+        diffs = fpd.compare(_single_check_yaml_norm(), live)
+        assert [d["field"] for d in diffs] == ["required_pull_request_reviews"]
+        assert diffs[0]["a_present"] is True
+        assert diffs[0]["b_present"] is False
+
+    def test_absent_block_counts_as_a_weakening(self, monkeypatch, tmp_path):
+        live = self._live_without_the_block(monkeypatch, tmp_path)
+        weak, fields = fpd.is_weakening(_single_check_yaml_norm(), live)
+        assert weak is True
+        assert "required_pull_request_reviews" in fields
+
+    def test_adding_the_block_where_it_was_absent_is_not_a_weakening(self, monkeypatch, tmp_path):
+        live = self._live_without_the_block(monkeypatch, tmp_path)
+        weak, fields = fpd.is_weakening(live, _single_check_yaml_norm())
+        assert weak is False
+        assert fields == []
+
+    def test_a_present_block_still_diffs_field_by_field(self, monkeypatch, tmp_path):
+        """Control: the per-field comparison is untouched by the presence model."""
+        payload = json.loads(json.dumps(_PROTECTION_PAYLOAD))
+        payload["required_pull_request_reviews"]["required_approving_review_count"] = 2
+        monkeypatch.setattr(fpd.subprocess, "run", _gh_live_stub(payload))
+        live = fpd.fetch_live_protection(tmp_path, branch="main")
+        diffs = fpd.compare(_single_check_yaml_norm(), live)
+        assert [d["field"] for d in diffs] == [
+            "required_pull_request_reviews.required_approving_review_count"
+        ]
+
+    def test_yaml_may_declare_the_block_absent_with_an_explicit_null(self):
+        doc = _base_config_dict(required_pull_request_reviews=None)
+        config = fpd.parse_protection_config(yaml.safe_dump(doc))
+        assert config.required_pull_request_reviews_present is False
+        assert fpd.to_normalized_dict(config)["required_pull_request_reviews"] is None
+
+    def test_a_partial_block_in_the_yaml_is_still_refused(self):
+        doc = _base_config_dict()
+        del doc["required_pull_request_reviews"]["dismiss_stale_reviews"]
+        with pytest.raises(fpd.ProtectionConfigError, match="verplichte velden"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+
+class TestBypassPullRequestAllowances:
+    """Fix-forward punt 5: a bypass grant on the PR requirement lets named
+    users/teams/apps merge around it. Dropped in normalization, it is
+    invisible to the merge door and to ``vnx doctor`` alike.
+    """
+
+    def _live_with_a_bypass(self, monkeypatch, tmp_path) -> Dict[str, Any]:
+        payload = json.loads(json.dumps(_PROTECTION_PAYLOAD))
+        payload["required_pull_request_reviews"]["bypass_pull_request_allowances"] = {
+            "users": [{"login": "vincent"}],
+            "teams": [],
+            "apps": [{"slug": "some-bot"}],
+        }
+        monkeypatch.setattr(fpd.subprocess, "run", _gh_live_stub(payload))
+        return fpd.fetch_live_protection(tmp_path, branch="main")
+
+    def test_a_live_grant_survives_normalization(self, monkeypatch, tmp_path):
+        live = self._live_with_a_bypass(monkeypatch, tmp_path)
+        assert live["required_pull_request_reviews"]["bypass_pull_request_allowances"] == [
+            "apps:some-bot", "users:vincent",
+        ]
+
+    def test_a_live_grant_is_drift_against_a_yaml_without_one(self, monkeypatch, tmp_path):
+        live = self._live_with_a_bypass(monkeypatch, tmp_path)
+        diffs = fpd.compare(_single_check_yaml_norm(), live)
+        assert [d["field"] for d in diffs] == [
+            "required_pull_request_reviews.bypass_pull_request_allowances"
+        ]
+
+    def test_a_live_grant_counts_as_a_weakening(self, monkeypatch, tmp_path):
+        live = self._live_with_a_bypass(monkeypatch, tmp_path)
+        weak, fields = fpd.is_weakening(_single_check_yaml_norm(), live)
+        assert weak is True
+        assert "required_pull_request_reviews.bypass_pull_request_allowances" in fields
+
+    def test_removing_a_grant_is_not_a_weakening(self, monkeypatch, tmp_path):
+        live = self._live_with_a_bypass(monkeypatch, tmp_path)
+        weak, fields = fpd.is_weakening(live, _single_check_yaml_norm())
+        assert weak is False
+
+    def test_no_grant_anywhere_is_an_empty_list_not_a_missing_key(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fpd.subprocess, "run", _gh_live_stub(_PROTECTION_PAYLOAD))
+        live = fpd.fetch_live_protection(tmp_path, branch="main")
+        assert live["required_pull_request_reviews"]["bypass_pull_request_allowances"] == []
+        assert _single_check_yaml_norm()["required_pull_request_reviews"][
+            "bypass_pull_request_allowances"
+        ] == []
+
+    def test_the_yaml_may_declare_a_grant_explicitly(self):
+        doc = _base_config_dict()
+        doc["required_pull_request_reviews"]["bypass_pull_request_allowances"] = {
+            "users": ["vincent"], "teams": [], "apps": [],
+        }
+        config = fpd.parse_protection_config(yaml.safe_dump(doc))
+        assert config.bypass_pull_request_allowances == ("users:vincent",)
+
+    def test_a_malformed_grant_in_the_yaml_is_refused(self):
+        doc = _base_config_dict()
+        doc["required_pull_request_reviews"]["bypass_pull_request_allowances"] = ["vincent"]
+        with pytest.raises(fpd.ProtectionConfigError, match="bypass_pull_request_allowances"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))

--- a/tests/test_forge_protection_drift.py
+++ b/tests/test_forge_protection_drift.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/forge_protection_drift.py (Golf B, B1).
+
+Covers: schema validation of branch_protection.yaml (including the
+vnx-gate/* app_id guard), the compare()/is_weakening() diff engine, and the
+gh-backed fetchers (fetch_live_protection, fetch_yaml_from_ref) with the
+``gh`` subprocess call mocked — the comparator itself is NEVER mocked, per
+dispatch instructions.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+import yaml
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+import forge_protection_drift as fpd
+
+
+# ---------------------------------------------------------------------------
+# Fixture config helpers
+# ---------------------------------------------------------------------------
+
+def _base_config_dict(**overrides: Any) -> Dict[str, Any]:
+    doc: Dict[str, Any] = {
+        "branch": "main",
+        "required_status_checks": {
+            "strict": False,
+            "checks": [
+                {"context": "Profile A", "app_id": 15368},
+                {"context": "Profile B", "app_id": 15368},
+            ],
+        },
+        "pending_checks": [],
+        "required_pull_request_reviews": {
+            "required_approving_review_count": 0,
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "require_last_push_approval": False,
+        },
+        "enforce_admins": True,
+        "required_signatures": False,
+        "required_linear_history": False,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+        "allow_fork_syncing": False,
+        "block_creations": False,
+        "lock_branch": False,
+        "required_conversation_resolution": False,
+        "restrictions": None,
+        "repo": {"allow_auto_merge": False},
+        "rulesets": [],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _yaml_text(**overrides: Any) -> str:
+    return yaml.safe_dump(_base_config_dict(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+class TestParseProtectionConfig:
+    def test_valid_config_parses(self):
+        config = fpd.parse_protection_config(_yaml_text())
+        assert config.branch == "main"
+        assert len(config.checks) == 2
+        assert config.checks[0].context == "Profile A"
+        assert config.checks[0].app_id == 15368
+        assert config.enforce_admins is True
+
+    def test_the_real_shipped_yaml_parses_and_has_fourteen_checks(self):
+        """The actual scripts/forge/branch_protection.yaml this dispatch ships."""
+        path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
+        config = fpd.load_protection_config(path)
+        assert len(config.checks) == 14
+        assert all(c.app_id == 15368 for c in config.checks)
+        assert config.branch == "main"
+        assert config.enforce_admins is True
+        assert config.allow_auto_merge is False
+        assert config.rulesets == ()
+
+    def test_unknown_top_level_field_is_rejected(self):
+        doc = _base_config_dict()
+        doc["mystery_field"] = True
+        with pytest.raises(fpd.ProtectionConfigError, match="onbekende velden"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_missing_top_level_field_is_rejected(self):
+        doc = _base_config_dict()
+        del doc["enforce_admins"]
+        with pytest.raises(fpd.ProtectionConfigError, match="verplichte velden"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_missing_required_status_checks_field_is_rejected(self):
+        doc = _base_config_dict()
+        del doc["required_status_checks"]["strict"]
+        with pytest.raises(fpd.ProtectionConfigError, match="required_status_checks"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_unknown_check_entry_field_is_rejected(self):
+        doc = _base_config_dict()
+        doc["required_status_checks"]["checks"][0]["extra"] = "nope"
+        with pytest.raises(fpd.ProtectionConfigError, match="onbekende velden"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_restrictions_must_be_null(self):
+        doc = _base_config_dict(restrictions={"users": []})
+        with pytest.raises(fpd.ProtectionConfigError, match="restrictions"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_duplicate_check_context_is_rejected(self):
+        doc = _base_config_dict()
+        doc["required_status_checks"]["checks"].append({"context": "Profile A", "app_id": 999})
+        with pytest.raises(fpd.ProtectionConfigError, match="dubbel"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_empty_checks_list_is_rejected(self):
+        doc = _base_config_dict()
+        doc["required_status_checks"]["checks"] = []
+        with pytest.raises(fpd.ProtectionConfigError, match="niet-lege lijst"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_invalid_yaml_syntax_is_rejected(self):
+        with pytest.raises(fpd.ProtectionConfigError, match="geldige YAML"):
+            fpd.parse_protection_config("branch: main\n  bad indent: [")
+
+    def test_pending_checks_is_parsed_but_not_in_normalized_dict(self):
+        """(h) pending_checks with an entry: apply and drift ignore it."""
+        doc = _base_config_dict()
+        doc["pending_checks"] = ["vnx-gate/review"]
+        config = fpd.parse_protection_config(yaml.safe_dump(doc))
+        assert config.pending_checks == ("vnx-gate/review",)
+        normalized = fpd.to_normalized_dict(config)
+        assert "pending_checks" not in normalized
+        assert "vnx-gate/review" not in json.dumps(normalized)
+
+    class TestVnxGateAppIdGuard:
+        """(e) a vnx-gate/*-entry with app_id null or -1 (ANY_APP_ID) is refused."""
+
+        def test_vnx_gate_check_with_null_app_id_is_rejected(self):
+            doc = _base_config_dict()
+            doc["required_status_checks"]["checks"].append({"context": "vnx-gate/review", "app_id": None})
+            with pytest.raises(fpd.ProtectionConfigError, match="vnx-gate/review"):
+                fpd.parse_protection_config(yaml.safe_dump(doc))
+
+        def test_vnx_gate_check_with_any_app_id_sentinel_is_rejected(self):
+            doc = _base_config_dict()
+            doc["required_status_checks"]["checks"].append(
+                {"context": "vnx-gate/review", "app_id": fpd.ANY_APP_ID}
+            )
+            with pytest.raises(fpd.ProtectionConfigError, match="vnx-gate/review"):
+                fpd.parse_protection_config(yaml.safe_dump(doc))
+
+        def test_vnx_gate_check_with_a_bound_app_id_is_accepted(self):
+            doc = _base_config_dict()
+            doc["required_status_checks"]["checks"].append({"context": "vnx-gate/review", "app_id": 99999})
+            config = fpd.parse_protection_config(yaml.safe_dump(doc))
+            names = {c.context: c.app_id for c in config.checks}
+            assert names["vnx-gate/review"] == 99999
+
+        def test_non_vnx_gate_check_with_null_app_id_is_accepted(self):
+            """The guard is specific to the vnx-gate/* prefix -- a legacy
+            contexts[]-style entry elsewhere is not what this schema forbids."""
+            doc = _base_config_dict()
+            doc["required_status_checks"]["checks"].append({"context": "Some Other Check", "app_id": None})
+            config = fpd.parse_protection_config(yaml.safe_dump(doc))
+            names = {c.context: c.app_id for c in config.checks}
+            assert names["Some Other Check"] is None
+
+
+# ---------------------------------------------------------------------------
+# compare()
+# ---------------------------------------------------------------------------
+
+class TestCompare:
+    def test_identical_states_produce_no_diffs(self):
+        norm = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        assert fpd.compare(norm, dict(norm)) == []
+
+    def test_missing_check_on_live_side_is_reported_with_its_name(self):
+        """(a) YAML with 13 checks vs a live response with 14: drift names the missing check."""
+        yaml_norm = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        live_norm = dict(yaml_norm)
+        live_norm["required_status_checks"] = {
+            "strict": False,
+            "checks": [
+                {"context": "Profile A", "app_id": 15368},
+                {"context": "Profile B", "app_id": 15368},
+                {"context": "Profile C (extra on live)", "app_id": 15368},
+            ],
+        }
+        diffs = fpd.compare(yaml_norm, live_norm)
+        fields = {d["field"] for d in diffs}
+        assert "required_status_checks.checks[Profile C (extra on live)]" in fields
+        extra_diff = next(
+            d for d in diffs if d["field"] == "required_status_checks.checks[Profile C (extra on live)]"
+        )
+        assert extra_diff["a_present"] is False
+        assert extra_diff["b_present"] is True
+
+    def test_allow_force_pushes_mismatch_is_reported(self):
+        """(b) live allow_force_pushes: true vs YAML false: red on that field."""
+        yaml_norm = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        live_norm = dict(yaml_norm)
+        live_norm["allow_force_pushes"] = True
+        diffs = fpd.compare(yaml_norm, live_norm)
+        assert {"field": "allow_force_pushes", "a": False, "b": True} in diffs
+
+    def test_allow_auto_merge_mismatch_is_reported(self):
+        """(c) live allow_auto_merge: true is red."""
+        yaml_norm = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        live_norm = dict(yaml_norm)
+        live_norm["repo"] = {"allow_auto_merge": True}
+        diffs = fpd.compare(yaml_norm, live_norm)
+        assert {"field": "repo.allow_auto_merge", "a": False, "b": True} in diffs
+
+    def test_nonempty_rulesets_is_reported(self):
+        """(c) a non-empty rulesets list on live is red."""
+        yaml_norm = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        live_norm = dict(yaml_norm)
+        live_norm["rulesets"] = ["some-ruleset"]
+        diffs = fpd.compare(yaml_norm, live_norm)
+        assert any(d["field"] == "rulesets" for d in diffs)
+
+    def test_app_id_mismatch_on_a_shared_check_name_is_reported(self):
+        yaml_norm = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        live_norm = json.loads(json.dumps(yaml_norm))
+        live_norm["required_status_checks"]["checks"][0]["app_id"] = 999
+        diffs = fpd.compare(yaml_norm, live_norm)
+        field = "required_status_checks.checks[Profile A]"
+        assert any(d["field"] == field for d in diffs)
+
+
+# ---------------------------------------------------------------------------
+# is_weakening()
+# ---------------------------------------------------------------------------
+
+class TestIsWeakening:
+    def _norm(self, **overrides: Any) -> Dict[str, Any]:
+        return fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text(**overrides)))
+
+    def test_identical_states_are_not_weakening(self):
+        old = self._norm()
+        weak, fields = fpd.is_weakening(old, dict(old))
+        assert weak is False
+        assert fields == []
+
+    def test_removing_a_check_is_weakening(self):
+        old = self._norm()
+        new = json.loads(json.dumps(old))
+        new["required_status_checks"]["checks"] = [{"context": "Profile A", "app_id": 15368}]
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is True
+        assert "required_status_checks.checks[Profile B]" in fields
+
+    def test_adding_a_check_is_not_weakening(self):
+        old = self._norm()
+        new = json.loads(json.dumps(old))
+        new["required_status_checks"]["checks"].append({"context": "Profile C", "app_id": 1})
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is False
+
+    def test_enforce_admins_true_to_false_is_weakening(self):
+        old = self._norm(enforce_admins=True)
+        new = self._norm(enforce_admins=False)
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is True
+        assert "enforce_admins" in fields
+
+    def test_strict_true_to_false_is_weakening(self):
+        old_doc = _base_config_dict()
+        old_doc["required_status_checks"]["strict"] = True
+        old = fpd.to_normalized_dict(fpd.parse_protection_config(yaml.safe_dump(old_doc)))
+        new = self._norm()  # strict: False
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is True
+        assert "required_status_checks.strict" in fields
+
+    def test_review_count_lowered_is_weakening(self):
+        old_doc = _base_config_dict()
+        old_doc["required_pull_request_reviews"]["required_approving_review_count"] = 2
+        old = fpd.to_normalized_dict(fpd.parse_protection_config(yaml.safe_dump(old_doc)))
+        new = self._norm()  # count: 0
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is True
+        assert "required_pull_request_reviews.required_approving_review_count" in fields
+
+    def test_review_count_raised_is_not_weakening(self):
+        old = self._norm()  # count: 0
+        new_doc = _base_config_dict()
+        new_doc["required_pull_request_reviews"]["required_approving_review_count"] = 2
+        new = fpd.to_normalized_dict(fpd.parse_protection_config(yaml.safe_dump(new_doc)))
+        weak, _ = fpd.is_weakening(old, new)
+        assert weak is False
+
+    def test_allow_auto_merge_false_to_true_is_weakening(self):
+        old = self._norm()
+        new_doc = _base_config_dict()
+        new_doc["repo"]["allow_auto_merge"] = True
+        new = fpd.to_normalized_dict(fpd.parse_protection_config(yaml.safe_dump(new_doc)))
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is True
+        assert "repo.allow_auto_merge" in fields
+
+    def test_allow_force_pushes_false_to_true_is_weakening(self):
+        old = self._norm()
+        new_doc = _base_config_dict()
+        new_doc["allow_force_pushes"] = True
+        new = fpd.to_normalized_dict(fpd.parse_protection_config(yaml.safe_dump(new_doc)))
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is True
+        assert "allow_force_pushes" in fields
+
+    def test_rulesets_change_alone_is_never_weakening(self):
+        """rulesets is checked, never applied/weakened -- not in the weaken vocabulary."""
+        old = self._norm()
+        new = json.loads(json.dumps(old))
+        new["rulesets"] = ["something"]
+        weak, fields = fpd.is_weakening(old, new)
+        assert weak is False
+
+
+# ---------------------------------------------------------------------------
+# fetch_live_protection() — gh subprocess mocked, comparator untouched
+# ---------------------------------------------------------------------------
+
+_PROTECTION_PAYLOAD = {
+    "required_status_checks": {
+        "strict": False,
+        "checks": [{"context": "Profile A", "app_id": 15368}],
+    },
+    "required_pull_request_reviews": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews": False,
+        "require_code_owner_reviews": False,
+        "require_last_push_approval": False,
+    },
+    "enforce_admins": {"enabled": True},
+    "required_signatures": {"enabled": False},
+    "required_linear_history": {"enabled": False},
+    "allow_force_pushes": {"enabled": False},
+    "allow_deletions": {"enabled": False},
+    "allow_fork_syncing": {"enabled": False},
+    "block_creations": {"enabled": False},
+    "lock_branch": {"enabled": False},
+    "required_conversation_resolution": {"enabled": False},
+}
+
+
+def _ok(stdout: Any) -> "subprocess.CompletedProcess[str]":
+    text = stdout if isinstance(stdout, str) else json.dumps(stdout)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=text, stderr="")
+
+
+def _err(stderr: str, returncode: int = 1) -> "subprocess.CompletedProcess[str]":
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+
+
+class TestFetchLiveProtection:
+    def test_reads_and_normalizes_all_three_endpoints(self, monkeypatch, tmp_path):
+        # The repo-object call ("repos/{owner}/{repo}") is a prefix of the
+        # rulesets/protection endpoints too, so it is matched last and only
+        # on an exact final argv element.
+        def fake_run(argv, **kwargs):
+            joined = " ".join(argv)
+            if "branches/main/protection" in joined:
+                return _ok(_PROTECTION_PAYLOAD)
+            if "rulesets" in joined:
+                return _ok([])
+            if argv[-1] == "repos/{owner}/{repo}":
+                return _ok({"allow_auto_merge": True})
+            raise AssertionError(f"unexpected gh call: {joined}")
+
+        monkeypatch.setattr(fpd.subprocess, "run", fake_run)
+        result = fpd.fetch_live_protection(tmp_path, branch="main")
+        assert result["enforce_admins"] is True
+        assert result["required_signatures"] is False
+        assert result["repo"]["allow_auto_merge"] is True
+        assert result["rulesets"] == []
+        assert result["required_status_checks"]["checks"] == [{"context": "Profile A", "app_id": 15368}]
+
+    def test_unreadable_protection_endpoint_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fpd.subprocess, "run", lambda argv, **k: _err("boom", 500))
+        with pytest.raises(fpd.ProtectionDriftError):
+            fpd.fetch_live_protection(tmp_path, branch="main")
+
+    def test_non_dict_protection_payload_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fpd.subprocess, "run", lambda argv, **k: _ok([1, 2, 3]))
+        with pytest.raises(fpd.ProtectionDriftError):
+            fpd.fetch_live_protection(tmp_path, branch="main")
+
+    def test_gh_missing_binary_raises(self, monkeypatch, tmp_path):
+        def raise_missing(argv, **kwargs):
+            raise FileNotFoundError("gh not found")
+
+        monkeypatch.setattr(fpd.subprocess, "run", raise_missing)
+        with pytest.raises(fpd.ProtectionDriftError, match="niet beschikbaar"):
+            fpd.fetch_live_protection(tmp_path, branch="main")
+
+
+# ---------------------------------------------------------------------------
+# fetch_yaml_from_ref() — 404 vs other failures (i)
+# ---------------------------------------------------------------------------
+
+class TestFetchYamlFromRef:
+    def test_404_is_not_found_not_error(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            fpd.subprocess, "run",
+            lambda argv, **k: _err("gh: Not Found (HTTP 404)", 1),
+        )
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is True
+        assert result.error is None
+        assert result.text is None
+
+    def test_500_is_an_error_not_not_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            fpd.subprocess, "run",
+            lambda argv, **k: _err("gh: Internal Server Error (HTTP 500)", 1),
+        )
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None
+
+    def test_403_is_an_error_not_not_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            fpd.subprocess, "run",
+            lambda argv, **k: _err("gh: Forbidden (HTTP 403)", 1),
+        )
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None
+
+    def test_successful_fetch_decodes_base64_content(self, monkeypatch, tmp_path):
+        raw = "branch: main\n"
+        payload = {"content": base64.b64encode(raw.encode("utf-8")).decode("ascii"), "sha": "abc123"}
+        monkeypatch.setattr(fpd.subprocess, "run", lambda argv, **k: _ok(payload))
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is None
+        assert result.text == raw
+
+    def test_gh_missing_is_an_error(self, monkeypatch, tmp_path):
+        def raise_missing(argv, **kwargs):
+            raise FileNotFoundError("gh not found")
+
+        monkeypatch.setattr(fpd.subprocess, "run", raise_missing)
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None
+
+    def test_unparseable_json_is_an_error(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fpd.subprocess, "run", lambda argv, **k: _ok("not json"))
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None
+
+    def test_missing_content_field_is_an_error(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fpd.subprocess, "run", lambda argv, **k: _ok({"sha": "abc"}))
+        result = fpd.fetch_yaml_from_ref(tmp_path, "main")
+        assert result.not_found is False
+        assert result.error is not None

--- a/tests/test_pr_merge_branch_protection.py
+++ b/tests/test_pr_merge_branch_protection.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Tests for the branch-protection merge gate wired into pr_merge.py
+(Golf B, B1).
+
+``_run_branch_protection_gate`` runs four checks in order: (a) read main's
+own YAML (a 404 on that exact path is the bootstrap no-op), (b) live vs
+main's YAML drift (no override), (c) the PR's own YAML must not weaken
+main's (``--allow-weaken`` is the only override), (d) the running
+``scripts/pr_merge.py`` must hash-match main's copy. Only the two network
+primitives (``fetch_yaml_from_ref``, ``fetch_live_protection``) and the door
+hash-check are mocked per test — ``compare``/``is_weakening`` run for real.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+from forge_protection_drift import YamlFetchResult, to_normalized_dict, load_protection_config
+
+
+SHA = "c" * 40
+YAML_PATH = SCRIPTS_DIR / "forge" / "branch_protection.yaml"
+PR_DATA = {
+    "number": 1, "title": "t", "state": "OPEN",
+    "headRefName": "feature/x", "baseRefName": "main", "headRefOid": SHA,
+}
+
+
+def _real_yaml_text() -> str:
+    return YAML_PATH.read_text(encoding="utf-8")
+
+
+def _real_norm() -> Dict[str, Any]:
+    return to_normalized_dict(load_protection_config(YAML_PATH))
+
+
+def _go(**overrides: Any) -> Dict[str, Any]:
+    gate = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+    gate.update(overrides)
+    return gate
+
+
+def _found(text: str) -> YamlFetchResult:
+    return YamlFetchResult(text=text, not_found=False, error=None)
+
+
+def _not_found() -> YamlFetchResult:
+    return YamlFetchResult(text=None, not_found=True, error=None)
+
+
+def _fetch_error(msg: str = "gh api faalde (rc=1): boom") -> YamlFetchResult:
+    return YamlFetchResult(text=None, not_found=False, error=msg)
+
+
+def _stub_matching_door_hash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr_merge, "_door_blob_hash_gate", lambda project_root: _go())
+
+
+# ---------------------------------------------------------------------------
+# _door_blob_hash_gate — direct
+# ---------------------------------------------------------------------------
+
+class TestDoorBlobHashGate:
+    def _fake_run(self, *, local_hash="abc123", remote_hash="abc123", local_rc=0, remote_rc=0):
+        def fake(argv, **kwargs):
+            if argv[:2] == ["git", "hash-object"]:
+                return subprocess.CompletedProcess(argv, local_rc, stdout=f"{local_hash}\n", stderr="")
+            assert argv[0] == "gh"
+            return subprocess.CompletedProcess(argv, remote_rc, stdout=f"{remote_hash}\n", stderr="boom" if remote_rc else "")
+        return fake
+
+    def test_matching_hashes_is_go(self, monkeypatch):
+        monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(local_hash="x", remote_hash="x"))
+        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        assert result["verdict"] == "GO"
+
+    def test_mismatched_hashes_is_no_go(self, monkeypatch):
+        """(l) blob-hash of the running pr_merge.py differs from main: refused."""
+        monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(local_hash="local", remote_hash="onmain"))
+        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        assert result["verdict"] == "NO-GO"
+        assert "main" in result["message"]
+
+    def test_local_git_failure_is_no_go(self, monkeypatch):
+        monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(local_rc=1))
+        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        assert result["verdict"] == "NO-GO"
+
+    def test_remote_gh_failure_is_no_go(self, monkeypatch):
+        monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(remote_rc=1))
+        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        assert result["verdict"] == "NO-GO"
+
+
+# ---------------------------------------------------------------------------
+# _run_branch_protection_gate — the four steps
+# ---------------------------------------------------------------------------
+
+class TestRunBranchProtectionGate:
+    def test_bootstrap_noop_when_main_has_no_yaml(self, monkeypatch):
+        """(i) 404 on exactly the YAML path: no-op with the loud bootstrap message."""
+        calls: List[str] = []
+
+        def fake_fetch(project_root, ref, *a, **k):
+            calls.append(ref)
+            return _not_found()
+
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", fake_fetch)
+        live_calls: List[Any] = []
+        monkeypatch.setattr(
+            pr_merge, "fetch_live_protection", lambda *a, **k: live_calls.append(1) or _real_norm(),
+        )
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+        assert result["verdict"] == "GO"
+        assert result["bootstrap"] is True
+        assert "geen YAML op main" in result["message"]
+        assert calls == ["main"]
+        assert not live_calls, "the bootstrap no-op must not go on to read live state"
+
+    def test_main_yaml_unreadable_blocks(self, monkeypatch):
+        """(i) a non-404 fault (500/403) on the YAML read is a refusal."""
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", lambda *a, **k: _fetch_error("HTTP 500"))
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+        assert result["verdict"] == "NO-GO"
+        assert "niet leesbaar" in result["message"]
+
+    def test_main_yaml_forbidden_blocks(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", lambda *a, **k: _fetch_error("HTTP 403"))
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+        assert result["verdict"] == "NO-GO"
+
+    def test_main_yaml_invalid_blocks(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", lambda *a, **k: _found("branch: main\nnot_a_known_field: 1\n"))
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+        assert result["verdict"] == "NO-GO"
+        assert "ongeldig" in result["message"]
+
+    def test_live_drift_blocks_naming_the_field(self, monkeypatch):
+        """(b) live differs from main's own declared YAML: refused, field named."""
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", lambda project_root, ref, *a, **k: _found(_real_yaml_text()))
+        drifted_live = _real_norm()
+        drifted_live["allow_force_pushes"] = True
+        monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: drifted_live)
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+        assert result["verdict"] == "NO-GO"
+        assert "allow_force_pushes" in result["message"]
+
+    def test_live_fetch_exception_blocks(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", lambda project_root, ref, *a, **k: _found(_real_yaml_text()))
+
+        def raise_error(*a, **k):
+            raise RuntimeError("network unreachable")
+
+        monkeypatch.setattr(pr_merge, "fetch_live_protection", raise_error)
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+        assert result["verdict"] == "NO-GO"
+        assert "niet leesbaar" in result["message"]
+
+    def _stub_main_matches_live(self, monkeypatch):
+        """main's YAML, live state, and the PR-head's YAML all identical --
+        the "nothing to refuse" baseline other tests build on."""
+        live = _real_norm()
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", lambda project_root, ref, *a, **k: _found(_real_yaml_text()))
+        monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: live)
+
+    def test_pr_deletes_the_yaml_is_refused_with_the_path(self, monkeypatch):
+        """(j) the PR removes scripts/forge/branch_protection.yaml: refused, path named."""
+        def fake_fetch(project_root, ref, *a, **k):
+            if ref == "main":
+                return _found(_real_yaml_text())
+            return _not_found()
+
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", fake_fetch)
+        monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: _real_norm())
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+        assert result["verdict"] == "NO-GO"
+        assert "scripts/forge/branch_protection.yaml" in result["message"]
+        assert "verwijdert" in result["message"]
+
+    def test_pr_yaml_read_error_blocks(self, monkeypatch):
+        def fake_fetch(project_root, ref, *a, **k):
+            if ref == "main":
+                return _found(_real_yaml_text())
+            return _fetch_error("HTTP 500")
+
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", fake_fetch)
+        monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: _real_norm())
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+        assert result["verdict"] == "NO-GO"
+
+    def test_pr_head_unresolvable_blocks(self, monkeypatch):
+        self._stub_main_matches_live(monkeypatch)
+        result = pr_merge._run_branch_protection_gate(1, pr_data={})
+        assert result["verdict"] == "NO-GO"
+        assert "PR-head" in result["message"]
+
+    class TestWeakeningOnPrSide:
+        """(k) the PR's own YAML weakens main's — enforce_admins: false, or a
+        vnx-gate/* entry dropped from checks[]."""
+
+        def _pr_yaml_with_enforce_admins_false(self) -> str:
+            return _real_yaml_text().replace("enforce_admins: true", "enforce_admins: false")
+
+        def test_enforce_admins_false_is_refused_without_allow_weaken(self, monkeypatch):
+            def fake_fetch(project_root, ref, *a, **k):
+                if ref == "main":
+                    return _found(_real_yaml_text())
+                return _found(self._pr_yaml_with_enforce_admins_false())
+
+            monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", fake_fetch)
+            monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: _real_norm())
+            _stub_matching_door_hash(monkeypatch)
+
+            result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+            assert result["verdict"] == "NO-GO"
+            assert "enforce_admins" in result["message"]
+            assert "allow-weaken" in result["message"]
+
+        def test_enforce_admins_false_with_allow_weaken_and_reason_proceeds(self, monkeypatch):
+            def fake_fetch(project_root, ref, *a, **k):
+                if ref == "main":
+                    return _found(_real_yaml_text())
+                return _found(self._pr_yaml_with_enforce_admins_false())
+
+            monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", fake_fetch)
+            monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: _real_norm())
+            _stub_matching_door_hash(monkeypatch)
+
+            result = pr_merge._run_branch_protection_gate(
+                1, pr_data=PR_DATA, allow_weaken_reason="operator akkoord",
+            )
+
+            assert result["verdict"] == "GO"
+            assert result["overridden"] is True
+            assert result["override_reason"] == "operator akkoord"
+            assert "OVERRIDE" in result["message"]
+
+        def test_allow_weaken_with_empty_reason_is_refused(self, monkeypatch):
+            def fake_fetch(project_root, ref, *a, **k):
+                if ref == "main":
+                    return _found(_real_yaml_text())
+                return _found(self._pr_yaml_with_enforce_admins_false())
+
+            monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", fake_fetch)
+            monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: _real_norm())
+
+            result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA, allow_weaken_reason="   ")
+
+            assert result["verdict"] == "NO-GO"
+            assert result["overridden"] is True
+            assert "niet-lege reden" in result["message"]
+
+        def test_removing_a_vnx_gate_check_is_refused_without_allow_weaken(self, monkeypatch):
+            main_text = _real_yaml_text().replace(
+                "    - {context: \"vnx doctor smoke\", app_id: 15368}\n",
+                "    - {context: \"vnx doctor smoke\", app_id: 15368}\n"
+                "    - {context: \"vnx-gate/review\", app_id: 424242}\n",
+            )
+            pr_text = _real_yaml_text()  # PR-side lacks the vnx-gate/* entry main now has
+
+            def fake_fetch(project_root, ref, *a, **k):
+                if ref == "main":
+                    return _found(main_text)
+                return _found(pr_text)
+
+            monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", fake_fetch)
+            main_norm = to_normalized_dict(pr_merge.parse_protection_config(main_text))
+            monkeypatch.setattr(pr_merge, "fetch_live_protection", lambda *a, **k: main_norm)
+
+            result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+            assert result["verdict"] == "NO-GO"
+            assert "vnx-gate/review" in result["message"]
+
+    def test_door_hash_check_runs_after_a_clean_pr_and_its_no_go_propagates(self, monkeypatch):
+        self._stub_main_matches_live(monkeypatch)
+        monkeypatch.setattr(
+            pr_merge, "_door_blob_hash_gate",
+            lambda project_root: {"verdict": "NO-GO", "message": "deur draait niet op main", "overridden": False, "override_reason": None},
+        )
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+        assert result["verdict"] == "NO-GO"
+        assert "deur draait niet op main" in result["message"]
+
+    def test_clean_pr_with_matching_door_hash_is_go(self, monkeypatch):
+        self._stub_main_matches_live(monkeypatch)
+        _stub_matching_door_hash(monkeypatch)
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+        assert result["verdict"] == "GO"
+        assert result["overridden"] is False
+
+
+# ---------------------------------------------------------------------------
+# main() wiring
+# ---------------------------------------------------------------------------
+
+class TestMainWiring:
+    def _ok_dry_run_result(self):
+        return {
+            "success": True, "pr_number": 1, "dispatch_id": "", "merge_method": "squash",
+            "pr_title": "", "branch": "", "receipt_status": None, "receipt_ok": False,
+            "register_ok": False, "error": "", "dry_run": True, "overlaps": [],
+        }
+
+    def _bypass_everything_but_protection(self, monkeypatch):
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (_go(), dict(PR_DATA)))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (_go(), dict(PR_DATA)))
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", lambda pr, **k: _go())
+        monkeypatch.setattr(pr_merge, "_run_contract_invalid_gate", lambda *a, **k: _go(skipped=True))
+
+    def test_main_invokes_the_branch_protection_gate(self, monkeypatch, capsys):
+        """(f) presence test, pattern tests/test_pr_merge_ci_gate.py::TestMainGateWiring."""
+        self._bypass_everything_but_protection(monkeypatch)
+        seen: List[Any] = []
+        monkeypatch.setattr(
+            pr_merge, "_run_branch_protection_gate",
+            lambda pr, **k: seen.append(k) or _go(),
+        )
+        monkeypatch.setattr(pr_merge, "merge_pr", lambda **k: self._ok_dry_run_result())
+
+        rc = pr_merge.main(["--pr", "1", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert seen, "_run_branch_protection_gate must be invoked by main()"
+        assert "Branch-protection gate" in capsys.readouterr().out
+
+    def test_main_refuses_before_merge_when_gate_is_no_go(self, monkeypatch, capsys):
+        self._bypass_everything_but_protection(monkeypatch)
+        merge_called: List[Any] = []
+        monkeypatch.setattr(
+            pr_merge, "_run_branch_protection_gate",
+            lambda pr, **k: {"verdict": "NO-GO", "message": "branch-protection wijkt af: X", "overridden": False, "override_reason": None},
+        )
+        monkeypatch.setattr(pr_merge, "merge_pr", lambda **k: merge_called.append(1) or self._ok_dry_run_result())
+
+        rc = pr_merge.main(["--pr", "1", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not merge_called
+        assert "branch-protection wijkt af" in capsys.readouterr().err
+
+    def test_main_forwards_allow_weaken_flag(self, monkeypatch):
+        self._bypass_everything_but_protection(monkeypatch)
+        seen: Dict[str, Any] = {}
+
+        def fake_gate(pr, **k):
+            seen.update(k)
+            return _go()
+
+        monkeypatch.setattr(pr_merge, "_run_branch_protection_gate", fake_gate)
+        monkeypatch.setattr(pr_merge, "merge_pr", lambda **k: self._ok_dry_run_result())
+
+        rc = pr_merge.main(["--pr", "1", "--dry-run", "--allow-weaken", "operator zei ja"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert seen.get("allow_weaken_reason") == "operator zei ja"
+
+    def test_main_json_no_go_outputs_json(self, monkeypatch, capsys):
+        self._bypass_everything_but_protection(monkeypatch)
+        monkeypatch.setattr(
+            pr_merge, "_run_branch_protection_gate",
+            lambda pr, **k: {"verdict": "NO-GO", "message": "branch-protection wijkt af: X", "overridden": False, "override_reason": None},
+        )
+
+        rc = pr_merge.main(["--pr", "1", "--json"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        import json as _json
+        stdout = capsys.readouterr().out
+        out = _json.loads(stdout[stdout.index("{"):])
+        assert out["success"] is False
+        assert "branch-protection wijkt af" in out["error"]

--- a/tests/test_pr_merge_branch_protection.py
+++ b/tests/test_pr_merge_branch_protection.py
@@ -2,13 +2,14 @@
 """Tests for the branch-protection merge gate wired into pr_merge.py
 (Golf B, B1).
 
-``_run_branch_protection_gate`` runs four checks in order: (a) read main's
-own YAML (a 404 on that exact path is the bootstrap no-op), (b) live vs
-main's YAML drift (no override), (c) the PR's own YAML must not weaken
-main's (``--allow-weaken`` is the only override), (d) the running
-``scripts/pr_merge.py`` must hash-match main's copy. Only the two network
-primitives (``fetch_yaml_from_ref``, ``fetch_live_protection``) and the door
-hash-check are mocked per test — ``compare``/``is_weakening`` run for real.
+``_run_branch_protection_gate`` runs four checks in order: (a) every file
+the door's verdict depends on must hash-match main's copy, (b) read main's
+own YAML (a 404 on that exact path, at a confirmed ref, is the bootstrap
+no-op), (c) live vs main's YAML drift (no override), (d) the PR's own YAML
+must not weaken main's (``--allow-weaken`` is the only override). Only the
+two network primitives (``fetch_yaml_from_ref``, ``fetch_live_protection``)
+and the door hash-check are mocked per test — ``compare``/``is_weakening``
+run for real.
 """
 
 from __future__ import annotations
@@ -67,6 +68,14 @@ def _stub_matching_door_hash(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pr_merge, "_door_blob_hash_gate", lambda project_root: _go())
 
 
+#: The REAL door-integrity check, captured at import time. tests/conftest.py
+#: carries an autouse fixture that stubs ``pr_merge._door_blob_hash_gate`` to
+#: GO for the whole suite (it is the gate's first step since the B1
+#: fix-forward and shells out to git + gh), so the two classes that exercise
+#: the check itself must hold their own reference to it.
+_REAL_DOOR_BLOB_HASH_GATE = pr_merge._door_blob_hash_gate
+
+
 # ---------------------------------------------------------------------------
 # _door_blob_hash_gate — direct
 # ---------------------------------------------------------------------------
@@ -82,25 +91,103 @@ class TestDoorBlobHashGate:
 
     def test_matching_hashes_is_go(self, monkeypatch):
         monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(local_hash="x", remote_hash="x"))
-        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        result = _REAL_DOOR_BLOB_HASH_GATE(VNX_ROOT)
         assert result["verdict"] == "GO"
 
     def test_mismatched_hashes_is_no_go(self, monkeypatch):
         """(l) blob-hash of the running pr_merge.py differs from main: refused."""
         monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(local_hash="local", remote_hash="onmain"))
-        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        result = _REAL_DOOR_BLOB_HASH_GATE(VNX_ROOT)
         assert result["verdict"] == "NO-GO"
         assert "main" in result["message"]
 
     def test_local_git_failure_is_no_go(self, monkeypatch):
         monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(local_rc=1))
-        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        result = _REAL_DOOR_BLOB_HASH_GATE(VNX_ROOT)
         assert result["verdict"] == "NO-GO"
 
     def test_remote_gh_failure_is_no_go(self, monkeypatch):
         monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(remote_rc=1))
-        result = pr_merge._door_blob_hash_gate(VNX_ROOT)
+        result = _REAL_DOOR_BLOB_HASH_GATE(VNX_ROOT)
         assert result["verdict"] == "NO-GO"
+
+
+class TestDoorBlobHashCoversTheWholeDoor:
+    """Fix-forward punt 4: hashing only the entry point leaves every file
+    that actually renders the verdict unguarded. A one-line edit to
+    ``is_weakening`` in ``forge_protection_drift.py`` keeps
+    ``scripts/pr_merge.py`` byte-identical to main, so the integrity check
+    passed while the door's judgment was neutralized.
+    """
+
+    #: The files whose content decides what the door refuses. Mutating any of
+    #: them changes a verdict without touching scripts/pr_merge.py.
+    DOOR_FILES = (
+        "scripts/pr_merge.py",
+        "scripts/lib/forge_protection_drift.py",
+        "scripts/lib/merge_preflight_adr_check.py",
+        "scripts/lib/merge_preflight_ci_check.py",
+        "scripts/lib/contract_invalid_ledger.py",
+    )
+
+    def _fake_run(self, *, local_overrides: Optional[Dict[str, str]] = None,
+                  remote_overrides: Optional[Dict[str, str]] = None,
+                  seen: Optional[List[str]] = None):
+        local_overrides = local_overrides or {}
+        remote_overrides = remote_overrides or {}
+
+        def fake(argv, **kwargs):
+            if argv[:2] == ["git", "hash-object"]:
+                path = argv[-1]
+                if seen is not None:
+                    seen.append(path)
+                return subprocess.CompletedProcess(
+                    argv, 0, stdout=f"{local_overrides.get(path, 'same-' + path)}\n", stderr="",
+                )
+            assert argv[0] == "gh"
+            endpoint = next(a for a in argv if "contents/" in a)
+            path = endpoint.split("contents/", 1)[1].split("?", 1)[0]
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=f"{remote_overrides.get(path, 'same-' + path)}\n", stderr="",
+            )
+
+        return fake
+
+    def test_every_door_file_is_hashed_against_main(self, monkeypatch):
+        seen: List[str] = []
+        monkeypatch.setattr(pr_merge.subprocess, "run", self._fake_run(seen=seen))
+        result = _REAL_DOOR_BLOB_HASH_GATE(VNX_ROOT)
+        assert result["verdict"] == "GO"
+        assert set(seen) == set(self.DOOR_FILES)
+
+    @pytest.mark.parametrize("mutated", [
+        "scripts/lib/forge_protection_drift.py",
+        "scripts/lib/merge_preflight_adr_check.py",
+        "scripts/lib/merge_preflight_ci_check.py",
+        "scripts/lib/contract_invalid_ledger.py",
+    ])
+    def test_a_mutated_library_file_refuses_and_is_named(self, monkeypatch, mutated):
+        monkeypatch.setattr(
+            pr_merge.subprocess, "run",
+            self._fake_run(local_overrides={mutated: "locally-edited"}),
+        )
+        result = _REAL_DOOR_BLOB_HASH_GATE(VNX_ROOT)
+        assert result["verdict"] == "NO-GO"
+        assert mutated in result["message"]
+
+    def test_a_file_missing_on_main_refuses(self, monkeypatch):
+        def fake(argv, **kwargs):
+            if argv[:2] == ["git", "hash-object"]:
+                return subprocess.CompletedProcess(argv, 0, stdout="x\n", stderr="")
+            endpoint = next(a for a in argv if "contents/" in a)
+            if "forge_protection_drift" in endpoint:
+                return subprocess.CompletedProcess(argv, 1, stdout="", stderr="gh: Not Found (HTTP 404)")
+            return subprocess.CompletedProcess(argv, 0, stdout="x\n", stderr="")
+
+        monkeypatch.setattr(pr_merge.subprocess, "run", fake)
+        result = _REAL_DOOR_BLOB_HASH_GATE(VNX_ROOT)
+        assert result["verdict"] == "NO-GO"
+        assert "forge_protection_drift.py" in result["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +195,14 @@ class TestDoorBlobHashGate:
 # ---------------------------------------------------------------------------
 
 class TestRunBranchProtectionGate:
+    @pytest.fixture(autouse=True)
+    def _door_hash_go_by_default(self, monkeypatch):
+        """The door-integrity check is the FIRST step since the fix-forward
+        (punt 2), so every test in this class now passes through it. Default
+        it to GO; the tests that exercise it re-patch in their own body
+        (same monkeypatch instance, later call wins)."""
+        monkeypatch.setattr(pr_merge, "_door_blob_hash_gate", lambda project_root: _go())
+
     def test_bootstrap_noop_when_main_has_no_yaml(self, monkeypatch):
         """(i) 404 on exactly the YAML path: no-op with the loud bootstrap message."""
         calls: List[str] = []
@@ -129,6 +224,43 @@ class TestRunBranchProtectionGate:
         assert "geen YAML op main" in result["message"]
         assert calls == ["main"]
         assert not live_calls, "the bootstrap no-op must not go on to read live state"
+
+    def test_the_door_hash_check_also_guards_the_bootstrap_branch(self, monkeypatch):
+        """Fix-forward punt 2: the bootstrap no-op returned GO while skipping
+        every later step, the door-integrity check included -- so the one
+        check that proves the door itself is unedited sat behind the branch
+        that skips it."""
+        monkeypatch.setattr(pr_merge, "fetch_yaml_from_ref", lambda *a, **k: _not_found())
+        monkeypatch.setattr(
+            pr_merge, "_door_blob_hash_gate",
+            lambda project_root: {"verdict": "NO-GO", "message": "deur draait niet op main",
+                                  "overridden": False, "override_reason": None},
+        )
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+        assert result["verdict"] == "NO-GO"
+        assert "deur draait niet op main" in result["message"]
+
+    def test_the_door_hash_check_runs_before_any_network_read(self, monkeypatch):
+        order: List[str] = []
+        monkeypatch.setattr(
+            pr_merge, "_door_blob_hash_gate",
+            lambda project_root: order.append("door") or _go(),
+        )
+        monkeypatch.setattr(
+            pr_merge, "fetch_yaml_from_ref",
+            lambda project_root, ref, *a, **k: order.append(f"yaml:{ref}") or _found(_real_yaml_text()),
+        )
+        monkeypatch.setattr(
+            pr_merge, "fetch_live_protection",
+            lambda *a, **k: order.append("live") or _real_norm(),
+        )
+
+        result = pr_merge._run_branch_protection_gate(1, pr_data=PR_DATA)
+
+        assert result["verdict"] == "GO"
+        assert order[0] == "door", f"door-integrity must be step one, got {order}"
 
     def test_main_yaml_unreadable_blocks(self, monkeypatch):
         """(i) a non-404 fault (500/403) on the YAML read is a refusal."""
@@ -291,7 +423,7 @@ class TestRunBranchProtectionGate:
             assert result["verdict"] == "NO-GO"
             assert "vnx-gate/review" in result["message"]
 
-    def test_door_hash_check_runs_after_a_clean_pr_and_its_no_go_propagates(self, monkeypatch):
+    def test_door_hash_check_no_go_propagates(self, monkeypatch):
         self._stub_main_matches_live(monkeypatch)
         monkeypatch.setattr(
             pr_merge, "_door_blob_hash_gate",

--- a/tests/test_vnx_doctor_branch_protection.py
+++ b/tests/test_vnx_doctor_branch_protection.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for scripts/vnx_doctor.py::check_branch_protection_drift (Golf B, B1).
+
+(m) pass (no diffs), fail (with the differing fields), warn (unreachable
+live state, or the YAML missing on disk). Uses the SAME comparator
+(``forge_protection_drift.compare``) the merge-door preflight and
+``apply_branch_protection.py`` use — only ``fetch_live_protection`` is
+mocked per test.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts"))
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+import vnx_doctor
+import forge_protection_drift as fpd
+
+YAML_PATH = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
+
+
+def _real_norm() -> Dict[str, Any]:
+    return fpd.to_normalized_dict(fpd.load_protection_config(YAML_PATH))
+
+
+def _paths(vnx_home: Path) -> Dict[str, str]:
+    return {"VNX_HOME": str(vnx_home)}
+
+
+class TestCheckBranchProtectionDrift:
+    def test_pass_when_live_matches_the_yaml(self, monkeypatch):
+        monkeypatch.setattr(fpd, "fetch_live_protection", lambda *a, **k: _real_norm())
+
+        results = vnx_doctor.check_branch_protection_drift(_paths(VNX_ROOT))
+
+        assert len(results) == 1
+        assert results[0].status == vnx_doctor.PASS
+        assert results[0].name == "branch_protection_drift"
+
+    def test_fail_when_live_drifts_naming_the_fields(self, monkeypatch):
+        drifted = _real_norm()
+        drifted["allow_force_pushes"] = True
+        drifted["enforce_admins"] = False
+        monkeypatch.setattr(fpd, "fetch_live_protection", lambda *a, **k: drifted)
+
+        results = vnx_doctor.check_branch_protection_drift(_paths(VNX_ROOT))
+
+        assert len(results) == 1
+        assert results[0].status == vnx_doctor.FAIL
+        assert "allow_force_pushes" in results[0].message
+        assert "enforce_admins" in results[0].message
+        assert set(results[0].details) == {"allow_force_pushes", "enforce_admins"}
+
+    def test_warn_when_live_state_is_unreachable(self, monkeypatch):
+        def raise_drift_error(*a, **k):
+            raise fpd.ProtectionDriftError("gh CLI niet beschikbaar: boom")
+
+        monkeypatch.setattr(fpd, "fetch_live_protection", raise_drift_error)
+
+        results = vnx_doctor.check_branch_protection_drift(_paths(VNX_ROOT))
+
+        assert len(results) == 1
+        assert results[0].status == vnx_doctor.WARN
+        assert "niet leesbaar" in results[0].message
+
+    def test_warn_when_yaml_missing_on_disk(self, tmp_path):
+        empty_vnx_home = tmp_path / "no-scripts-here"
+        empty_vnx_home.mkdir()
+
+        results = vnx_doctor.check_branch_protection_drift(_paths(empty_vnx_home))
+
+        assert len(results) == 1
+        assert results[0].status == vnx_doctor.WARN
+        assert "ontbreekt" in results[0].message
+
+    def test_fail_when_yaml_on_disk_is_invalid(self, monkeypatch, tmp_path):
+        vnx_home = tmp_path / "vnx-system"
+        forge_dir = vnx_home / "scripts" / "forge"
+        forge_dir.mkdir(parents=True)
+        (forge_dir / "branch_protection.yaml").write_text("branch: main\nnot_a_known_field: 1\n", encoding="utf-8")
+
+        results = vnx_doctor.check_branch_protection_drift(_paths(vnx_home))
+
+        assert len(results) == 1
+        assert results[0].status == vnx_doctor.FAIL
+        assert "ongeldig" in results[0].message
+
+    def test_run_doctor_never_fails_on_this_check_with_a_synthetic_vnx_home(self):
+        """run_doctor's existing healthy-system test (tmp VNX_HOME, no
+        scripts/forge/ present) must keep getting WARN, not FAIL, from this
+        check -- a bare tmp dir is "not evidence of drift", not "drifted"."""
+        tmp_home = Path(__file__).resolve().parent  # any dir without scripts/forge/
+        results = vnx_doctor.check_branch_protection_drift(_paths(tmp_home))
+        assert results[0].status in (vnx_doctor.WARN, vnx_doctor.PASS)


### PR DESCRIPTION
## Summary
- Adds `scripts/forge/branch_protection.yaml`: the canonical, schema-validated declaration of `main`'s branch protection, measured live via `gh api` on 2026-09-07 (14 checks, all `app_id` 15368, `enforce_admins: true`, everything else off, `allow_auto_merge: false`, `rulesets: []`).
- Adds `scripts/forge/apply_branch_protection.py`: applies the YAML idempotently (zero API writes on a second run with no drift), with a fail-closed weaken-refusal (`--allow-weaken "<reason>"` is the only override). Writes a receipt (before/after state, reason) on every non-dry-run invocation.
- Adds `scripts/lib/forge_protection_drift.py`: the schema parser plus the shared `compare()`/`is_weakening()` diff engine — one comparator, reused by `apply_branch_protection.py`, `pr_merge.py`'s preflight, and `vnx_doctor.py`'s check, so none of them can silently disagree.
- `pr_merge.py::main()` gains a fourth fail-closed preflight gate, alongside the B6 (ADR) and B7 (contract_invalid) blocks: (a) main's own YAML is read via the contents API — a 404 on that exact path is the bootstrap no-op, any other fault blocks; (b) live protection on `main` must match that YAML, no override; (c) the PR's own copy of the YAML must not weaken main's (`--allow-weaken` only, empty reason refused); (d) the running `pr_merge.py`'s git blob hash must match main's copy.
- `vnx_doctor.py` gains `check_branch_protection_drift(paths)`, wired into the main check loop: PASS on no drift, FAIL naming the fields on drift, WARN when the YAML is missing on disk or live state is unreachable (never a false FAIL from an offline/fresh checkout).

## Changes
- `scripts/forge/branch_protection.yaml` (new)
- `scripts/forge/apply_branch_protection.py` (new)
- `scripts/lib/forge_protection_drift.py` (new)
- `scripts/pr_merge.py` — imports + `_no_go_protection`/`_door_blob_hash_gate`/`_run_branch_protection_gate` + `--allow-weaken` CLI flag + the `main()` invocation block (alongside the existing B6/B7 blocks)
- `scripts/vnx_doctor.py` — `check_branch_protection_drift` + one line in the `run_doctor` collection loop
- `tests/conftest.py` — autouse `_stub_branch_protection_gate_gh_calls` fixture (mirrors the existing ADR-gate stub; the "not found" default is real production state as of this PR — main has no YAML yet)
- `tests/test_forge_protection_drift.py`, `tests/test_apply_branch_protection.py`, `tests/test_pr_merge_branch_protection.py`, `tests/test_vnx_doctor_branch_protection.py` (new, 81 tests total)

## Verification
- Red-then-green (implementation temporarily moved aside, tracked-file changes stashed via `git stash push -u` scoped to the 3 tracked files, then restored — see report for the exact commands): 4/4 new test files failed collection (`ModuleNotFoundError`) without the implementation; 81/81 pass with it.
- `python3 scripts/forge/apply_branch_protection.py --dry-run` against the LIVE repo prints an object identical to the measured live protection (zero diffs); `python3 scripts/lib/forge_protection_drift.py` independently reports "geen verschillen". No real apply was run — the first apply is an operator step (see Open Items in the dispatch report).
- 432 tests green across the 4 new files + all `test_pr_merge_*.py`, `test_merge_preflight_adr_check.py`, and `test_vnx_doctor*.py` neighbours (no regressions). `python3 scripts/check_subsystems_drift.py` and the local `ci_lint_patterns.py` scan on added lines both pass clean.

Full dispatch report: `20260907-golfb-b1-branch-protection-config.md` in the unified reports store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)