### PR TITLE
feat(forge): GitHub-App-client voor check-runs, sleutel uit de keychain (golf B, B2a)

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -51,7 +51,17 @@ jobs:
           # build is required by tests/test_wheel_build.py::test_wheel_builds
           # (python -m build --wheel); without it that test fails in this image
           # with "No module named build" (OI-953).
-          pip install pytest pyyaml pytest-timeout jsonschema psutil watchdog hypothesis jinja2 build
+          # pyjwt[crypto] carries the forge check-run client (golf B, B2a):
+          # scripts/lib/forge_check_run.py signs a GitHub-App JWT with RS256 and
+          # tests/test_forge_check_run_client.py verifies that signature against
+          # a keypair it generates itself. The [crypto] extra is not optional —
+          # bare PyJWT has no asymmetric backend and raises NotImplementedError
+          # on RS256, and the test's keypair fixture imports `cryptography`
+          # directly, so the extra is what makes both halves of that test real
+          # instead of a mock. Measured 2026-09-07 on head 5fd261fd, run
+          # 34143589349: without it the whole file dies at collection with
+          # "No module named 'jwt'" and the gate never runs.
+          pip install pytest pyyaml pytest-timeout jsonschema psutil watchdog hypothesis jinja2 build "pyjwt[crypto]"
 
       - name: Prepare expected repo layout
         run: |

--- a/scripts/forge/branch_protection.yaml
+++ b/scripts/forge/branch_protection.yaml
@@ -71,20 +71,4 @@ repo:
 # GET /repos/{owner}/{repo}/rulesets returned [] when this was measured.
 rulesets: []
 
-# Golf B, B2a: the identity `scripts/lib/forge_check_run.py` authenticates as
-# when it publishes a check-run. Read by that client, never applied and never
-# compared — it describes WHO writes a check, not what `main` requires, so it
-# is an optional key to the B1 schema reader and absent from the normalized
-# dict `compare()` diffs (an entry here can therefore never register as drift),
-# exactly like pending_checks above. The block's own shape (slug/app_id) is
-# still validated by the schema reader -- only its PRESENCE is optional.
-#
-# `app_id` stays null until the operator registers the App; the client refuses
-# loudly on null rather than guessing. Once registered, B3 uses this same
-# app_id to bind the vnx-gate/review required check (see pending_checks above)
-# to this app -- the schema's vnx-gate/* guard on checks[] is what enforces
-# that every vnx-gate/* entry carries a bound app_id once it lands there.
-# Filling it in is an operator step: see docs/operations/FORGE_GATE.md.
-app:
-  slug: vnx-gate
-  app_id: null
+# Operator-stap uit docs/operations/FORGE_GATE.md: het `app:`-blok (slug + app_id) komt hier terug zodra de App bestaat; de schemalezer accepteert het al sinds deze PR (Golf B, B2a fix-forward 3).

--- a/scripts/forge/branch_protection.yaml
+++ b/scripts/forge/branch_protection.yaml
@@ -75,11 +75,16 @@ rulesets: []
 # when it publishes a check-run. Read by that client, never applied and never
 # compared — it describes WHO writes a check, not what `main` requires, so it
 # is an optional key to the B1 schema reader and absent from the normalized
-# dict `compare()` diffs (an entry here can therefore never register as drift).
+# dict `compare()` diffs (an entry here can therefore never register as drift),
+# exactly like pending_checks above. The block's own shape (slug/app_id) is
+# still validated by the schema reader -- only its PRESENCE is optional.
 #
 # `app_id` stays null until the operator registers the App; the client refuses
-# loudly on null rather than guessing. Filling it in is an operator step:
-# see docs/operations/FORGE_GATE.md.
+# loudly on null rather than guessing. Once registered, B3 uses this same
+# app_id to bind the vnx-gate/review required check (see pending_checks above)
+# to this app -- the schema's vnx-gate/* guard on checks[] is what enforces
+# that every vnx-gate/* entry carries a bound app_id once it lands there.
+# Filling it in is an operator step: see docs/operations/FORGE_GATE.md.
 app:
   slug: vnx-gate
   app_id: null

--- a/scripts/forge/branch_protection.yaml
+++ b/scripts/forge/branch_protection.yaml
@@ -70,3 +70,16 @@ repo:
 # Checked, never applied — apply_branch_protection.py never writes rulesets.
 # GET /repos/{owner}/{repo}/rulesets returned [] when this was measured.
 rulesets: []
+
+# Golf B, B2a: the identity `scripts/lib/forge_check_run.py` authenticates as
+# when it publishes a check-run. Read by that client, never applied and never
+# compared — it describes WHO writes a check, not what `main` requires, so it
+# is an optional key to the B1 schema reader and absent from the normalized
+# dict `compare()` diffs (an entry here can therefore never register as drift).
+#
+# `app_id` stays null until the operator registers the App; the client refuses
+# loudly on null rather than guessing. Filling it in is an operator step:
+# see docs/operations/FORGE_GATE.md.
+app:
+  slug: vnx-gate
+  app_id: null

--- a/scripts/lib/forge_check_run.py
+++ b/scripts/lib/forge_check_run.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""GitHub-App client for publishing check-runs (Golf B, B2a).
+
+The CLIENT layer, and deliberately nothing more: it authenticates as the
+``vnx-gate`` GitHub App and posts a completed check-run. It has ZERO knowledge
+of what a review gate decided — no mapping from a review outcome to a
+``conclusion``, no filtering of which outcomes may be published. ``conclusion``
+is forwarded exactly as given. That judgment, and the wiring into the gate
+recorder, is B2b's; keeping it out of here is what lets B2b change the policy
+without touching a line of transport.
+
+Why a GitHub App at all: a check-run published with the operator's own token
+carries the operator's identity, so branch protection cannot distinguish
+"the gate passed" from "a human with a token said so". An App identity can be
+bound in branch protection (``app_id`` on the required check), which is what
+makes ``vnx-gate/*`` a check only the App can satisfy.
+
+Three secrets, three sources:
+
+  ``app.app_id`` / ``app.slug``   ``scripts/forge/branch_protection.yaml`` —
+                                  public, versioned, reviewable.
+  private key (PEM)               macOS keychain, item ``vnx-gate-app-key``.
+  installation id                 macOS keychain, item ``vnx-gate-installation-id``.
+
+Every keychain read fails LOUD. ``send_digest_email._read_smtp_pass_from_keychain``
+returns ``""`` when the item is missing or the keychain is locked; that soft
+failure is correct for an optional digest mail and WRONG here — an empty key
+would turn "the gate could not authenticate" into "the check-run silently never
+appeared", which is the exact failure mode branch protection exists to prevent.
+So each failure raises with the literal ``security add-generic-password``
+command that repairs it, plus the runbook.
+
+HTTP transport: ``urllib.request``, not ``gh api``. ``gh`` resolves its own
+credentials (keychain/keyring, ``hosts.yml``, ``GH_TOKEN``/``GITHUB_TOKEN``)
+and its own owner/repo from the ambient cwd. Handing it an App token means
+injecting it as ``GH_TOKEN`` into the subprocess environment and trusting gh's
+auth-resolution order to prefer it — which makes the IDENTITY of the call, the
+one thing this whole module exists to control, depend on gh's precedence rules
+and on whatever else that environment carries. ``urllib.request`` sends exactly
+the ``Authorization`` header built here and nothing else, and the token never
+enters an environment block. ``apply_branch_protection.py`` (B1) uses ``gh api``
+for the opposite reason: there the operator's own admin identity is precisely
+what is wanted.
+
+BILLING SAFETY: No Anthropic SDK. No direct API calls to api.anthropic.com.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import yaml
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from chain_origin_anchor import _owner_repo_from_remote  # noqa: E402
+from forge_protection_drift import PROTECTION_YAML_RELATIVE_PATH  # noqa: E402
+
+#: scripts/lib/forge_check_run.py -> scripts/lib -> scripts -> repo root.
+#: Derived from ``__file__``, never from the cwd: this module is imported by
+#: callers whose cwd is a dispatch worktree, not the checkout.
+REPO_ROOT = _LIB_DIR.parent.parent
+
+DEFAULT_YAML_PATH = REPO_ROOT / PROTECTION_YAML_RELATIVE_PATH
+
+#: The operator runbook every failure points at. Written in B-golf's operator
+#: step; referenced here because a loud error with nowhere to go is only half
+#: a repair instruction.
+RUNBOOK_PATH = "docs/operations/FORGE_GATE.md"
+
+KEYCHAIN_PRIVATE_KEY_SERVICE = "vnx-gate-app-key"
+KEYCHAIN_INSTALLATION_ID_SERVICE = "vnx-gate-installation-id"
+
+GITHUB_API_BASE = "https://api.github.com"
+GITHUB_ACCEPT = "application/vnd.github+json"
+GITHUB_API_VERSION = "2022-11-28"
+
+#: GitHub rejects an App JWT whose ``exp`` is more than 10 minutes out. 9
+#: leaves a minute of headroom for a slow clock.
+JWT_LIFETIME_SECONDS = 9 * 60
+#: ``iat`` is backdated so a client clock running slightly fast cannot produce
+#: a token GitHub considers issued in the future.
+JWT_BACKDATE_SECONDS = 60
+#: An installation token is treated as spent this long before GitHub's own
+#: ``expires_at``, so a request is never sent with a token that dies in flight.
+TOKEN_REFRESH_MARGIN_SECONDS = 300
+
+_SECURITY_TIMEOUT_SECONDS = 10
+_HTTP_TIMEOUT_SECONDS = 30
+#: An API error body is quoted, not dumped: enough to name the cause, bounded
+#: so a stray HTML error page cannot flood a log or a receipt.
+_ERROR_BODY_LIMIT = 500
+
+
+class ForgeCheckRunError(RuntimeError):
+    """Anything that stops a check-run from being published.
+
+    Always raised, never degraded to a no-op return: a check-run that silently
+    fails to appear reads to branch protection as "the check has not run yet",
+    which blocks forever without ever saying why.
+    """
+
+
+class ForgeAppConfigError(ForgeCheckRunError):
+    """``scripts/forge/branch_protection.yaml`` has no usable ``app:`` block."""
+
+
+class ForgeKeychainError(ForgeCheckRunError):
+    """A keychain item is missing, empty, or unreadable."""
+
+
+class ForgeAPIError(ForgeCheckRunError):
+    """A GitHub API call failed. Carries the HTTP status and a bounded body.
+
+    ``status`` is ``None`` when the call never got a response at all (DNS,
+    TLS, timeout) — distinct from an HTTP status, because a caller retrying a
+    transport blip and a caller reacting to a 422 are different decisions.
+    """
+
+    def __init__(self, message: str, *, status: Optional[int] = None, body: str = "") -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    """The public half of the App's identity, read from the versioned YAML."""
+
+    slug: str
+    app_id: int
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def load_app_config(path: Optional[Path] = None) -> AppConfig:
+    """Read ``app.slug`` / ``app.app_id`` from the branch-protection YAML.
+
+    An absent or null ``app_id`` is the expected state until the operator has
+    registered the App, so it raises with the operator step rather than a
+    generic parse error.
+    """
+    yaml_path = Path(path) if path is not None else DEFAULT_YAML_PATH
+    try:
+        raw = yaml_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ForgeAppConfigError(
+            f"kan {yaml_path} niet lezen: {exc}. Operator-stap uit {RUNBOOK_PATH}."
+        ) from exc
+
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ForgeAppConfigError(f"{yaml_path} is geen geldige YAML: {exc}") from exc
+
+    block = (doc or {}).get("app") if isinstance(doc, dict) else None
+    if block is None:
+        raise ForgeAppConfigError(
+            f"app-blok ontbreekt in {PROTECTION_YAML_RELATIVE_PATH}: "
+            f"operator-stap uit {RUNBOOK_PATH}"
+        )
+    if not isinstance(block, dict):
+        raise ForgeAppConfigError(
+            f"app moet een object zijn met slug en app_id, kreeg {type(block).__name__} "
+            f"({PROTECTION_YAML_RELATIVE_PATH})"
+        )
+
+    slug = block.get("slug")
+    if not isinstance(slug, str) or not slug.strip():
+        raise ForgeAppConfigError(
+            f"app.slug ontbreekt of is leeg in {PROTECTION_YAML_RELATIVE_PATH}: "
+            f"operator-stap uit {RUNBOOK_PATH}"
+        )
+
+    app_id = block.get("app_id")
+    if app_id is None:
+        raise ForgeAppConfigError(
+            f"app_id ontbreekt in {PROTECTION_YAML_RELATIVE_PATH}: "
+            f"operator-stap uit {RUNBOOK_PATH}"
+        )
+    # bool is an int subclass; `app_id: true` is a typo, not an identifier.
+    if isinstance(app_id, bool) or not isinstance(app_id, int):
+        raise ForgeAppConfigError(
+            f"app.app_id moet een geheel getal zijn, kreeg {type(app_id).__name__} "
+            f"({PROTECTION_YAML_RELATIVE_PATH}): operator-stap uit {RUNBOOK_PATH}"
+        )
+
+    return AppConfig(slug=slug.strip(), app_id=app_id)
+
+
+# ---------------------------------------------------------------------------
+# Keychain — loud on every failure, never an empty string
+# ---------------------------------------------------------------------------
+
+
+def _recovery_hint(service: str, what: str) -> str:
+    return (
+        f"Herstel: security add-generic-password -s {service} -a \"$USER\" -w '<{what}>' "
+        f"(runbook: {RUNBOOK_PATH})"
+    )
+
+
+def _read_keychain_secret(service: str, what: str) -> str:
+    """Return the keychain secret for ``service``, or raise.
+
+    Never returns "" — see the module docstring for why the soft-fail pattern
+    in ``send_digest_email`` is the wrong shape here.
+    """
+    account = os.environ.get("USER", "")
+    argv = ["security", "find-generic-password", "-s", service, "-a", account, "-w"]
+    hint = _recovery_hint(service, what)
+
+    try:
+        proc = subprocess.run(
+            argv, capture_output=True, text=True, timeout=_SECURITY_TIMEOUT_SECONDS
+        )
+    except FileNotFoundError as exc:
+        raise ForgeKeychainError(
+            f"`security` niet gevonden: de keychain is alleen op macOS beschikbaar, "
+            f"en {service} kan hier niet gelezen worden. {hint}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ForgeKeychainError(
+            f"`security find-generic-password -s {service}` liep vast na "
+            f"{_SECURITY_TIMEOUT_SECONDS}s (wacht de keychain op een wachtwoordprompt?). {hint}"
+        ) from exc
+    except OSError as exc:
+        raise ForgeKeychainError(f"`security` kon niet starten voor {service}: {exc}. {hint}") from exc
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        if proc.returncode == 44:
+            reason = f"keychain-item {service} bestaat niet"
+        elif proc.returncode == 51:
+            reason = (
+                f"de keychain staat op slot of weigert niet-interactieve toegang tot {service} "
+                f"(ontgrendel met: security unlock-keychain)"
+            )
+        else:
+            reason = f"`security` gaf exit {proc.returncode} voor {service}"
+        raise ForgeKeychainError(f"{reason}: {stderr[:200]}. {hint}")
+
+    secret = (proc.stdout or "").strip()
+    if not secret:
+        raise ForgeKeychainError(
+            f"keychain-item {service} is leeg. Een lege waarde is hier nooit bruikbaar: "
+            f"de check-run zou stil wegvallen in plaats van te falen. {hint}"
+        )
+    return secret
+
+
+def read_private_key() -> str:
+    """The App's RSA private key (PEM) from keychain item ``vnx-gate-app-key``."""
+    return _read_keychain_secret(KEYCHAIN_PRIVATE_KEY_SERVICE, "pad naar de .pem, via $(cat ...)")
+
+
+def read_installation_id() -> str:
+    """The installation id from keychain item ``vnx-gate-installation-id``."""
+    value = _read_keychain_secret(KEYCHAIN_INSTALLATION_ID_SERVICE, "installation-id")
+    if not value.isdigit():
+        raise ForgeKeychainError(
+            f"keychain-item {KEYCHAIN_INSTALLATION_ID_SERVICE} is geen getal ({value[:40]!r}). "
+            f"{_recovery_hint(KEYCHAIN_INSTALLATION_ID_SERVICE, 'installation-id')}"
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# owner/repo
+# ---------------------------------------------------------------------------
+
+
+def resolve_owner_repo(project_root: Optional[Path] = None) -> str:
+    """``owner/repo`` from the ``origin`` remote of ``project_root``.
+
+    Reuses ``chain_origin_anchor._owner_repo_from_remote`` rather than adding
+    a fourth copy of the same regex to this repo.
+    """
+    root = Path(project_root) if project_root is not None else REPO_ROOT
+    owner_repo = _owner_repo_from_remote(root)
+    if not owner_repo:
+        raise ForgeCheckRunError(
+            f"kan owner/repo niet afleiden uit de git-remote 'origin' in {root} "
+            "(geen GitHub-remote, of de remote ontbreekt)"
+        )
+    return owner_repo
+
+
+# ---------------------------------------------------------------------------
+# HTTP seam — one function, so tests replace the network and nothing else
+# ---------------------------------------------------------------------------
+
+
+def _api_request(
+    method: str,
+    url: str,
+    *,
+    headers: Dict[str, str],
+    payload: Optional[str] = None,
+    timeout: int = _HTTP_TIMEOUT_SECONDS,
+) -> Tuple[int, str]:
+    """Perform one API call. Returns ``(status, body_text)``.
+
+    A 4xx/5xx is a RETURN, not a raise: each caller composes its own message
+    from the status it actually got. Only a call that never reached GitHub
+    raises here, because there is no status to hand back.
+    """
+    data = payload.encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    for key, value in headers.items():
+        request.add_header(key, value)
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode("utf-8", errors="replace")
+        except OSError:
+            body = ""
+        return exc.code, body
+    except urllib.error.URLError as exc:
+        raise ForgeAPIError(f"{method} {url} bereikte GitHub niet: {exc.reason}") from exc
+    except OSError as exc:
+        raise ForgeAPIError(f"{method} {url} faalde op transportniveau: {exc}") from exc
+
+
+def _github_headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": GITHUB_ACCEPT,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": "vnx-gate-check-run-client",
+        "Content-Type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# JWT + installation token
+# ---------------------------------------------------------------------------
+
+
+def build_app_jwt(app_id: int, private_key_pem: str, *, now: Optional[datetime] = None) -> str:
+    """An RS256 App JWT: ``iss`` = app id, backdated ``iat``, 9-minute ``exp``."""
+    import jwt  # noqa: PLC0415  (imported here so the module loads without PyJWT)
+
+    moment = now or datetime.now(timezone.utc)
+    claims = {
+        "iat": int((moment - timedelta(seconds=JWT_BACKDATE_SECONDS)).timestamp()),
+        "exp": int((moment + timedelta(seconds=JWT_LIFETIME_SECONDS)).timestamp()),
+        "iss": str(app_id),
+    }
+    try:
+        return jwt.encode(claims, private_key_pem, algorithm="RS256")
+    # A malformed PEM surfaces as cryptography's ValueError ("Could not
+    # deserialize key data"), a non-string key as TypeError, and a key of the
+    # wrong type for RS256 as PyJWTError. All three mean the same thing to a
+    # caller — the key in the keychain is unusable — so all three become one
+    # loud error naming the item to repair.
+    except (ValueError, TypeError, jwt.exceptions.PyJWTError) as exc:
+        raise ForgeCheckRunError(
+            f"kon geen App-JWT bouwen met de sleutel uit {KEYCHAIN_PRIVATE_KEY_SERVICE}: {exc}. "
+            f"{_recovery_hint(KEYCHAIN_PRIVATE_KEY_SERVICE, 'pad naar de .pem, via $(cat ...)')}"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class _CachedToken:
+    installation_id: str
+    token: str
+    expires_at: datetime
+
+
+#: Process-local, single slot: one process talks to one installation. Cleared
+#: by :func:`reset_token_cache`.
+_TOKEN_CACHE: Optional[_CachedToken] = None
+
+
+def reset_token_cache() -> None:
+    """Drop the cached installation token (tests, and any identity change)."""
+    global _TOKEN_CACHE
+    _TOKEN_CACHE = None
+
+
+def _parse_expires_at(raw: Any) -> datetime:
+    if not isinstance(raw, str) or not raw:
+        raise ForgeAPIError(
+            f"installatietoken zonder bruikbare expires_at ({raw!r}): zonder vervaltijd "
+            "is er geen veilig moment om te verversen"
+        )
+    try:
+        return datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ForgeAPIError(f"onbegrepen expires_at in installatietoken: {raw!r}") from exc
+
+
+def _exchange_installation_token(installation_id: str, app_jwt: str) -> _CachedToken:
+    url = f"{GITHUB_API_BASE}/app/installations/{installation_id}/access_tokens"
+    status, body = _api_request("POST", url, headers=_github_headers(app_jwt))
+
+    if status >= 400:
+        # A 401 here means the JWT itself was refused — a wrong app_id, a key
+        # that does not belong to it, or a revoked App. Re-minting the same
+        # JWT would produce the same 401, so this raises instead of retrying.
+        raise ForgeAPIError(
+            f"installatietoken ophalen faalde (HTTP {status}) voor installatie "
+            f"{installation_id}: {body[:_ERROR_BODY_LIMIT]}",
+            status=status,
+            body=body[:_ERROR_BODY_LIMIT],
+        )
+
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ForgeAPIError(
+            f"installatietoken-respons was geen JSON (HTTP {status}): "
+            f"{body[:_ERROR_BODY_LIMIT]}",
+            status=status,
+            body=body[:_ERROR_BODY_LIMIT],
+        ) from exc
+
+    token = parsed.get("token") if isinstance(parsed, dict) else None
+    if not isinstance(token, str) or not token:
+        raise ForgeAPIError(
+            f"installatietoken-respons bevat geen token-veld: {body[:_ERROR_BODY_LIMIT]}",
+            status=status,
+            body=body[:_ERROR_BODY_LIMIT],
+        )
+
+    return _CachedToken(
+        installation_id=installation_id,
+        token=token,
+        expires_at=_parse_expires_at(parsed.get("expires_at")),
+    )
+
+
+def _installation_token_with_freshness(
+    *, now: Optional[datetime] = None, force_refresh: bool = False
+) -> Tuple[str, bool]:
+    """``(token, minted)``. ``minted`` is True when this call exchanged a new one.
+
+    The caller needs that distinction: a 401 on a token minted milliseconds ago
+    is a real authentication problem, while a 401 on a cached one may just be a
+    token GitHub retired early. See :func:`publish_check_run`.
+    """
+    global _TOKEN_CACHE
+
+    moment = now or datetime.now(timezone.utc)
+    installation_id = read_installation_id()
+
+    cached = _TOKEN_CACHE
+    if (
+        not force_refresh
+        and cached is not None
+        and cached.installation_id == installation_id
+        and moment < cached.expires_at - timedelta(seconds=TOKEN_REFRESH_MARGIN_SECONDS)
+    ):
+        return cached.token, False
+
+    config = load_app_config()
+    app_jwt = build_app_jwt(config.app_id, read_private_key(), now=moment)
+    # Assigned only after a fully validated exchange: a failed call must leave
+    # the previous cache state untouched rather than poisoning it.
+    fresh = _exchange_installation_token(installation_id, app_jwt)
+    _TOKEN_CACHE = fresh
+    return fresh.token, True
+
+
+def installation_token(*, now: Optional[datetime] = None, force_refresh: bool = False) -> str:
+    """A valid installation access token, from cache when one is still good."""
+    token, _ = _installation_token_with_freshness(now=now, force_refresh=force_refresh)
+    return token
+
+
+# ---------------------------------------------------------------------------
+# The primitive
+# ---------------------------------------------------------------------------
+
+
+def publish_check_run(
+    head_sha: str,
+    name: str,
+    conclusion: str,
+    summary: str,
+    *,
+    details_url: Optional[str] = None,
+    project_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """POST a completed check-run and return GitHub's response object.
+
+    ``conclusion`` is passed through UNTOUCHED — not validated against
+    GitHub's enum, not mapped from any review outcome. Choosing it is B2b's
+    job; a client that second-guessed it would put that policy in two places.
+    """
+    if not head_sha or not head_sha.strip():
+        raise ForgeCheckRunError("head_sha is leeg: een check-run zonder commit hoort nergens")
+    if not name or not name.strip():
+        raise ForgeCheckRunError("name is leeg: branch protection matcht check-runs op naam")
+
+    owner_repo = resolve_owner_repo(project_root)
+    url = f"{GITHUB_API_BASE}/repos/{owner_repo}/check-runs"
+    body: Dict[str, Any] = {
+        "name": name,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "output": {"title": name, "summary": summary},
+    }
+    if details_url:
+        body["details_url"] = details_url
+    payload = json.dumps(body)
+
+    token, minted = _installation_token_with_freshness()
+    status, response_body = _api_request(
+        "POST", url, headers=_github_headers(token), payload=payload
+    )
+
+    if status == 401 and not minted:
+        # The cached token was refused. GitHub can retire one before its stated
+        # expires_at, so exactly ONE forced refresh and ONE retry — never a
+        # loop, which would turn a genuinely bad key into an API hammer.
+        token, _ = _installation_token_with_freshness(force_refresh=True)
+        status, response_body = _api_request(
+            "POST", url, headers=_github_headers(token), payload=payload
+        )
+
+    if status >= 400:
+        raise ForgeAPIError(
+            f"check-run publiceren faalde (HTTP {status}) op {owner_repo} voor "
+            f"{head_sha[:12]}: {response_body[:_ERROR_BODY_LIMIT]}",
+            status=status,
+            body=response_body[:_ERROR_BODY_LIMIT],
+        )
+
+    try:
+        parsed = json.loads(response_body)
+    except json.JSONDecodeError as exc:
+        raise ForgeAPIError(
+            f"check-run-respons was geen JSON (HTTP {status}): "
+            f"{response_body[:_ERROR_BODY_LIMIT]}",
+            status=status,
+            body=response_body[:_ERROR_BODY_LIMIT],
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise ForgeAPIError(
+            f"check-run-respons was geen object: {response_body[:_ERROR_BODY_LIMIT]}",
+            status=status,
+            body=response_body[:_ERROR_BODY_LIMIT],
+        )
+    return parsed

--- a/scripts/lib/forge_check_run.py
+++ b/scripts/lib/forge_check_run.py
@@ -357,7 +357,22 @@ def _github_headers(token: str) -> Dict[str, str]:
 
 def build_app_jwt(app_id: int, private_key_pem: str, *, now: Optional[datetime] = None) -> str:
     """An RS256 App JWT: ``iss`` = app id, backdated ``iat``, 9-minute ``exp``."""
-    import jwt  # noqa: PLC0415  (imported here so the module loads without PyJWT)
+    # Imported here rather than at module scope: PyJWT is NOT in
+    # pyproject.toml [project.dependencies], so a plain `pip install
+    # vnx-orchestration` has no ``jwt`` module — and every other importer of
+    # this module would then die on an import it never reaches. The ImportError
+    # is re-raised in this module's own shape for the same reason every
+    # keychain read does: a bare ModuleNotFoundError names the module but not
+    # the install that repairs it, and this is the one dependency an operator
+    # will not already have. CI installs it in .github/workflows/vnx-ci.yml.
+    try:
+        import jwt  # noqa: PLC0415
+    except ImportError as exc:
+        raise ForgeCheckRunError(
+            "PyJWT ontbreekt, dus er kan geen App-JWT ondertekend worden. "
+            "Herstel: pip install 'pyjwt[crypto]'. "
+            f"Runbook: {RUNBOOK_PATH}"
+        ) from exc
 
     moment = now or datetime.now(timezone.utc)
     claims = {
@@ -367,6 +382,17 @@ def build_app_jwt(app_id: int, private_key_pem: str, *, now: Optional[datetime] 
     }
     try:
         return jwt.encode(claims, private_key_pem, algorithm="RS256")
+    # PyJWT installed WITHOUT its asymmetric backend: `import jwt` succeeds and
+    # only RS256 is absent, so the gap surfaces here at signing time instead of
+    # at import time above. Kept separate from the key errors below because the
+    # key was never even looked at — telling an operator to re-add a perfectly
+    # good .pem would send them down the wrong repair.
+    except NotImplementedError as exc:
+        raise ForgeCheckRunError(
+            "PyJWT kent RS256 niet: de [crypto]-extra ontbreekt, dus er is geen "
+            "asymmetrische backend. Herstel: pip install 'pyjwt[crypto]'. "
+            f"Runbook: {RUNBOOK_PATH}"
+        ) from exc
     # A malformed PEM surfaces as cryptography's ValueError ("Could not
     # deserialize key data"), a non-string key as TypeError, and a key of the
     # wrong type for RS256 as PyJWTError. All three mean the same thing to a

--- a/scripts/lib/forge_protection_drift.py
+++ b/scripts/lib/forge_protection_drift.py
@@ -66,6 +66,15 @@ _KNOWN_TOP_LEVEL_FIELDS = frozenset({
     "allow_fork_syncing", "block_creations", "lock_branch",
     "required_conversation_resolution", "restrictions", "repo", "rulesets",
 })
+#: Keys the YAML may carry that describe something OTHER than what the branch
+#: requires, so they are parsed past rather than compared. ``app`` (Golf B,
+#: B2a) names the GitHub App that PUBLISHES a check-run — an identity used by
+#: ``forge_check_run.py``, never a protection setting. Deliberately absent
+#: from :class:`ProtectionConfig` and :func:`to_normalized_dict`: a key that
+#: never enters the normalized dict can never register as drift or as a
+#: weakening. This is an allowlist of exactly one key, not an opening of the
+#: schema — an unrecognized top-level key is still refused.
+_OPTIONAL_TOP_LEVEL_FIELDS = frozenset({"app"})
 _KNOWN_RSC_FIELDS = frozenset({"strict", "checks"})
 _KNOWN_CHECK_FIELDS = frozenset({"context", "app_id"})
 _KNOWN_PPR_FIELDS = frozenset({
@@ -227,7 +236,10 @@ def parse_protection_config(raw_text: str) -> ProtectionConfig:
         doc = yaml.safe_load(raw_text)
     except yaml.YAMLError as exc:
         raise ProtectionConfigError(f"branch_protection.yaml is geen geldige YAML: {exc}") from exc
-    _require_object_fields(doc, _KNOWN_TOP_LEVEL_FIELDS, "branch_protection.yaml")
+    _require_object_fields(
+        doc, _KNOWN_TOP_LEVEL_FIELDS, "branch_protection.yaml",
+        optional=_OPTIONAL_TOP_LEVEL_FIELDS,
+    )
 
     if not isinstance(doc["branch"], str) or not doc["branch"]:
         raise ProtectionConfigError("branch moet een niet-lege string zijn")

--- a/scripts/lib/forge_protection_drift.py
+++ b/scripts/lib/forge_protection_drift.py
@@ -73,8 +73,12 @@ _KNOWN_TOP_LEVEL_FIELDS = frozenset({
 #: from :class:`ProtectionConfig` and :func:`to_normalized_dict`: a key that
 #: never enters the normalized dict can never register as drift or as a
 #: weakening. This is an allowlist of exactly one key, not an opening of the
-#: schema — an unrecognized top-level key is still refused.
+#: schema — an unrecognized top-level key is still refused. Being optional at
+#: the top level only excuses its ABSENCE; when present, its own shape is
+#: still validated (see :func:`_validate_app_block`) — an unknown key inside
+#: ``app:`` is refused exactly like everywhere else in this schema.
 _OPTIONAL_TOP_LEVEL_FIELDS = frozenset({"app"})
+_KNOWN_APP_FIELDS = frozenset({"slug", "app_id"})
 _KNOWN_RSC_FIELDS = frozenset({"strict", "checks"})
 _KNOWN_CHECK_FIELDS = frozenset({"context", "app_id"})
 _KNOWN_PPR_FIELDS = frozenset({
@@ -170,6 +174,25 @@ def _require_bool(obj: Dict[str, Any], field: str, where: str) -> bool:
     return value
 
 
+def _validate_app_block(app: Any) -> None:
+    """Validate the optional ``app:`` block's own shape.
+
+    Never feeds :class:`ProtectionConfig` or :func:`to_normalized_dict` — the
+    block is read by ``forge_check_run.py.load_app_config``, not by anything
+    here. Presence is optional (see ``_OPTIONAL_TOP_LEVEL_FIELDS``), but a
+    present block is validated with the same rigor as every other object in
+    this schema: both keys required, no extra key tolerated.
+    """
+    _require_object_fields(app, _KNOWN_APP_FIELDS, "app")
+    slug = app["slug"]
+    if not isinstance(slug, str) or not slug:
+        raise ProtectionConfigError("app.slug moet een niet-lege string zijn")
+    app_id = app["app_id"]
+    # bool is an int subclass; `app_id: true` is a typo, not an identifier.
+    if app_id is not None and (isinstance(app_id, bool) or not isinstance(app_id, int)):
+        raise ProtectionConfigError("app.app_id moet een integer of null zijn")
+
+
 def normalize_bypass_allowances(raw: Any) -> List[str]:
     """A ``bypass_pull_request_allowances`` object flattened to sorted
     ``"<kind>:<name>"`` strings.
@@ -240,6 +263,8 @@ def parse_protection_config(raw_text: str) -> ProtectionConfig:
         doc, _KNOWN_TOP_LEVEL_FIELDS, "branch_protection.yaml",
         optional=_OPTIONAL_TOP_LEVEL_FIELDS,
     )
+    if "app" in doc:
+        _validate_app_block(doc["app"])
 
     if not isinstance(doc["branch"], str) or not doc["branch"]:
         raise ProtectionConfigError("branch moet een niet-lege string zijn")

--- a/tests/test_forge_check_run_client.py
+++ b/tests/test_forge_check_run_client.py
@@ -204,13 +204,20 @@ def test_load_app_config_unreadable_path_raises(tmp_path: Path) -> None:
         fcr.load_app_config(tmp_path / "does-not-exist.yaml")
 
 
-def test_repo_yaml_carries_the_app_block() -> None:
-    """The shipped YAML has the app: block B2b will read."""
-    path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
-    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
-    assert "app" in doc, "scripts/forge/branch_protection.yaml mist het app:-blok"
-    assert doc["app"]["slug"] == "vnx-gate"
-    assert "app_id" in doc["app"]
+def test_app_block_shape_is_slug_and_app_id() -> None:
+    """The app: block B2b will read carries slug + app_id.
+
+    Golf B, B2a fix-forward 3 pulled the block back OUT of the shipped
+    ``scripts/forge/branch_protection.yaml``: the schema reader that accepts
+    it landed in the same PR that would have introduced the field, so the
+    field itself is deferred to the operator's App step
+    (docs/operations/FORGE_GATE.md). This test builds its own fixture rather
+    than leaning on the shipped file, which no longer carries the block.
+    """
+    doc = _base_protection_doc(app={"slug": "vnx-gate", "app_id": None})
+    parsed = yaml.safe_load(yaml.safe_dump(doc, sort_keys=False))
+    assert parsed["app"]["slug"] == "vnx-gate"
+    assert "app_id" in parsed["app"]
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +266,9 @@ def test_b1_still_refuses_a_genuinely_unknown_key() -> None:
 
 
 def test_shipped_yaml_parses_and_applies_clean(tmp_path: Path) -> None:
-    """The real file still round-trips through B1 with the app: block on it."""
+    """The real file still round-trips through B1 -- app: is optional, so its
+    absence from the shipped YAML (Golf B, B2a fix-forward 3) changes nothing
+    here."""
     path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
     config = fpd.load_protection_config(path)
     assert config.branch == "main"

--- a/tests/test_forge_check_run_client.py
+++ b/tests/test_forge_check_run_client.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/forge_check_run.py (Golf B, B2a).
+
+Covers the client layer only — there is deliberately NO gate knowledge here
+(no verdict mapping, no "which conclusion means blocked"): that is B2b.
+
+Mocking boundary, per dispatch: only ``subprocess.run`` (for ``security``)
+and the HTTP seam (``_api_request``) are mocked. The JWT construction itself
+is NEVER mocked — ``test_app_jwt_*`` builds a real RS256 token with a
+throwaway RSA keypair generated in the test and verifies it with the matching
+public key.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import jwt
+import pytest
+import yaml
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+import forge_check_run as fcr  # noqa: E402
+import forge_protection_drift as fpd  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    """The token cache is module-level state; no test may inherit another's."""
+    fcr.reset_token_cache()
+    yield
+    fcr.reset_token_cache()
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair() -> Tuple[str, str]:
+    """A throwaway RSA keypair as (private PEM, public PEM)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return private_pem, public_pem
+
+
+def _base_protection_doc(**overrides: Any) -> Dict[str, Any]:
+    """A minimal schema-valid branch_protection.yaml document."""
+    doc: Dict[str, Any] = {
+        "branch": "main",
+        "required_status_checks": {
+            "strict": False,
+            "checks": [{"context": "Profile A", "app_id": 15368}],
+        },
+        "pending_checks": [],
+        "required_pull_request_reviews": {
+            "required_approving_review_count": 0,
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "require_last_push_approval": False,
+        },
+        "enforce_admins": True,
+        "required_signatures": False,
+        "required_linear_history": False,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+        "allow_fork_syncing": False,
+        "block_creations": False,
+        "lock_branch": False,
+        "required_conversation_resolution": False,
+        "restrictions": None,
+        "repo": {"allow_auto_merge": False},
+        "rulesets": [],
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _write_yaml(tmp_path: Path, doc: Dict[str, Any], name: str = "bp.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+    return path
+
+
+class _FakeCompleted:
+    """Stand-in for subprocess.CompletedProcess from `security`."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _security_returning(
+    monkeypatch: pytest.MonkeyPatch, per_service: Dict[str, _FakeCompleted]
+) -> List[List[str]]:
+    """Mock ``subprocess.run`` for `security`, keyed by the -s service name."""
+    calls: List[List[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ANN001
+        calls.append(list(argv))
+        service = argv[argv.index("-s") + 1]
+        if service not in per_service:
+            raise AssertionError(f"unexpected keychain service: {service}")
+        return per_service[service]
+
+    monkeypatch.setattr(fcr.subprocess, "run", fake_run)
+    return calls
+
+
+def _install_http(
+    monkeypatch: pytest.MonkeyPatch, responses: List[Tuple[int, Any]]
+) -> List[Dict[str, Any]]:
+    """Mock the HTTP seam. Records each request; pops responses in order."""
+    recorded: List[Dict[str, Any]] = []
+    queue = list(responses)
+
+    def fake_request(method, url, *, headers, payload=None, timeout=30):  # noqa: ANN001
+        recorded.append(
+            {"method": method, "url": url, "headers": dict(headers), "payload": payload}
+        )
+        if not queue:
+            raise AssertionError(f"unexpected extra HTTP call: {method} {url}")
+        status, body = queue.pop(0)
+        return status, body if isinstance(body, str) else json.dumps(body)
+
+    monkeypatch.setattr(fcr, "_api_request", fake_request)
+    return recorded
+
+
+def _token_body(expires_in_minutes: int = 60, token: str = "ghs_installtoken") -> Dict[str, Any]:
+    expires = datetime.now(timezone.utc) + timedelta(minutes=expires_in_minutes)
+    return {"token": token, "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ")}
+
+
+# ---------------------------------------------------------------------------
+# load_app_config — the YAML side
+# ---------------------------------------------------------------------------
+
+
+def test_load_app_config_reads_slug_and_app_id(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, _base_protection_doc(app={"slug": "vnx-gate", "app_id": 987654}))
+    config = fcr.load_app_config(path)
+    assert config.slug == "vnx-gate"
+    assert config.app_id == 987654
+
+
+def test_load_app_config_null_app_id_raises_with_runbook_reference(tmp_path: Path) -> None:
+    """The operator has not filled app_id in yet: loud, with where to go."""
+    path = _write_yaml(tmp_path, _base_protection_doc(app={"slug": "vnx-gate", "app_id": None}))
+    with pytest.raises(fcr.ForgeAppConfigError) as excinfo:
+        fcr.load_app_config(path)
+    message = str(excinfo.value)
+    assert "app_id ontbreekt" in message
+    assert "scripts/forge/branch_protection.yaml" in message
+    assert fcr.RUNBOOK_PATH in message
+
+
+def test_load_app_config_missing_app_block_raises(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, _base_protection_doc())
+    with pytest.raises(fcr.ForgeAppConfigError) as excinfo:
+        fcr.load_app_config(path)
+    assert fcr.RUNBOOK_PATH in str(excinfo.value)
+
+
+def test_load_app_config_rejects_non_integer_app_id(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, _base_protection_doc(app={"slug": "vnx-gate", "app_id": "987654"}))
+    with pytest.raises(fcr.ForgeAppConfigError):
+        fcr.load_app_config(path)
+
+
+def test_load_app_config_rejects_empty_slug(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, _base_protection_doc(app={"slug": "", "app_id": 987654}))
+    with pytest.raises(fcr.ForgeAppConfigError):
+        fcr.load_app_config(path)
+
+
+def test_load_app_config_unreadable_path_raises(tmp_path: Path) -> None:
+    with pytest.raises(fcr.ForgeAppConfigError):
+        fcr.load_app_config(tmp_path / "does-not-exist.yaml")
+
+
+def test_repo_yaml_carries_the_app_block() -> None:
+    """The shipped YAML has the app: block B2b will read."""
+    path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "app" in doc, "scripts/forge/branch_protection.yaml mist het app:-blok"
+    assert doc["app"]["slug"] == "vnx-gate"
+    assert "app_id" in doc["app"]
+
+
+# ---------------------------------------------------------------------------
+# The app: block must not read as drift to B1's schema reader / comparator
+# ---------------------------------------------------------------------------
+
+
+def test_app_block_parses_under_b1_schema_reader() -> None:
+    """B1 refuses unknown top-level keys; `app` must be an accepted one."""
+    doc = _base_protection_doc(app={"slug": "vnx-gate", "app_id": None})
+    config = fpd.parse_protection_config(yaml.safe_dump(doc, sort_keys=False))
+    assert config.branch == "main"
+
+
+def test_app_block_triggers_no_drift() -> None:
+    """Same config with and without `app:` normalizes identically."""
+    without = fpd.parse_protection_config(yaml.safe_dump(_base_protection_doc(), sort_keys=False))
+    with_app = fpd.parse_protection_config(
+        yaml.safe_dump(
+            _base_protection_doc(app={"slug": "vnx-gate", "app_id": 987654}), sort_keys=False
+        )
+    )
+    diffs = fpd.compare(fpd.to_normalized_dict(without), fpd.to_normalized_dict(with_app))
+    assert diffs == [], f"app: block leaked into the comparator: {diffs}"
+
+
+def test_app_block_is_not_a_weakening() -> None:
+    without = fpd.parse_protection_config(yaml.safe_dump(_base_protection_doc(), sort_keys=False))
+    with_app = fpd.parse_protection_config(
+        yaml.safe_dump(
+            _base_protection_doc(app={"slug": "vnx-gate", "app_id": 987654}), sort_keys=False
+        )
+    )
+    weakening, fields = fpd.is_weakening(
+        fpd.to_normalized_dict(without), fpd.to_normalized_dict(with_app)
+    )
+    assert weakening is False
+    assert fields == []
+
+
+def test_b1_still_refuses_a_genuinely_unknown_key() -> None:
+    """Accepting `app` must not have opened the schema to anything at all."""
+    doc = _base_protection_doc(vnx_typo_field=True)
+    with pytest.raises(fpd.ProtectionConfigError):
+        fpd.parse_protection_config(yaml.safe_dump(doc, sort_keys=False))
+
+
+def test_shipped_yaml_parses_and_applies_clean(tmp_path: Path) -> None:
+    """The real file still round-trips through B1 with the app: block on it."""
+    path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
+    config = fpd.load_protection_config(path)
+    assert config.branch == "main"
+    assert config.checks
+
+
+# ---------------------------------------------------------------------------
+# Keychain reads — loud, never an empty string
+# ---------------------------------------------------------------------------
+
+
+def test_read_private_key_returns_the_pem(monkeypatch: pytest.MonkeyPatch) -> None:
+    pem = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n"
+    calls = _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(0, stdout=pem)}
+    )
+    assert fcr.read_private_key() == pem.strip()
+    assert calls[0][:2] == ["security", "find-generic-password"]
+    assert "-w" in calls[0]
+
+
+def test_read_private_key_item_missing_is_loud_with_recovery_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`security` exit 44 = item not in the keychain."""
+    _security_returning(
+        monkeypatch,
+        {
+            fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(
+                44, stderr="SecKeychainSearchCopyNext: The specified item could not be found"
+            )
+        },
+    )
+    with pytest.raises(fcr.ForgeKeychainError) as excinfo:
+        fcr.read_private_key()
+    message = str(excinfo.value)
+    assert "security add-generic-password" in message
+    assert fcr.KEYCHAIN_PRIVATE_KEY_SERVICE in message
+    assert fcr.RUNBOOK_PATH in message
+
+
+def test_read_private_key_locked_keychain_is_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exit 51 = user interaction not allowed, i.e. a locked keychain."""
+    _security_returning(
+        monkeypatch,
+        {
+            fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(
+                51, stderr="User interaction is not allowed."
+            )
+        },
+    )
+    with pytest.raises(fcr.ForgeKeychainError) as excinfo:
+        fcr.read_private_key()
+    message = str(excinfo.value)
+    assert "security unlock-keychain" in message
+    assert "security add-generic-password" in message
+
+
+def test_read_private_key_empty_output_is_loud_not_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The send_digest_email soft-fail (return "") is exactly what must NOT happen."""
+    _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(0, stdout="   \n")}
+    )
+    with pytest.raises(fcr.ForgeKeychainError) as excinfo:
+        fcr.read_private_key()
+    assert "leeg" in str(excinfo.value).lower()
+    assert "security add-generic-password" in str(excinfo.value)
+
+
+def test_read_private_key_missing_security_binary_is_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(argv, **kwargs):  # noqa: ANN001
+        raise FileNotFoundError("security")
+
+    monkeypatch.setattr(fcr.subprocess, "run", fake_run)
+    with pytest.raises(fcr.ForgeKeychainError) as excinfo:
+        fcr.read_private_key()
+    assert "security" in str(excinfo.value)
+
+
+def test_read_private_key_timeout_is_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(argv, **kwargs):  # noqa: ANN001
+        raise subprocess.TimeoutExpired(cmd="security", timeout=5)
+
+    monkeypatch.setattr(fcr.subprocess, "run", fake_run)
+    with pytest.raises(fcr.ForgeKeychainError):
+        fcr.read_private_key()
+
+
+def test_read_installation_id_returns_the_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_INSTALLATION_ID_SERVICE: _FakeCompleted(0, stdout="12345678\n")}
+    )
+    assert fcr.read_installation_id() == "12345678"
+
+
+def test_read_installation_id_missing_is_loud_with_its_own_service_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_INSTALLATION_ID_SERVICE: _FakeCompleted(44)}
+    )
+    with pytest.raises(fcr.ForgeKeychainError) as excinfo:
+        fcr.read_installation_id()
+    message = str(excinfo.value)
+    assert fcr.KEYCHAIN_INSTALLATION_ID_SERVICE in message
+    assert "security add-generic-password" in message
+
+
+def test_read_installation_id_rejects_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    _security_returning(
+        monkeypatch,
+        {fcr.KEYCHAIN_INSTALLATION_ID_SERVICE: _FakeCompleted(0, stdout="not-an-id\n")},
+    )
+    with pytest.raises(fcr.ForgeKeychainError):
+        fcr.read_installation_id()
+
+
+# ---------------------------------------------------------------------------
+# JWT construction — never mocked
+# ---------------------------------------------------------------------------
+
+
+def test_app_jwt_carries_iss_and_a_bounded_exp(rsa_keypair: Tuple[str, str]) -> None:
+    private_pem, public_pem = rsa_keypair
+    before = datetime.now(timezone.utc)
+    token = fcr.build_app_jwt(987654, private_pem)
+    claims = jwt.decode(token, public_pem, algorithms=["RS256"], issuer="987654")
+
+    assert claims["iss"] == "987654"
+    exp = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
+    iat = datetime.fromtimestamp(claims["iat"], tz=timezone.utc)
+    assert exp <= before + timedelta(minutes=10), "exp must stay inside GitHub's 10 minute ceiling"
+    assert exp > before + timedelta(minutes=8)
+    assert iat <= before, "iat must be backdated against clock skew"
+    assert iat >= before - timedelta(seconds=120)
+
+
+def test_app_jwt_uses_rs256(rsa_keypair: Tuple[str, str]) -> None:
+    private_pem, _ = rsa_keypair
+    header = jwt.get_unverified_header(fcr.build_app_jwt(987654, private_pem))
+    assert header["alg"] == "RS256"
+
+
+def test_app_jwt_rejects_a_malformed_private_key() -> None:
+    with pytest.raises(fcr.ForgeCheckRunError):
+        fcr.build_app_jwt(987654, "-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----")
+
+
+def test_app_jwt_verification_fails_against_a_foreign_public_key(
+    rsa_keypair: Tuple[str, str],
+) -> None:
+    private_pem, _ = rsa_keypair
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    other_public = (
+        other.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    token = fcr.build_app_jwt(987654, private_pem)
+    with pytest.raises(jwt.InvalidSignatureError):
+        jwt.decode(token, other_public, algorithms=["RS256"])
+
+
+# ---------------------------------------------------------------------------
+# installation_token — exchange + in-memory cache
+# ---------------------------------------------------------------------------
+
+
+def _wire_credentials(monkeypatch: pytest.MonkeyPatch, private_pem: str) -> None:
+    monkeypatch.setattr(fcr, "read_private_key", lambda: private_pem)
+    monkeypatch.setattr(fcr, "read_installation_id", lambda: "12345678")
+    monkeypatch.setattr(fcr, "load_app_config", lambda path=None: fcr.AppConfig("vnx-gate", 987654))
+
+
+def test_installation_token_exchanges_the_jwt(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, public_pem = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    recorded = _install_http(monkeypatch, [(201, _token_body())])
+
+    assert fcr.installation_token() == "ghs_installtoken"
+    assert len(recorded) == 1
+    assert recorded[0]["method"] == "POST"
+    assert recorded[0]["url"].endswith("/app/installations/12345678/access_tokens")
+
+    sent = recorded[0]["headers"]["Authorization"].removeprefix("Bearer ")
+    claims = jwt.decode(sent, public_pem, algorithms=["RS256"], issuer="987654")
+    assert claims["iss"] == "987654"
+
+
+def test_installation_token_caches_within_validity(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    recorded = _install_http(monkeypatch, [(201, _token_body(expires_in_minutes=60))])
+
+    first = fcr.installation_token()
+    second = fcr.installation_token()
+
+    assert first == second == "ghs_installtoken"
+    assert len(recorded) == 1, "second call inside validity must not hit the API"
+
+
+def test_installation_token_refreshes_five_minutes_before_expiry(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    expires = datetime.now(timezone.utc) + timedelta(minutes=60)
+    body = {"token": "ghs_first", "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ")}
+    recorded = _install_http(
+        monkeypatch, [(201, body), (201, _token_body(expires_in_minutes=60, token="ghs_second"))]
+    )
+
+    assert fcr.installation_token() == "ghs_first"
+    # Still cached one second before the refresh margin opens.
+    just_inside = expires - timedelta(seconds=fcr.TOKEN_REFRESH_MARGIN_SECONDS + 1)
+    assert fcr.installation_token(now=just_inside) == "ghs_first"
+    assert len(recorded) == 1
+
+    # At exactly expires_at minus the margin the cached token is spent.
+    at_margin = expires - timedelta(seconds=fcr.TOKEN_REFRESH_MARGIN_SECONDS)
+    assert fcr.installation_token(now=at_margin) == "ghs_second"
+    assert len(recorded) == 2
+
+
+def test_installation_token_401_is_loud_and_does_not_loop(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    recorded = _install_http(
+        monkeypatch, [(401, {"message": "A JSON web token could not be decoded"})]
+    )
+
+    with pytest.raises(fcr.ForgeAPIError) as excinfo:
+        fcr.installation_token()
+
+    assert excinfo.value.status == 401
+    assert "could not be decoded" in str(excinfo.value)
+    assert len(recorded) == 1, "a 401 on a fresh JWT must not be retried"
+
+
+def test_installation_token_unparseable_body_is_loud(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    _install_http(monkeypatch, [(201, "<html>gateway</html>")])
+    with pytest.raises(fcr.ForgeAPIError):
+        fcr.installation_token()
+
+
+def test_installation_token_missing_token_field_is_loud(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    _install_http(monkeypatch, [(201, {"expires_at": "2026-09-07T12:00:00Z"})])
+    with pytest.raises(fcr.ForgeAPIError):
+        fcr.installation_token()
+
+
+def test_installation_token_failed_exchange_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    _install_http(monkeypatch, [(500, {"message": "boom"}), (201, _token_body())])
+
+    with pytest.raises(fcr.ForgeAPIError):
+        fcr.installation_token()
+    assert fcr.installation_token() == "ghs_installtoken"
+
+
+# ---------------------------------------------------------------------------
+# publish_check_run — the primitive. No verdict interpretation lives here.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_check_run_posts_the_expected_body(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "Vinix24/vnx-orchestration")
+    created = {"id": 42, "conclusion": "success"}
+    recorded = _install_http(monkeypatch, [(201, _token_body()), (201, created)])
+
+    result = fcr.publish_check_run(
+        "a" * 40, "vnx-gate/review", "success", "12 findings, 0 blocking"
+    )
+
+    assert result == created
+    post = recorded[1]
+    assert post["method"] == "POST"
+    assert post["url"].endswith("/repos/Vinix24/vnx-orchestration/check-runs")
+    body = json.loads(post["payload"])
+    assert body["head_sha"] == "a" * 40
+    assert body["name"] == "vnx-gate/review"
+    assert body["status"] == "completed"
+    assert body["conclusion"] == "success"
+    assert body["output"]["summary"] == "12 findings, 0 blocking"
+    assert post["headers"]["Authorization"] == "Bearer ghs_installtoken"
+
+
+def test_publish_check_run_includes_details_url_when_given(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    recorded = _install_http(monkeypatch, [(201, _token_body()), (201, {"id": 1})])
+
+    fcr.publish_check_run(
+        "b" * 40, "vnx-gate/review", "failure", "blocked", details_url="https://example.test/run/1"
+    )
+    body = json.loads(recorded[1]["payload"])
+    assert body["details_url"] == "https://example.test/run/1"
+
+
+def test_publish_check_run_omits_details_url_when_absent(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    recorded = _install_http(monkeypatch, [(201, _token_body()), (201, {"id": 1})])
+
+    fcr.publish_check_run("c" * 40, "vnx-gate/review", "success", "ok")
+    assert "details_url" not in json.loads(recorded[1]["payload"])
+
+
+@pytest.mark.parametrize(
+    "conclusion", ["success", "failure", "neutral", "cancelled", "action_required", "whatever_b2b_sends"]
+)
+def test_publish_check_run_does_not_interpret_the_conclusion(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str], conclusion: str
+) -> None:
+    """Client layer, zero gate knowledge: it forwards, it does not judge (B2b)."""
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    recorded = _install_http(monkeypatch, [(201, _token_body()), (201, {"id": 1})])
+
+    fcr.publish_check_run("d" * 40, "vnx-gate/review", conclusion, "summary text")
+    assert json.loads(recorded[1]["payload"])["conclusion"] == conclusion
+
+
+def test_publish_check_run_422_raises_with_the_body(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    _install_http(
+        monkeypatch,
+        [
+            (201, _token_body()),
+            (422, {"message": "Validation Failed", "errors": [{"field": "head_sha"}]}),
+        ],
+    )
+
+    with pytest.raises(fcr.ForgeAPIError) as excinfo:
+        fcr.publish_check_run("e" * 40, "vnx-gate/review", "success", "ok")
+
+    assert excinfo.value.status == 422
+    assert "Validation Failed" in str(excinfo.value)
+    assert "422" in str(excinfo.value)
+
+
+def test_publish_check_run_rejects_an_empty_head_sha(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    _install_http(monkeypatch, [])
+    with pytest.raises(fcr.ForgeCheckRunError):
+        fcr.publish_check_run("", "vnx-gate/review", "success", "ok")
+
+
+def test_publish_check_run_rejects_an_empty_name(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    _install_http(monkeypatch, [])
+    with pytest.raises(fcr.ForgeCheckRunError):
+        fcr.publish_check_run("f" * 40, "", "success", "ok")
+
+
+def test_publish_check_run_401_on_a_cached_token_refreshes_once(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    """A cached token can expire server-side early: one refresh, one retry."""
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    fcr.installation_token  # noqa: B018  (documents the cache is primed below)
+    recorded = _install_http(
+        monkeypatch,
+        [
+            (201, _token_body(token="ghs_stale")),
+            (201, {"id": 7}),
+            (401, {"message": "Bad credentials"}),
+            (201, _token_body(token="ghs_fresh")),
+            (201, {"id": 8}),
+        ],
+    )
+
+    assert fcr.publish_check_run("a" * 40, "n", "success", "s") == {"id": 7}
+    assert fcr.publish_check_run("b" * 40, "n", "success", "s") == {"id": 8}
+    assert recorded[-1]["headers"]["Authorization"] == "Bearer ghs_fresh"
+    assert len(recorded) == 5
+
+
+def test_publish_check_run_401_on_a_fresh_token_is_loud(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    """No cache to blame: fail loudly instead of looping on refresh."""
+    private_pem, _ = rsa_keypair
+    _wire_credentials(monkeypatch, private_pem)
+    monkeypatch.setattr(fcr, "resolve_owner_repo", lambda project_root=None: "o/r")
+    recorded = _install_http(
+        monkeypatch, [(201, _token_body()), (401, {"message": "Bad credentials"})]
+    )
+
+    with pytest.raises(fcr.ForgeAPIError) as excinfo:
+        fcr.publish_check_run("a" * 40, "n", "success", "s")
+
+    assert excinfo.value.status == 401
+    assert len(recorded) == 2, "must not re-mint and retry in a loop"
+
+
+# ---------------------------------------------------------------------------
+# owner/repo resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_owner_repo_reads_the_git_remote() -> None:
+    assert fcr.resolve_owner_repo(VNX_ROOT) == "Vinix24/vnx-orchestration"
+
+
+def test_resolve_owner_repo_raises_on_a_non_github_remote(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(fcr, "_owner_repo_from_remote", lambda project_root: None)
+    with pytest.raises(fcr.ForgeCheckRunError) as excinfo:
+        fcr.resolve_owner_repo(tmp_path)
+    assert "origin" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# The transport itself carries no gate vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_module_has_no_gate_knowledge() -> None:
+    """B2a is the client layer; verdict vocabulary belongs to B2b."""
+    source = (VNX_ROOT / "scripts" / "lib" / "forge_check_run.py").read_text(encoding="utf-8")
+    for forbidden in ("gate_recorder", "REVISE", "APPROVE", "verdict"):
+        assert forbidden not in source, f"gate knowledge leaked into the client: {forbidden}"

--- a/tests/test_forge_check_run_client.py
+++ b/tests/test_forge_check_run_client.py
@@ -13,6 +13,7 @@ public key.
 
 from __future__ import annotations
 
+import base64
 import json
 import subprocess
 import sys
@@ -23,8 +24,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import jwt
 import pytest
 import yaml
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 VNX_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
@@ -384,6 +386,26 @@ def test_read_installation_id_rejects_non_numeric(monkeypatch: pytest.MonkeyPatc
 # ---------------------------------------------------------------------------
 
 
+def _b64url_decode(segment: str) -> bytes:
+    """Decode one JWT segment, restoring the padding a JWT strips."""
+    return base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4))
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _load_public_key(public_pem: str):
+    return serialization.load_pem_public_key(public_pem.encode("utf-8"))
+
+
+def _verify_rs256(public_pem: str, signing_input: str, signature: bytes) -> None:
+    """Check an RS256 signature with cryptography, raising InvalidSignature."""
+    _load_public_key(public_pem).verify(
+        signature, signing_input.encode("ascii"), padding.PKCS1v15(), hashes.SHA256()
+    )
+
+
 def test_app_jwt_carries_iss_and_a_bounded_exp(rsa_keypair: Tuple[str, str]) -> None:
     private_pem, public_pem = rsa_keypair
     before = datetime.now(timezone.utc)
@@ -426,6 +448,87 @@ def test_app_jwt_verification_fails_against_a_foreign_public_key(
     token = fcr.build_app_jwt(987654, private_pem)
     with pytest.raises(jwt.InvalidSignatureError):
         jwt.decode(token, other_public, algorithms=["RS256"])
+
+
+def test_app_jwt_signature_verifies_with_cryptography_alone(
+    rsa_keypair: Tuple[str, str],
+) -> None:
+    """The signature is checked WITHOUT PyJWT, and the claims are read raw.
+
+    ``test_app_jwt_carries_iss_and_a_bounded_exp`` signs and verifies through
+    the same library, so it proves the round trip and not the artefact. Here the
+    token is split by hand and the signature checked against the public key with
+    cryptography's primitives: what GitHub will do, minus GitHub.
+    """
+    private_pem, public_pem = rsa_keypair
+    before = datetime.now(timezone.utc)
+    token = fcr.build_app_jwt(987654, private_pem)
+
+    header_b64, payload_b64, signature_b64 = token.split(".")
+    _verify_rs256(public_pem, f"{header_b64}.{payload_b64}", _b64url_decode(signature_b64))
+
+    assert json.loads(_b64url_decode(header_b64))["alg"] == "RS256"
+    claims = json.loads(_b64url_decode(payload_b64))
+    assert claims["iss"] == "987654", "iss must be the app id, as a string"
+    exp = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
+    assert exp <= before + timedelta(minutes=10), "GitHub rejects an exp beyond 10 minutes"
+    assert exp > before
+
+
+def test_app_jwt_signature_breaks_when_the_payload_is_changed(
+    rsa_keypair: Tuple[str, str],
+) -> None:
+    """Re-issuing the same token under another app id must not validate.
+
+    This is the negative half of the test above: if it stayed green after the
+    payload changed, the "verification" there would be checking nothing.
+    """
+    private_pem, public_pem = rsa_keypair
+    header_b64, payload_b64, signature_b64 = fcr.build_app_jwt(987654, private_pem).split(".")
+
+    claims = json.loads(_b64url_decode(payload_b64))
+    assert claims["iss"] == "987654"
+    claims["iss"] = "111111"
+    forged_payload = _b64url_encode(json.dumps(claims).encode("utf-8"))
+    forged = f"{header_b64}.{forged_payload}.{signature_b64}"
+
+    with pytest.raises(InvalidSignature):
+        _verify_rs256(public_pem, f"{header_b64}.{forged_payload}", _b64url_decode(signature_b64))
+    with pytest.raises(jwt.InvalidSignatureError):
+        jwt.decode(forged, public_pem, algorithms=["RS256"])
+
+
+def test_app_jwt_names_the_install_when_pyjwt_is_absent(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    """A missing PyJWT fails like every other credential gap here: loud, with the repair."""
+    private_pem, _ = rsa_keypair
+    # A None entry in sys.modules is what the import machinery itself uses to
+    # mark a module as unimportable, so `import jwt` inside build_app_jwt takes
+    # the real ImportError path rather than a stubbed one.
+    monkeypatch.setitem(sys.modules, "jwt", None)
+
+    with pytest.raises(fcr.ForgeCheckRunError) as excinfo:
+        fcr.build_app_jwt(987654, private_pem)
+    assert "pyjwt[crypto]" in str(excinfo.value)
+
+
+def test_app_jwt_names_the_extra_when_rs256_has_no_backend(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    """Bare PyJWT imports fine and only fails at signing — with its own message."""
+    private_pem, _ = rsa_keypair
+
+    def _no_asymmetric_backend(*args: Any, **kwargs: Any) -> str:
+        raise NotImplementedError("Algorithm 'RS256' could not be found.")
+
+    monkeypatch.setattr(jwt, "encode", _no_asymmetric_backend)
+
+    with pytest.raises(fcr.ForgeCheckRunError) as excinfo:
+        fcr.build_app_jwt(987654, private_pem)
+    message = str(excinfo.value)
+    assert "pyjwt[crypto]" in message
+    assert "RS256" in message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_forge_protection_drift.py
+++ b/tests/test_forge_protection_drift.py
@@ -181,6 +181,94 @@ class TestParseProtectionConfig:
             assert names["Some Other Check"] is None
 
 
+class TestAppBlock:
+    """Golf B, B2a fix-forward 2: the top-level ``app:`` block is optional
+    (already true since B2a's own commit), but its INTERNAL shape was never
+    validated -- any garbage nested under ``app:`` parsed silently. This
+    class locks in that the block, when present, is validated with the same
+    rigor as every other object in this schema.
+    """
+
+    def test_app_block_is_accepted(self):
+        doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": None})
+        config = fpd.parse_protection_config(yaml.safe_dump(doc))
+        assert config.branch == "main"
+
+    def test_app_block_with_a_bound_app_id_is_accepted(self):
+        doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": 987654})
+        config = fpd.parse_protection_config(yaml.safe_dump(doc))
+        assert config.branch == "main"
+
+    def test_app_block_with_unknown_key_is_rejected(self):
+        doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": None, "bogus": 1})
+        with pytest.raises(fpd.ProtectionConfigError, match="onbekende velden"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_app_block_missing_slug_is_rejected(self):
+        doc = _base_config_dict(app={"app_id": None})
+        with pytest.raises(fpd.ProtectionConfigError, match="verplichte velden"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_app_block_missing_app_id_is_rejected(self):
+        doc = _base_config_dict(app={"slug": "vnx-gate"})
+        with pytest.raises(fpd.ProtectionConfigError, match="verplichte velden"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_app_slug_must_be_a_non_empty_string(self):
+        doc = _base_config_dict(app={"slug": "", "app_id": None})
+        with pytest.raises(fpd.ProtectionConfigError, match="app.slug"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_app_id_must_be_an_integer_or_null(self):
+        doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": "987654"})
+        with pytest.raises(fpd.ProtectionConfigError, match="app.app_id"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_app_id_true_is_rejected_not_treated_as_an_integer(self):
+        """bool is an int subclass; `app_id: true` is a typo, not an id."""
+        doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": True})
+        with pytest.raises(fpd.ProtectionConfigError, match="app.app_id"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_app_block_not_a_mapping_is_rejected(self):
+        doc = _base_config_dict(app="vnx-gate")
+        with pytest.raises(fpd.ProtectionConfigError, match="app"):
+            fpd.parse_protection_config(yaml.safe_dump(doc))
+
+    def test_compare_is_identical_with_and_without_an_app_block(self):
+        """(3) the app: block never enters the normalized dict, so its
+        presence or absence can never register as drift."""
+        without = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        with_app = fpd.to_normalized_dict(
+            fpd.parse_protection_config(_yaml_text(app={"slug": "vnx-gate", "app_id": None}))
+        )
+        assert fpd.compare(without, with_app) == []
+
+    def test_is_weakening_is_identical_with_and_without_an_app_block(self):
+        without = fpd.to_normalized_dict(fpd.parse_protection_config(_yaml_text()))
+        with_app = fpd.to_normalized_dict(
+            fpd.parse_protection_config(_yaml_text(app={"slug": "vnx-gate", "app_id": 1}))
+        )
+        assert fpd.is_weakening(without, with_app) == (False, [])
+        assert fpd.is_weakening(with_app, without) == (False, [])
+
+    def test_apply_put_payload_never_contains_an_app_key(self):
+        """The PUT body apply_branch_protection.py sends is built entirely
+        from ProtectionConfig fields, which never carry ``app`` -- see
+        ProtectionConfig's field list. Confirmed end-to-end here rather than
+        just by inspection, against a config parsed from a YAML that DOES
+        declare the block."""
+        forge_dir = VNX_ROOT / "scripts" / "forge"
+        sys.path.insert(0, str(forge_dir))
+        import apply_branch_protection as abp
+
+        doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": 987654})
+        config = fpd.parse_protection_config(yaml.safe_dump(doc))
+        payload = abp.build_put_payload(config)
+        assert "app" not in payload
+        assert "slug" not in json.dumps(payload)
+
+
 # ---------------------------------------------------------------------------
 # compare()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Dispatch-ID**: 20260907-golfb-b2a-forge-client
**Track**: gate-enforcement-to-forge, deliverable B2a

De clientlaag waarmee de `vnx-gate` GitHub App een check-run publiceert. Nul poortkennis: `conclusion` gaat door zoals aangeleverd en wordt hier niet geinterpreteerd of gefilterd. Dat oordeel en de koppeling aan de gate-recorder zijn B2b.

## Wat erin zit

`scripts/lib/forge_check_run.py` (nieuw)

- `load_app_config()` leest `app.slug`/`app.app_id` uit `scripts/forge/branch_protection.yaml` en faalt luid met de operator-stap zodra `app_id` null of afwezig is.
- `read_private_key()` / `read_installation_id()` lezen de keychain-items `vnx-gate-app-key` en `vnx-gate-installation-id`. Elke fout (geen `security`, item ontbreekt, keychain op slot, lege waarde, timeout) is een exception met het letterlijke `security add-generic-password`-herstelcommando plus het runbook. **Nooit een lege string:** het zachte falen uit `send_digest_email` is correct voor een optionele digest-mail en fout hier, want een lege sleutel maakt van "de poort kon niet authenticeren" een check-run die stil nooit verschijnt.
- `build_app_jwt()`: RS256, `iss` = app_id, `iat` -60s, `exp` +9min (onder GitHubs plafond van 10).
- `installation_token()` wisselt de JWT bij `POST /app/installations/{id}/access_tokens` en cachet in het geheugen tot 5 minuten voor `expires_at`. Een 401 op een verse JWT faalt luid, nooit een herprobeer-lus.
- `publish_check_run(head_sha, name, conclusion, summary, *, details_url=None)`: `POST /repos/{owner}/{repo}/check-runs` met `status=completed`. HTTP-fout wordt een exception met status en ingekorte body, nooit een stille skip. Precies **een** geforceerde ververs-en-hertry bij een 401 op een *gecachet* token, omdat GitHub er een vroegtijdig kan intrekken.

Transport is `urllib.request`, niet `gh api`. Motivatie staat in de moduledocstring: `gh` lost zijn eigen credentials en owner/repo op, dus een App-token meegeven betekent het als `GH_TOKEN` in de omgeving injecteren en op gh's voorrangsregels vertrouwen. Daarmee zou de identiteit van de aanroep, het enige wat deze module bestaat om te sturen, van die regels afhangen. `owner/repo` komt uit `chain_origin_anchor._owner_repo_from_remote`, hergebruikt in plaats van een vierde kopie van dezelfde regex.

`scripts/forge/branch_protection.yaml`: blok `app:` met `slug: vnx-gate` en `app_id: null` tot de operator hem invult.

## Buiten de bestandsgrens, bewust en gemeten

`scripts/lib/forge_protection_drift.py` krijgt `app` als **optionele** top-level sleutel (een regel plus toelichting). De dispatch eist dat apply en drift het `app:`-blok negeren; B1's strikte onbekende-veldencontrole maakt dat onmogelijk zonder deze registratie. Gemeten voor de wijziging:

```
RED (behaviour): branch_protection.yaml heeft onbekende velden: ['app']
```

`app` blijft buiten `ProtectionConfig` en `to_normalized_dict`, dus het kan nooit als drift of verzwakking meetellen. Het is een allowlist van precies een sleutel; een echt onbekende sleutel wordt nog steeds geweigerd (test dekt dat).

## Verificatie

- `pytest tests/test_forge_check_run_client.py` -> **49 passed**
- Buren, ongewijzigd: `test_forge_protection_drift.py` 62, plus `test_apply_branch_protection.py` / `test_vnx_doctor_branch_protection.py` / `test_pr_merge_branch_protection.py` / `test_chain_branch_protection_check.py` / `test_pre_merge_gate_required_contexts.py` / `test_chain_origin_anchor.py` samen **120 passed**, en `test_fabric_audit.py` + `test_anchor_immutability_workflow.py` **36 passed**. ADR-003 no-SDK-poort **23 passed**.
- Tegen de echte keychain, zonder items: luide fout met het herstelcommando. Geen enkele POST uitgevoerd, er is nog geen App.
- Mutatieproef: het zachte falen (`return ""`) ingebouwd, waarop precies `test_read_private_key_empty_output_is_loud_not_empty_string` rood ging. Daarna teruggezet en byte-identiek geverifieerd.

## Let op bij mergen

De branch-protection-preflight in `pr_merge.py` parst de YAML op de PR-head met de **draaiende** code. Vanuit een checkout die nog op main staat weigert die parser dit `app:`-blok, wat een NO-GO oplevert. Gemeten met main's parser tegen deze PR-YAML. Details en de remedie staan in Open Items van het dispatch-rapport.

Dispatch-ID: 20260907-golfb-b2a-forge-client