### PR TITLE
fix(gate-recorder): poortbewijs hangt aan de head, een oude uitspraak blokkeert geen verse (OI-1668)

### DIFF
--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -337,6 +337,34 @@ class ResultOverwriteRefused(ValueError):
     decided one (OI-1469/OI-1470)."""
 
 
+def result_is_for_head(result: Dict[str, Any], head_sha: str) -> bool:
+    """Does this result record judge ``head_sha``? (OI-1668)
+
+    A gate verdict is a statement about ONE commit. The result record carries
+    the commit it judged in ``commit_sha`` (stamped by
+    :func:`stamp_request_identity` on every production writer), and the merge
+    door already joins on exactly that field — a result whose ``commit_sha``
+    is not the PR head is not evidence the door can use.
+
+    Three answers, and the third is why this is a function rather than a
+    comparison written out at each call site:
+
+    - ``head_sha`` is empty: the head is UNKNOWN, not different. ``gh`` may be
+      absent, unauthenticated or rate-limited, and a lookup failure must never
+      silently reclassify existing evidence. Returns True — every caller then
+      behaves exactly as it did before this function existed.
+    - the record's ``commit_sha`` is empty: it belongs to NO head, so it is
+      not this one's. Returns False. Callers log that loudly; an unanchored
+      verdict losing its slot is something an operator has to be able to see.
+    - both present: a plain equality. Never a prefix match — an abbreviated
+      sha and a full one are two different strings, and accepting a prefix
+      would let a 7-char collision pass as evidence.
+    """
+    if not (head_sha or "").strip():
+        return True
+    return (result.get("commit_sha") or "").strip() == head_sha.strip()
+
+
 class _CorruptResult:
     """Sentinel: the result file exists but could not be parsed as a dict.
 
@@ -395,6 +423,32 @@ def _check_overwrite_guard(
     record with NO complete evidence (e.g. an existing not_executable) is
     not "decided" and stays freely overwritable — it must not permanently
     freeze the slot.
+
+    OI-1668 scopes all of the above to ONE HEAD. Measured live on PR #1808
+    (2026-09-07): codex_gate signed ``completed`` on head ``5fd261fd``, a
+    fix-forward moved the head to ``1f8c985f``, and three re-gate attempts
+    for the new head were refused — ``write_refused: true``,
+    ``attempted_commit_sha: 1f8c985f``. The slot stayed pinned to a verdict
+    about code that no longer existed, and the merge door reported ``geen
+    review-gate resultaat gevonden voor codex_gate op 1808: merge niet
+    toetsbaar``. The guard was comparing decidedness and evidence, and never
+    asked which commit either record was about.
+
+    So: when this write names a head (``commit_sha``) the existing record
+    does not carry, that record is not evidence about this head and the write
+    proceeds — even when it is less decided. That is not a downgrade; there
+    was nothing here to downgrade. Everything the guard protected against
+    still holds WITHIN one head, which is the only scope in which "this
+    verdict is more decided than that one" was ever a meaningful comparison.
+
+    A write with no ``commit_sha`` of its own names no head, so it gets
+    today's behaviour unchanged: the escape hatch needs a head to be about,
+    and a sha-less writer must not silently lose the protection. The
+    asymmetry with an EXISTING record's empty ``commit_sha`` (which does
+    yield, loudly) is deliberate — one side is "I cannot say which head this
+    write is for", the other is "that record never said which head it
+    judged", and only the second is a statement about the record being
+    displaced.
     """
     from gate_status import is_terminal, has_complete_evidence, canonical_status  # noqa: PLC0415
 
@@ -425,6 +479,32 @@ def _check_overwrite_guard(
         return
     existing_status = canonical_status(existing)
     new_status = canonical_status(new_payload)
+    new_sha = (new_payload.get("commit_sha") or "").strip()
+    if new_sha and not result_is_for_head(existing, new_sha):
+        # OI-1668: the existing record judges a different commit (or none at
+        # all), so it is not evidence about the head being written now. Two
+        # log lines, not one: an operator reading this needs to tell "the head
+        # moved on, as it does after every fix-forward" apart from "a verdict
+        # that never recorded what it judged just lost its slot", and the
+        # second is the one worth chasing.
+        existing_sha = (existing.get("commit_sha") or "").strip()
+        if not existing_sha:
+            logger.warning(
+                "gate_recorder: replacing terminal result gate=%s pr=%s "
+                "existing_status=%r that carries no commit_sha with status=%r "
+                "for head=%s — an unanchored verdict is evidence for no head, "
+                "so it cannot hold this slot (OI-1668)",
+                gate, pr_ref, existing_status, new_status, new_sha,
+            )
+        else:
+            logger.info(
+                "gate_recorder: replacing terminal result gate=%s pr=%s "
+                "existing_status=%r recorded against head=%s with status=%r "
+                "for head=%s — a verdict about another commit does not gate "
+                "this one (OI-1668)",
+                gate, pr_ref, existing_status, existing_sha, new_status, new_sha,
+            )
+        return
     if not is_terminal(new_payload):
         logger.warning(
             "gate_recorder: REFUSING to overwrite terminal result gate=%s pr=%s "

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -18,7 +18,7 @@ from atomic_io import atomic_write_json
 from auto_merge_policy import codex_final_gate_required
 from review_contract import ReviewContract
 from gemini_prompt_renderer import render_gemini_prompt
-from gate_recorder import get_pr_head_sha, write_result_guarded
+from gate_recorder import get_pr_head_sha, result_is_for_head, write_result_guarded
 from governance_emit import _classify_lane_log_text
 from claude_github_receipt import (
     ClaudeGitHubReviewReceipt,
@@ -858,6 +858,28 @@ class GateRequestHandlerMixin:
         is still ``lane_exhausted``, that is a NAMED terminal end-state
         (``_chain_exhausted_result``) -- never a silent fallback to
         re-dispatching the originally-requested ``gate``.
+
+        HEAD SCOPING (OI-1668): every one of those decisions rests on a
+        candidate's last recorded result, and a result is a statement about
+        ONE commit. A record produced against an earlier head says nothing
+        about the head under review now, so it may not decide whether this
+        seat gets skipped -- ``gate_recorder.result_is_for_head`` answers
+        that, and a record belonging to another head (or to none) STOPS the
+        walk exactly as a missing record does: the candidate is dispatched
+        live. Live shape this closes, PR #1808 on 2026-09-07: codex's seat
+        held an exhaustion recorded against head ``5fd261fd`` while the PR had
+        already moved to ``1f8c985f``, and the walk kept routing around a seat
+        that had never been asked about the current code.
+
+        The head sha is resolved LAZILY -- once, on the first candidate that
+        actually has a prior result -- so the common first-round shape (no
+        record anywhere) still costs no GitHub round-trip, and a multi-hop
+        walk costs one lookup rather than one per hop. When it cannot be
+        resolved at all (``""``: gh missing, unauthenticated, or a PR that
+        does not resolve) the head question is unanswerable, and
+        ``result_is_for_head`` answers True so the walk behaves exactly as it
+        did before -- a failed lookup must never silently redirect a takeover
+        decision.
         """
         if chain is None:
             chain = _build_review_gate_takeover_chain()
@@ -874,9 +896,22 @@ class GateRequestHandlerMixin:
 
         path: List[Dict[str, Any]] = []
         current = gate
+        head_sha: Optional[str] = None  # resolved lazily; see docstring
         while True:
             existing_result = self._read_existing_gate_result(current, pr_number)
             if existing_result is None:
+                break
+            if head_sha is None:
+                head_sha = get_pr_head_sha(pr_number)
+            if not result_is_for_head(existing_result, head_sha):
+                logger.info(
+                    "gate_request_handler: ignoring gate=%s result for pr=%s "
+                    "recorded against head=%r while the PR head is %r -- a "
+                    "verdict about another commit cannot decide whether this "
+                    "seat is skipped; dispatching it live (OI-1668)",
+                    current, pr_number,
+                    (existing_result.get("commit_sha") or ""), head_sha,
+                )
                 break
             seat_state = self._classify_review_seat_failure(existing_result)
             if seat_state != "lane_exhausted":

--- a/tests/test_oi1488_refused_write_is_not_a_verdict.py
+++ b/tests/test_oi1488_refused_write_is_not_a_verdict.py
@@ -28,6 +28,31 @@ turns a result into ``decided_pass`` refuses to count a record whose commit is
 not the head being merged. The annotation alone would not be enough: a flag
 only protects a caller that reads it, and the harm happens in a caller that
 reads ``status`` and ``contract_hash``.
+
+SUPERSEDED IN PART BY OI-1668 (2026-09-07), and the split runs exactly along
+the "load-bearing" line above. The second half — ``sha_binding`` in
+``gate_executor._execute_requested_gates``, the six tests at the bottom of this
+file — is untouched and still the protection.
+
+The first half assumed a cross-head write would be REFUSED, and that
+assumption was itself the next defect. Measured on PR #1808: codex signed
+``completed`` on head ``5fd261fd``, a fix-forward moved the head to
+``1f8c985f``, and every attempt to record a verdict for the new head was
+refused because a decided verdict for the OLD head held the slot. The merge
+door then reported ``geen review-gate resultaat gevonden voor codex_gate op
+1808: merge niet toetsbaar`` — the same "a verdict about another commit is not
+evidence about this one" principle this file opens with, arriving one level
+further down and blocking a legitimate merge. OI-1668 makes the overwrite
+guard head-scoped, so a write naming a head the stored record does not carry
+now lands.
+
+The three refusal tests below therefore no longer describe a cross-head
+write. They describe a SAME-head refusal, which is the case
+``annotate_refused_write`` still exists for: an outage that would erase a
+decided verdict about the very commit under review. That is the invariant
+OI-1488 was protecting; only the fixture's sha moved. The cross-head case is
+pinned as its own test, so the supersession is visible here rather than only
+in the file that changed the guard.
 """
 from __future__ import annotations
 
@@ -83,10 +108,14 @@ def dirs(tmp_path):
     return requests, results, state
 
 
-def _request_payload():
+def _request_payload(commit_sha=REQUESTED_SHA):
+    # OI-1668: the sha is now a parameter because it decides whether the guard
+    # engages at all. A refusal only happens on the SAME head as the stored
+    # record; a request naming a different head is a different scenario, not a
+    # variation of this one.
     return {
         "gate": "codex_gate", "pr_id": "1705", "pr_number": 1705,
-        "branch": "fix/whatever", "commit_sha": REQUESTED_SHA,
+        "branch": "fix/whatever", "commit_sha": commit_sha,
         "contract_hash": "088a30754169bb91",
     }
 
@@ -101,7 +130,7 @@ def test_a_refused_not_executable_is_marked_as_not_written(dirs):
     payload = record_not_executable(
         gate="codex_gate", pr_number=1705, pr_id="",
         reason="provider_unavailable", reason_detail="codex quota exhausted",
-        request_payload=_request_payload(),
+        request_payload=_request_payload(PRIOR_SHA),
         requests_dir=requests, results_dir=results, state_dir=state,
     )
 
@@ -114,9 +143,10 @@ def test_a_refused_not_executable_is_marked_as_not_written(dirs):
         "actually wrote"
     )
     assert payload.get("attempted_status") == "not_executable"
-    assert payload.get("attempted_commit_sha") == REQUESTED_SHA, (
-        "without the attempted sha beside the preserved one, a reader cannot "
-        "see that the two are about different commits"
+    assert payload.get("attempted_commit_sha") == PRIOR_SHA, (
+        "the attempted sha must still be reported beside the preserved record "
+        "— after OI-1668 the two always name the same head on a refusal, and a "
+        "reader has to be able to CHECK that rather than assume it"
     )
 
 
@@ -129,13 +159,43 @@ def test_a_refused_failure_is_marked_as_not_written(dirs):
             "reason": "timeout", "reason_detail": "codex stalled at 900s",
             "duration_seconds": 900.0, "partial_output_lines": 0, "runner_pid": 42,
         },
-        request_payload=_request_payload(),
+        request_payload=_request_payload(PRIOR_SHA),
         requests_dir=requests, results_dir=results,
     )
 
     assert payload["status"] == "fail"
     assert payload.get("write_refused") is True
     assert payload.get("attempted_status") == "unavailable"
+
+
+def test_a_write_for_a_new_head_is_no_longer_refused(dirs):
+    """The half of OI-1488 that OI-1668 supersedes, pinned where it is read.
+
+    Identical to the test above except for one field: the request names a
+    head the stored record does not carry. Before OI-1668 that was refused
+    identically, which is how a decided verdict about deleted code came to
+    block PR #1808's merge. It must now land — and the preserved-record
+    annotation must be ABSENT, because nothing was preserved.
+    """
+    requests, results, _state = dirs
+
+    payload = record_failure(
+        gate="codex_gate", pr_number=1705, pr_id="",
+        result={
+            "reason": "timeout", "reason_detail": "codex stalled at 900s",
+            "duration_seconds": 900.0, "partial_output_lines": 0, "runner_pid": 42,
+        },
+        request_payload=_request_payload(REQUESTED_SHA),
+        requests_dir=requests, results_dir=results,
+    )
+
+    assert "write_refused" not in payload
+    assert payload["status"] == "unavailable"
+    on_disk = json.loads((results / "pr-1705-codex_gate.json").read_text(encoding="utf-8"))
+    assert on_disk["commit_sha"] == REQUESTED_SHA, (
+        "a verdict about 109181d2 cannot keep the slot the head 1425faa1 "
+        "needs — that is the OI-1668 merge blockage (PR #1808)"
+    )
 
 
 def test_a_landed_write_is_not_marked_refused(dirs):
@@ -161,7 +221,7 @@ def test_the_decided_record_on_disk_is_untouched(dirs):
     record_not_executable(
         gate="codex_gate", pr_number=1705, pr_id="",
         reason="provider_unavailable", reason_detail="quota",
-        request_payload=_request_payload(),
+        request_payload=_request_payload(PRIOR_SHA),
         requests_dir=requests, results_dir=results, state_dir=state,
     )
 

--- a/tests/test_oi1668_gate_result_head_scoped.py
+++ b/tests/test_oi1668_gate_result_head_scoped.py
@@ -1,0 +1,365 @@
+"""Gate evidence hangs on the HEAD it was produced against (OI-1668).
+
+Live measurement, PR #1808 on 2026-09-07 (T0, reproduced read-only in this
+dispatch from ``state/review_gates/results/pr-1808-codex_gate.json``):
+
+  18:33  codex_gate ran against head ``5fd261fd`` and recorded
+         ``status=completed``, ``contract_hash=b37403cb1d40fc3f``.
+  18:41  a fix-forward pushed head ``1f8c985f``.
+  18:48 / 18:54 / 18:57  three attempts to make codex sign for the NEW head
+         produced no new record. The write path reported
+         ``write_refused: true``, ``attempted_status: unavailable``,
+         ``attempted_commit_sha: 1f8c985f...`` -- the guard compared
+         decidedness and evidence, and never looked at which commit either
+         record was about.
+  Result, verbatim from the merge door: ``NO-GO: geen review-gate resultaat
+  gevonden voor codex_gate op 1808: merge niet toetsbaar``. A legitimate PR
+  with green CI could not merge, because a decided verdict about code that no
+  longer exists occupied the slot the current head needed.
+
+Two mechanisms, one property:
+
+  1. ``gate_recorder._check_overwrite_guard`` -- a terminal, evidenced record
+     for a DIFFERENT head is not evidence for the head being written now, so
+     it may be replaced (even by something less decided). Same head: the
+     OI-1469/OI-1470 protection is unchanged.
+  2. ``gate_request_handler._dispatch_review_seat`` -- the takeover walk reads
+     each candidate's last result to decide whether to route AROUND that seat.
+     A record about another head says nothing about this head, so the seat is
+     dispatched again instead of being routed around.
+
+Both halves only engage when the head being written/reviewed is actually
+KNOWN. A payload with no ``commit_sha``, or a PR whose head sha cannot be
+resolved, leaves today's behaviour exactly as it was -- the fix must not
+weaken the guard on the (many) paths that never carried a sha.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import gate_request_handler
+from gate_recorder import record_failure, write_result_guarded
+from gate_request_handler import GateRequestHandlerMixin
+
+# The two real heads of PR #1808 (see module docstring).
+SHA_A = "5fd261fd9af761ff94911df5eea14c5a6e8caa74"
+SHA_B = "1f8c985f73d3e5900034b9eb93ff36479a3bfc82"
+
+# OI-1569 recency gate: a lane_exhausted fixture must carry a FRESH
+# recorded_at, or the handler tests below would exercise the TTL branch
+# instead of the head-scoping branch they are about.
+_FRESH_RECORDED_AT = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _decided_pass(commit_sha: str, **overrides: Any) -> Dict[str, Any]:
+    """A terminal, fully-evidenced codex verdict -- the shape the overwrite
+    guard exists to protect."""
+    payload = {
+        "gate": "codex_gate",
+        "pr_id": "1808",
+        "pr_number": 1808,
+        "status": "completed",
+        "contract_hash": "b37403cb1d40fc3f",
+        "report_path": "/tmp/codex-report-1808.md",
+        "blocking_findings": [],
+        "dispatch_id": "20260907-golfb-b2a-forge-client",
+        "branch": "dispatch/20260907-golfb-b2a-forge-client",
+        "commit_sha": commit_sha,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _outage(commit_sha: str) -> Dict[str, Any]:
+    """The live attempted write: an execution failure booked as
+    ``unavailable`` with no evidence, carrying the NEW head's sha."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": "1808",
+        "pr_number": 1808,
+        "status": "unavailable",
+        "reason": "exit_nonzero",
+        "reason_detail": "Subprocess exited with code 1",
+        "contract_hash": "",
+        "report_path": "",
+        "commit_sha": commit_sha,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. The overwrite guard is head-scoped
+# ---------------------------------------------------------------------------
+
+
+class TestOverwriteGuardIsHeadScoped:
+
+    def test_outage_for_a_new_head_may_replace_a_pass_from_an_old_head(self, tmp_path):
+        """RED on main: refused, so the slot stayed pinned to ``5fd261fd``
+        and the merge door found no result for ``1f8c985f``."""
+        out = tmp_path / "pr-1808-codex_gate.json"
+        out.write_text(json.dumps(_decided_pass(SHA_A)), encoding="utf-8")
+
+        payload, written = write_result_guarded(
+            out, _outage(SHA_B), gate="codex_gate", pr_ref="1808",
+        )
+
+        assert written is True, (
+            "a decided verdict about head 5fd261fd is not evidence about head "
+            "1f8c985f -- it must not block a write for the new head (OI-1668)"
+        )
+        on_disk = json.loads(out.read_text(encoding="utf-8"))
+        assert on_disk["commit_sha"] == SHA_B
+        assert on_disk["status"] == "unavailable"
+        assert payload["commit_sha"] == SHA_B
+
+    def test_live_record_failure_path_for_a_new_head_lands(self, tmp_path):
+        """The same claim through the writer that actually produced the live
+        refusal: ``record_failure`` (gate_runner's exit_nonzero booking),
+        whose request payload carries the new head."""
+        results_dir = tmp_path / "results"
+        requests_dir = tmp_path / "requests"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        requests_dir.mkdir(parents=True, exist_ok=True)
+        rf = results_dir / "pr-1808-codex_gate.json"
+        rf.write_text(json.dumps(_decided_pass(SHA_A)), encoding="utf-8")
+
+        result = record_failure(
+            # pr_id="" so result_file_path resolves the pr-<N>-<gate>.json
+            # slot the live record occupies, not the pr_id contract slug.
+            gate="codex_gate", pr_number=1808, pr_id="",
+            result={
+                "reason": "exit_nonzero",
+                "reason_detail": "Subprocess exited with code 1",
+                "duration_seconds": 12.0, "partial_output_lines": 4, "runner_pid": 1,
+            },
+            request_payload={
+                "gate": "codex_gate", "pr_number": 1808,
+                "branch": "dispatch/20260907-golfb-b2a-forge-client",
+                "commit_sha": SHA_B,
+                "dispatch_id": "20260907-golfb-shafix-2",
+            },
+            requests_dir=requests_dir, results_dir=results_dir,
+        )
+
+        assert result.get("write_refused") is not True, (
+            "the live shape: a re-gate for the new head must not come back "
+            "annotated as a refused write (OI-1668)"
+        )
+        on_disk = json.loads(rf.read_text(encoding="utf-8"))
+        assert on_disk["commit_sha"] == SHA_B
+        assert on_disk["status"] == "unavailable"
+
+    def test_outage_for_the_same_head_is_still_refused(self, tmp_path):
+        """The OI-1469/OI-1470 protection must not weaken: on the SAME head a
+        provider outage still may not erase a decided, evidenced verdict."""
+        out = tmp_path / "pr-1808-codex_gate.json"
+        existing = _decided_pass(SHA_A)
+        out.write_text(json.dumps(existing), encoding="utf-8")
+
+        payload, written = write_result_guarded(
+            out, _outage(SHA_A), gate="codex_gate", pr_ref="1808",
+        )
+
+        assert written is False
+        assert payload == existing
+        assert json.loads(out.read_text(encoding="utf-8")) == existing
+
+    def test_pass_for_a_new_head_replaces_a_pass_on_an_old_head(self, tmp_path):
+        """Control (already green on main via terminal-over-terminal): a real
+        re-gate on the new head lands. Kept so a head-scoping regression that
+        froze the slot the other way round would be caught here too."""
+        out = tmp_path / "pr-1808-codex_gate.json"
+        out.write_text(json.dumps(_decided_pass(SHA_A)), encoding="utf-8")
+
+        fresh = _decided_pass(SHA_B, contract_hash="fresh0000head0b", dispatch_id="rerun-2")
+        payload, written = write_result_guarded(
+            out, fresh, gate="codex_gate", pr_ref="1808",
+        )
+
+        assert written is True
+        assert json.loads(out.read_text(encoding="utf-8"))["commit_sha"] == SHA_B
+
+    def test_existing_record_without_a_commit_sha_belongs_to_no_head(self, tmp_path, caplog):
+        """A record that never recorded which commit it judged cannot be
+        evidence for the head being written now. Overwritable -- and LOUD,
+        because an unanchored verdict being displaced is exactly the thing an
+        operator must be able to see in the log."""
+        out = tmp_path / "pr-1808-codex_gate.json"
+        unanchored = _decided_pass(SHA_A)
+        unanchored.pop("commit_sha")
+        out.write_text(json.dumps(unanchored), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="gate_recorder"):
+            _payload, written = write_result_guarded(
+                out, _outage(SHA_B), gate="codex_gate", pr_ref="1808",
+            )
+
+        assert written is True
+        assert json.loads(out.read_text(encoding="utf-8"))["commit_sha"] == SHA_B
+        assert any(
+            "no commit_sha" in record.getMessage() and record.levelno >= logging.WARNING
+            for record in caplog.records
+        ), (
+            "displacing an unanchored terminal record must be logged loudly, "
+            f"got: {[r.getMessage() for r in caplog.records]!r}"
+        )
+
+    def test_new_payload_without_a_commit_sha_does_not_unlock_the_guard(self, tmp_path):
+        """The escape hatch needs a KNOWN head to be about. A write that
+        carries no sha of its own says nothing about which head it is for, so
+        the guard stays exactly as strict as it is today -- otherwise every
+        sha-less writer in the tree would silently lose the protection."""
+        out = tmp_path / "pr-1808-codex_gate.json"
+        existing = _decided_pass(SHA_A)
+        out.write_text(json.dumps(existing), encoding="utf-8")
+
+        sha_less = _outage("")
+        sha_less.pop("commit_sha")
+        _payload, written = write_result_guarded(
+            out, sha_less, gate="codex_gate", pr_ref="1808",
+        )
+
+        assert written is False
+        assert json.loads(out.read_text(encoding="utf-8")) == existing
+
+
+# ---------------------------------------------------------------------------
+# 2. The takeover walk is head-scoped
+# ---------------------------------------------------------------------------
+
+
+_CHAIN = {"codex_gate": "kimi_gate"}
+
+
+class _StubHandler(GateRequestHandlerMixin):
+    """Minimal stand-in for ReviewGateManager: the two path helpers plus a
+    recording ``_dispatch_one_review``. ``_dispatch_review_seat`` itself is
+    real production code."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self.requests_dir = state_dir / "review_gates" / "requests"
+        self.results_dir = state_dir / "review_gates" / "results"
+        self.requests_dir.mkdir(parents=True, exist_ok=True)
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+        self.dispatched: List[str] = []
+
+    def _request_path(self, gate: str, pr_number: int) -> Path:
+        return self.requests_dir / f"pr-{pr_number}-{gate}.json"
+
+    def _result_path(self, gate: str, pr_number: int) -> Path:
+        return self.results_dir / f"pr-{pr_number}-{gate}.json"
+
+    def _dispatch_one_review(self, gate, pr_number, branch, risk_class, changed_files, mode, dispatch_id):
+        self.dispatched.append(gate)
+        return {"gate": gate, "pr_number": pr_number, "status": "requested"}
+
+
+def _lane_exhausted(commit_sha: str) -> Dict[str, Any]:
+    """A codex seat whose own last result is a real lane exhaustion. The
+    marker sits in ``residual_risk`` so ``_scan_seat_failure_text`` classifies
+    it from the record's own fields, without needing a lane log on disk."""
+    return {
+        "gate": "codex_gate",
+        "pr_id": "1808",
+        "pr_number": 1808,
+        "status": "not_executable",
+        "reason": "provider_quota_exhausted",
+        "reason_detail": "You've hit your usage limit.",
+        "residual_risk": "Error code: 429 - You've hit your usage limit. Upgrade to Pro",
+        "summary": "codex_gate not executable",
+        "contract_hash": "",
+        "report_path": "",
+        "recorded_at": _FRESH_RECORDED_AT,
+        "branch": "dispatch/20260907-golfb-b2a-forge-client",
+        "commit_sha": commit_sha,
+    }
+
+
+def _seat(handler: _StubHandler) -> Dict[str, Any]:
+    return handler._dispatch_review_seat(
+        "codex_gate", 1808, "dispatch/20260907-golfb-b2a-forge-client",
+        "medium", ["scripts/lib/gate_recorder.py"], "per_pr",
+        "20260907-golfb-shafix-poortbewijs-per-head", chain=dict(_CHAIN),
+    )
+
+
+class TestTakeoverWalkIsHeadScoped:
+
+    def test_record_from_another_head_does_not_route_around_the_seat(self, tmp_path, monkeypatch):
+        """RED on main: the walk read a record about ``5fd261fd``, concluded
+        the codex seat was dead, and handed the seat to the successor -- while
+        the head under review had moved on and codex had never been asked
+        about it."""
+        handler = _StubHandler(tmp_path / "state")
+        handler._result_path("codex_gate", 1808).write_text(
+            json.dumps(_lane_exhausted(SHA_A)), encoding="utf-8",
+        )
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda _pr: SHA_B)
+
+        payload = _seat(handler)
+
+        assert handler.dispatched == ["codex_gate"], (
+            "an exhaustion recorded against another head is no statement about "
+            "the current head -- the seat must be dispatched again (OI-1668)"
+        )
+        assert payload["gate"] == "codex_gate"
+        assert "takeover" not in payload
+
+    def test_record_from_the_current_head_still_routes_around_the_seat(self, tmp_path, monkeypatch):
+        """Control: on the SAME head the takeover mechanism is untouched."""
+        handler = _StubHandler(tmp_path / "state")
+        handler._result_path("codex_gate", 1808).write_text(
+            json.dumps(_lane_exhausted(SHA_B)), encoding="utf-8",
+        )
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda _pr: SHA_B)
+
+        payload = _seat(handler)
+
+        assert handler.dispatched == ["kimi_gate"]
+        assert payload["takeover"] is True
+        assert payload["takeover_from"] == "codex_gate"
+
+    def test_unresolvable_head_leaves_the_walk_exactly_as_it_was(self, tmp_path, monkeypatch):
+        """No head to compare against (gh unavailable/unauthenticated, or a PR
+        that does not resolve) means the head question cannot be answered --
+        and an unanswerable question must not silently change the takeover
+        decision."""
+        handler = _StubHandler(tmp_path / "state")
+        handler._result_path("codex_gate", 1808).write_text(
+            json.dumps(_lane_exhausted(SHA_A)), encoding="utf-8",
+        )
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda _pr: "")
+
+        payload = _seat(handler)
+
+        assert handler.dispatched == ["kimi_gate"]
+        assert payload["takeover"] is True
+
+    def test_head_sha_is_not_resolved_when_there_is_no_prior_result(self, tmp_path, monkeypatch):
+        """The common first-round shape must not pay for a GitHub round-trip:
+        with no prior record there is nothing to compare a head against."""
+        handler = _StubHandler(tmp_path / "state")
+        calls: List[Any] = []
+
+        def _counting(pr_number):
+            calls.append(pr_number)
+            return SHA_B
+
+        monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", _counting)
+
+        _seat(handler)
+
+        assert handler.dispatched == ["codex_gate"]
+        assert calls == [], "no prior result means no head lookup is needed"


### PR DESCRIPTION
**Dispatch-ID**: 20260907-golfb-shafix-poortbewijs-per-head · **Track**: gate-enforcement-to-forge (golf B) · **Open item**: OI-1668 · blokkeert #1808

## Wat er misging, gemeten

Live op PR #1808 (07-09), nagemeten in deze dispatch uit `state/review_gates/results/pr-1808-codex_gate.json`:

- 18:33 codex draaide op head `5fd261fd` en schreef `status: completed`, `contract_hash b37403cb1d40`.
- 18:41 duwde een fix-forward head `1f8c985f`.
- Elke poging om voor de nieuwe head te tekenen werd geweigerd: `write_refused: true`, `attempted_status: unavailable`, `attempted_commit_sha 1f8c985f`.
- Uit de merge-deur: `NO-GO: geen review-gate resultaat gevonden voor codex_gate op 1808: merge niet toetsbaar`.

De overschrijfwacht vergeleek beslistheid en bewijs en vroeg nooit over welke commit de twee records gingen.

## Wat dit doet

Een poortuitspraak gaat over EEN commit. Twee mechanismen worden head-bewust, met een gedeelde vergelijking in `gate_recorder.result_is_for_head` (drie antwoorden: onbekende head, ankerloos record, gelijkheid; nooit een prefix-match).

1. **`_check_overwrite_guard`** — een bestaand terminaal record dat een andere head noemt is geen bewijs voor de head waarvoor nu geschreven wordt en mag wijken, ook voor iets minder beslists. Binnen dezelfde head blijft OI-1469/OI-1470 exact zoals hij is. Een leeg `commit_sha` op het bestaande record hoort bij geen enkele head en wijkt, met een WARNING. Een schrijver zonder eigen `commit_sha` noemt geen head en krijgt het gedrag van vandaag.
2. **`_dispatch_review_seat`** — de overname-wandeling routeert alleen om een zetel heen als diens laatste record bij de huidige head hoort. De head wordt lui opgehaald: geen prior record betekent geen GitHub-lookup, en een onoplosbare head (`""`) laat de wandeling ongemoeid.

Takeover-route, contract-hash-logica en merge-deur zijn niet aangeraakt.

## Bevinding: OI-1488 gedeeltelijk gesuperseded

De eerste helft van `tests/test_oi1488_refused_write_is_not_a_verdict.py` (drie tests) bouwt een cross-head schrijfactie en verwacht een weigering. Dat is exact het gedrag dat OI-1668 verwijdert; #1808 is die weigering, één laag lager, een merge aan het blokkeren. De drie zijn heranker'd op een same-head weigering (waarvoor `annotate_refused_write` overblijft) en de cross-head zaak staat nu als eigen test in datzelfde bestand. De dragende helft van OI-1488, `sha_binding` in `gate_executor`, is niet aangeraakt en blijft groen.

## Verificatie

Rode tests eerst, tegen HEAD `7df60d8e` in een aparte worktree: 4 failed, 6 passed. Na de wijziging 10 passed.

- `pytest tests/test_oi1668_gate_result_head_scoped.py tests/test_gate_recorder_overwrite_guard.py tests/test_gate_recorder_provenance.py tests/test_gate_recorder_depth.py tests/test_gate_recorder_register.py tests/test_oi1576_merge_door_takeover_evidence.py tests/test_oi1488_refused_write_is_not_a_verdict.py tests/test_b8_takeover_result_order_independent.py` → **99 passed**
- Bredere buren (34 bestanden, incl. `test_dlv5_review_gate_takeover.py`, `test_beta3_e1_review_gate_chain.py`, `test_oi1472_residual_guard_writers.py`, `test_closure_verifier.py`, `test_pr_merge_review_gate.py`) → 796 passed, 2 failed. Beide falen identiek op HEAD zonder deze wijziging: `test_gate_status_schema.py::test_closure_verifier_reads_status_completed_as_pass` en `test_gate_dispatch_id.py::TestRequestHandlerDispatchId::test_request_reviews_propagates_dispatch_id_to_claude_github`.
- Live geval read-only nagespeeld op een kopie van het echte record: vóór de fix `written=False`, slot blijft op `5fd261fd`; erna `written=True`, slot staat op `1f8c985f`. Het echte bestand is byte-identiek (sha256 `3db229d7…` voor en na).

🤖 Generated with [Claude Code](https://claude.com/claude-code)