### PR TITLE
feat(forge): check-run-publicatie na het schijf-record, allowlist en sha-toestanden (golf B, B2b)

### DIFF
--- a/scripts/lib/forge_gate_publisher.py
+++ b/scripts/lib/forge_gate_publisher.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import shutil
 import subprocess
 import sys
@@ -74,6 +75,7 @@ __all__ = [
     "CONCLUSION_FAILURE",
     "CONCLUSION_SUCCESS",
     "FORGE_CONCLUSIONS",
+    "FORGE_EVENT_LANE",
     "RECOVERY_COMMAND_TEMPLATE",
     "ForgeAPIError",
     "ForgeAppConfigError",
@@ -89,9 +91,12 @@ __all__ = [
     "main",
     "publish_for_record",
     "read_result_record",
+    "read_result_record_at",
     "refuse_if_auto_merge_is_armed",
     "result_record_path",
 ]
+
+logger = logging.getLogger(__name__)
 
 CONCLUSION_SUCCESS = "success"
 CONCLUSION_FAILURE = "failure"
@@ -116,6 +121,13 @@ RECOVERY_COMMAND_TEMPLATE = (
 )
 
 _GH_TIMEOUT_SECONDS = 15
+
+#: The event stream a publication attempt leaves its NDJSON line in (ADR-005).
+#: Its OWN lane, never ``T{n}``: ``.vnx-data/events/T{n}.ndjson`` is a
+#: per-dispatch ring buffer, and appending a publication to it under the
+#: record's ``dispatch_id`` would trip ``EventStore``'s dispatch-boundary
+#: rotation and archive a running terminal's stream out from under it.
+FORGE_EVENT_LANE = "forge"
 
 
 class ForgeStatusUnmapped(ForgeCheckRunError):
@@ -419,6 +431,45 @@ def result_record_path(results_dir: Path, pr_number: int, gate: str) -> Optional
     return None
 
 
+def read_result_record_at(record_path: Path) -> Dict[str, Any]:
+    """The record at an EXPLICIT path — that file or nothing, never the store.
+
+    The path variant of :func:`read_result_record`, and the only one a WRITER
+    may use. A writer already knows which file it just wrote; re-deriving that
+    file from ``${VNX_STATE_DIR}`` would answer a different question ("what
+    does the default store hold for this PR and gate") whose answer is a
+    different record whenever the writer used a store that is not the default
+    one — which in this project is every gate run, since they all run with
+    ``VNX_DATA_DIR=~/.vnx-data/vnx-dev``. Publishing that other record can turn
+    a fresh failure into a stale green check.
+
+    So a missing or unreadable path REFUSES instead of returning None. Absent
+    is a legitimate answer to "does the store have a record" (it publishes
+    ``action_required``) and never a legitimate answer to "read the file I just
+    wrote" — there the absence is a plumbing fault, and falling back to the
+    store would hide it behind whatever that store happens to hold.
+    """
+    path = Path(record_path)
+    if not path.exists():
+        raise ForgePublishRefused(
+            f"het opgegeven schijf-record {path} bestaat niet — publicatie geweigerd. "
+            "Een expliciet pad wordt nooit vervangen door de standaardopslag: dat zou "
+            "een ander record publiceren dan de schrijver bedoelde."
+        )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ForgePublishRefused(
+            f"het schijf-record {path} bestaat maar is onleesbaar ({exc}) — een "
+            "beschadigd record levert geen conclusie op, en 'afwezig' zou hier liegen"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ForgePublishRefused(
+            f"het schijf-record {path} is geen object maar {type(data).__name__}"
+        )
+    return data
+
+
 def read_result_record(
     pr_number: int,
     gate: str,
@@ -433,24 +484,20 @@ def read_result_record(
     ``gate_recorder._read_existing_result`` already draws), and reading a torn
     write as "never ran" would publish ``action_required`` while hiding that
     something corrupted the evidence.
+
+    ``record_path`` names the file directly and is handed to
+    :func:`read_result_record_at`, which refuses rather than returns None when
+    that file is absent. Only the store-resolved route can answer None, because
+    only there is "no record" a real state of the world.
     """
-    path = record_path or result_record_path(
+    if record_path is not None:
+        return read_result_record_at(Path(record_path))
+    path = result_record_path(
         results_dir if results_dir is not None else _default_results_dir(), pr_number, gate
     )
     if path is None or not path.exists():
         return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ForgePublishRefused(
-            f"het schijf-record {path} bestaat maar is onleesbaar ({exc}) — een "
-            "beschadigd record levert geen conclusie op, en 'afwezig' zou hier liegen"
-        ) from exc
-    if not isinstance(data, dict):
-        raise ForgePublishRefused(
-            f"het schijf-record {path} is geen object maar {type(data).__name__}"
-        )
-    return data
+    return read_result_record_at(path)
 
 
 def gates_with_a_record(results_dir: Path, pr_number: int) -> List[str]:
@@ -565,6 +612,61 @@ def _check_run_summary(gate: str, verdict: ForgeVerdict, head_sha: str, pr_numbe
     return "\n".join(lines)
 
 
+def _emit_publication_event(
+    *,
+    pr_number: int,
+    gate: str,
+    head_sha: str,
+    outcome: str,
+    detail: str,
+    conclusion: str = "",
+    record: Optional[Dict[str, Any]] = None,
+) -> None:
+    """One NDJSON line per publication attempt (ADR-005), best-effort.
+
+    A check-run mutates state on GitHub, so the attempt belongs in the audit
+    trail whichever way it went — ``published`` and ``failed`` both write a
+    line. Never raises: this is a trace OF the publication, and a trace that
+    can break the thing it traces is worse than a missing line (the same rule
+    ``gate_recorder.publish_forge_check_run`` applies one level up).
+
+    ``dispatch_id`` is deliberately left empty on the envelope and carried in
+    ``data`` instead. The envelope field is what drives ``EventStore``'s
+    per-dispatch ring-buffer rotation; stamping it here would make every
+    publication from a new dispatch archive and truncate the lane, so the
+    producing dispatch is recorded as data rather than as a rotation key.
+    """
+    try:
+        from event_store import EventStore  # noqa: PLC0415
+
+        EventStore().append(
+            FORGE_EVENT_LANE,
+            {
+                "type": f"forge_check_run_{outcome}",
+                "dispatch_id": "",
+                "data": {
+                    "pr_number": pr_number,
+                    "gate": gate,
+                    "check_run_name": check_run_name(gate),
+                    "head_sha": head_sha,
+                    "outcome": outcome,
+                    "conclusion": conclusion,
+                    "detail": detail,
+                    "record_dispatch_id": str((record or {}).get("dispatch_id") or ""),
+                },
+            },
+        )
+    # vnx-broad-except: the audit line may never take down the publication it
+    # describes. Event-store resolution reaches the data-dir resolver, the
+    # filesystem and a lock — an open-ended surface, and every failure in it is
+    # a missing line, not a wrong check-run.
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "forge_gate_publisher: geen event geschreven (%s) voor gate=%s pr=%s: %s",
+            outcome, gate, pr_number, exc,
+        )
+
+
 def publish_for_record(
     pr_number: int,
     gate: str,
@@ -580,6 +682,16 @@ def publish_for_record(
     Reads the record, maps it, and posts. Returns the payload that was sent
     (or, under ``dry_run``, the payload that would have been) — the mapping's
     decision is always visible to the caller, never only to GitHub.
+
+    **Which record.** Three ways to name it, and a writer may only use the
+    first: ``record_path`` is THE file, read as given
+    (:func:`read_result_record_at`, which refuses a missing one rather than
+    falling back); ``results_dir`` is the CLI's store; neither is the default
+    store. The recorder hook passes the path it just wrote, because every gate
+    run in this project runs against a non-default store
+    (``VNX_DATA_DIR=~/.vnx-data/vnx-dev``) and a re-resolved lookup would then
+    read a different file than the one that was written — publishing a stale
+    ``success`` over a verdict that had just failed.
 
     Two refusals, both before anything is sent: an armed auto-merge
     (:func:`refuse_if_auto_merge_is_armed`), and a ``success`` for a record
@@ -604,39 +716,71 @@ def publish_for_record(
     if not dry_run:
         load_app_config()
 
-    refuse_if_auto_merge_is_armed(pr_number)
+    record: Optional[Dict[str, Any]] = None
+    try:
+        # An explicit path is resolved here, before the ``gh`` round-trip, so a
+        # publication that names a file nobody wrote costs nothing and fails
+        # where the fault is.
+        if record_path is not None:
+            record = read_result_record_at(Path(record_path))
 
-    record = read_result_record(
-        pr_number, gate, results_dir=results_dir, record_path=record_path
-    )
-    verdict = classify_record(record, resolved_head)
+        refuse_if_auto_merge_is_armed(pr_number)
 
-    if verdict.conclusion == CONCLUSION_SUCCESS:
-        proven, why = _proven_pass_on_head(record, resolved_head)
-        if not proven:
-            raise ForgePublishRefused(
-                f"weiger success voor {check_run_name(gate)} op {resolved_head[:12]}: het "
-                f"record is geen bewezen pass op deze kop — {why}"
-            )
+        if record_path is None:
+            record = read_result_record(pr_number, gate, results_dir=results_dir)
+        verdict = classify_record(record, resolved_head)
 
-    name = check_run_name(gate)
-    payload: Dict[str, Any] = {
-        "pr_number": pr_number,
-        "gate": gate,
-        "name": name,
-        "head_sha": resolved_head,
-        "conclusion": verdict.conclusion,
-        "reason": verdict.reason,
-        "summary": _check_run_summary(gate, verdict, resolved_head, pr_number),
-        "dry_run": dry_run,
-    }
-    if dry_run:
-        return payload
+        if verdict.conclusion == CONCLUSION_SUCCESS:
+            proven, why = _proven_pass_on_head(record, resolved_head)
+            if not proven:
+                raise ForgePublishRefused(
+                    f"weiger success voor {check_run_name(gate)} op {resolved_head[:12]}: "
+                    f"het record is geen bewezen pass op deze kop — {why}"
+                )
 
-    response = publish_check_run(
-        resolved_head, name, verdict.conclusion, payload["summary"], project_root=project_root
-    )
+        name = check_run_name(gate)
+        payload: Dict[str, Any] = {
+            "pr_number": pr_number,
+            "gate": gate,
+            "name": name,
+            "head_sha": resolved_head,
+            "conclusion": verdict.conclusion,
+            "reason": verdict.reason,
+            "summary": _check_run_summary(gate, verdict, resolved_head, pr_number),
+            "dry_run": dry_run,
+        }
+        # A rehearsal posts nothing, so there is no publication to record.
+        if dry_run:
+            return payload
+
+        response = publish_check_run(
+            resolved_head, name, verdict.conclusion, payload["summary"], project_root=project_root
+        )
+    # vnx-broad-except: every way this can end without a check-run — a refusal,
+    # a corrupt record, GitHub saying no — is one line in the trail, and the
+    # exception is re-raised unchanged. Catching only ForgeCheckRunError would
+    # leave the surprises, which are the ones worth a trace, untraced.
+    except Exception as exc:  # noqa: BLE001
+        _emit_publication_event(
+            pr_number=pr_number,
+            gate=gate,
+            head_sha=resolved_head,
+            outcome="failed",
+            detail=f"{type(exc).__name__}: {exc}",
+            record=record,
+        )
+        raise
+
     payload["check_run_id"] = response.get("id")
+    _emit_publication_event(
+        pr_number=pr_number,
+        gate=gate,
+        head_sha=resolved_head,
+        outcome="published",
+        detail=str(payload["reason"]),
+        conclusion=str(payload["conclusion"]),
+        record=record,
+    )
     return payload
 
 

--- a/scripts/lib/forge_gate_publisher.py
+++ b/scripts/lib/forge_gate_publisher.py
@@ -84,6 +84,7 @@ __all__ = [
     "ForgePublishRefused",
     "ForgeStatusUnmapped",
     "ForgeVerdict",
+    "auto_merge_is_armed",
     "check_run_name",
     "classify_record",
     "conclusion_for",
@@ -563,26 +564,78 @@ def _gh_pr_json(pr_number: int, field: str) -> Dict[str, Any]:
     return data
 
 
+def auto_merge_is_armed(pr_number: int) -> bool:
+    """Whether this PR will merge itself once its checks go green.
+
+    Raises :class:`ForgePublishRefused` when the answer cannot be established —
+    see :func:`_gh_pr_json`. "I could not look" is not "no".
+    """
+    data = _gh_pr_json(pr_number, "autoMergeRequest")
+    return bool(data.get("autoMergeRequest"))
+
+
 def refuse_if_auto_merge_is_armed(pr_number: int) -> None:
-    """Refuse any publication on a PR that has auto-merge queued.
+    """Refuse a ``success`` publication on a PR that has auto-merge queued.
 
     ``pr_merge.py:430`` adds ``--auto`` as soon as the repo allows it, and the
     repo does not (``allow_auto_merge: false``, held there by B1's drift
-    check). If that ever flips, an armed PR turns this publisher into the thing
-    that performs the merge: GitHub merges the moment the last required check
-    goes green, with no human between the check-run and ``main``.
+    check). If that ever flips, an armed PR turns a GREEN check-run into the
+    thing that performs the merge: GitHub merges the moment the last required
+    check passes, with no human between the check-run and ``main``.
 
-    So the refusal covers EVERY conclusion, not just ``success``. A queued
-    auto-merge means a human already handed the decision to a robot, and this
-    robot declines to be the one that pulls it — whatever it was about to say.
+    **Only green.** The refusal used to cover every conclusion, on the reading
+    that a queued auto-merge means a human handed the decision to a robot and
+    this robot declines to pull the trigger. That reading inverts on a red
+    conclusion. Withholding a ``failure`` does not stop the merge — it leaves
+    whatever the head already carries standing, and if that is a stale
+    ``success`` from an earlier run, branch protection stays satisfied and the
+    auto-merge proceeds on evidence this very gate just contradicted. The red
+    check-run is the brake, so refusing to publish it removes the brake.
+
+    ``success`` is the only conclusion that can COMPLETE a merge, and it is the
+    only one refused here. Callers publish red regardless (and say so out loud:
+    :func:`_note_red_over_armed_auto_merge`).
     """
-    data = _gh_pr_json(pr_number, "autoMergeRequest")
-    if data.get("autoMergeRequest"):
+    if auto_merge_is_armed(pr_number):
         raise ForgePublishRefused(
-            f"PR #{pr_number} heeft een actieve auto-merge (autoMergeRequest): elke "
-            "publicatie is geweigerd, want een groene check zou hier de merge zelf "
-            "uitvoeren. Zet auto-merge uit (`gh pr merge --disable-auto`) en publiceer "
-            "daarna opnieuw."
+            f"PR #{pr_number} heeft een actieve auto-merge (autoMergeRequest): een "
+            "success-publicatie is geweigerd, want een groene check zou hier de merge "
+            "zelf uitvoeren. Zet auto-merge uit (`gh pr merge --disable-auto`) en "
+            "publiceer daarna opnieuw."
+        )
+
+
+def _note_red_over_armed_auto_merge(pr_number: int, gate: str, conclusion: str) -> None:
+    """Say out loud that a red conclusion is going out onto a self-merging PR.
+
+    Advisory only, and deliberately unable to stop anything: the auto-merge
+    state cannot change what a red publication does, so a ``gh`` outage here
+    must never become the reason a failing gate stays invisible on the PR. That
+    would rebuild the stale-green hole this narrowing just closed, one level
+    further down.
+
+    Warning level either way. "Auto-merge armed" is precisely the state in
+    which an operator wants to know a machine just wrote a verdict onto that
+    PR, and an unanswerable lookup on the path where the answer no longer
+    blocks is worth one line too — otherwise a permanently broken ``gh`` would
+    be indistinguishable from a permanently unarmed PR.
+    """
+    try:
+        armed = auto_merge_is_armed(pr_number)
+    except ForgePublishRefused as exc:
+        logger.warning(
+            "forge_gate_publisher: auto-merge-status van PR #%s niet vast te stellen (%s); "
+            "%s voor %s wordt tóch gepubliceerd — een rode uitkomst houdt een eventuele "
+            "auto-merge juist tegen, dus deze onbekende blokkeert niets",
+            pr_number, exc, conclusion, check_run_name(gate),
+        )
+        return
+    if armed:
+        logger.warning(
+            "forge_gate_publisher: PR #%s heeft een actieve auto-merge en krijgt tóch %s "
+            "voor %s — een rode check houdt die auto-merge tegen; alleen een success "
+            "wordt hier geweigerd",
+            pr_number, conclusion, check_run_name(gate),
         )
 
 
@@ -661,8 +714,15 @@ def _emit_publication_event(
     # filesystem and a lock — an open-ended surface, and every failure in it is
     # a missing line, not a wrong check-run.
     except Exception as exc:  # noqa: BLE001
-        logger.debug(
-            "forge_gate_publisher: geen event geschreven (%s) voor gate=%s pr=%s: %s",
+        # WARNING, not debug. A check-run mutates state on GitHub; if the
+        # ADR-005 line behind it is lost, the ledger silently disagrees with
+        # what the world now looks like. Swallowing that at debug level makes
+        # an audit gap indistinguishable from a quiet success — the trace is
+        # allowed to fail, it is not allowed to fail invisibly.
+        logger.warning(
+            "forge_gate_publisher: ADR-005-gebeurtenis NIET weggeschreven (%s) voor "
+            "gate=%s pr=%s: %s — de check-run-mutatie staat wél op GitHub, dus het "
+            "gebeurtenissenspoor mist hier een regel",
             outcome, gate, pr_number, exc,
         )
 
@@ -693,14 +753,20 @@ def publish_for_record(
     read a different file than the one that was written — publishing a stale
     ``success`` over a verdict that had just failed.
 
-    Two refusals, both before anything is sent: an armed auto-merge
-    (:func:`refuse_if_auto_merge_is_armed`), and a ``success`` for a record
-    that is not a proven pass on this head. The second one re-asks
-    :func:`_proven_pass_on_head` rather than trusting the conclusion it was
-    just handed. That is not distrust of :func:`classify_record` — it is the
-    one place where a mistake anywhere upstream turns into a green light on
-    ``main``, so the predicate that DEFINES "proven" is consulted at the exact
-    moment the green light would be given.
+    **Two refusals, and both are about ``success`` alone.** An armed auto-merge
+    (:func:`refuse_if_auto_merge_is_armed`) and a record that is not a proven
+    pass on this head. The second one re-asks :func:`_proven_pass_on_head`
+    rather than trusting the conclusion it was just handed. That is not
+    distrust of :func:`classify_record` — it is the one place where a mistake
+    anywhere upstream turns into a green light on ``main``, so the predicate
+    that DEFINES "proven" is consulted at the exact moment the green light
+    would be given.
+
+    Which is why the conclusion is computed BEFORE either refusal runs.
+    ``failure`` and ``action_required`` are published unconditionally: they
+    cannot complete a merge, they are what holds an armed auto-merge back, and
+    withholding one would leave a stale ``success`` on the head as the last
+    thing branch protection sees.
     """
     resolved_head = _require_head(head_sha)
 
@@ -718,25 +784,29 @@ def publish_for_record(
 
     record: Optional[Dict[str, Any]] = None
     try:
-        # An explicit path is resolved here, before the ``gh`` round-trip, so a
-        # publication that names a file nobody wrote costs nothing and fails
-        # where the fault is.
+        # The record and its conclusion FIRST, before any ``gh`` round-trip.
+        # Not merely cheaper (a publication that names a file nobody wrote
+        # costs nothing and fails where the fault is): the conclusion is what
+        # decides whether the auto-merge question is even asked, so it cannot be
+        # asked before the conclusion exists.
         if record_path is not None:
             record = read_result_record_at(Path(record_path))
-
-        refuse_if_auto_merge_is_armed(pr_number)
-
-        if record_path is None:
+        else:
             record = read_result_record(pr_number, gate, results_dir=results_dir)
         verdict = classify_record(record, resolved_head)
 
         if verdict.conclusion == CONCLUSION_SUCCESS:
+            refuse_if_auto_merge_is_armed(pr_number)
             proven, why = _proven_pass_on_head(record, resolved_head)
             if not proven:
                 raise ForgePublishRefused(
                     f"weiger success voor {check_run_name(gate)} op {resolved_head[:12]}: "
                     f"het record is geen bewezen pass op deze kop — {why}"
                 )
+        elif not dry_run:
+            # Red goes out whatever the auto-merge state is; the operator still
+            # gets told. A rehearsal posts nothing, so it has nothing to note.
+            _note_red_over_armed_auto_merge(pr_number, gate, verdict.conclusion)
 
         name = check_run_name(gate)
         payload: Dict[str, Any] = {

--- a/scripts/lib/forge_gate_publisher.py
+++ b/scripts/lib/forge_gate_publisher.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+"""Gate verdict -> GitHub check-run: the judgment layer (Golf B, B2b).
+
+``forge_check_run.py`` (B2a) is the CLIENT: it authenticates as the
+``vnx-gate`` GitHub App and posts whatever ``conclusion`` it is handed. It
+knows nothing about review gates on purpose. This module is the other half —
+which record on disk may become which conclusion, which publications are
+refused outright, and the CLI that republishes from a record.
+
+**Why a separate module and not the bottom of forge_check_run.py.** B2a
+states, and ``tests/test_forge_check_run_client.py::
+test_module_has_no_gate_knowledge`` enforces, that the client file carries no
+gate vocabulary at all — that separation is what lets this policy change
+without touching a line of transport. Appending the mapping to that file would
+have made the claim false and the test red, and a test that goes red because
+of a design choice is the design choice being wrong, not the test. So: one
+import edge, from here to there, and never back.
+
+**Three conclusions, and the asymmetry is the whole point.** On a required
+check GitHub treats ``neutral`` and ``skipped`` as SATISFIED. A review gate
+that could not speak must therefore never book either one; it books
+``action_required``, which blocks. ``success`` is reserved for a verdict that
+is a proven pass on THIS EXACT HEAD, ``failure`` for a gate that ran and said
+no. Absence of evidence gets the blocking conclusion, never the permissive
+one.
+
+BILLING SAFETY: No Anthropic SDK. No direct API calls to api.anthropic.com.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+_SCRIPTS_DIR = _LIB_DIR.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from forge_check_run import (  # noqa: E402
+    RUNBOOK_PATH,
+    AppConfig,
+    ForgeAPIError,
+    ForgeAppConfigError,
+    ForgeCheckRunError,
+    ForgeKeychainError,
+    load_app_config,
+    publish_check_run,
+)
+from gate_status import (  # noqa: E402
+    ALL_KNOWN_STATES,
+    FAIL_STATES,
+    INCOMPLETE_STATES,
+    PASS_STATES,
+    UNAVAILABLE_STATES,
+    canonical_status,
+    is_test_run_record,
+)
+
+# Re-exported so a caller that already imports this module never needs a second
+# import of the client just to catch what this module can raise.
+__all__ = [
+    "AppConfig",
+    "CHECK_RUN_NAME_PREFIX",
+    "CONCLUSION_ACTION_REQUIRED",
+    "CONCLUSION_FAILURE",
+    "CONCLUSION_SUCCESS",
+    "FORGE_CONCLUSIONS",
+    "RECOVERY_COMMAND_TEMPLATE",
+    "ForgeAPIError",
+    "ForgeAppConfigError",
+    "ForgeCheckRunError",
+    "ForgeKeychainError",
+    "ForgePublishRefused",
+    "ForgeStatusUnmapped",
+    "ForgeVerdict",
+    "check_run_name",
+    "classify_record",
+    "conclusion_for",
+    "gates_with_a_record",
+    "main",
+    "publish_for_record",
+    "read_result_record",
+    "refuse_if_auto_merge_is_armed",
+    "result_record_path",
+]
+
+CONCLUSION_SUCCESS = "success"
+CONCLUSION_FAILURE = "failure"
+CONCLUSION_ACTION_REQUIRED = "action_required"
+
+#: Every conclusion this module will ever emit. Deliberately excludes
+#: ``neutral`` and ``skipped`` — see the module docstring.
+FORGE_CONCLUSIONS = (CONCLUSION_SUCCESS, CONCLUSION_FAILURE, CONCLUSION_ACTION_REQUIRED)
+
+#: Branch protection matches a required check by NAME, so the name is a
+#: contract, not a label. One check per gate: ``vnx-gate/glm_gate``,
+#: ``vnx-gate/codex_gate``. WHICH of them becomes required is B3's decision
+#: (``pending_checks`` in ``scripts/forge/branch_protection.yaml``); this
+#: module publishes them all and requires none.
+CHECK_RUN_NAME_PREFIX = "vnx-gate"
+
+#: The command that republishes a check-run from the record already on disk.
+#: Carried in every failure log, so a publication the recorder swallowed is
+#: always one copy-paste away from repair.
+RECOVERY_COMMAND_TEMPLATE = (
+    "python3 scripts/lib/forge_gate_publisher.py publish --pr {pr} --gate {gate}"
+)
+
+_GH_TIMEOUT_SECONDS = 15
+
+
+class ForgeStatusUnmapped(ForgeCheckRunError):
+    """A gate result carries a status this module has no mapping for.
+
+    Raised, never defaulted. A permissive fallback would silently pick a
+    conclusion for a verdict nobody classified — and whichever way it fell it
+    would be wrong for half the unknown statuses that will ever exist. A status
+    outside :data:`gate_status.ALL_KNOWN_STATES` means a writer and this
+    mapping have drifted apart; that is an operator's problem to see, not a
+    default's to hide.
+    """
+
+
+class ForgePublishRefused(ForgeCheckRunError):
+    """This publication is refused on policy, not on transport.
+
+    Distinct from :class:`ForgeAPIError` (GitHub said no) and
+    :class:`ForgeKeychainError` (we could not authenticate): here nothing was
+    ever sent, because sending it would have been wrong.
+    """
+
+
+def check_run_name(gate: str) -> str:
+    """``vnx-gate/<gate>`` — the name branch protection matches on."""
+    if not gate or not gate.strip():
+        raise ForgeCheckRunError("gate is leeg: een check-run zonder poortnaam matcht niets")
+    return f"{CHECK_RUN_NAME_PREFIX}/{gate.strip()}"
+
+
+@dataclass(frozen=True)
+class ForgeVerdict:
+    """A conclusion plus the reason it was reached.
+
+    The reason is not decoration: it becomes the check-run's summary, which is
+    the only thing an operator sees on a blocked PR. An ``action_required``
+    without a reason is a red cross with no instruction attached.
+    """
+
+    conclusion: str
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# The disqualifiers, each defined once
+# ---------------------------------------------------------------------------
+
+
+def _require_head(head_sha: str) -> str:
+    """The head this publication is about, or raise.
+
+    Deliberately NOT ``gate_recorder.result_is_for_head`` semantics. That
+    function returns True for an EMPTY ``head_sha`` on purpose: it serves the
+    merge door, where a failed ``gh`` lookup must never silently reclassify
+    existing evidence. Here the opposite holds — a check-run IS a statement
+    about one commit, and with no commit to name there is nothing to state.
+    Leniency there and refusal here are the same rule applied to two different
+    questions.
+    """
+    resolved = (head_sha or "").strip()
+    if not resolved:
+        raise ForgeCheckRunError(
+            "head_sha is leeg: een conclusie hangt aan een kop, en zonder kop valt "
+            "er niets te concluderen"
+        )
+    return resolved
+
+
+def _head_binding_reason(record: Dict[str, Any], head_sha: str) -> Optional[str]:
+    """Why this record is not about ``head_sha``, or None when it is.
+
+    One phrase for all three ways of missing the head — absent record, empty
+    ``commit_sha``, other ``commit_sha`` — because the operator's next action
+    is identical in all three: run the gate on this head.
+    """
+    record_sha = (record.get("commit_sha") or "").strip()
+    if not record_sha:
+        return (
+            "poort niet gedraaid op deze kop: het record draagt geen commit_sha, "
+            "dus het oordeelt over geen enkele commit"
+        )
+    if record_sha != head_sha:
+        return (
+            f"poort niet gedraaid op deze kop: het record oordeelt over "
+            f"{record_sha[:12]}, de kop is {head_sha[:12]}"
+        )
+    return None
+
+
+def _test_run_reason(record: Dict[str, Any]) -> Optional[str]:
+    """Offline test runs are not production evidence (``gate_status``' own rule)."""
+    if is_test_run_record(record):
+        return (
+            "poort niet gedraaid op deze kop: het record is gemarkeerd als test_run, "
+            "een offline proefrun en geen oordeel over deze PR"
+        )
+    return None
+
+
+def _evidence_source_reason(record: Dict[str, Any]) -> Optional[str]:
+    """Why this record's provenance disqualifies it as a live verdict.
+
+    Measured 2026-09-08 over 1148 result records across every project store:
+    only ``glm_gate`` (89 live / 5 reprocessed) and ``kimi_gate`` (26 / 1)
+    write this field at all. codex_gate (599 records), gemini_review (161),
+    ci_gate (147), claude_github_optional (147) and deepseek_gate (3) never do.
+
+    So an ABSENT field is not a provenance claim to distrust — it is the normal
+    shape of a plain live run, and demanding the literal string would make
+    ``success`` structurally unreachable for the fleet's most-used review gate.
+    A PRESENT field IS a claim, and then only ``live`` will do: ``reprocessed``
+    (``glm_gate --reprocess``) and ``reanchored`` (``gate_reanchor_cli``) both
+    mean the verdict was not produced by a run against this head, and any
+    future value nobody has taught this function about lands in the same
+    bucket. Unknown provenance fails closed.
+    """
+    raw = record.get("evidence_source")
+    if raw is None:
+        return None
+    value = str(raw).strip().lower()
+    if not value or value == "live":
+        return None
+    return (
+        f"poort niet live gedraaid op deze kop: evidence_source is {value!r}, "
+        "geen live poortrun"
+    )
+
+
+def _proven_pass_on_head(record: Optional[Dict[str, Any]], head_sha: str) -> Tuple[bool, str]:
+    """THE definition of "this record is a proven pass on this head".
+
+    Returns ``(ok, reason)``. This is the predicate :func:`classify_record`
+    consults for a pass, and the one :func:`publish_for_record` re-asks
+    immediately before a green check leaves the machine — one definition read
+    twice, never two definitions that have to agree.
+
+    "Proven pass" is not restated here. It is what the merge door already
+    enforces on one record: ``closure_verifier._merge_door_record_verdict``,
+    the exact chain ``check_review_gate_for_merge`` runs (terminal, complete
+    evidence per ``gate_status.has_complete_evidence``, the report exists and
+    is readable, the verdict is a pass, and the report does not contradict it).
+    Calling it rather than re-deriving it is the point: a second, weaker copy
+    of those invariants would be a check that says GO where the merge door says
+    NO-GO, and the entire purpose of this check-run is that GitHub and the door
+    agree.
+
+    On top of the door's chain, three conditions the door has no reason to care
+    about but a published check does: the record judges THIS head, it is not an
+    offline test run, and its provenance is a live run.
+    """
+    resolved_head = _require_head(head_sha)
+    if record is None:
+        return False, "poort niet gedraaid op deze kop: er is geen schijf-record voor deze poort"
+
+    status = canonical_status(record)
+    if status not in PASS_STATES:
+        return False, f"geen pass-status (status={status or 'ontbreekt'!r})"
+
+    for reason in (
+        _head_binding_reason(record, resolved_head),
+        _test_run_reason(record),
+        _evidence_source_reason(record),
+    ):
+        if reason:
+            return False, reason
+
+    # Imported here, not at module scope: gate_recorder reaches this module
+    # after every result write, and closure_verifier's own import tail
+    # (review_contract, codex_final_gate, dispatch_spec, ...) has no business
+    # being loaded by every gate run that merely records a result.
+    from closure_verifier import _merge_door_record_verdict  # noqa: PLC0415
+
+    label = str(record.get("gate") or record.get("gate_type") or "poort")
+    pr_ref = str(record.get("pr_id") or record.get("pr_number") or "?")
+    door = _merge_door_record_verdict(record, label, pr_ref)
+    if door.get("verdict") != "GO":
+        return False, str(door.get("message") or "merge-deur weigert dit record")
+    return True, str(door.get("message") or "bewezen pass op deze kop")
+
+
+# ---------------------------------------------------------------------------
+# The mapping
+# ---------------------------------------------------------------------------
+
+
+def classify_record(record: Optional[Dict[str, Any]], head_sha: str) -> ForgeVerdict:
+    """Map one gate-result record onto a check-run conclusion, with its reason.
+
+    Exhaustive over ``gate_status.ALL_KNOWN_STATES`` and raising outside it.
+    :func:`conclusion_for` is the same decision without the reason.
+
+    Order matters, and the head comes first. A verdict about another commit is
+    not a lenient verdict about this one; it is the absence of any verdict here
+    (OI-1668), whichever way it went on the commit it did judge. So a stale
+    fail books ``action_required`` ("run the gate on this head"), not
+    ``failure`` — publishing the old answer on a new head is precisely what
+    this layer exists to prevent.
+    """
+    resolved_head = _require_head(head_sha)
+
+    if record is None:
+        return ForgeVerdict(
+            CONCLUSION_ACTION_REQUIRED,
+            "poort niet gedraaid op deze kop: er is geen schijf-record voor deze poort",
+        )
+
+    status = canonical_status(record)
+    if not status:
+        # A REACHABLE state, not an unknown one: measured 2026-09-08, 147
+        # claude_github_optional records carry neither status, verdict, nor a
+        # completed state/result_status pair. The gate has said nothing yet.
+        return ForgeVerdict(
+            CONCLUSION_ACTION_REQUIRED,
+            "poort heeft geen uitspraak gedaan: het record draagt geen status of verdict",
+        )
+    if status not in ALL_KNOWN_STATES:
+        raise ForgeStatusUnmapped(
+            f"onbekende poortstatus {status!r} in het record voor "
+            f"{record.get('gate') or 'onbekende poort'} — deze afbeelding kent alleen "
+            f"{sorted(ALL_KNOWN_STATES)}. Een onbekende status krijgt bewust geen "
+            "conclusie toegewezen: schrijver en afbeelding zijn uit elkaar gelopen."
+        )
+
+    for reason in (
+        _head_binding_reason(record, resolved_head),
+        _test_run_reason(record),
+        _evidence_source_reason(record),
+    ):
+        if reason:
+            return ForgeVerdict(CONCLUSION_ACTION_REQUIRED, reason)
+
+    if status in PASS_STATES:
+        proven, reason = _proven_pass_on_head(record, resolved_head)
+        # A pass that does not survive the merge door's chain is a
+        # CONTRADICTED pass, not a missing one: the gate ran on this head and
+        # what it left behind does not hold up. That is a failure, not a
+        # "please run it".
+        return ForgeVerdict(CONCLUSION_SUCCESS if proven else CONCLUSION_FAILURE, reason)
+    if status in FAIL_STATES:
+        return ForgeVerdict(CONCLUSION_FAILURE, f"poort wees deze kop af (status={status})")
+    if status in UNAVAILABLE_STATES:
+        return ForgeVerdict(
+            CONCLUSION_ACTION_REQUIRED,
+            f"poort kwam niet tot een uitspraak (status={status}): provider-uitval is "
+            "afwezigheid van bewijs, geen afkeuring — draai de poort opnieuw",
+        )
+    if status == "not_executable":
+        return ForgeVerdict(
+            CONCLUSION_ACTION_REQUIRED,
+            "poort was niet uitvoerbaar (status=not_executable): er is niets beoordeeld "
+            "— draai de poort opnieuw",
+        )
+    if status in INCOMPLETE_STATES:
+        return ForgeVerdict(
+            CONCLUSION_ACTION_REQUIRED,
+            f"poort loopt nog (status={status}): er is nog geen uitspraak",
+        )
+
+    # Only reachable when gate_status grows a state set this mapping was never
+    # taught about. Fail closed and name it, rather than let a new canonical
+    # status inherit whichever branch happened to be last.
+    raise ForgeStatusUnmapped(
+        f"poortstatus {status!r} staat in gate_status.ALL_KNOWN_STATES maar heeft hier "
+        "geen afbeelding — voeg hem expliciet toe"
+    )
+
+
+def conclusion_for(record: Optional[Dict[str, Any]], head_sha: str) -> str:
+    """``success`` / ``failure`` / ``action_required`` for one record."""
+    return classify_record(record, head_sha).conclusion
+
+
+# ---------------------------------------------------------------------------
+# Reading the record off disk
+# ---------------------------------------------------------------------------
+
+
+def _default_results_dir() -> Path:
+    """``${VNX_STATE_DIR}/review_gates/results`` — the same slot the recorder
+    writes and ``pr_merge`` reads."""
+    from vnx_paths import ensure_env  # noqa: PLC0415
+
+    return Path(ensure_env()["VNX_STATE_DIR"]) / "review_gates" / "results"
+
+
+def result_record_path(results_dir: Path, pr_number: int, gate: str) -> Optional[Path]:
+    """The existing result slot for ``pr_number`` + ``gate``, or None.
+
+    Both of ``gate_recorder.result_file_path``'s conventions are tried: the
+    ``pr-<N>-<gate>.json`` form (pr_number keyed) and the
+    ``<pr_id>-<gate>-contract.json`` form. Which one a gate used depends on
+    whether its writer had a ``pr_id``, and a reader that knew only one of them
+    would report a perfectly good record as absent.
+    """
+    for candidate in (
+        results_dir / f"pr-{pr_number}-{gate}.json",
+        results_dir / f"{pr_number}-{gate}-contract.json",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def read_result_record(
+    pr_number: int,
+    gate: str,
+    *,
+    results_dir: Optional[Path] = None,
+    record_path: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    """The gate result record on disk, or None when there is none.
+
+    A file that exists but does not parse as a JSON object is NOT None: absent
+    and unreadable are different states (the distinction
+    ``gate_recorder._read_existing_result`` already draws), and reading a torn
+    write as "never ran" would publish ``action_required`` while hiding that
+    something corrupted the evidence.
+    """
+    path = record_path or result_record_path(
+        results_dir if results_dir is not None else _default_results_dir(), pr_number, gate
+    )
+    if path is None or not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ForgePublishRefused(
+            f"het schijf-record {path} bestaat maar is onleesbaar ({exc}) — een "
+            "beschadigd record levert geen conclusie op, en 'afwezig' zou hier liegen"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ForgePublishRefused(
+            f"het schijf-record {path} is geen object maar {type(data).__name__}"
+        )
+    return data
+
+
+def gates_with_a_record(results_dir: Path, pr_number: int) -> List[str]:
+    """Every gate that has a result slot for this PR, sorted."""
+    gates = set()
+    for path in results_dir.glob(f"pr-{pr_number}-*.json"):
+        gates.add(path.stem[len(f"pr-{pr_number}-"):])
+    for path in results_dir.glob(f"{pr_number}-*-contract.json"):
+        gates.add(path.stem[len(f"{pr_number}-"): -len("-contract")])
+    return sorted(g for g in gates if g)
+
+
+# ---------------------------------------------------------------------------
+# The auto-merge refusal
+# ---------------------------------------------------------------------------
+
+
+def _gh_pr_json(pr_number: int, field: str) -> Dict[str, Any]:
+    """One ``gh pr view --json <field>`` object, or refuse.
+
+    Deliberately NOT ``gate_recorder._gh_pr_view_field``, which returns "" on
+    every failure. That leniency is right for stamping identity onto a record
+    (a missing branch is logged, the record is still written) and wrong here:
+    the single question this function answers is "is auto-merge armed", and
+    answering "no" because ``gh`` was absent, rate-limited or unauthenticated
+    would let a ``success`` land on a PR that merges itself the moment it does.
+    A lookup that did not happen is not a negative answer.
+    """
+    if shutil.which("gh") is None:
+        raise ForgePublishRefused(
+            f"`gh` staat niet op PATH, dus {field} van PR #{pr_number} is niet op te "
+            "vragen — publicatie geweigerd in plaats van te gokken dat auto-merge uit "
+            f"staat (runbook: {RUNBOOK_PATH}, faalmodus 'launchd-runner met kaal PATH')"
+        )
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", field],
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise ForgePublishRefused(
+            f"`gh pr view {pr_number} --json {field}` faalde ({exc}) — publicatie geweigerd"
+        ) from exc
+    if proc.returncode != 0 or not (proc.stdout or "").strip():
+        raise ForgePublishRefused(
+            f"`gh pr view {pr_number} --json {field}` gaf exit {proc.returncode}: "
+            f"{(proc.stderr or '').strip()[:200]} — publicatie geweigerd"
+        )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ForgePublishRefused(
+            f"`gh pr view {pr_number} --json {field}` gaf geen JSON: {proc.stdout[:200]!r}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ForgePublishRefused(
+            f"`gh pr view {pr_number} --json {field}` gaf geen object maar "
+            f"{type(data).__name__}"
+        )
+    return data
+
+
+def refuse_if_auto_merge_is_armed(pr_number: int) -> None:
+    """Refuse any publication on a PR that has auto-merge queued.
+
+    ``pr_merge.py:430`` adds ``--auto`` as soon as the repo allows it, and the
+    repo does not (``allow_auto_merge: false``, held there by B1's drift
+    check). If that ever flips, an armed PR turns this publisher into the thing
+    that performs the merge: GitHub merges the moment the last required check
+    goes green, with no human between the check-run and ``main``.
+
+    So the refusal covers EVERY conclusion, not just ``success``. A queued
+    auto-merge means a human already handed the decision to a robot, and this
+    robot declines to be the one that pulls it — whatever it was about to say.
+    """
+    data = _gh_pr_json(pr_number, "autoMergeRequest")
+    if data.get("autoMergeRequest"):
+        raise ForgePublishRefused(
+            f"PR #{pr_number} heeft een actieve auto-merge (autoMergeRequest): elke "
+            "publicatie is geweigerd, want een groene check zou hier de merge zelf "
+            "uitvoeren. Zet auto-merge uit (`gh pr merge --disable-auto`) en publiceer "
+            "daarna opnieuw."
+        )
+
+
+# ---------------------------------------------------------------------------
+# The publisher
+# ---------------------------------------------------------------------------
+
+
+def _check_run_summary(gate: str, verdict: ForgeVerdict, head_sha: str, pr_number: int) -> str:
+    lines = [
+        f"**{check_run_name(gate)}** — {verdict.conclusion}",
+        "",
+        verdict.reason,
+        "",
+        f"Kop: `{head_sha}`",
+    ]
+    if verdict.conclusion != CONCLUSION_SUCCESS:
+        lines += [
+            "",
+            "Opnieuw publiceren vanaf het schijf-record:",
+            "",
+            "```",
+            RECOVERY_COMMAND_TEMPLATE.format(pr=pr_number, gate=gate),
+            "```",
+        ]
+    lines += ["", f"Runbook: `{RUNBOOK_PATH}`"]
+    return "\n".join(lines)
+
+
+def publish_for_record(
+    pr_number: int,
+    gate: str,
+    head_sha: str,
+    *,
+    results_dir: Optional[Path] = None,
+    record_path: Optional[Path] = None,
+    dry_run: bool = False,
+    project_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Publish ``vnx-gate/<gate>`` for ``pr_number`` from the record on disk.
+
+    Reads the record, maps it, and posts. Returns the payload that was sent
+    (or, under ``dry_run``, the payload that would have been) — the mapping's
+    decision is always visible to the caller, never only to GitHub.
+
+    Two refusals, both before anything is sent: an armed auto-merge
+    (:func:`refuse_if_auto_merge_is_armed`), and a ``success`` for a record
+    that is not a proven pass on this head. The second one re-asks
+    :func:`_proven_pass_on_head` rather than trusting the conclusion it was
+    just handed. That is not distrust of :func:`classify_record` — it is the
+    one place where a mistake anywhere upstream turns into a green light on
+    ``main``, so the predicate that DEFINES "proven" is consulted at the exact
+    moment the green light would be given.
+    """
+    resolved_head = _require_head(head_sha)
+
+    # FIRST, and before any network call: is this feature switched on at all?
+    # Until the operator has registered the App and filled ``app_id`` (runbook
+    # §1/§3) there is nothing to publish with, and the gate recorder calls this
+    # after EVERY result write. Asking the local YAML first means a pending
+    # operator step costs zero ``gh`` round-trips and zero keychain prompts,
+    # instead of one of each per gate run for as long as the step is open. A
+    # ``--dry-run`` deliberately skips this: showing which conclusion a record
+    # maps to needs no App, and that is exactly the rehearsal an operator wants
+    # BEFORE registering one.
+    if not dry_run:
+        load_app_config()
+
+    refuse_if_auto_merge_is_armed(pr_number)
+
+    record = read_result_record(
+        pr_number, gate, results_dir=results_dir, record_path=record_path
+    )
+    verdict = classify_record(record, resolved_head)
+
+    if verdict.conclusion == CONCLUSION_SUCCESS:
+        proven, why = _proven_pass_on_head(record, resolved_head)
+        if not proven:
+            raise ForgePublishRefused(
+                f"weiger success voor {check_run_name(gate)} op {resolved_head[:12]}: het "
+                f"record is geen bewezen pass op deze kop — {why}"
+            )
+
+    name = check_run_name(gate)
+    payload: Dict[str, Any] = {
+        "pr_number": pr_number,
+        "gate": gate,
+        "name": name,
+        "head_sha": resolved_head,
+        "conclusion": verdict.conclusion,
+        "reason": verdict.reason,
+        "summary": _check_run_summary(gate, verdict, resolved_head, pr_number),
+        "dry_run": dry_run,
+    }
+    if dry_run:
+        return payload
+
+    response = publish_check_run(
+        resolved_head, name, verdict.conclusion, payload["summary"], project_root=project_root
+    )
+    payload["check_run_id"] = response.get("id")
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# CLI — republish from the record on disk
+# ---------------------------------------------------------------------------
+
+#: Published, and the record really is about the current head.
+EXIT_OK = 0
+#: Something refused or failed outright; nothing was published.
+EXIT_ERROR = 1
+#: Published (as ``action_required``), but the slot holds a decided verdict for
+#: an OLDER head. Non-zero because the operator has work to do — the check
+#: stays red until the gate runs again — while the check-run itself IS posted,
+#: so the PR carries a visible reason instead of a missing check.
+EXIT_STALE_VERDICT = 2
+
+
+def _resolve_head_sha(pr_number: int) -> str:
+    """The PR head from GitHub, via the fleet's single source of truth.
+
+    ``gate_recorder.get_pr_head_sha`` — never ``git rev-parse HEAD``, which
+    resolves against the process cwd and is not the PR head (OI-1307).
+    """
+    from gate_recorder import get_pr_head_sha  # noqa: PLC0415
+
+    return get_pr_head_sha(pr_number)
+
+
+def _publish_one(
+    pr_number: int, gate: str, head_sha: str, results_dir: Path, *, dry_run: bool
+) -> int:
+    record = read_result_record(pr_number, gate, results_dir=results_dir)
+    verdict = classify_record(record, head_sha)
+    payload = publish_for_record(
+        pr_number, gate, head_sha, results_dir=results_dir, dry_run=dry_run
+    )
+
+    prefix = "[dry-run] " if dry_run else ""
+    print(f"{prefix}{payload['name']} -> {payload['conclusion']}")
+    print(f"  kop:    {head_sha}")
+    print(f"  reden:  {payload['reason']}")
+    if dry_run:
+        print("  payload:")
+        print(
+            json.dumps(
+                {
+                    "name": payload["name"],
+                    "head_sha": payload["head_sha"],
+                    "status": "completed",
+                    "conclusion": payload["conclusion"],
+                    "output": {"title": payload["name"], "summary": payload["summary"]},
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+
+    # A slot holding a DECIDED verdict for another head is the one outcome
+    # worth its own exit code: nothing is broken, but the check stays red until
+    # someone re-runs the gate, and a zero exit would let a script conclude the
+    # publication finished the job.
+    if record is not None and verdict.conclusion == CONCLUSION_ACTION_REQUIRED:
+        record_sha = (record.get("commit_sha") or "").strip()
+        if canonical_status(record) in (PASS_STATES | FAIL_STATES) and record_sha != head_sha:
+            print(
+                f"  LET OP: het slot draagt een {canonical_status(record)} voor "
+                f"{record_sha[:12] or '<geen sha>'}, niet voor deze kop — "
+                "draai de poort opnieuw."
+            )
+            return EXIT_STALE_VERDICT
+    return EXIT_OK
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="forge_gate_publisher.py",
+        description=(
+            "Publiceer het poortoordeel van een PR als GitHub check-run "
+            "(vnx-gate/<poort>), vanaf het schijf-record."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    publish = sub.add_parser("publish", help="herpubliceer vanaf het schijf-record van een PR")
+    publish.add_argument("--pr", type=int, required=True, help="PR-nummer")
+    publish.add_argument(
+        "--gate",
+        default=None,
+        help="poortnaam (laat weg om elke poort met een record voor deze PR te doen)",
+    )
+    publish.add_argument(
+        "--dry-run", action="store_true", help="toon conclusie en payload, POST niets"
+    )
+    publish.add_argument(
+        "--results-dir",
+        default=None,
+        help="resultatenmap (standaard ${VNX_STATE_DIR}/review_gates/results)",
+    )
+
+    args = parser.parse_args(argv)
+
+    results_dir = Path(args.results_dir) if args.results_dir else _default_results_dir()
+
+    head_sha = _resolve_head_sha(args.pr)
+    if not head_sha:
+        print(
+            f"kan de kop van PR #{args.pr} niet ophalen (gh pr view --json headRefOid gaf "
+            "niets terug) — zonder kop wordt er niets gepubliceerd",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    gates = [args.gate] if args.gate else gates_with_a_record(results_dir, args.pr)
+    if not gates:
+        print(
+            f"geen enkel poort-record gevonden voor PR #{args.pr} in {results_dir} — "
+            "draai eerst een review-poort op deze kop",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    worst = EXIT_OK
+    for gate in gates:
+        try:
+            rc = _publish_one(args.pr, gate, head_sha, results_dir, dry_run=args.dry_run)
+        except ForgeCheckRunError as exc:
+            print(f"{check_run_name(gate)}: {exc}", file=sys.stderr)
+            worst = EXIT_ERROR
+            continue
+        if rc != EXIT_OK and worst == EXIT_OK:
+            worst = rc
+    return worst
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -674,7 +674,9 @@ def annotate_refused_write(
     return annotated
 
 
-def publish_forge_check_run(payload: Dict[str, Any], *, gate: str) -> None:
+def publish_forge_check_run(
+    payload: Dict[str, Any], *, gate: str, result_path: Path
+) -> None:
     """Publish the just-written result as a GitHub check-run (Golf B, B2b).
 
     Called AFTER the atomic write has landed and after the slot lock is
@@ -706,6 +708,19 @@ def publish_forge_check_run(payload: Dict[str, Any], *, gate: str) -> None:
     record with no head belongs to no head, and falling back to the local
     ``git rev-parse HEAD`` would attach the verdict to whatever the process
     cwd happened to be — OI-1307).
+
+    ``result_path`` is the third, and it is passed for exactly the same reason
+    as the other two. The publisher can resolve a record itself, from
+    ``${VNX_STATE_DIR}/review_gates/results``; handing it the path this call
+    just wrote is what makes it publish THIS record instead of whatever that
+    store holds for the same PR and gate. The two are not the same file
+    whenever the writer used a non-default store — which in this project is
+    every gate run, since they all run with
+    ``VNX_DATA_DIR=~/.vnx-data/vnx-dev``. A re-resolved lookup could therefore
+    publish a stale ``success`` over a verdict that had just failed: a
+    false-positive gate closure produced by the publication of a record nobody
+    asked for. A path that does not exist is refused loudly by the publisher
+    and logged here, never quietly replaced by the store's copy.
     """
     pr_number = payload.get("pr_number")
     head_sha = (payload.get("commit_sha") or "").strip()
@@ -722,7 +737,7 @@ def publish_forge_check_run(payload: Dict[str, Any], *, gate: str) -> None:
             RECOVERY_COMMAND_TEMPLATE, ForgeAppConfigError, publish_for_record,
         )
 
-        publish_for_record(pr_number, gate, head_sha)
+        publish_for_record(pr_number, gate, head_sha, record_path=result_path)
     # vnx-broad-except: this hook may not be able to fail a gate run, and the
     # publisher's failure surface is open-ended by nature (keychain, JWT,
     # DNS, GitHub, YAML, a lazy import). Narrowing it to the Forge exception
@@ -817,7 +832,7 @@ def write_result_guarded(
     # another writer's record standing, so publishing here would describe a
     # write that never happened (the same reason record_failure gates its
     # register emit on ``written``, OI-1469/OI-1470).
-    publish_forge_check_run(payload, gate=gate)
+    publish_forge_check_run(payload, gate=gate, result_path=result_path)
     return payload, True
 
 
@@ -908,7 +923,7 @@ def record_terminal_result(
     # :func:`publish_forge_check_run`. A refusal from the overwrite guard
     # raises above and never reaches this line, so the same "only publish a
     # write that landed" rule holds here as in write_result_guarded.
-    publish_forge_check_run(payload, gate=gate)
+    publish_forge_check_run(payload, gate=gate, result_path=result_path)
     return result_path
 
 

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -674,6 +674,94 @@ def annotate_refused_write(
     return annotated
 
 
+def publish_forge_check_run(payload: Dict[str, Any], *, gate: str) -> None:
+    """Publish the just-written result as a GitHub check-run (Golf B, B2b).
+
+    Called AFTER the atomic write has landed and after the slot lock is
+    released, and NEVER able to change the outcome of that write. A gate run
+    exists to record a verdict; publishing that verdict to the forge is a
+    consequence of the record, never a condition for it. So every failure here
+    — a locked keychain, an App that was never registered, a GitHub 500 — is
+    logged with the command that repairs it and then swallowed. The record on
+    disk is already the truth; the check-run is a copy of it, and a missing
+    copy is repaired by :data:`forge_check_run.RECOVERY_COMMAND_TEMPLATE`,
+    not by failing the gate run that produced the evidence.
+
+    The publisher is imported lazily and inside the ``try``. It reaches
+    ``closure_verifier`` (for the merge door's own invariant chain) and
+    therefore a long import tail; loading that on every ``import
+    gate_recorder`` would tax every gate run for a side effect most of them do
+    not reach. Inside the ``try`` because an ImportError is exactly as
+    non-fatal here as a keychain failure.
+
+    ``forge_gate_publisher``, not ``forge_check_run``: the first is the policy
+    layer that decides which conclusion a record earns, the second is the bare
+    transport it calls. Reaching past it into the client from here would put
+    that decision in two places.
+
+    Two identity fields decide whether there is anything to publish at all,
+    and both come from the payload that was just written rather than from any
+    ambient lookup: ``pr_number`` (the check-run needs a PR) and
+    ``commit_sha`` (branch protection matches a check-run to ONE commit; a
+    record with no head belongs to no head, and falling back to the local
+    ``git rev-parse HEAD`` would attach the verdict to whatever the process
+    cwd happened to be — OI-1307).
+    """
+    pr_number = payload.get("pr_number")
+    head_sha = (payload.get("commit_sha") or "").strip()
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool) or not head_sha:
+        logger.debug(
+            "gate_recorder: no forge check-run for gate=%s — pr_number=%r head_sha=%r "
+            "(a record without both cannot be attached to a commit on a PR)",
+            gate, pr_number, head_sha,
+        )
+        return
+
+    try:
+        from forge_gate_publisher import (  # noqa: PLC0415
+            RECOVERY_COMMAND_TEMPLATE, ForgeAppConfigError, publish_for_record,
+        )
+
+        publish_for_record(pr_number, gate, head_sha)
+    # vnx-broad-except: this hook may not be able to fail a gate run, and the
+    # publisher's failure surface is open-ended by nature (keychain, JWT,
+    # DNS, GitHub, YAML, a lazy import). Narrowing it to the Forge exception
+    # tree would let anything outside that tree take down a write that has
+    # already succeeded. Nothing is silent: every branch logs with the repair
+    # command.
+    except Exception as exc:  # noqa: BLE001
+        try:
+            recovery = RECOVERY_COMMAND_TEMPLATE.format(pr=pr_number, gate=gate)
+            app_not_registered = isinstance(exc, ForgeAppConfigError)
+        except NameError:
+            # The import itself is what failed.
+            recovery = (
+                f"python3 scripts/lib/forge_gate_publisher.py publish --pr {pr_number} "
+                f"--gate {gate}"
+            )
+            app_not_registered = False
+        if app_not_registered:
+            # The expected state until the operator has registered the App and
+            # filled app_id in scripts/forge/branch_protection.yaml (runbook
+            # §1/§3). A pending operator step is not a malfunction, and logging
+            # it as one on every single gate write would train the reader to
+            # ignore this line — which is the line that has to be believed on
+            # the day the keychain really is locked.
+            logger.info(
+                "gate_recorder: geen check-run gepubliceerd voor gate=%s pr=%s — de "
+                "vnx-gate App is nog niet geregistreerd (%s). Operator-stap uit het "
+                "runbook; daarna: %s",
+                gate, pr_number, exc, recovery,
+            )
+            return
+        logger.warning(
+            "gate_recorder: check-run PUBLICATIE MISLUKT voor gate=%s pr=%s head=%s — "
+            "%s: %s. Het resultaat op schijf is ongewijzigd en blijft geldig; "
+            "herstel met: %s",
+            gate, pr_number, head_sha[:12], type(exc).__name__, exc, recovery,
+        )
+
+
 def write_result_guarded(
     result_path: Path,
     payload: Dict[str, Any],
@@ -725,6 +813,11 @@ def write_result_guarded(
             on_disk = existing if isinstance(existing, dict) else {}
             return on_disk or payload, False
         _write_result_atomic(result_path, payload)
+    # Outside the lock, and only on a write that landed: a refused write left
+    # another writer's record standing, so publishing here would describe a
+    # write that never happened (the same reason record_failure gates its
+    # register emit on ``written``, OI-1469/OI-1470).
+    publish_forge_check_run(payload, gate=gate)
     return payload, True
 
 
@@ -811,6 +904,11 @@ def record_terminal_result(
     with slot_lock(result_path):
         _check_overwrite_guard(result_path, payload, gate=gate, pr_ref=pr_id)
         _write_result_atomic(result_path, payload)
+    # After the write, outside the lock, non-fatal — see
+    # :func:`publish_forge_check_run`. A refusal from the overwrite guard
+    # raises above and never reaches this line, so the same "only publish a
+    # write that landed" rule holds here as in write_result_guarded.
+    publish_forge_check_run(payload, gate=gate)
     return result_path
 
 

--- a/tests/test_forge_gate_publisher.py
+++ b/tests/test_forge_gate_publisher.py
@@ -36,6 +36,10 @@ import gate_status  # noqa: E402
 HEAD = "a" * 40
 OTHER_HEAD = "b" * 40
 
+#: What ``gh pr view --json autoMergeRequest`` returns on a PR that will merge
+#: itself the moment its last required check goes green.
+ARMED_AUTO_MERGE = {"autoMergeRequest": {"enabledAt": "2026-09-08T00:00:00Z"}}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -401,6 +405,144 @@ def test_publish_refuses_when_the_auto_merge_lookup_itself_fails(
     with pytest.raises(fcr.ForgePublishRefused):
         fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
     assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# The auto-merge refusal covers ``success`` and nothing else
+# ---------------------------------------------------------------------------
+
+
+def test_a_failure_is_published_even_when_auto_merge_is_armed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """Refusing the RED update is what would be dangerous here.
+
+    The refusal exists so that ``publish --pr N`` cannot finish a merge after a
+    gate went red. That argument is about ``success`` only. Withholding a
+    ``failure`` on a PR with auto-merge queued leaves whatever check-run the
+    head already carries — a stale ``success`` included — as the last word
+    branch protection sees, and the merge proceeds on evidence that has since
+    been contradicted. Publishing the red one is the thing that STOPS it.
+    """
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, status="fail"))
+    _gh_returning(monkeypatch, ARMED_AUTO_MERGE)
+    calls = _capture_publish(monkeypatch)
+
+    payload = fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert payload["conclusion"] == "failure"
+    assert [c["conclusion"] for c in calls] == ["failure"], (
+        "een rode uitkomst houdt een armed auto-merge tegen en moet dus juist wél landen"
+    )
+
+
+def test_action_required_is_published_even_when_auto_merge_is_armed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """Same rule for the blocking non-verdict: a record for another head."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, commit_sha=OTHER_HEAD))
+    _gh_returning(monkeypatch, ARMED_AUTO_MERGE)
+    calls = _capture_publish(monkeypatch)
+
+    payload = fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert payload["conclusion"] == "action_required"
+    assert [c["conclusion"] for c in calls] == ["action_required"]
+
+
+def test_a_proven_pass_is_still_refused_when_auto_merge_is_armed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """The narrowing changes the SCOPE of the refusal, never its content: the
+    one conclusion that could perform the merge is refused with the same reason
+    and the same repair instruction as before."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, ARMED_AUTO_MERGE)
+    calls = _capture_publish(monkeypatch)
+
+    with pytest.raises(fcr.ForgePublishRefused) as excinfo:
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    message = str(excinfo.value)
+    assert "auto-merge" in message
+    assert "autoMergeRequest" in message
+    assert "gh pr merge --disable-auto" in message
+    assert calls == [], "een groene check zou hier de merge zelf uitvoeren"
+
+
+def test_a_red_publication_over_an_armed_auto_merge_is_logged_loudly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Publishing red onto a self-merging PR is a state an operator must see.
+
+    Not because anything went wrong — it is the correct outcome — but because
+    "auto-merge armed" is exactly the situation where a human wants to know a
+    machine just decided something on that PR.
+    """
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, status="fail"))
+    _gh_returning(monkeypatch, ARMED_AUTO_MERGE)
+    _capture_publish(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="forge_gate_publisher"):
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "auto-merge" in logged
+    assert "failure" in logged
+    assert "tegen" in logged, "de reden hoort erbij: rood houdt de auto-merge juist tegen"
+
+
+def test_a_failed_auto_merge_lookup_never_blocks_a_red_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fail CLOSED applies to ``success``; a red check has nothing to fail into.
+
+    ``test_publish_refuses_when_the_auto_merge_lookup_itself_fails`` keeps the
+    strict rule where it belongs. Here the answer cannot change the decision, so
+    a gh outage must not be the reason a failing gate stays invisible on the PR
+    — that would recreate the stale-green hole through the back door.
+    """
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, status="fail"))
+    _gh_returning(monkeypatch, None, returncode=1)
+    calls = _capture_publish(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="forge_gate_publisher"):
+        payload = fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert payload["conclusion"] == "failure"
+    assert [c["conclusion"] for c in calls] == ["failure"]
+    assert "auto-merge" in "\n".join(r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({}, "success"),
+        ({"status": "fail"}, "failure"),
+        ({"status": "unavailable"}, "action_required"),
+    ],
+)
+def test_without_an_armed_auto_merge_every_conclusion_publishes_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None,
+    overrides: Dict[str, Any], expected: str,
+) -> None:
+    """The control arm: narrowing the refusal changed nothing on a normal PR."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, **overrides))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    payload = fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert payload["conclusion"] == expected
+    assert [c["conclusion"] for c in calls] == [expected]
 
 
 def test_publish_dry_run_shows_the_payload_and_posts_nothing(
@@ -953,3 +1095,36 @@ def test_an_event_store_failure_never_breaks_the_publication(
 
     assert payload["conclusion"] == "success"
     assert len(calls) == 1
+
+
+def test_a_swallowed_audit_line_is_visible_at_warning_level(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A check-run mutated on GitHub with no ledger line behind it is a gap.
+
+    The line may not break the publication (the test above), but swallowing it
+    at ``debug`` means the state mutation happened, the ADR-005 trail does not
+    show it, and nothing anywhere says so. Warning level is what makes a
+    missing trace an observable event instead of a silent one.
+    """
+    import event_store
+
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    _capture_publish(monkeypatch)
+
+    def exploding_append(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("de schijf is vol")
+
+    monkeypatch.setattr(event_store.EventStore, "append", exploding_append)
+
+    with caplog.at_level(logging.WARNING, logger="forge_gate_publisher"):
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "een ingeslikte auditregel hoort zichtbaar te zijn"
+    logged = "\n".join(r.getMessage() for r in warnings)
+    assert "de schijf is vol" in logged, "de reden hoort in de melding"
+    assert "glm_gate" in logged and "1811" in logged

--- a/tests/test_forge_gate_publisher.py
+++ b/tests/test_forge_gate_publisher.py
@@ -675,3 +675,281 @@ def test_publication_never_shells_out_from_the_recorder_on_import() -> None:
         if line.startswith("import forge_") or line.startswith("from forge_")
     ]
     assert module_level == []
+
+
+# ---------------------------------------------------------------------------
+# The explicit path — publish the record that was written, or nothing
+# ---------------------------------------------------------------------------
+
+
+def test_the_recorder_publishes_the_record_it_just_wrote_not_the_store_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """The store holds a PASS for this PR and gate; the write that just landed
+    is a FAIL, in a DIFFERENT store.
+
+    Not a contrived split: every gate run in this project writes with
+    ``VNX_DATA_DIR=~/.vnx-data/vnx-dev``, so "the record just written" and "the
+    record the default store resolves to" are routinely two different files. A
+    publisher that re-derives its own source can therefore publish a stale
+    ``success`` over a verdict that had just failed — a green required check
+    for a gate that said no.
+    """
+    default_store = tmp_path / "default_store"
+    _write_record(default_store, 1811, "glm_gate", _proven_pass(tmp_path))
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: default_store)
+
+    written_dir = tmp_path / "vnx-dev" / "review_gates" / "results"
+    written_dir.mkdir(parents=True)
+    result_path = written_dir / "pr-1811-glm_gate.json"
+
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    payload = _recorder_payload()
+    payload["status"] = "fail"
+    payload["summary"] = "glm_gate FAIL"
+    payload["blocking_findings"] = [{"message": "kapot"}]
+
+    _on_disk, written = gate_recorder.write_result_guarded(
+        result_path, payload, gate="glm_gate", pr_ref="1811"
+    )
+
+    assert written is True
+    assert len(calls) == 1, (
+        "precies een publicatie hoort bij precies een geslaagde schrijf "
+        f"(kreeg {calls!r})"
+    )
+    assert calls[0]["conclusion"] == "failure", (
+        "de publicatie beschrijft het record dat zojuist geschreven is, nooit het "
+        "pass-record dat in de standaardopslag voor dezelfde PR en poort staat"
+    )
+
+
+def test_terminal_result_publishes_from_the_path_it_wrote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """The same rule on the other writer (``record_terminal_result``), which
+    resolves its own ``result_path`` and is the one free-form gates use."""
+    import gate_depth
+
+    default_store = tmp_path / "default_store"
+    _write_record(default_store, 1811, "glm_gate", _proven_pass(tmp_path))
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: default_store)
+
+    written_dir = tmp_path / "vnx-dev" / "review_gates" / "results"
+    written_dir.mkdir(parents=True)
+    result_path = written_dir / "pr-1811-glm_gate.json"
+
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    payload = _recorder_payload()
+    payload["status"] = "fail"
+    payload["blocking_findings"] = [{"message": "kapot"}]
+
+    gate_recorder.record_terminal_result(
+        gate="glm_gate",
+        pr_id="1811",
+        result_path=result_path,
+        payload=payload,
+        execution_depth=gate_depth.single_shot_depth(4096, False),
+    )
+
+    assert [c["conclusion"] for c in calls] == ["failure"]
+
+
+def test_an_explicit_record_path_that_is_absent_refuses_and_never_falls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """No record at the named path is a plumbing fault, not an absent verdict.
+
+    The store's own copy is a proven pass here, so a fallback would not merely
+    be sloppy — it would publish ``success``.
+    """
+    default_store = tmp_path / "default_store"
+    _write_record(default_store, 1811, "glm_gate", _proven_pass(tmp_path))
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: default_store)
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    missing = tmp_path / "nergens" / "pr-1811-glm_gate.json"
+    with pytest.raises(fcr.ForgePublishRefused) as excinfo:
+        fcr.publish_for_record(1811, "glm_gate", HEAD, record_path=missing)
+
+    assert str(missing) in str(excinfo.value)
+    assert calls == [], "een ontbrekend pad publiceert niets, ook niet uit de opslag"
+
+
+def test_an_explicit_record_path_that_is_corrupt_refuses_and_publishes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    default_store = tmp_path / "default_store"
+    _write_record(default_store, 1811, "glm_gate", _proven_pass(tmp_path))
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: default_store)
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    torn = tmp_path / "pr-1811-glm_gate.json"
+    torn.write_text("{ dit is geen json", encoding="utf-8")
+
+    with pytest.raises(fcr.ForgePublishRefused) as excinfo:
+        fcr.publish_for_record(1811, "glm_gate", HEAD, record_path=torn)
+
+    assert "onleesbaar" in str(excinfo.value)
+    assert calls == []
+
+
+def test_the_recorder_hands_the_publisher_the_path_it_wrote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The contract itself: the hook names the file, the publisher never has to
+    guess which one."""
+    result_path = tmp_path / "vnx-dev" / "pr-1811-glm_gate.json"
+    result_path.parent.mkdir(parents=True)
+    seen: Dict[str, Any] = {}
+
+    def recording(pr_number: int, gate: str, head_sha: str, **kwargs: Any) -> Dict[str, Any]:
+        seen.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(fcr, "publish_for_record", recording)
+
+    gate_recorder.write_result_guarded(
+        result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+    )
+
+    assert seen.get("record_path") == result_path
+    assert "results_dir" not in seen, "de haak wijst een bestand aan, geen opslag"
+
+
+def test_a_missing_path_from_the_recorder_is_logged_and_never_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+    _registered_app: None,
+) -> None:
+    """The refusal is loud in the log and still cannot fail the gate run."""
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: tmp_path / "leeg")
+    monkeypatch.setattr(
+        fcr, "read_result_record_at",
+        lambda _p: (_ for _ in ()).throw(fcr.ForgePublishRefused("bestaat niet")),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gate_recorder"):
+        _payload, written = gate_recorder.write_result_guarded(
+            result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+        )
+
+    assert written is True
+    assert json.loads(result_path.read_text())["status"] == "pass"
+    assert calls == []
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "PUBLICATIE MISLUKT" in logged
+
+
+def test_the_cli_publishes_from_the_results_dir_flag_not_a_single_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """The CLI route is unchanged: ``--results-dir`` still names a STORE, and
+    ``publish --pr N`` still resolves the record inside it."""
+    flag_dir = tmp_path / "flag_store"
+    _write_record(flag_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    empty_default = tmp_path / "default_store"
+    empty_default.mkdir()
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: empty_default)
+    monkeypatch.setattr(fcr, "_resolve_head_sha", lambda _pr: HEAD)
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    rc = fcr.main(
+        ["publish", "--pr", "1811", "--gate", "glm_gate", "--results-dir", str(flag_dir)]
+    )
+
+    assert rc == 0
+    assert [c["conclusion"] for c in calls] == ["success"]
+
+
+# ---------------------------------------------------------------------------
+# The audit line (ADR-005)
+# ---------------------------------------------------------------------------
+
+
+def _forge_events() -> List[Dict[str, Any]]:
+    """Every event in the publisher's own lane (conftest pins the data dir)."""
+    from event_store import EventStore
+
+    return list(EventStore().tail(fcr.FORGE_EVENT_LANE))
+
+
+def test_a_publication_leaves_one_ndjson_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    _capture_publish(monkeypatch)
+
+    fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    events = _forge_events()
+    assert [e["type"] for e in events] == ["forge_check_run_published"]
+    data = events[0]["data"]
+    assert data["conclusion"] == "success"
+    assert data["check_run_name"] == "vnx-gate/glm_gate"
+    assert data["head_sha"] == HEAD
+    assert data["pr_number"] == 1811
+
+
+def test_a_refused_publication_leaves_an_ndjson_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """A publication that did NOT happen is exactly the one worth a trace."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": {"enabledAt": "2026-09-08T00:00:00Z"}})
+    _capture_publish(monkeypatch)
+
+    with pytest.raises(fcr.ForgePublishRefused):
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    events = _forge_events()
+    assert [e["type"] for e in events] == ["forge_check_run_failed"]
+    assert "auto-merge" in events[0]["data"]["detail"]
+
+
+def test_a_dry_run_leaves_no_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """A rehearsal posts nothing, so there is nothing to record."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    _capture_publish(monkeypatch)
+
+    fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir, dry_run=True)
+
+    assert _forge_events() == []
+
+
+def test_an_event_store_failure_never_breaks_the_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """The trace may never take down the thing it traces."""
+    import event_store
+
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    def exploding_append(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("de schijf is vol")
+
+    monkeypatch.setattr(event_store.EventStore, "append", exploding_append)
+
+    payload = fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert payload["conclusion"] == "success"
+    assert len(calls) == 1

--- a/tests/test_forge_gate_publisher.py
+++ b/tests/test_forge_gate_publisher.py
@@ -1,0 +1,677 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/forge_gate_publisher.py (Golf B, B2b).
+
+Where ``test_forge_check_run_client.py`` covers the transport (B2a), this
+covers the judgment: which gate-result record may become which GitHub
+``conclusion``, which records are refused outright, and the fact that a
+failing publication never touches the record on disk.
+
+Mocking boundary, per dispatch: only the client's POST
+(``forge_check_run.publish_check_run``, imported here) and ``gh pr view``
+(``subprocess.run``) are mocked. The mapping itself is NEVER
+mocked — every conclusion in this file is computed by the real
+``conclusion_for``/``classify_record`` against a real record on disk, and the
+proven-pass path runs the real merge-door invariant chain over a real report
+file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(VNX_ROOT / "scripts"))
+
+import forge_gate_publisher as fcr  # noqa: E402
+import gate_recorder  # noqa: E402
+import gate_status  # noqa: E402
+
+HEAD = "a" * 40
+OTHER_HEAD = "b" * 40
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_report(tmp_path: Path, name: str = "report.md") -> Path:
+    """A gate report with no blocking indicators at all."""
+    path = tmp_path / name
+    path.write_text(
+        "# glm_gate\n\nDe poort heeft de diff gelezen en niets gevonden dat merge tegenhoudt.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _proven_pass(tmp_path: Path, **overrides: Any) -> Dict[str, Any]:
+    """A record that satisfies every condition for ``success``."""
+    record: Dict[str, Any] = {
+        "gate": "glm_gate",
+        "pr_id": "",
+        "pr_number": 1811,
+        "status": "pass",
+        "commit_sha": HEAD,
+        "branch": "dispatch/x",
+        "contract_hash": "sha256:deadbeef",
+        "report_path": str(_clean_report(tmp_path)),
+        "blocking_findings": [],
+        "advisory_findings": [],
+        "dispatch_id": "20260908-golfb-b2b-forge-integratie",
+        "evidence_source": "live",
+        "test_run": False,
+        "summary": "glm_gate PASS",
+    }
+    record.update(overrides)
+    return record
+
+
+def _write_record(results_dir: Path, pr_number: int, gate: str, record: Dict[str, Any]) -> Path:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / f"pr-{pr_number}-{gate}.json"
+    path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+    return path
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _gh_returning(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: Optional[Dict[str, Any]],
+    *,
+    returncode: int = 0,
+) -> None:
+    """Make every ``gh pr view --json ...`` call answer ``payload``."""
+
+    def fake_run(argv: List[str], **_kwargs: Any) -> _FakeCompleted:
+        assert argv[0] == "gh", f"only gh may be shelled out to here, got {argv!r}"
+        body = "" if payload is None else json.dumps(payload)
+        return _FakeCompleted(returncode, stdout=body)
+
+    monkeypatch.setattr(fcr.subprocess, "run", fake_run)
+    monkeypatch.setattr(fcr.shutil, "which", lambda _name: "/usr/bin/gh")
+
+
+def _capture_publish(monkeypatch: pytest.MonkeyPatch) -> List[Dict[str, Any]]:
+    """Replace the client POST; return the list it appends each call to."""
+    calls: List[Dict[str, Any]] = []
+
+    def fake_publish(
+        head_sha: str,
+        name: str,
+        conclusion: str,
+        summary: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        calls.append(
+            {
+                "head_sha": head_sha,
+                "name": name,
+                "conclusion": conclusion,
+                "summary": summary,
+                **kwargs,
+            }
+        )
+        return {"id": 1, "conclusion": conclusion}
+
+    monkeypatch.setattr(fcr, "publish_check_run", fake_publish)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# The mapping — statuses
+# ---------------------------------------------------------------------------
+
+
+def test_proven_pass_on_this_head_is_success(tmp_path: Path) -> None:
+    """The positive control: without it every negative below is vacuous."""
+    assert fcr.conclusion_for(_proven_pass(tmp_path), HEAD) == "success"
+
+
+def test_unavailable_is_action_required(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, status="unavailable")
+    verdict = fcr.classify_record(record, HEAD)
+    assert verdict.conclusion == "action_required"
+    assert "unavailable" in verdict.reason
+
+
+def test_not_executable_is_action_required(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, status="not_executable")
+    assert fcr.conclusion_for(record, HEAD) == "action_required"
+
+
+def test_pass_without_contract_hash_is_failure(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, contract_hash="")
+    verdict = fcr.classify_record(record, HEAD)
+    assert verdict.conclusion == "failure"
+    assert "contract_hash" in verdict.reason
+
+
+def test_pass_whose_report_is_gone_is_failure(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, report_path=str(tmp_path / "nope.md"))
+    assert fcr.conclusion_for(record, HEAD) == "failure"
+
+
+def test_fail_status_is_failure(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, status="fail")
+    assert fcr.conclusion_for(record, HEAD) == "failure"
+
+
+def test_blocked_status_is_failure(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, status="blocked")
+    assert fcr.conclusion_for(record, HEAD) == "failure"
+
+
+def test_pass_with_blocking_findings_is_failure(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, blocking_findings=[{"message": "kapot"}])
+    assert fcr.conclusion_for(record, HEAD) == "failure"
+
+
+def test_every_status_the_recorder_can_write_lands_in_one_of_three(tmp_path: Path) -> None:
+    """Read the vocabulary from the recorder's own status module, never a list
+    written out here — a list of my own would agree with itself forever."""
+    vocabulary = gate_status.ALL_KNOWN_STATES
+    assert vocabulary, "nul is eerst een meetfout: ALL_KNOWN_STATES is leeg"
+    landed = {}
+    for status in sorted(vocabulary):
+        record = _proven_pass(tmp_path, status=status)
+        landed[status] = fcr.conclusion_for(record, HEAD)
+    assert set(landed.values()) <= {"success", "failure", "action_required"}
+    # And the buckets are actually distinct: a mapping that answered
+    # action_required for everything would satisfy the assertion above.
+    assert set(landed.values()) == {"success", "failure", "action_required"}
+
+
+def test_record_without_any_status_is_action_required(tmp_path: Path) -> None:
+    """147 claude_github_optional records on disk carry no status at all
+    (measured 2026-09-08). That is an absent verdict, not an unknown one."""
+    record = _proven_pass(tmp_path)
+    del record["status"]
+    verdict = fcr.classify_record(record, HEAD)
+    assert verdict.conclusion == "action_required"
+    assert "uitspraak" in verdict.reason
+
+
+def test_invented_status_raises(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, status="approve_with_notes")
+    with pytest.raises(fcr.ForgeStatusUnmapped) as excinfo:
+        fcr.conclusion_for(record, HEAD)
+    assert "approve_with_notes" in str(excinfo.value)
+
+
+def test_unmapped_status_never_degrades_to_a_default(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, status="probably-fine")
+    with pytest.raises(fcr.ForgeStatusUnmapped):
+        fcr.conclusion_for(record, HEAD)
+
+
+# ---------------------------------------------------------------------------
+# The mapping — head binding
+# ---------------------------------------------------------------------------
+
+
+def test_record_for_another_sha_is_action_required_never_success(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, commit_sha=OTHER_HEAD)
+    verdict = fcr.classify_record(record, HEAD)
+    assert verdict.conclusion == "action_required"
+    assert "poort niet gedraaid op deze kop" in verdict.reason
+
+
+def test_record_with_empty_sha_is_action_required(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, commit_sha="")
+    verdict = fcr.classify_record(record, HEAD)
+    assert verdict.conclusion == "action_required"
+    assert "poort niet gedraaid op deze kop" in verdict.reason
+
+
+def test_absent_record_is_action_required() -> None:
+    verdict = fcr.classify_record(None, HEAD)
+    assert verdict.conclusion == "action_required"
+    assert "poort niet gedraaid op deze kop" in verdict.reason
+
+
+def test_empty_head_sha_raises_rather_than_leniently_matching(tmp_path: Path) -> None:
+    """``gate_recorder.result_is_for_head`` returns True on an empty head — the
+    right call for the merge door, which must not reclassify evidence on a gh
+    outage. Publishing has no such head to be lenient about."""
+    with pytest.raises(fcr.ForgeCheckRunError):
+        fcr.conclusion_for(_proven_pass(tmp_path), "")
+
+
+def test_test_run_record_is_never_success(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, test_run=True)
+    verdict = fcr.classify_record(record, HEAD)
+    assert verdict.conclusion == "action_required"
+    assert "test_run" in verdict.reason
+
+
+def test_reprocessed_evidence_is_never_success(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, evidence_source="reprocessed")
+    verdict = fcr.classify_record(record, HEAD)
+    assert verdict.conclusion == "action_required"
+    assert "reprocessed" in verdict.reason
+
+
+def test_reanchored_evidence_is_never_success(tmp_path: Path) -> None:
+    record = _proven_pass(tmp_path, evidence_source="reanchored")
+    assert fcr.conclusion_for(record, HEAD) == "action_required"
+
+
+def test_absent_evidence_source_still_passes(tmp_path: Path) -> None:
+    """Measured 2026-09-08 over 1148 result records in ~/.vnx-data: only
+    glm_gate and kimi_gate write ``evidence_source`` at all. Requiring the
+    literal string would make ``success`` unreachable for codex_gate (460
+    ``completed`` records), i.e. a check that can never go green."""
+    record = _proven_pass(tmp_path)
+    del record["evidence_source"]
+    assert fcr.conclusion_for(record, HEAD) == "success"
+
+
+# ---------------------------------------------------------------------------
+# The publisher
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _registered_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend the operator has done runbook §1/§3.
+
+    The shipped YAML carries ``app_id: null`` on purpose until then, and
+    ``publish_for_record`` short-circuits on it before touching gh or the
+    keychain — see ``test_publish_is_a_cheap_no_op_until_the_app_exists``.
+    """
+    monkeypatch.setattr(fcr, "load_app_config", lambda *_a, **_k: fcr.AppConfig("vnx-gate", 42))
+
+
+def test_publish_is_a_cheap_no_op_until_the_app_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No App, no gh round-trip: the recorder calls this after every write."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    shelled: List[Any] = []
+    monkeypatch.setattr(fcr.subprocess, "run", lambda *a, **k: shelled.append(a))
+    calls = _capture_publish(monkeypatch)
+    monkeypatch.setattr(
+        fcr,
+        "load_app_config",
+        lambda *_a, **_k: (_ for _ in ()).throw(fcr.ForgeAppConfigError("app_id ontbreekt")),
+    )
+
+    with pytest.raises(fcr.ForgeAppConfigError):
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert shelled == [], "geen gh-aanroep zolang de App niet bestaat"
+    assert calls == []
+
+
+def test_dry_run_needs_no_registered_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rehearsal an operator wants BEFORE registering the App."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    monkeypatch.setattr(
+        fcr,
+        "load_app_config",
+        lambda *_a, **_k: (_ for _ in ()).throw(fcr.ForgeAppConfigError("app_id ontbreekt")),
+    )
+
+    payload = fcr.publish_for_record(
+        1811, "glm_gate", HEAD, results_dir=results_dir, dry_run=True
+    )
+    assert payload["conclusion"] == "success"
+
+
+def test_publish_calls_the_client_with_the_vnx_gate_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert len(calls) == 1
+    assert calls[0]["name"] == "vnx-gate/glm_gate"
+    assert calls[0]["conclusion"] == "success"
+    assert calls[0]["head_sha"] == HEAD
+
+
+def test_publish_refuses_success_for_a_record_that_is_not_a_proven_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """The publisher does not take the mapping's word for it: even if
+    ``classify_record`` were changed to hand back ``success``, the publisher
+    re-asks the proven-pass predicate before a green check leaves the machine."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, contract_hash=""))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+    monkeypatch.setattr(
+        fcr, "classify_record", lambda *_a, **_k: fcr.ForgeVerdict("success", "gelogen")
+    )
+
+    with pytest.raises(fcr.ForgePublishRefused) as excinfo:
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert "bewezen pass" in str(excinfo.value)
+    assert calls == []
+
+
+def test_publish_refuses_a_pr_with_an_active_auto_merge_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": {"enabledAt": "2026-09-08T00:00:00Z"}})
+    calls = _capture_publish(monkeypatch)
+
+    with pytest.raises(fcr.ForgePublishRefused) as excinfo:
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert "auto-merge" in str(excinfo.value)
+    assert calls == [], "geen enkele publicatie op een PR die zichzelf kan mergen"
+
+
+def test_publish_refuses_when_the_auto_merge_lookup_itself_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    """Fail CLOSED: a gh outage must not be read as "no auto-merge armed"."""
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, None, returncode=1)
+    calls = _capture_publish(monkeypatch)
+
+    with pytest.raises(fcr.ForgePublishRefused):
+        fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+    assert calls == []
+
+
+def test_publish_dry_run_shows_the_payload_and_posts_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    payload = fcr.publish_for_record(
+        1811, "glm_gate", HEAD, results_dir=results_dir, dry_run=True
+    )
+
+    assert calls == []
+    assert payload["conclusion"] == "success"
+    assert payload["name"] == "vnx-gate/glm_gate"
+    assert payload["head_sha"] == HEAD
+    assert payload["dry_run"] is True
+
+
+def test_publish_of_an_absent_record_is_action_required_not_a_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+
+    fcr.publish_for_record(1811, "glm_gate", HEAD, results_dir=results_dir)
+
+    assert calls[0]["conclusion"] == "action_required"
+
+
+# ---------------------------------------------------------------------------
+# The CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_publish_on_a_pass_for_an_older_sha_exits_nonzero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    _registered_app: None,
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, commit_sha=OTHER_HEAD))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+    monkeypatch.setattr(fcr, "_resolve_head_sha", lambda _pr: HEAD)
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: results_dir)
+
+    rc = fcr.main(["publish", "--pr", "1811", "--gate", "glm_gate"])
+
+    assert rc != 0
+    out = capsys.readouterr().out
+    assert "draai de poort opnieuw" in out
+    assert calls[0]["conclusion"] == "action_required", (
+        "de nieuwe kop wordt gemarkeerd, maar nooit met het oude oordeel"
+    )
+
+
+def test_cli_publish_never_posts_an_old_verdict_on_a_new_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path, commit_sha=OTHER_HEAD))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+    monkeypatch.setattr(fcr, "_resolve_head_sha", lambda _pr: HEAD)
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: results_dir)
+
+    fcr.main(["publish", "--pr", "1811", "--gate", "glm_gate"])
+
+    assert [c["conclusion"] for c in calls] == ["action_required"]
+    assert all(c["conclusion"] != "success" for c in calls)
+
+
+def test_cli_publish_on_a_fresh_pass_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+    monkeypatch.setattr(fcr, "_resolve_head_sha", lambda _pr: HEAD)
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: results_dir)
+
+    rc = fcr.main(["publish", "--pr", "1811", "--gate", "glm_gate"])
+
+    assert rc == 0
+    assert calls[0]["conclusion"] == "success"
+
+
+def test_cli_without_gate_publishes_every_slot_for_the_pr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _registered_app: None
+) -> None:
+    results_dir = tmp_path / "results"
+    _write_record(results_dir, 1811, "glm_gate", _proven_pass(tmp_path))
+    _write_record(
+        results_dir, 1811, "codex_gate", _proven_pass(tmp_path, gate="codex_gate", status="unavailable")
+    )
+    _gh_returning(monkeypatch, {"autoMergeRequest": None})
+    calls = _capture_publish(monkeypatch)
+    monkeypatch.setattr(fcr, "_resolve_head_sha", lambda _pr: HEAD)
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: results_dir)
+
+    fcr.main(["publish", "--pr", "1811"])
+
+    assert {c["name"] for c in calls} == {"vnx-gate/glm_gate", "vnx-gate/codex_gate"}
+
+
+def test_cli_refuses_a_pr_without_a_resolvable_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(fcr, "_resolve_head_sha", lambda _pr: "")
+    monkeypatch.setattr(fcr, "_default_results_dir", lambda: tmp_path)
+    calls = _capture_publish(monkeypatch)
+
+    rc = fcr.main(["publish", "--pr", "1811", "--gate", "glm_gate"])
+
+    assert rc != 0
+    assert calls == []
+    assert "kop" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# The recorder hook — after the write, never fatal, never mutating
+# ---------------------------------------------------------------------------
+
+
+def _recorder_payload() -> Dict[str, Any]:
+    return {
+        "gate": "glm_gate",
+        "pr_id": "",
+        "pr_number": 1811,
+        "status": "pass",
+        "commit_sha": HEAD,
+        "branch": "dispatch/x",
+        "contract_hash": "sha256:deadbeef",
+        "report_path": "/dev/null",
+        "blocking_findings": [],
+        "dispatch_id": "20260908-golfb-b2b-forge-integratie",
+        "recorded_at": "2026-09-08T00:00:00Z",
+    }
+
+
+def test_a_throwing_publisher_leaves_the_record_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    seen: Dict[str, bytes] = {}
+
+    def exploding_publisher(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
+        seen["before"] = result_path.read_bytes()
+        raise fcr.ForgeAPIError("GitHub gaf 500", status=500, body="boom")
+
+    monkeypatch.setattr(fcr, "publish_for_record", exploding_publisher)
+
+    payload, written = gate_recorder.write_result_guarded(
+        result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+    )
+
+    assert written is True
+    assert "before" in seen, "de publicatie hangt NA de schrijf, niet ervoor"
+    assert result_path.read_bytes() == seen["before"]
+    assert payload["status"] == "pass"
+
+
+def test_a_closed_keychain_logs_the_recovery_command_and_keeps_the_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+
+    def locked_keychain(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
+        raise fcr.ForgeKeychainError("de keychain staat op slot")
+
+    monkeypatch.setattr(fcr, "publish_for_record", locked_keychain)
+
+    with caplog.at_level(logging.WARNING, logger="gate_recorder"):
+        payload, written = gate_recorder.write_result_guarded(
+            result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+        )
+
+    assert written is True
+    assert json.loads(result_path.read_text())["status"] == "pass"
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "forge_gate_publisher.py publish --pr 1811 --gate glm_gate" in logged
+    assert "keychain" in logged
+
+
+def test_terminal_result_publishes_after_the_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gate_depth
+
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    calls: List[Dict[str, Any]] = []
+
+    def recording_publisher(pr_number: int, gate: str, head_sha: str, **kwargs: Any) -> Dict[str, Any]:
+        calls.append(
+            {
+                "pr_number": pr_number,
+                "gate": gate,
+                "head_sha": head_sha,
+                "on_disk": json.loads(result_path.read_text()),
+                **kwargs,
+            }
+        )
+        return {}
+
+    monkeypatch.setattr(fcr, "publish_for_record", recording_publisher)
+
+    gate_recorder.record_terminal_result(
+        gate="glm_gate",
+        pr_id="1811",
+        result_path=result_path,
+        payload=_recorder_payload(),
+        # A real diff length: single_shot_depth(0, ...) is degenerate and
+        # record_terminal_result would rewrite the pass to `unavailable`,
+        # which would test the reclassification instead of the publication.
+        execution_depth=gate_depth.single_shot_depth(4096, False),
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["pr_number"] == 1811
+    assert calls[0]["gate"] == "glm_gate"
+    assert calls[0]["head_sha"] == HEAD
+    assert calls[0]["on_disk"]["status"] == "pass"
+
+
+def test_a_record_without_a_head_publishes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No head, nothing to hang a check-run on — and never an ambient fallback
+    to the local HEAD (OI-1307)."""
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    calls: List[Any] = []
+    monkeypatch.setattr(fcr, "publish_for_record", lambda *a, **k: calls.append(a))
+
+    payload = _recorder_payload()
+    payload["commit_sha"] = ""
+    gate_recorder.write_result_guarded(
+        result_path, payload, gate="glm_gate", pr_ref="1811"
+    )
+
+    assert calls == []
+
+
+def test_a_refused_write_publishes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refused write left another writer's record standing; publishing would
+    describe a write that never happened (OI-1469/OI-1470)."""
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    result_path.write_text("{ this is not json", encoding="utf-8")
+    calls: List[Any] = []
+    monkeypatch.setattr(fcr, "publish_for_record", lambda *a, **k: calls.append(a))
+
+    _payload, written = gate_recorder.write_result_guarded(
+        result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+    )
+
+    assert written is False
+    assert calls == []
+
+
+def test_publication_never_shells_out_from_the_recorder_on_import() -> None:
+    """The recorder imports the publisher lazily: importing gate_recorder must
+    not drag closure_verifier (and its import chain) into every gate run."""
+    source = (VNX_ROOT / "scripts" / "lib" / "gate_recorder.py").read_text(encoding="utf-8")
+    module_level = [
+        line for line in source.splitlines()
+        if line.startswith("import forge_") or line.startswith("from forge_")
+    ]
+    assert module_level == []


### PR DESCRIPTION
De poortuitspraak op schijf wordt een GitHub check-run `vnx-gate/<poort>`. B2a (#1808) leverde de client — transport, geen oordeel. Dit is de laag erboven die beslist welk record welke `conclusion` verdient.

## Wat er verandert

**`scripts/lib/forge_gate_publisher.py` (nieuw)** — de afbeelding, de weigeringen en de CLI.
**`scripts/lib/gate_recorder.py`** — één aanroep, ná de atomaire schrijf, niet-fataal.
**`tests/test_forge_gate_publisher.py` (nieuw)** — 39 tests.

### Drie conclusions, en de asymmetrie is de kern

GitHub telt `neutral` en `skipped` als voldaan voor een verplichte check. Een poort die niets kon zeggen boekt daarom nooit een van die twee: afwezigheid van bewijs krijgt `action_required` (blokkeert), `success` alleen bij een bewezen pass op precies deze kop, `failure` bij een poort die draaide en nee zei.

### "Bewezen pass" wordt hier niet opnieuw gedefinieerd

`_proven_pass_on_head` roept `closure_verifier._merge_door_record_verdict` aan — exact de keten die `check_review_gate_for_merge` per record draait. Een tweede, zwakkere kopie zou een check opleveren die GO zegt waar de merge-deur NO-GO zegt, en dat die twee het eens zijn is het hele punt van deze check-run.

### De kop bindt vóór de status

Een oordeel over een andere commit is geen mild oordeel over deze, maar de afwezigheid ervan (OI-1668). Een verouderde fail boekt dus `action_required` ("draai de poort op deze kop"), niet `failure`. Een oud oordeel gaat nooit op een nieuwe kop.

### Uitputtend, en gooit erbuiten

De match loopt over `gate_status.ALL_KNOWN_STATES` en gooit `ForgeStatusUnmapped` op alles daarbuiten — nooit een toegeeflijke default. Een LEGE status is wel een bereikbare toestand (147 `claude_github_optional`-records dragen er geen) en boekt `action_required`, geen exception.

### Twee weigeringen vóór er iets verstuurd wordt

1. Een actieve `autoMergeRequest`: een groene check zou daar de merge zelf uitvoeren. De weigering geldt voor élke conclusion, niet alleen `success`. De `gh`-lookup faalt closed — een uitval is geen "nee".
2. Een `success` voor een record dat de bewezen-pass-toets niet haalt. Die vraagt het predicaat opnieuw in plaats van de zojuist gekregen conclusion te geloven.

### De schrijfvolgorde

De aanroep hangt ná `_write_result_atomic`, buiten het slot, en alleen op een schrijf die landde (een geweigerde schrijf liet andermans record staan — publiceren zou een schrijf beschrijven die nooit gebeurde). Elke exception is niet-fataal en wordt gelogd met het herstelcommando: het record op schijf is de waarheid, de check-run is een kopie ervan.

## Twee afwijkingen van de dispatch, allebei gemeten

**1. Aparte module, niet onderaan `forge_check_run.py`.** De dispatch stond beide toe. De keuze is gemaakt door een bestaande test: `test_forge_check_run_client.py::test_module_has_no_gate_knowledge` legt vast dat het clientbestand geen poortwoordenschat draagt, en die scheiding is juist wat dit beleid laat wijzigen zonder een regel transport aan te raken. Die test rood maken om mijn eigen wijziging groen te krijgen was geen optie. Gevolg: het herstelcommando is `python3 scripts/lib/forge_gate_publisher.py publish --pr N --gate <poort>`, en het testbestand heet `test_forge_gate_publisher.py`.

**2. `evidence_source == "live"` is een insluitende regel geworden, geen letterlijke eis.** Gemeten over 1148 result-records in `~/.vnx-data`: alleen `glm_gate` (89 live / 5 reprocessed) en `kimi_gate` (26 / 1) schrijven dit veld. codex_gate (599), gemini_review (161), ci_gate (147), claude_github_optional (147) en deepseek_gate (3) nooit. Een letterlijke eis had `success` structureel onbereikbaar gemaakt voor codex_gate — 460 `completed`-records, de meestgebruikte review-poort — dus een check die nooit groen kan worden. Een ONTBREKEND veld is de normale vorm van een gewone live run; een AANWEZIG veld is wel een claim, en dan telt alleen `live`. `reprocessed` en `reanchored` vallen af, en elke toekomstige waarde die niemand deze functie heeft geleerd ook.

## Verificatie

39 nieuwe tests groen, 191 groen over de nieuwe suite plus de buren van de recorder. Volledige commando's en uitkomsten in het rapport.

**Bevinding, niet van deze PR:** `tests/test_gate_status_schema.py::test_closure_verifier_reads_status_completed_as_pass` staat rood, óók op een schone export van `main` (`git archive HEAD` naar een tijdelijke map). Hij staat niet op `tests/test_exclusions.txt`. `closure_verifier` importeert `gate_recorder` niet, dus deze PR raakt dat pad niet.

Dispatch-ID: 20260908-golfb-b2b-forge-integratie