### PR TITLE
fix(forge): de keychain geeft een meerregelig geheim hex terug, dus decodeer het (OI-1673)

### DIFF
--- a/scripts/forge/branch_protection.yaml
+++ b/scripts/forge/branch_protection.yaml
@@ -71,4 +71,20 @@ repo:
 # GET /repos/{owner}/{repo}/rulesets returned [] when this was measured.
 rulesets: []
 
-# Operator-stap uit docs/operations/FORGE_GATE.md: het `app:`-blok (slug + app_id) komt hier terug zodra de App bestaat; de schemalezer accepteert het al sinds deze PR (Golf B, B2a fix-forward 3).
+# WIE publiceert, niet wat main vereist.
+#
+# De publieke helft van de identiteit van de review-poort-App, gelezen door
+# `scripts/lib/forge_check_run.py::load_app_config` om het App-JWT te
+# ondertekenen. Het legt main geen enkele eis op: apply_branch_protection.py
+# laat dit blok uit het PUT-object en forge_protection_drift.py vergelijkt het
+# niet, dus een wijziging hier kan nooit als drift of als verzwakking lezen.
+# De vereiste-check zelf komt in B3 in required_status_checks hierboven, met
+# dit app_id eraan gebonden.
+#
+# App geregistreerd op 2026-09-08 (checks: write + metadata: read, alleen op
+# Vinix24/vnx-orchestration). De sleutel en het installation-id staan in de
+# keychain onder vnx-gate-app-key en vnx-gate-installation-id — zie
+# docs/operations/FORGE_GATE.md.
+app:
+  slug: vnx-gate
+  app_id: 4869217

--- a/scripts/lib/forge_check_run.py
+++ b/scripts/lib/forge_check_run.py
@@ -22,6 +22,15 @@ Three secrets, three sources:
   private key (PEM)               macOS keychain, item ``vnx-gate-app-key``.
   installation id                 macOS keychain, item ``vnx-gate-installation-id``.
 
+The private key does not come back as a PEM. ``security find-generic-password
+-w`` refuses to print a secret containing newlines and prints its raw bytes as
+a hex dump instead — silently, with nothing in the output saying so. Measured
+2026-09-08 on the registered App: 3356 hex characters where the 1678-byte,
+27-line PEM was stored. So every keychain read here recognizes that shape and
+decodes it (:func:`_looks_hex_encoded`, :func:`_decode_hex_secret`); without it
+``build_app_jwt`` fails on a key that is perfectly intact in the keychain, and
+the check-run can never be published (OI-1673).
+
 Every keychain read fails LOUD. ``send_digest_email._read_smtp_pass_from_keychain``
 returns ``""`` when the item is missing or the keychain is locked; that soft
 failure is correct for an optional digest mail and WRONG here — an empty key
@@ -47,6 +56,7 @@ BILLING SAFETY: No Anthropic SDK. No direct API calls to api.anthropic.com.
 
 from __future__ import annotations
 
+import binascii
 import json
 import os
 import subprocess
@@ -207,11 +217,69 @@ def load_app_config(path: Optional[Path] = None) -> AppConfig:
 # ---------------------------------------------------------------------------
 
 
+#: The alphabet a macOS hex dump is drawn from. ``security`` emits lowercase;
+#: uppercase is accepted because the shape, not the casing, is what identifies
+#: it. A PEM can never match: ``-----BEGIN`` is outside this set, so a keychain
+#: that hands the key back verbatim takes the untouched path.
+_HEX_ALPHABET = frozenset("0123456789abcdefABCDEF")
+
+#: Below this many characters a hex-shaped value is left alone. Every decimal id
+#: is also a valid hex string, so ``vnx-gate-installation-id`` (8-10 digits)
+#: would otherwise be "decoded" into four or five bytes of nonsense whenever it
+#: happened to have an even length. A hex dump of a multi-line secret is orders
+#: of magnitude longer — the App's PEM measured 3356 characters — so a floor of
+#: 32 separates the two without the reader needing to know which item it holds.
+_HEX_DECODE_MIN_CHARS = 32
+
+#: Whitespace a decoded secret may legitimately contain (a PEM is newlines).
+#: Any OTHER non-printable character means the hex decoded to bytes, not text.
+_ALLOWED_CONTROL_CHARS = frozenset("\t\n\r")
+
+
 def _recovery_hint(service: str, what: str) -> str:
     return (
         f"Herstel: security add-generic-password -s {service} -a \"$USER\" -w '<{what}>' "
         f"(runbook: {RUNBOOK_PATH})"
     )
+
+
+def _looks_hex_encoded(value: str) -> bool:
+    """True when ``value`` has the shape of macOS's hex dump of a secret."""
+    return (
+        len(value) >= _HEX_DECODE_MIN_CHARS
+        and len(value) % 2 == 0
+        and all(char in _HEX_ALPHABET for char in value)
+    )
+
+
+def _decode_hex_secret(value: str, service: str, what: str) -> str:
+    """Decode a hex-dumped keychain secret, or raise.
+
+    Never falls back to returning ``value`` unchanged. Handing the hex string
+    on would push the failure into ``build_app_jwt``, which can only report
+    "could not deserialize key data" — it does not know a keychain item is
+    involved, so the operator is sent to repair a key that is already correct.
+    """
+    # unhexlify cannot fail here: _looks_hex_encoded already established an
+    # even-length string drawn entirely from the hex alphabet.
+    raw = binascii.unhexlify(value)
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ForgeKeychainError(
+            f"keychain-item {service} heeft de hex-vorm die macOS teruggeeft voor een "
+            f"meerregelig geheim, maar decodeert niet naar tekst ({exc.reason}). "
+            f"{_recovery_hint(service, what)}"
+        ) from exc
+
+    # Valid UTF-8 is not the same as usable text: a run of control bytes decodes
+    # cleanly and is still bytes. Returning it would be a silent wrong value.
+    if any(char not in _ALLOWED_CONTROL_CHARS and not char.isprintable() for char in decoded):
+        raise ForgeKeychainError(
+            f"keychain-item {service} decodeert vanuit de hex-vorm naar bytes in plaats "
+            f"van tekst (niet-afdrukbare tekens). {_recovery_hint(service, what)}"
+        )
+    return decoded.strip()
 
 
 def _read_keychain_secret(service: str, what: str) -> str:
@@ -260,16 +328,27 @@ def _read_keychain_secret(service: str, what: str) -> str:
             f"keychain-item {service} is leeg. Een lege waarde is hier nooit bruikbaar: "
             f"de check-run zou stil wegvallen in plaats van te falen. {hint}"
         )
+    if _looks_hex_encoded(secret):
+        return _decode_hex_secret(secret, service, what)
     return secret
 
 
 def read_private_key() -> str:
-    """The App's RSA private key (PEM) from keychain item ``vnx-gate-app-key``."""
+    """The App's RSA private key (PEM) from keychain item ``vnx-gate-app-key``.
+
+    This is the read that hits the hex dump in practice: the key is multi-line,
+    so macOS never returns it verbatim on the machine where it was measured.
+    """
     return _read_keychain_secret(KEYCHAIN_PRIVATE_KEY_SERVICE, "pad naar de .pem, via $(cat ...)")
 
 
 def read_installation_id() -> str:
-    """The installation id from keychain item ``vnx-gate-installation-id``."""
+    """The installation id from keychain item ``vnx-gate-installation-id``.
+
+    A single-line number, so ``security`` prints it as-is and the hex decode
+    never engages — see ``_HEX_DECODE_MIN_CHARS`` for why an id that happens to
+    have an even length is still safe.
+    """
     value = _read_keychain_secret(KEYCHAIN_INSTALLATION_ID_SERVICE, "installation-id")
     if not value.isdigit():
         raise ForgeKeychainError(

--- a/tests/test_forge_check_run_client.py
+++ b/tests/test_forge_check_run_client.py
@@ -14,6 +14,7 @@ public key.
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 import subprocess
 import sys
@@ -30,9 +31,13 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 VNX_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "forge"))
 
+import apply_branch_protection as abp  # noqa: E402
 import forge_check_run as fcr  # noqa: E402
 import forge_protection_drift as fpd  # noqa: E402
+
+SHIPPED_YAML_PATH = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
 
 
 # ---------------------------------------------------------------------------
@@ -205,19 +210,26 @@ def test_load_app_config_unreadable_path_raises(tmp_path: Path) -> None:
 
 
 def test_app_block_shape_is_slug_and_app_id() -> None:
-    """The app: block B2b will read carries slug + app_id.
-
-    Golf B, B2a fix-forward 3 pulled the block back OUT of the shipped
-    ``scripts/forge/branch_protection.yaml``: the schema reader that accepts
-    it landed in the same PR that would have introduced the field, so the
-    field itself is deferred to the operator's App step
-    (docs/operations/FORGE_GATE.md). This test builds its own fixture rather
-    than leaning on the shipped file, which no longer carries the block.
-    """
+    """The app: block B2b reads carries slug + app_id."""
     doc = _base_protection_doc(app={"slug": "vnx-gate", "app_id": None})
     parsed = yaml.safe_load(yaml.safe_dump(doc, sort_keys=False))
     assert parsed["app"]["slug"] == "vnx-gate"
     assert "app_id" in parsed["app"]
+
+
+def test_shipped_yaml_carries_the_registered_app_id() -> None:
+    """The real ``app:`` block, read the way the client reads it.
+
+    Golf B, B2a fix-forward 3 pulled the block OUT of the shipped YAML because
+    the App did not exist yet and the schema reader accepting it landed in the
+    same PR. The App was registered on 2026-09-08, so the block is back and
+    ``load_app_config()`` on its default path must find it — no fixture, the
+    shipped file itself.
+    """
+    config = fcr.load_app_config()
+    assert config.slug == "vnx-gate"
+    assert config.app_id == 4869217
+    assert fcr.DEFAULT_YAML_PATH == SHIPPED_YAML_PATH
 
 
 # ---------------------------------------------------------------------------
@@ -266,13 +278,53 @@ def test_b1_still_refuses_a_genuinely_unknown_key() -> None:
 
 
 def test_shipped_yaml_parses_and_applies_clean(tmp_path: Path) -> None:
-    """The real file still round-trips through B1 -- app: is optional, so its
-    absence from the shipped YAML (Golf B, B2a fix-forward 3) changes nothing
-    here."""
-    path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
-    config = fpd.load_protection_config(path)
+    """The real file, carrying a real app_id, still round-trips through B1."""
+    config = fpd.load_protection_config(SHIPPED_YAML_PATH)
     assert config.branch == "main"
     assert config.checks
+
+
+def _shipped_doc_without_app() -> str:
+    """The shipped YAML with the ``app:`` block removed, as YAML text."""
+    doc = yaml.safe_load(SHIPPED_YAML_PATH.read_text(encoding="utf-8"))
+    assert "app" in doc, "the shipped YAML must carry the app: block for this test to mean anything"
+    doc.pop("app")
+    return yaml.safe_dump(doc, sort_keys=False)
+
+
+def test_shipped_app_block_is_invisible_to_the_comparator() -> None:
+    """Dropping the real ``app:`` block changes nothing the drift check sees."""
+    with_app = fpd.load_protection_config(SHIPPED_YAML_PATH)
+    without_app = fpd.parse_protection_config(_shipped_doc_without_app())
+    diffs = fpd.compare(fpd.to_normalized_dict(without_app), fpd.to_normalized_dict(with_app))
+    assert diffs == [], f"the registered app_id leaked into the comparator: {diffs}"
+
+    weakening, fields = fpd.is_weakening(
+        fpd.to_normalized_dict(without_app), fpd.to_normalized_dict(with_app)
+    )
+    assert weakening is False
+    assert fields == []
+
+
+def test_shipped_app_block_never_reaches_the_branch_protection_put(monkeypatch) -> None:
+    """``app:`` describes WHO publishes; the PUT describes what main requires.
+
+    A stray ``app`` key in the PUT body would be sent to
+    ``PUT /repos/{owner}/{repo}/branches/main/protection``, which does not know
+    the field — so this is checked on the object ``--dry-run`` actually prints,
+    not on the YAML.
+    """
+    live = fpd.to_normalized_dict(fpd.load_protection_config(SHIPPED_YAML_PATH))
+    monkeypatch.setattr(abp, "fetch_live_protection", lambda *a, **k: live)
+
+    result = abp.run_apply(yaml_path=SHIPPED_YAML_PATH, project_root=VNX_ROOT, dry_run=True)
+
+    assert result["verdict"] == "DRY-RUN"
+    assert result["diffs"] == []
+    assert "app" not in result["payload"]
+    # The checks[] entries legitimately carry app_id, so "no app anywhere" is
+    # the wrong assertion — it is the top-level key that must be absent.
+    assert "slug" not in json.dumps(result["payload"])
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +440,141 @@ def test_read_installation_id_rejects_non_numeric(monkeypatch: pytest.MonkeyPatc
     )
     with pytest.raises(fcr.ForgeKeychainError):
         fcr.read_installation_id()
+
+
+# ---------------------------------------------------------------------------
+# macOS hands a multi-line secret back hex-encoded (OI-1673)
+# ---------------------------------------------------------------------------
+
+
+def _as_macos_hex(text: str) -> str:
+    """What ``security find-generic-password -w`` prints for a multi-line secret.
+
+    Measured 2026-09-08 on the real ``vnx-gate-app-key`` item: a 1678-byte PEM
+    over 27 lines came back as 3356 hex characters, with nothing in the output
+    saying so.
+    """
+    return binascii.hexlify(text.encode("utf-8")).decode("ascii")
+
+
+def test_read_private_key_decodes_the_hex_form_macos_returns(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    """The regression: today this returns 3356 hex characters, not a PEM."""
+    private_pem, _ = rsa_keypair
+    hex_form = _as_macos_hex(private_pem)
+    assert "PRIVATE KEY" not in hex_form, "the fixture must be the hex form, not a PEM"
+    _security_returning(
+        monkeypatch,
+        {fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(0, stdout=hex_form + "\n")},
+    )
+
+    assert fcr.read_private_key() == private_pem.strip()
+
+
+def test_the_hex_decoded_key_actually_signs_an_app_jwt(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    """The whole point of the decode: a key read this way must be usable.
+
+    ``build_app_jwt`` on the undecoded hex string is exactly where OI-1673
+    surfaced, so the proof runs the real signing path end to end and verifies
+    the result against the matching public key.
+    """
+    private_pem, public_pem = rsa_keypair
+    _security_returning(
+        monkeypatch,
+        {
+            fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(
+                0, stdout=_as_macos_hex(private_pem) + "\n"
+            )
+        },
+    )
+
+    token = fcr.build_app_jwt(4869217, fcr.read_private_key())
+    assert jwt.decode(token, public_pem, algorithms=["RS256"], issuer="4869217")["iss"] == "4869217"
+
+
+def test_read_private_key_leaves_an_already_decoded_pem_untouched(
+    monkeypatch: pytest.MonkeyPatch, rsa_keypair: Tuple[str, str]
+) -> None:
+    """A keychain that hands back the PEM verbatim must not be second-guessed."""
+    private_pem, _ = rsa_keypair
+    _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(0, stdout=private_pem)}
+    )
+    assert fcr.read_private_key() == private_pem.strip()
+
+
+@pytest.mark.parametrize("value", ["159965649", "12345678", "4869217"])
+def test_a_short_all_hex_value_like_an_installation_id_passes_through(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Every decimal id is also a valid hex string.
+
+    ``12345678`` is even-length and entirely within the hex alphabet, so a
+    decode rule that looked only at the alphabet would turn an installation id
+    into four bytes of nonsense. The real id (``159965649``, 9 digits) came back
+    plain when measured; this must hold for the even-length case too.
+    """
+    _security_returning(
+        monkeypatch,
+        {fcr.KEYCHAIN_INSTALLATION_ID_SERVICE: _FakeCompleted(0, stdout=value + "\n")},
+    )
+    assert fcr.read_installation_id() == value
+
+
+def test_a_hex_shaped_secret_that_is_not_text_is_loud_never_passed_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hex-shaped but not decodable as UTF-8: name the item, do not hand it on.
+
+    Passing the raw string through would push the failure into
+    ``build_app_jwt``, which can only say "could not deserialize key data" —
+    it has no idea a keychain item is involved.
+    """
+    not_utf8 = binascii.hexlify(b"\xff\xfe\x80" * 16).decode("ascii")
+    _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(0, stdout=not_utf8)}
+    )
+
+    with pytest.raises(fcr.ForgeKeychainError) as excinfo:
+        fcr.read_private_key()
+    message = str(excinfo.value)
+    assert fcr.KEYCHAIN_PRIVATE_KEY_SERVICE in message
+    assert "security add-generic-password" in message
+    assert fcr.RUNBOOK_PATH in message
+
+
+def test_a_hex_shaped_secret_that_decodes_to_control_bytes_is_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid UTF-8 is not the same as usable text.
+
+    ``\\x00\\x01\\x02...`` decodes cleanly as UTF-8 and is still bytes, not a
+    secret. Returning it would be a silent wrong value, which is the one
+    outcome this module refuses everywhere else.
+    """
+    control_bytes = binascii.hexlify(bytes(range(0, 24))).decode("ascii")
+    _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(0, stdout=control_bytes)}
+    )
+
+    with pytest.raises(fcr.ForgeKeychainError) as excinfo:
+        fcr.read_private_key()
+    assert fcr.KEYCHAIN_PRIVATE_KEY_SERVICE in str(excinfo.value)
+    assert "security add-generic-password" in str(excinfo.value)
+
+
+def test_a_long_non_hex_secret_passes_through_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long enough to reach the length floor, but not hex: untouched."""
+    value = "ghp_" + "z" * 60
+    _security_returning(
+        monkeypatch, {fcr.KEYCHAIN_PRIVATE_KEY_SERVICE: _FakeCompleted(0, stdout=value + "\n")}
+    )
+    assert fcr.read_private_key() == value
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Wat er mis was

`security find-generic-password -w` weigert een geheim met nieuwe regels af te drukken. Het dumpt de ruwe bytes als hex, en niets in de uitvoer zegt dat. Gemeten op 08-09 tegen de geregistreerde App: 3356 hex-tekens waar de PEM van 1678 bytes over 27 regels staat.

`_read_keychain_secret` gaf stdout ongewijzigd door. Dus `read_private_key()` leverde de hex-string, `build_app_jwt` faalde daarop en de publisher uit #1812 kon nooit een check-run plaatsen.

De bestaande tests misten dit omdat ze een zelfgemaakte PEM rechtstreeks aan de JWT-bouw voeden. De keychain-heenweg werd nooit geraakt.

## Wat er verandert

`_read_keychain_secret` herkent de hex-vorm en decodeert hem: even lengte, uitsluitend het hex-alfabet, en minstens 32 tekens. Die lengtevloer is het punt. Elk decimaal id is ook een geldige hex-string, dus zonder vloer zou een installation-id met een even aantal cijfers in vier bytes onzin veranderen. Een PEM matcht nooit: `-----BEGIN` valt buiten het alfabet, dus een keychain die de sleutel wel gewoon teruggeeft loopt langs het onaangeroerde pad.

Decodeert de waarde niet naar bruikbare tekst, dan volgt een luide fout met de servicenaam en het herstelcommando. Twee gevallen: geen geldige UTF-8, en bytes die wel geldige UTF-8 zijn maar geen tekst (een reeks control-bytes decodeert schoon en is nog steeds geen geheim). Stil doorgeven zou de fout naar `build_app_jwt` duwen, en die kan alleen "could not deserialize key data" zeggen. Dan repareert de operator een sleutel die al klopt.

Het `app:`-blok staat weer in `scripts/forge/branch_protection.yaml`, met het echte app_id 4869217. Het beschrijft WIE publiceert, niet wat main vereist: `apply_branch_protection.py` laat het uit het PUT-object en `forge_protection_drift.py` vergelijkt het niet.

## Verificatie

Zes tests eerst rood op gedrag, daarna groen:

```
FAILED tests/test_forge_check_run_client.py::test_shipped_yaml_carries_the_registered_app_id
FAILED tests/test_forge_check_run_client.py::test_shipped_app_block_is_invisible_to_the_comparator
FAILED tests/test_forge_check_run_client.py::test_read_private_key_decodes_the_hex_form_macos_returns
FAILED tests/test_forge_check_run_client.py::test_the_hex_decoded_key_actually_signs_an_app_jwt
FAILED tests/test_forge_check_run_client.py::test_a_hex_shaped_secret_that_is_not_text_is_loud_never_passed_through
FAILED tests/test_forge_check_run_client.py::test_a_hex_shaped_secret_that_decodes_to_control_bytes_is_loud
6 failed, 59 passed in 1.67s
```

Na de fix, met de buren erbij:

```
python3 -m pytest tests/test_forge_check_run_client.py tests/test_forge_gate_publisher.py \
  tests/test_forge_protection_drift.py tests/test_apply_branch_protection.py \
  tests/test_pr_merge_branch_protection.py -q
243 passed in 2.67s
```

Tegen de echte keychain, zonder de sleutel zelf af te drukken:

```
PEM ok
installation: 159965649
```

Dispatch-ID: 20260908-golfb-hexfix-keychain-decode