### PR TITLE
feat(forge): vnx-gate/review van pending_checks naar de vereiste checks (golf B, OP-B3)

### DIFF
--- a/docs/operations/FORGE_GATE.md
+++ b/docs/operations/FORGE_GATE.md
@@ -2,19 +2,23 @@
 
 Operator-runbook voor golf B (`gate-enforcement-to-forge`). Plan: `claudedocs/plans/2026-09-06-golf-B-forge-dwingt-af.md` (deliverables B4, OP-B3, B5). Doel: GitHub weigert elke merge naar `main` zonder een gepubliceerd poortoordeel op exact de PR-head, ook een kale `gh pr merge`, ook van de operator zelf.
 
-## 0. Wat bestaat er vandaag, wat nog niet (gemeten 2026-09-07)
+## 0. Wat bestaat er vandaag, wat nog niet (gemeten 2026-09-08)
 
 Dit runbook beschrijft twee lagen.
 
-| Laag | Status op 2026-09-07 | Commando's in dit runbook |
+| Laag | Status op 2026-09-08 | Commando's in dit runbook |
 |---|---|---|
 | **1. Branch-protection als YAML** (B1, #1807, **gemerged**) — `scripts/forge/branch_protection.yaml`, `scripts/forge/apply_branch_protection.py`, `scripts/lib/forge_protection_drift.py`, de preflight in `scripts/pr_merge.py`, de doctor-check in `scripts/vnx_doctor.py` | **Op `main`.** | Geverifieerd tegen elk script zijn eigen `--help`, en tegen een echte `gh api`-meting op de repo (zie §4). |
-| **2a. Forge-client** (`scripts/lib/forge_check_run.py`) | **Nog niet op `main` — open als PR #1808** (`dispatch/20260907-golfb-b2a-forge-client`, tijdens het schrijven van dit runbook geopend; Profile A stond nog rood). Deze PR bevat óók de YAML-uitbreiding uit §3 en een aanpassing van `forge_protection_drift.py`'s schema. | Geverifieerd tegen de broncode van PR #1808 zelf (niet tegen `--help`: de client heeft **geen CLI**, alleen library-functies — zie §2 en §5). Herlees de PR bij twijfel, want hij is nog niet gereviewd. |
-| **2b. Integratie in de gate-recorder + `vnx-gate/review` als verplichte check** (B2b, B3, OP-B3, B5) | **Niet gebouwd.** Geen `--pr`-CLI, geen allowlist-afbeelding van poortstatus naar `conclusion`, geen `pending_checks`-entry voor `vnx-gate/review`. | **Ontwerp uit het plan, niet uit code.** Elke vlag hierop in §5 en §8 is gemarkeerd **(ontwerp)** en moet herverifieerd worden zodra B2b/B3 mergen — vóór uitvoering. |
+| **2a. Forge-client** (`scripts/lib/forge_check_run.py`) | **Op `main`** (B2a, #1808, plus de keychain-fix #1813). Bracht ook het `app:`-blok uit §3 en de schema-aanpassing in `forge_protection_drift.py` mee. Het App ID staat inmiddels ingevuld: `4869217`, slug `vnx-gate`. | De client heeft **geen CLI**, alleen library-functies — de toets in §2 is dus een directe library-aanroep. |
+| **2b. Publicatie + de samenvattende check** (B2b #1812, B3 #1814) — `scripts/lib/forge_gate_publisher.py`, aangeroepen door de gate-recorder na elk schijf-record | **Op `main`.** De afbeelding van poortstatus naar `conclusion`, de `--pr`-CLI (`publish`, `review`, `pending-preview`) en `vnx-gate/review` als samenvattend oordeel bestaan en zijn getest. | Geverifieerd tegen de broncode op `main` en tegen `pending-preview`, dat niets schrijft en niets opvraagt. |
+| **3. `vnx-gate/review` als VEREISTE check** (OP-B3) | **Half.** De entry staat sinds OP-B3 in `required_status_checks.checks` van `branch_protection.yaml` op `main` (15 checks), gebonden aan app_id `4869217`. De **apply is nog niet gedraaid**: de live bescherming vereist nog 14 checks. Zie §5 — tussen die twee momenten staat de merge-deur dicht. | §5. |
+| **4. Terugweg één keer live bewijzen** (B5) | **Niet gedaan.** | §7 beschrijft de stappen; B5 voert ze één keer uit en quoteert de API-feiten. |
 
 **Meetcorrectie op de aanname achter §4:** de dispatch-instructie voor dit runbook noemt de eerste apply als het moment waarop de bescherming ontstaat. Gemeten op 2026-09-07 via `gh api repos/Vinix24/vnx-orchestration/branches/main/protection` (+ `.../required_signatures`, `repos/{owner}/{repo}`, `.../rulesets`) staat de bescherming al live en komt hij op elk veld overeen met `branch_protection.yaml` (14/14 checks, `enforce_admins: true`, `allow_auto_merge: false`, `required_signatures: false`, 0 rulesets) — precies zoals de YAML's eigen kopregel zegt ("Measured live ... on 2026-09-07"). Een `--dry-run` bevestigt dit: `verdict: DRY-RUN, changed: False, diffs: []`. De eerste apply-run is dus vandaag een **no-op**: hij schrijft de eerste receipt en bewijst idempotentie, hij legt de bescherming niet voor het eerst vast — die staat er al.
 
 **Meetcorrectie op de aanname achter §3:** de dispatch-instructie gaat ervan uit dat het App ID op de `pending_checks`-entry zelf komt te staan, zoals bij `checks[]` (`{context, app_id}`). Gemeten in PR #1808: `pending_checks` blijft een lijst van kale context-strings (`parse_protection_config` eist `all(isinstance(p, str) ...)`), en het App ID komt in een **apart, nieuw top-level `app:`-blok** te staan dat de client leest, nooit toegepast en nooit vergeleken wordt voor drift. Zie §3.
+
+Dat verschil verdwijnt bij de promotie van OP-B3, en dat is geen inconsistentie: `checks[]` **is** het PUT-object, en GitHub eist de app-binding daar per entry. Een `vnx-gate/*`-entry zonder eigen `app_id` zou elke app die status laten zetten, en precies daarom weigert de schemalezer hem (`null` of de "elke app"-sentinel `-1`). In `pending_checks` was die tweede kopie overbodig — die lijst gaat nooit de deur uit, en de proefdraai bindt zo'n entry op leestijd aan `app.app_id`.
 
 ## 1. App aanmaken **[operator]**
 
@@ -30,7 +34,7 @@ Resultaat van deze stap: een App ID, een installation-ID, en een `.pem`-bestand 
 
 ## 2. Keychain **[operator]**
 
-**Geverifieerd tegen de broncode van PR #1808** (`scripts/lib/forge_check_run.py`, nog niet gemerged — zie §0). De client leest twee keychain-items via exact hetzelfde patroon als de bestaande `vnx-smtp-pass`-lezer (`scripts/send_digest_email.py::_read_smtp_pass_from_keychain`), maar faalt — in tegenstelling tot die lezer — altijd LUID in plaats van een lege string terug te geven: een leeg keychain-item zou een check-run stil laten verdwijnen in plaats van de publicatie te laten falen, en dat is precies wat deze poort moet voorkomen (module-docstring van `forge_check_run.py`).
+**Geverifieerd tegen `scripts/lib/forge_check_run.py` op `main`** (#1808, plus de keychain-fix #1813 — zie §0). De client leest twee keychain-items via exact hetzelfde patroon als de bestaande `vnx-smtp-pass`-lezer (`scripts/send_digest_email.py::_read_smtp_pass_from_keychain`), maar faalt — in tegenstelling tot die lezer — altijd LUID in plaats van een lege string terug te geven: een leeg keychain-item zou een check-run stil laten verdwijnen in plaats van de publicatie te laten falen, en dat is precies wat deze poort moet voorkomen (module-docstring van `forge_check_run.py`).
 
 De twee itemnamen liggen al vast in de code (`KEYCHAIN_PRIVATE_KEY_SERVICE`, `KEYCHAIN_INSTALLATION_ID_SERVICE`):
 
@@ -42,7 +46,7 @@ rm /pad/naar/vnx-gate.pem
 
 Verwijder de `.pem` van schijf zodra hij in de keychain staat — dat is de enige kopie die overblijft.
 
-**Toets (werkt zodra PR #1808 op `main` staat — de client heeft geen CLI, dus dit is een directe library-aanroep, geen subcommando):**
+**Toets (de client heeft geen CLI, dus dit is een directe library-aanroep, geen subcommando):**
 
 ```bash
 python3 -c "
@@ -62,35 +66,37 @@ Na deze stap moet `keychain OK` verschijnen.
 
 ## 3. app_id in de YAML **[operator via PR]**
 
-**Geverifieerd tegen PR #1808**, niet tegen B3 (B3 bestaat nog niet — zie de meetcorrectie in §0). PR #1808 voegt zelf al een nieuw top-level blok toe aan `scripts/forge/branch_protection.yaml`:
+**Gedaan** — beschreven omdat de stap herhaald moet worden als de App ooit opnieuw wordt aangemaakt (§8). #1808 voegde een nieuw top-level blok toe aan `scripts/forge/branch_protection.yaml`, dat inmiddels het echte App ID draagt:
 
 ```yaml
 app:
   slug: vnx-gate
-  app_id: null
+  app_id: 4869217
 ```
 
 Dit blok is bewust **geen** onderdeel van `checks[]` of `pending_checks:`. Het beschrijft WIE publiceert, niet wat `main` vereist: `forge_protection_drift.py` behandelt `app` als een expliciet toegestane maar genegeerde top-level sleutel (`_OPTIONAL_TOP_LEVEL_FIELDS = frozenset({"app"})`) — nooit onderdeel van `ProtectionConfig`, nooit van `to_normalized_dict`, dus een wijziging hier kan nooit als drift of als verzwakking geregistreerd worden. Elke andere onbekende top-level sleutel wordt nog steeds geweigerd; dit is een allowlist van precies één sleutel, geen opening van het schema.
 
-Zodra PR #1808 op `main` staat: vervang `app_id: null` door het echte App ID uit stap 1, via een kleine PR door de normale deur (glm-gate tekent). `app_id` blijft `null` totdat dit gebeurt — de client weigert expliciet en luid op `null` in plaats van te gokken (`load_app_config`'s eigen foutmelding verwijst naar dit runbook).
+Het invullen gaat via een kleine PR door de normale deur (glm-gate tekent). Zolang `app_id` `null` is weigert de client expliciet en luid in plaats van te gokken (`load_app_config`'s eigen foutmelding verwijst naar dit runbook).
 
-Dit is nog niet de `pending_checks`-entry voor `vnx-gate/review` zelf (die komt uit B3, nog niet gebouwd) — dit is alleen de identiteit die straks *publiceert*. Zie §0.
+Dit blok zegt alleen wie *publiceert*. Wat `main` vereist, staat in `required_status_checks.checks` — daar staat `vnx-gate/review` sinds OP-B3 in, met dit getal eraan gebonden. Houd de twee gelijk: de binding in `checks[]` moet de identiteit zijn die daadwerkelijk tekent, anders is de check onvervulbaar. Zie §5.
 
-## 4. Eerste apply **[operator]**
+## 4. Eerste apply **[operator]** — historisch, niet meer als no-op uit te voeren
 
-Onafhankelijk van stap 1-3 en van PR #1808: dit gaat over de bestaande, gemergede 14-checks-YAML van B1.
+> **Deze sectie beschrijft de apply zoals hij vóór OP-B3 was: een no-op tegen een 14-checks-YAML.** Dat is hij sinds de merge van OP-B3 niet meer. `branch_protection.yaml` draagt nu vijftien checks en de live poort er veertien, dus een kale `apply_branch_protection.py` **voert de OP-B3-mutatie uit** — de meest consequente wijziging van de golf. Wil je die uitvoeren, volg dan §5 inclusief de opus-leeszetel, niet deze sectie. Wat hieronder staat blijft geldig als beschrijving van de commando's en van de controles erna (receipt, `vnx doctor`).
+
+Dit ging over de bestaande, gemergede 14-checks-YAML van B1, onafhankelijk van stap 1-3.
 
 ```bash
 python3 scripts/forge/apply_branch_protection.py --dry-run
 ```
 
-Toont het volledige PUT-object dat zou worden verstuurd. Per OP-B3 leest een tweede lezer (opus-leeszetel) dit object voordat een toekomstige, echt-wijzigende apply draait; deze eerste run is een no-op (zie de meetcorrectie in §0), dus die tweede lezer is hier niet vereist.
+Toont het volledige PUT-object dat zou worden verstuurd. Per OP-B3 leest een tweede lezer (opus-leeszetel) dit object voordat een echt-wijzigende apply draait; die eerste run was een no-op (zie de meetcorrectie in §0), dus die tweede lezer was daar niet vereist. Voor de apply van §5 is hij dat wél.
 
 ```bash
 python3 scripts/forge/apply_branch_protection.py
 ```
 
-Verwacht bericht vandaag: `nul wijzigingen: live branch-protection komt al overeen met de YAML`. Controleer de receipt:
+Verwacht bericht destijds: `nul wijzigingen: live branch-protection komt al overeen met de YAML`. Controleer de receipt:
 
 ```bash
 grep branch_protection_applied "$VNX_DATA_DIR/state/t0_receipts.ndjson" | tail -1
@@ -102,14 +108,26 @@ En bevestig dat `vnx doctor` nul drift toont:
 vnx doctor
 ```
 
-`branch_protection_drift` moet `PASS` zijn.
+`branch_protection_drift` moet `PASS` zijn. Let op: tussen de merge van OP-B3 en de apply van §5 staat deze check op `FAIL` (vijftien in de YAML, veertien live), en dat is dan de verwachte toestand — geen storing.
 
 ## 5. OP-B3 — entry van `pending_checks` naar `checks[]`, en migratie van openstaande PR's
 
-**Operator-stap met eigen poort — nog niet uitvoerbaar (B2b en B3 ontbreken, zie §0).** Verwacht verloop zodra ze er zijn:
+**Operator-stap.** Stap 1 is gedaan; vanaf stap 2 is dit werk dat nog voor je ligt.
 
-1. Kleine PR: `vnx-gate/review` toevoegen aan `pending_checks:` (als kale string, zie §0) met het App ID uit §3 elders vastgelegd (via B3's eigen mechanisme — nog niet ontworpen op het niveau van broncode).
-2. `python3 scripts/forge/apply_branch_protection.py --dry-run` — het exacte PUT-object, gequoteerd in de PR.
+1. **De promotie in de YAML — gedaan.** `vnx-gate/review` is uit `pending_checks:` gehaald (die lijst is nu `[]`) en staat als vijftiende entry in `required_status_checks.checks`, met het App ID uit §3 als gebonden `app_id`:
+
+   ```yaml
+   - {context: "vnx-gate/review", app_id: 4869217}
+   ```
+
+   Het getal staat hier bewust wél per entry, anders dan in `pending_checks` — zie de meetcorrectie in §0. Het moet gelijk blijven aan `app.app_id` onderaan hetzelfde bestand: dat is de identiteit die tekent, en dus de enige App die deze check kan vervullen.
+
+2. `python3 scripts/forge/apply_branch_protection.py --dry-run` — het exacte PUT-object, gequoteerd in de PR. Vooraf, zonder de apply aan te raken, leest hetzelfde object ook:
+
+   ```bash
+   python3 scripts/lib/forge_gate_publisher.py pending-preview
+   ```
+
 3. Opus-leeszetel leest dat object vóór de apply (dit is de meest consequente mutatie van de golf: vanaf hier faalt elke merge zonder gepubliceerde check).
 4. `python3 scripts/forge/apply_branch_protection.py` (zonder `--dry-run`) — dit voegt een check toe, dus is per definitie geen verzwakking en heeft geen `--allow-weaken` nodig.
 5. **Migratie van openstaande PR's**, zodat geen enkele open PR na deze apply plotseling onmergebaar wordt zonder duidelijke reden:
@@ -118,13 +136,51 @@ vnx doctor
    gh pr list --state open --json number,headRefOid --jq '.[] | "\(.number) \(.headRefOid)"'
    ```
 
-   Per head **(ontwerp — B2b levert de `--pr`-resolutie en de allowlist-afbeelding; `forge_check_run.py` van vandaag (PR #1808) is uitsluitend `publish_check_run(head_sha, name, conclusion, summary)` als primitief, zonder CLI, zonder kennis van PR-nummers of poortstatus — zie module-docstring "The CLIENT layer, and deliberately nothing more")**:
+   Per head:
 
-   ```
-   <het commando dat B2b levert> --pr <n>
+   ```bash
+   python3 scripts/lib/forge_gate_publisher.py review --pr <n>
    ```
 
-   Een head zonder eerdere poortrun (geen schijf-record voor die PR plus poort) levert volgens het plan terecht `action_required` op en blijft geblokkeerd — dat is geen bug in de migratie, dat is de poort die zijn werk doet. Draai de review-poort eerst op die head, publiceer daarna opnieuw.
+   Een head zonder eerdere poortrun (geen schijf-record voor die PR plus poort) levert terecht `action_required` op en blijft geblokkeerd — dat is geen bug in de migratie, dat is de poort die zijn werk doet. Draai de review-poort eerst op die head, publiceer daarna opnieuw.
+
+### Tussen de merge en de apply staat de merge-deur dicht
+
+Dit is geen risico maar een zekerheid, en het volgt uit de deur zelf. `pr_merge.py::_run_branch_protection_gate` stap (c) vergelijkt de **live** bescherming met de YAML **zoals die op `main` staat**. Zodra de promotie-PR gemerged is zegt `main` vijftien checks en zegt de live poort er veertien. Dat is drift, en op drift heeft de deur geen enkele override: `--allow-weaken` dekt alleen een verzwakking die de PR zelf introduceert ten opzichte van `main`, nooit een verschil tussen live state en `main`'s eigen YAML.
+
+De melding is dan, gemeten door `compare` over precies deze twee toestanden:
+
+```
+branch-protection wijkt af van scripts/forge/branch_protection.yaml op main: required_status_checks.checks[vnx-gate/review]
+```
+
+Hij noemt het afwijkende veld en niet het herstel. Dat herstel is de apply uit stap 4 hierboven.
+
+Gevolg voor de planning: tussen de merge van de promotie en de apply mag niets zitten. Geen andere PR, geen pauze, geen "morgen verder". Ook de PR die deze situatie zou repareren komt er niet doorheen. De apply is de enige uitweg, en de terugweg in §7 (de entry er weer uit) vereist zelf óók een merge — die dus ook geblokkeerd is.
+
+### Na de apply leest een ongepubliceerde head als `unverified`, niet als "geen oordeel"
+
+Bekende leesbaarheidsgrens, en de melding wijst de verkeerde kant op. Geen enkele workflow in `.github/workflows/` maakt de context `vnx-gate/review` — dat doet de App, buiten CI om. `ci_contexts.classify_contexts` valt voor een head zonder gepubliceerd oordeel daarom in de tak "geen check run én geen workflow-job die deze context maakt" (`scripts/lib/ci_contexts.py:537-552`), en die tak zegt letterlijk:
+
+```
+no check run on this commit and no workflow job in the checkout produces this context — cannot tell 'not yet' from 'never'
+```
+
+`required_contexts_gate` telt die tak als `unverified` en maakt er `SKIPPED_UNVERIFIED` van, met als detailregel:
+
+```
+1 of 15 required contexts could not be classified: vnx-gate/review
+```
+
+Dat blokkeert, en dat is juist: een poort die niet kon kijken geeft geen toestemming.
+
+Wat er niet aan klopt is de aanwijzing. De tekst leest als een kapotte workflow-graaf — alsof er een workflow-bestand ontbreekt of niet parset. Dat is hier niet aan de hand; er is niets stuk. Het echte herstel is één commando:
+
+```bash
+python3 scripts/lib/forge_gate_publisher.py review --pr <n>
+```
+
+Herken dus `vnx-gate/review` in een `SKIPPED_UNVERIFIED`-regel als "publiceer het review-oordeel", niet als "repareer CI". Voor de veertien Actions-checks blijft dezelfde melding wel gewoon betekenen wat hij zegt.
 
 ## 6. Werkgevolg voor iedereen, na OP-B3
 
@@ -163,4 +219,4 @@ Letterlijk uit het plan (`claudedocs/plans/2026-09-06-golf-B-forge-dwingt-af.md`
 - Plan: `claudedocs/plans/2026-09-06-golf-B-forge-dwingt-af.md`
 - Merge-deur en zijn gates: `docs/core/DISPATCH_RULES.md` §2
 - Code op `main`: `scripts/forge/branch_protection.yaml`, `scripts/forge/apply_branch_protection.py`, `scripts/lib/forge_protection_drift.py`, `scripts/pr_merge.py::_run_branch_protection_gate`, `scripts/vnx_doctor.py::check_branch_protection_drift`
-- Code in open PR #1808 (nog niet gereviewd, kan veranderen): `scripts/lib/forge_check_run.py`, `tests/test_forge_check_run_client.py`
+- Publicatielaag op `main`: `scripts/lib/forge_check_run.py` (client), `scripts/lib/forge_gate_publisher.py` (afbeelding, samenvattende check, CLI), `tests/test_forge_check_run_client.py`, `tests/test_forge_review_summary.py`

--- a/docs/operations/FORGE_GATE.md
+++ b/docs/operations/FORGE_GATE.md
@@ -78,7 +78,9 @@ Dit blok is bewust **geen** onderdeel van `checks[]` of `pending_checks:`. Het b
 
 Het invullen gaat via een kleine PR door de normale deur (glm-gate tekent). Zolang `app_id` `null` is weigert de client expliciet en luid in plaats van te gokken (`load_app_config`'s eigen foutmelding verwijst naar dit runbook).
 
-Dit blok zegt alleen wie *publiceert*. Wat `main` vereist, staat in `required_status_checks.checks` — daar staat `vnx-gate/review` sinds OP-B3 in, met dit getal eraan gebonden. Houd de twee gelijk: de binding in `checks[]` moet de identiteit zijn die daadwerkelijk tekent, anders is de check onvervulbaar. Zie §5.
+Dit blok zegt alleen wie *publiceert*. Wat `main` vereist, staat in `required_status_checks.checks` — daar staat `vnx-gate/review` sinds OP-B3 in, met dit getal eraan gebonden. Zie §5.
+
+De twee getallen gelijk houden is geen leesinstructie meer maar een schemaregel: `parse_protection_config` weigert een `vnx-gate/*`-entry waarvan het `app_id` niet gelijk is aan `app.app_id`, en weigert er ook een wanneer er helemaal geen `app`-blok is (dan is er geen identiteit om aan te binden). De melding noemt beide getallen. Zonder die wachter zou een verwisselde cijfervolgorde gewoon parsen, geen verzwakking zijn voor de merge-deur — `is_weakening` kijkt in de checks-tak alleen naar aanwezigheid, niet naar een gewijzigd `app_id` — en netjes applyen, waarna `main` een check vereist die geen enkele App kan vervullen. Een permanent dichte merge-deur, geïnstalleerd door een typefout.
 
 ## 4. Eerste apply **[operator]** — historisch, niet meer als no-op uit te voeren
 
@@ -156,7 +158,9 @@ branch-protection wijkt af van scripts/forge/branch_protection.yaml op main: req
 
 Hij noemt het afwijkende veld en niet het herstel. Dat herstel is de apply uit stap 4 hierboven.
 
-Gevolg voor de planning: tussen de merge van de promotie en de apply mag niets zitten. Geen andere PR, geen pauze, geen "morgen verder". Ook de PR die deze situatie zou repareren komt er niet doorheen. De apply is de enige uitweg, en de terugweg in §7 (de entry er weer uit) vereist zelf óók een merge — die dus ook geblokkeerd is.
+Gevolg voor de planning: tussen de merge van de promotie en de apply mag niets zitten. Geen andere PR, geen pauze, geen "morgen verder". Ook de PR die deze situatie zou repareren komt er niet doorheen. De apply is de enige uitweg, en de terugweg in §7.1 (de entry er weer uit) vereist zelf óók een merge — die dus ook geblokkeerd is.
+
+Dezelfde redenering geldt ná de apply, en dat is niet dezelfde situatie. Hierboven is de blokkade tijdelijk en heft de apply hem op. Daarna vereist elke merge een gepubliceerde `vnx-gate/review`, dus zodra publiceren zélf onmogelijk wordt (§8: keychain blijvend dicht, App verwijderd) is de terugweg uit §7.1 een lus in precies die faalmodus: de terugdraai-PR heeft de check nodig die niemand nog kan zetten. Daarvoor bestaat **§7.2**, met één ongegovernde stap en een verplichte vastlegging ervan.
 
 ### Na de apply leest een ongepubliceerde head als `unverified`, niet als "geen oordeel"
 
@@ -186,27 +190,100 @@ Herken dus `vnx-gate/review` in een `SKIPPED_UNVERIFIED`-regel als "publiceer he
 
 Elke push naar een PR-branch **na** een poortrun maakt de PR onmergebaar totdat de poort opnieuw draait — ook een triviale docs-fixup na een groene poort. De volgorde wordt: `request` → `execute` → `glm_gate.py` (of de opvolger in de overnameketen) → publicatie → merge. Wat vóór OP-B3 nog kon (een groene poort, dan nog een klein commit, dan mergen) kan daarna niet meer zonder de poort opnieuw te draaien.
 
+### Wie publiceert wat, en wanneer
+
+"Publicatie" in die volgorde is geen handmatige stap. De **gate-recorder** publiceert na elk schijf-record twee check-runs, in deze volgorde, op de kop die in dat record staat (`scripts/lib/gate_recorder.py::publish_forge_check_run` en `::publish_forge_review_summary`):
+
+1. `vnx-gate/<poort>` — wat déze poort zei. Vereist door niets.
+2. `vnx-gate/review` — of er op deze kop een geldig review-akkoord ligt, volgens dezelfde regel als de merge-deur. **Dit is de check die `main` vereist.**
+
+De twee zijn onafhankelijk. De per-poort-publicatie gaat eerst en slaagt of faalt op eigen merites; de samenvatting is een aparte aanroep met een aparte foutafhandeling, dus een fout daar kan de eerste niet ongedaan maken en kan een geslaagde poortrun niet rood maken. Beide falen luid in de log, met het herstelcommando erin, en geen van beide raakt het record op schijf.
+
+Twee poortruns op dezelfde kop publiceren de samenvatting twee keer; dat is een update van dezelfde check-run, geen conflict.
+
+Het CLI-commando blijft bestaan als **handmatige terugvaloptie**, niet als de normale weg:
+
+```bash
+python3 scripts/lib/forge_gate_publisher.py review --pr <n>
+```
+
+Gebruik het voor een kop die nooit een poortrun heeft gehad (de migratie in §5 stap 5), en na een uitval waarbij de recorder de publicatie moest inslikken — een gesloten keychain, een GitHub-500, een launchd-runner zonder `gh` op zijn PATH (§8). De log-regel van die uitval draagt dit commando al.
+
+Wat de recorder **niet** doorgeeft, omdat hij het niet weet: `project_id` en `project_root`. De samenvatting valt daarvoor terug op de eigen resolutie van de publisher (`origin` van de checkout waarin hij draait). `results_dir` en `branch` komen wél mee, uit het record dat zojuist geschreven is, zodat de check dezelfde records leest als de deur straks toetst.
+
 ## 7. Terugweg **[operator]**
 
 De terugweg is een branch-brede actie op de bestaande, geverifieerde `apply_branch_protection.py` — geen nieuwe code nodig, ook niet zodra OP-B3 gedraaid heeft. B5 voert hem één keer uit en quoteert de API-feiten ervan en ervoor.
 
+Er zijn **twee gevallen**, en ze verschillen op precies één vraag: kun je nog publiceren? De deur zelf kent het verschil niet en krijgt er ook geen ontsnappingsluik voor. §7.1 is de terugweg; §7.2 is wat er overblijft als publiceren onmogelijk is.
+
+### 7.1 Het gewone geval — publiceren werkt, en dit is dus geen lus
+
+Van toepassing wanneer de App bestaat, de keychain open is en `forge_gate_publisher.py review --pr <n>` gewoon slaagt. Dan is de terugdraai-PR een PR als elke andere: hij krijgt zijn eigen review-poortrun, de recorder publiceert `vnx-gate/review` op zijn kop (§6), en de deur laat hem door. De terugweg vereist een merge, die merge vereist een gepubliceerde check, en die check is te leveren. Geen cirkel.
+
 1. Kleine PR: haal de `vnx-gate/review`-entry uit `checks[]` van `scripts/forge/branch_protection.yaml` (terug naar `pending_checks:`, of helemaal weg).
 2. `python3 scripts/forge/apply_branch_protection.py --dry-run` — dit is nu een verzwakking (een check minder), dus de dry-run toont ook de waarschuwing `zou een verzwakking zijn zonder --allow-weaken`.
-3. Apply met de reden verplicht ingevuld:
+3. Draai de review-poort op de kop van die PR en merge hem via de deur, mét `--allow-weaken` en een reden: de PR verzwakt `main`'s YAML, en dat is precies wat stap (d) van de deur tegenhoudt zonder die vlag.
+4. **Pas na de merge** de apply, met de reden verplicht ingevuld:
 
    ```bash
    python3 scripts/forge/apply_branch_protection.py --allow-weaken "vnx-gate/review teruggedraaid: <reden>"
    ```
 
-   Een lege reden wordt geweigerd (`run_apply` toetst expliciet op een niet-lege string) — er is geen stille bypass.
-4. Receipt controleren zoals in §4; het veld `weak_fields` in die receipt draagt de naam van de teruggedraaide check.
-5. Zodra het probleem verholpen is: dezelfde entry via een nieuwe PR terug in `checks[]`, opnieuw apply (nu weer een aanscherping, geen `--allow-weaken` nodig) — zie §5.
+   Een lege reden wordt geweigerd (`run_apply` toetst expliciet op een niet-lege string) — er is geen stille bypass. Tussen stap 3 en stap 4 zegt `main` veertien en zegt live er vijftien: dat is drift en de deur staat dicht, om dezelfde reden als in §5. Laat er dus niets tussen zitten.
+5. Receipt controleren zoals in §4; het veld `weak_fields` in die receipt draagt de naam van de teruggedraaide check.
+6. Zodra het probleem verholpen is: dezelfde entry via een nieuwe PR terug in `checks[]`, opnieuw apply (nu weer een aanscherping, geen `--allow-weaken` nodig) — zie §5.
+
+### 7.2 Het noodgeval — publiceren is onmogelijk
+
+**Alleen voor de twee faalmodi uit §8 waarin geen enkele publicatie meer kan slagen:** een blijvend ontoegankelijke keychain, en een verwijderde of gedeïnstalleerde App. In beide gevallen is §7.1 een lus in zijn eigen faalmodus. De terugdraai-PR heeft `vnx-gate/review` nodig om te mergen, en dat is nou juist de check die niemand meer kan zetten. De omweg via een lokale `apply --allow-weaken` vóór de merge helpt niet: die maakt live veertien terwijl `main`'s YAML vijftien zegt, en op dat verschil weigert `scripts/pr_merge.py::_run_branch_protection_gate` stap (c) zonder enige override.
+
+Deze volgorde werkt wél, en hij bevat **precies één ongegovernde stap**: stap 3, een kale `gh pr merge` buiten de deur om. Dat is het enige punt in dit hele runbook waar dat mag, en het mag alleen hier.
+
+1. **Kleine PR met alleen de terugdraai.** Haal de `vnx-gate/review`-entry uit `checks[]`. Niets anders in die PR — hoe kleiner de ongegovernde merge, hoe kleiner wat er ongereviewd binnenkomt.
+
+   Draai er wél de review-poort op. Die schrijft zijn record op schijf en dat record is het bewijsstuk; alleen de publicatie ervan naar GitHub lukt niet. De poort is dus niet overgeslagen, alleen zijn check-run ontbreekt.
+2. **Verwijder de vereiste live**, want anders komt stap 3 er ook niet doorheen:
+
+   ```bash
+   python3 scripts/forge/apply_branch_protection.py --allow-weaken "noodherstel: <keychain dicht|App weg>, vnx-gate/review tijdelijk uit de bescherming"
+   ```
+
+   Dit is de laatste gegovernde stap. Hij schrijft zijn eigen receipt (`branch_protection_applied`, met `weak_fields`), dus dit deel van de afwijking staat vanzelf in de audit trail.
+
+   Let op de volgorde ten opzichte van §7.1: daar apply je ná de merge, hier ervóór. Dat is het hele verschil. Hier is `main`'s YAML nog vijftien en live veertien, dus stap (c) van de deur zou een normale merge alsnog weigeren — daarom is stap 3 een kale merge en geen deur-merge.
+3. **Kale merge, buiten de deur om.** De ongegovernde stap:
+
+   ```bash
+   gh pr merge <n> --squash
+   ```
+
+   Waarom de gegovernde weg hier niet kan: `pr_merge.py` toetst live tegen `main`'s YAML (stap c). Die twee zijn na stap 2 met opzet verschillend, en dat verschil is geen verzwakking die de PR introduceert, dus `--allow-weaken` dekt hem niet. Er is geen vlag die dit opent, en die komt er ook niet — een ontsnappingsluik in de deur zou op elke andere dag ook openstaan.
+
+   Na deze merge zeggen `main`'s YAML en de live bescherming allebei veertien en is de deur weer normaal bruikbaar.
+4. **Leg de ongegovernde stap vast.** Verplicht, en niet te improviseren op de dag dat `main` dichtstaat. Twee dingen, in deze volgorde:
+
+   ```bash
+   python3 scripts/open_items_manager.py add \
+     --dispatch "<dispatch-id van de terugdraai>" \
+     --pr <n> \
+     --severity blocker \
+     --title "Ongegovernde merge van PR #<n>: vnx-gate/review noodterugweg (FORGE_GATE.md §7.2)" \
+     --details "Reden: <keychain dicht|App weg>. Poortrecord op schijf: <pad naar het review_gates/results-record>. Live bescherming teruggebracht naar 14 checks via apply --allow-weaken (receipt: branch_protection_applied). Merge uitgevoerd met een kale gh pr merge, buiten pr_merge.py om. Sluiten zodra de App hersteld is en de entry via §5 terugstaat."
+   ```
+
+   ```bash
+   grep branch_protection_applied "$VNX_DATA_DIR/state/t0_receipts.ndjson" | tail -1
+   ```
+
+   De receipt van stap 2 is het bewijs van de verzwakking; het open item is het bewijs van de merge zelf, want dáár schrijft niets een receipt — dat is precies wat "buiten de deur om" betekent. Zonder dit open item eindigt de stap als een gat in de audit trail.
+5. **Herstel.** Keychain weer open of App opnieuw aangemaakt (§1 en §2, inclusief een nieuw App ID in de YAML via §3 als de App echt nieuw is). Daarna de entry terug in `checks[]` via §5, apply, en het open item uit stap 4 sluiten met een verwijzing naar de PR die de entry terugzette.
 
 ## 8. Faalmodi
 
-- **Gesloten keychain in een niet-interactieve sessie.** Na OP-B3 vraagt elke merge een lokaal gedraaide publisher met keychain-toegang. Zonder die toegang: geen publicatie, dus geen merge — ook niet voor de PR die het repareert. Geverifieerd (PR #1808, §2): elke keychain-fout is luid en draagt het exacte herstelcommando (`security add-generic-password -s <item> -a "$USER" -w '<...>'`); geen stille lege string. Als dat herstel zelf niet lukt (keychain blijvend ontoegankelijk, bijvoorbeeld een niet-interactieve launchd-sessie zonder sessiesleutel — `security`'s exit 51, "wil geen niet-interactieve toegang"), is de terugweg uit §7 de enige echte uitweg: haal `vnx-gate/review` uit `checks[]`, merge, zet daarna terug.
-- **Verwijderde of gedeinstalleerde App.** `vnx-gate/review` is dan permanent onvervulbaar — geen enkele publicatie kan nog slagen. De terugweg uit §7 is het enige herstel; daarna de App opnieuw aanmaken (§1) en de hele keten opnieuw doorlopen.
-- **Fork-PR.** De repo is publiek en er is nog geen externe PR geweest (gemeten: `POST /check-runs` op de head-sha van een fork-PR in de base-repo is dus niet getoetst). Aanvaarde procedure: de operator publiceert vanaf het schijf-record zoals bij elke andere PR. Faalt dat met **422**: er is geen per-PR-override in `apply_branch_protection.py` (het werkt branch-breed, niet per PR) — het herstel is de branch-brede terugweg uit §7, die ene PR mergen, en de bescherming direct daarna weer aanzetten. De eerste externe PR is zo een meting, geen storing.
+- **Gesloten keychain in een niet-interactieve sessie.** Na OP-B3 vraagt elke merge een lokaal gedraaide publisher met keychain-toegang. Zonder die toegang: geen publicatie, dus geen merge — ook niet voor de PR die het repareert. Geverifieerd (PR #1808, §2): elke keychain-fout is luid en draagt het exacte herstelcommando (`security add-generic-password -s <item> -a "$USER" -w '<...>'`); geen stille lege string. Lukt dat herstel wél, dan is §7.1 de terugweg. Lukt het niet (keychain blijvend ontoegankelijk, bijvoorbeeld een niet-interactieve launchd-sessie zonder sessiesleutel — `security`'s exit 51, "wil geen niet-interactieve toegang"), dan kan er niets meer gepubliceerd worden en is **§7.2** de weg: §7.1 zou hier een lus zijn, want de terugdraai-PR heeft zelf de check nodig die niemand meer kan zetten.
+- **Verwijderde of gedeinstalleerde App.** `vnx-gate/review` is dan permanent onvervulbaar — geen enkele publicatie kan nog slagen. Dat is de tweede faalmodus waarvoor **§7.2** bestaat, om dezelfde reden: §7.1 vraagt een publicatie die per definitie niet meer kan. Daarna de App opnieuw aanmaken (§1), het nieuwe App ID in de YAML zetten (§3, en de schemalezer weigert een `vnx-gate/*`-entry die niet aan dat getal gebonden is) en de keten opnieuw doorlopen via §5.
+- **Fork-PR.** De repo is publiek en er is nog geen externe PR geweest (gemeten: `POST /check-runs` op de head-sha van een fork-PR in de base-repo is dus niet getoetst). Aanvaarde procedure: de operator publiceert vanaf het schijf-record zoals bij elke andere PR. Faalt dat met **422**: er is geen per-PR-override in `apply_branch_protection.py` (het werkt branch-breed, niet per PR) — het herstel is de branch-brede terugweg uit §7.1, die ene PR mergen, en de bescherming direct daarna weer aanzetten. Publiceren werkt in dit geval nog gewoon voor elke andere PR, dus §7.2 is hier niet aan de orde. De eerste externe PR is zo een meting, geen storing.
 - **launchd-runner met kaal PATH (OI-1663).** Een runner zonder de interactieve-shell-PATH boekt bijvoorbeeld codex als niet-geïnstalleerd. Voor deze poort betekent dat: als de publicatie via launchd draait, controleer eerst of `gh` en `security` op het PATH van die launchd-sessie staan vóór je een publicatiefout aan de keychain of de App toeschrijft.
 - **Drift in een week zonder merges.** Niemand hoeft te mergen om drift te veroorzaken — een handmatige wijziging in de GitHub-UI verandert de live protection zonder dat de YAML meebeweegt. `vnx doctor`'s `branch_protection_drift`-check (§4) vangt dit ook buiten de merge-deur om; draai hem periodiek, niet alleen rond een merge.
 

--- a/scripts/forge/branch_protection.yaml
+++ b/scripts/forge/branch_protection.yaml
@@ -13,6 +13,14 @@
 # the workflow must describe the same context names, or CI and branch
 # protection silently diverge (see scripts/lib/ci_contexts.py's docstring
 # for what that divergence looks like in practice: PR #1691).
+#
+# The one deliberate exception is vnx-gate/*: those contexts are produced by
+# the `vnx-gate` GitHub App, not by any workflow in this checkout. Do NOT add
+# a workflow for them. The cost of the exception is a readability one, and it
+# is known: ci_contexts cannot tell "not yet published" from "no producer
+# exists" for such a context, so a head without a published verdict reads as
+# SKIPPED_UNVERIFIED rather than as "run the publisher". Blocking is correct,
+# the wording points the wrong way — see FORGE_GATE.md §5.
 branch: main
 
 required_status_checks:
@@ -32,31 +40,38 @@ required_status_checks:
     - {context: "Trace Token Validation", app_id: 15368}
     - {context: "secret scan (gitleaks)", app_id: 15368}
     - {context: "vnx doctor smoke", app_id: 15368}
+    # De samenvattende check van B3 — vereist sinds OP-B3, niet langer
+    # geparkeerd. Hij zegt per head of er een geldig review-akkoord ligt,
+    # volgens dezelfde regel als de merge-deur
+    # (closure_verifier._REVIEW_PEER_GATES + check_review_gate_for_merge).
+    # Publiceren, per PR-head:
+    #
+    #   python3 scripts/lib/forge_gate_publisher.py review --pr <n>
+    #
+    # Anders dan bij een pending_checks-entry staat het app_id hier WEL als
+    # tweede kopie van `app.app_id` onderaan dit bestand, en dat is geen
+    # inconsistentie maar het verschil tussen de twee lijsten. pending_checks
+    # gaat nooit de deur uit: de proefdraai bindt zo'n entry op leestijd aan
+    # `app.app_id`, dus een tweede kopie daar was overbodig en vrij om af te
+    # wijken van het getal dat tekent. checks[] IS het PUT-object, en GitHub
+    # eist de binding per entry — zonder app_id in de entry zelf zou elke app
+    # deze status mogen zetten. Vandaar dat de schemalezer een vnx-gate/*-entry
+    # zonder gebonden app_id hier weigert (null of de "elke app"-sentinel -1).
+    # Blijf dit getal dus gelijkhouden aan `app.app_id`: dat is de identiteit
+    # die forge_check_run.py ondertekent, en dus de enige App die deze check
+    # kan vervullen.
+    #
+    # Terugweg (branch-breed, met verplichte reden): FORGE_GATE.md §7.
+    - {context: "vnx-gate/review", app_id: 4869217}
 
-# De samenvattende check van B3, geparkeerd en nog niet vereist.
-#
-# Ignored by both apply_branch_protection.py and forge_protection_drift.py —
-# an entry here is a future obligation, not a current requirement. The schema
-# still refuses a vnx-gate/* entry placed directly in checks[] above without a
-# bound app_id (null or the GitHub "any app" sentinel -1): an unbound
-# vnx-gate/* check would let any app satisfy it.
-#
-# vnx-gate/review zegt, per head, of er een geldig review-akkoord ligt volgens
-# dezelfde regel als de merge-deur (closure_verifier._REVIEW_PEER_GATES +
-# check_review_gate_for_merge). Publiceren:
-#
-#   python3 scripts/lib/forge_gate_publisher.py review --pr <n>
-#
-# Er staat hier bewust GEEN app_id per entry. Het app_id waaraan een
-# vnx-gate/*-check gebonden wordt is `app.app_id` onderaan dit bestand — de
-# identiteit die forge_check_run.py daadwerkelijk ondertekent, en dus per
-# definitie de enige App die zo'n check kan vervullen. Een tweede kopie van dat
-# getal hier zou kunnen gaan afwijken van het getal dat tekent. Het exacte
-# PUT-object dat de promotie oplevert lees je vooraf met:
+# Leeg sinds OP-B3. Het slot zelf blijft bestaan: een entry hier is een
+# toekomstige verplichting en geen huidige eis — apply_branch_protection.py
+# laat hem uit het PUT-object en forge_protection_drift.py vergelijkt hem niet.
+# Het PUT-object dat een promotie uit deze lijst zou opleveren lees je vooraf
+# met:
 #
 #   python3 scripts/lib/forge_gate_publisher.py pending-preview
-pending_checks:
-  - "vnx-gate/review"
+pending_checks: []
 
 required_pull_request_reviews:
   required_approving_review_count: 0

--- a/scripts/lib/forge_protection_drift.py
+++ b/scripts/lib/forge_protection_drift.py
@@ -265,6 +265,7 @@ def parse_protection_config(raw_text: str) -> ProtectionConfig:
     )
     if "app" in doc:
         _validate_app_block(doc["app"])
+    signing_app_id = doc["app"]["app_id"] if isinstance(doc.get("app"), dict) else None
 
     if not isinstance(doc["branch"], str) or not doc["branch"]:
         raise ProtectionConfigError("branch moet een niet-lege string zijn")
@@ -291,11 +292,35 @@ def parse_protection_config(raw_text: str) -> ProtectionConfig:
         app_id = entry["app_id"]
         if app_id is not None and not isinstance(app_id, int):
             raise ProtectionConfigError(f"{where}.app_id moet een integer of null zijn")
-        if context.startswith(VNX_GATE_PREFIX) and (app_id is None or app_id == ANY_APP_ID):
-            raise ProtectionConfigError(
-                f"{where} ('{context}') is een vnx-gate/*-check zonder gebonden app_id "
-                "(null of de 'elke app'-sentinel -1): dat zou elke app deze status laten zetten"
-            )
+        if context.startswith(VNX_GATE_PREFIX):
+            if app_id is None or app_id == ANY_APP_ID:
+                raise ProtectionConfigError(
+                    f"{where} ('{context}') is een vnx-gate/*-check zonder gebonden app_id "
+                    "(null of de 'elke app'-sentinel -1): dat zou elke app deze status laten zetten"
+                )
+            # Bound to SOMETHING is not bound to the right thing. checks[] is
+            # the PUT body and needs its own app_id per entry; `app:` is the
+            # identity forge_check_run.py actually signs with. Two copies of one
+            # number, and until this guard only a YAML comment asked an editor
+            # to keep them equal. A transposed digit parses, is not a weakening
+            # (is_weakening reads presence/absence in the checks branch, never a
+            # changed app_id), applies cleanly — and leaves main requiring a
+            # check no App can satisfy. That is a permanently shut merge door
+            # installed by a typo, so it is refused at read time.
+            if signing_app_id is None:
+                raise ProtectionConfigError(
+                    f"{where} ('{context}') is een vnx-gate/*-check, maar dit bestand "
+                    "declareert geen tekenende App (app.app_id ontbreekt of is null): "
+                    "er is geen identiteit om hem aan te binden, dus zou de check "
+                    "onvervulbaar zijn"
+                )
+            if app_id != signing_app_id:
+                raise ProtectionConfigError(
+                    f"{where} ('{context}') is gebonden aan app_id {app_id}, maar de App "
+                    f"die tekent is app.app_id {signing_app_id}: alleen die App kan deze "
+                    "check vervullen, dus zou hij permanent rood blijven. Houd het getal "
+                    "in de entry gelijk aan app.app_id"
+                )
         checks.append(RequiredCheck(context, None if app_id == ANY_APP_ID else app_id))
 
     pending_raw = doc["pending_checks"]

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -776,7 +776,14 @@ def annotate_refused_write(
 def publish_forge_check_run(
     payload: Dict[str, Any], *, gate: str, result_path: Path
 ) -> None:
-    """Publish the just-written result as a GitHub check-run (Golf B, B2b).
+    """Publish the just-written result as GitHub check-runs (Golf B, B2b).
+
+    TWO of them, in this order: ``vnx-gate/<gate>`` from this record, then
+    ``vnx-gate/review`` for the same head (:func:`publish_forge_review_summary`,
+    which carries the reasoning for the second one). The per-gate check goes
+    first and settles on its own merits; the summary is a separate call with a
+    separate failure handler, so it can never hold back or undo the
+    publication above it.
 
     Called AFTER the atomic write has landed and after the slot lock is
     released, and NEVER able to change the outcome of that write. A gate run
@@ -831,6 +838,7 @@ def publish_forge_check_run(
         )
         return
 
+    app_not_registered = False
     try:
         from forge_gate_publisher import (  # noqa: PLC0415
             RECOVERY_COMMAND_TEMPLATE, ForgeAppConfigError, publish_for_record,
@@ -867,12 +875,95 @@ def publish_forge_check_run(
                 "runbook; daarna: %s",
                 gate, pr_number, exc, recovery,
             )
-            return
+        else:
+            logger.warning(
+                "gate_recorder: check-run PUBLICATIE MISLUKT voor gate=%s pr=%s head=%s — "
+                "%s: %s. Het resultaat op schijf is ongewijzigd en blijft geldig; "
+                "herstel met: %s",
+                gate, pr_number, head_sha[:12], type(exc).__name__, exc, recovery,
+            )
+
+    if app_not_registered:
+        # No App means no publication of ANY kind, so attempting the summary
+        # would only reprint the line above under a second name — on every
+        # gate write, for as long as the operator step stays open.
+        return
+    publish_forge_review_summary(
+        payload, pr_number=pr_number, head_sha=head_sha, result_path=result_path
+    )
+
+
+def publish_forge_review_summary(
+    payload: Dict[str, Any], *, pr_number: int, head_sha: str, result_path: Path
+) -> None:
+    """Publish ``vnx-gate/review`` for the head this record was written against.
+
+    The second half of the recorder's publication, and the half branch
+    protection actually requires. OP-B3 moved ``vnx-gate/review`` out of
+    ``pending_checks`` into ``required_status_checks.checks``, and until this
+    hook existed its only producer in the tree was the ``review`` CLI
+    subcommand — one hand-run command, per PR head, forever. What publishes
+    automatically (``vnx-gate/<gate>``, :func:`publish_forge_check_run`) is
+    required by nothing; what is required had no automatic producer at all.
+
+    **Second, and separate.** The per-gate publication runs first and settles
+    on its own merits; this is a distinct call with a distinct failure handler,
+    so a 500 here can neither undo a check-run that already went out nor fail
+    the gate run that produced the evidence. The record on disk is the truth in
+    both directions — a missing summary is repaired by
+    :data:`forge_gate_publisher.REVIEW_RECOVERY_COMMAND_TEMPLATE`, never by
+    failing the write.
+
+    **The head is the recorded one, never "the PR's current head".** Same
+    binding as the per-gate check and for the same reason: branch protection
+    matches a check-run to ONE commit. A push after the gate ran gets no check
+    and blocks — which is the OP-B3 rule working (FORGE_GATE.md §6), not a gap
+    to paper over by re-resolving the head.
+
+    **What is handed through, and what deliberately is not.** ``results_dir``
+    is the directory of the record just written, so the summary reads the same
+    store the merge door will read — every gate run in this project writes to
+    ``VNX_DATA_DIR=~/.vnx-data/vnx-dev``, and the publisher's own default store
+    is a different place (the OI-1307-adjacent reason
+    :func:`publish_forge_check_run` passes ``record_path``). ``branch`` comes
+    from the record's own stamped field (:func:`stamp_request_identity`), which
+    scopes the door lookup exactly as the merge door scopes it; absent, it is
+    omitted rather than guessed, and the verdict then falls back to the
+    publisher's own wider scope. ``project_id`` and ``project_root`` are NOT
+    passed: the recorder holds neither. Deriving a project_root from
+    ``__file__`` here would name whichever checkout this module was imported
+    from — in a dispatch worktree, not the repo the PR lives in — so the
+    publisher's own ``origin``-based resolution is the better-informed one.
+    """
+    try:
+        from forge_gate_publisher import (  # noqa: PLC0415
+            REVIEW_RECOVERY_COMMAND_TEMPLATE, publish_review_summary,
+        )
+
+        publish_review_summary(
+            pr_number,
+            head_sha,
+            results_dir=result_path.parent,
+            branch=(payload.get("branch") or "").strip() or None,
+        )
+    # vnx-broad-except: same rule as the per-gate publication one call above —
+    # this hook may not be able to fail a gate run, and the publisher's failure
+    # surface is open-ended by nature (keychain, JWT, DNS, GitHub, YAML, a lazy
+    # import). Narrowing it to the Forge exception tree would let anything
+    # outside that tree take down a write that has already succeeded. Nothing
+    # is silent: the branch below logs with the repair command.
+    except Exception as exc:  # noqa: BLE001
+        try:
+            recovery = REVIEW_RECOVERY_COMMAND_TEMPLATE.format(pr=pr_number)
+        except NameError:
+            # The import itself is what failed.
+            recovery = f"python3 scripts/lib/forge_gate_publisher.py review --pr {pr_number}"
         logger.warning(
-            "gate_recorder: check-run PUBLICATIE MISLUKT voor gate=%s pr=%s head=%s — "
-            "%s: %s. Het resultaat op schijf is ongewijzigd en blijft geldig; "
-            "herstel met: %s",
-            gate, pr_number, head_sha[:12], type(exc).__name__, exc, recovery,
+            "gate_recorder: SAMENVATTENDE CHECK vnx-gate/review NIET GEPUBLICEERD voor "
+            "pr=%s head=%s — %s: %s. Het resultaat op schijf is ongewijzigd en blijft "
+            "geldig, en de per-poort-check is hier niet door geraakt; deze PR blijft "
+            "onmergebaar tot de check er staat. Herstel met: %s",
+            pr_number, head_sha[:12], type(exc).__name__, exc, recovery,
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -379,6 +379,53 @@ def _stub_branch_protection_gate_gh_calls(monkeypatch: pytest.MonkeyPatch) -> No
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_forge_check_run_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Golf B, OP-B3 fix-forward: no check-run POST leaves a unit-test run.
+
+    ``gate_recorder.publish_forge_check_run`` fires after EVERY gate-result
+    write, and since the OP-B3 fix-forward it publishes twice (the per-gate
+    check and the required ``vnx-gate/review`` summary). Both end in
+    ``forge_gate_publisher.publish_check_run`` → keychain → an installation
+    token from ``api.github.com`` → ``POST /repos/{owner}/{repo}/check-runs``.
+
+    Measured on this branch, over the 21 test files that drive a recorder
+    write: **51** outbound TCP connections to ``140.82.121.5:443`` before the
+    summary wiring and **102** after it — a live GitHub call per publication,
+    from a machine whose keychain happens to hold the App key. It swallows its
+    own failures (a fabricated sha earns a 422), so the suite stayed green and
+    said nothing about it. Green is not the same as offline.
+
+    Stubbed at ``forge_gate_publisher.publish_check_run``, the one choke point
+    both publications share, and NOT at ``forge_check_run.publish_check_run``:
+    that module's own transport tests (tests/test_forge_check_run_client.py)
+    exercise the real function against a stubbed ``_api_request`` and must keep
+    doing so. Returns GitHub's response shape rather than raising — a raise
+    would exercise the recorder's failure handler on every gate write instead
+    of its success path.
+
+    Tests that assert on WHAT was published set their own stub in the test body
+    (``tests/test_forge_gate_publisher.py::_capture_publish`` and the summary
+    fixture beside it): same function-scoped ``monkeypatch`` instance, later
+    call wins — the convention the three stubs above already document.
+    """
+    try:
+        import forge_gate_publisher
+    except ImportError:
+        # Only importable once a test module has put scripts/lib on sys.path.
+        # A run that never collects one never reaches the publisher either.
+        return
+
+    def offline_publish_check_run(
+        head_sha: str, name: str, conclusion: str, summary: str, **_kwargs: object
+    ) -> dict:
+        return {"id": 0, "name": name, "head_sha": head_sha, "conclusion": conclusion}
+
+    monkeypatch.setattr(
+        forge_gate_publisher, "publish_check_run", offline_publish_check_run
+    )
+
+
 # ---------------------------------------------------------------------------
 # DB / registry fixtures  (shared with test_burnin_certification)
 # ---------------------------------------------------------------------------

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -93,7 +93,11 @@ class TestDryRun:
         assert not put_calls
         out = json.loads(capsys.readouterr().out)
         assert out["required_status_checks"]["strict"] is False
-        assert len(out["required_status_checks"]["checks"]) == 14
+        # Fifteen since OP-B3: vnx-gate/review left pending_checks for checks[],
+        # so the apply now sends it. Counted against the shipped YAML rather
+        # than a literal, which is what makes this assertion notice the next
+        # promotion too.
+        assert len(out["required_status_checks"]["checks"]) == len(_real_config().checks) == 15
         assert out["restrictions"] is None
 
     def test_dry_run_prints_payload_even_when_state_matches_exactly(self, monkeypatch, capsys):

--- a/tests/test_apply_branch_protection.py
+++ b/tests/test_apply_branch_protection.py
@@ -94,9 +94,12 @@ class TestDryRun:
         out = json.loads(capsys.readouterr().out)
         assert out["required_status_checks"]["strict"] is False
         # Fifteen since OP-B3: vnx-gate/review left pending_checks for checks[],
-        # so the apply now sends it. Counted against the shipped YAML rather
-        # than a literal, which is what makes this assertion notice the next
-        # promotion too.
+        # so the apply now sends it. Two claims in one chain, and the literal is
+        # deliberately part of it: the printed payload must carry exactly what
+        # the shipped YAML declares (that half moves with the next promotion),
+        # and that number must be the fifteen this dispatch measured (that half
+        # is what makes a silently vanished check fail here instead of passing
+        # against a shrunken file).
         assert len(out["required_status_checks"]["checks"]) == len(_real_config().checks) == 15
         assert out["restrictions"] is None
 

--- a/tests/test_forge_check_run_client.py
+++ b/tests/test_forge_check_run_client.py
@@ -284,18 +284,38 @@ def test_shipped_yaml_parses_and_applies_clean(tmp_path: Path) -> None:
     assert config.checks
 
 
-def _shipped_doc_without_app() -> str:
-    """The shipped YAML with the ``app:`` block removed, as YAML text."""
+def _shipped_doc_without_the_app_bound_checks() -> Dict[str, Any]:
+    """The shipped YAML with every ``vnx-gate/*`` entry taken out of ``checks[]``.
+
+    The one part of the document whose validity DEPENDS on the ``app:`` block:
+    since the OP-B3 fix-forward the schema reader refuses a ``vnx-gate/*``
+    entry that is not bound to ``app.app_id``, so a document with the entry and
+    without the block no longer parses at all. Removing it from both sides is
+    what leaves ``app:`` as the only difference between them.
+    """
     doc = yaml.safe_load(SHIPPED_YAML_PATH.read_text(encoding="utf-8"))
     assert "app" in doc, "the shipped YAML must carry the app: block for this test to mean anything"
-    doc.pop("app")
-    return yaml.safe_dump(doc, sort_keys=False)
+    doc["required_status_checks"]["checks"] = [
+        c for c in doc["required_status_checks"]["checks"]
+        if not str(c.get("context", "")).startswith("vnx-gate/")
+    ]
+    assert doc["required_status_checks"]["checks"], "stripping must not empty the list"
+    return doc
 
 
 def test_shipped_app_block_is_invisible_to_the_comparator() -> None:
-    """Dropping the real ``app:`` block changes nothing the drift check sees."""
-    with_app = fpd.load_protection_config(SHIPPED_YAML_PATH)
-    without_app = fpd.parse_protection_config(_shipped_doc_without_app())
+    """Dropping the real ``app:`` block changes nothing the drift check sees.
+
+    Compared on two documents that differ in the ``app:`` block and in nothing
+    else — see :func:`_shipped_doc_without_the_app_bound_checks` for why the
+    ``vnx-gate/*`` entry comes out of both sides rather than one.
+    """
+    base = _shipped_doc_without_the_app_bound_checks()
+    stripped = {k: v for k, v in base.items() if k != "app"}
+
+    with_app = fpd.parse_protection_config(yaml.safe_dump(base, sort_keys=False))
+    without_app = fpd.parse_protection_config(yaml.safe_dump(stripped, sort_keys=False))
+
     diffs = fpd.compare(fpd.to_normalized_dict(without_app), fpd.to_normalized_dict(with_app))
     assert diffs == [], f"the registered app_id leaked into the comparator: {diffs}"
 

--- a/tests/test_forge_gate_publisher.py
+++ b/tests/test_forge_gate_publisher.py
@@ -135,6 +135,35 @@ def _capture_publish(monkeypatch: pytest.MonkeyPatch) -> List[Dict[str, Any]]:
     return calls
 
 
+@pytest.fixture(autouse=True)
+def _summary_publication_captured(monkeypatch: pytest.MonkeyPatch) -> List[Dict[str, Any]]:
+    """Capture the recorder's SUMMARY publication instead of performing it.
+
+    Since the OP-B3 fix-forward the recorder publishes TWO check-runs per
+    result write: ``vnx-gate/<gate>`` and ``vnx-gate/review``. Most tests in
+    this file replace only the first (``publish_for_record``), so without this
+    the second would run for real — ``load_app_config`` against the shipped
+    YAML (which carries a live ``app_id``), then the keychain, then a POST to
+    api.github.com from a unit test.
+
+    Autouse and function-scoped, so it shares this test's ``monkeypatch``
+    instance: a test that wants the real summary path, or a different stub,
+    sets its own and the later call wins — the same convention
+    ``conftest.py``'s offline stubs document.
+
+    Returns the list the stub appends to, so a test can request the fixture by
+    name and assert on WHAT was published.
+    """
+    calls: List[Dict[str, Any]] = []
+
+    def fake_summary(pr_number: int, head_sha: str, **kwargs: Any) -> Dict[str, Any]:
+        calls.append({"pr_number": pr_number, "head_sha": head_sha, **kwargs})
+        return {"conclusion": "action_required", "name": fcr.REVIEW_SUMMARY_CHECK_NAME}
+
+    monkeypatch.setattr(fcr, "publish_review_summary", fake_summary)
+    return calls
+
+
 # ---------------------------------------------------------------------------
 # The mapping — statuses
 # ---------------------------------------------------------------------------
@@ -806,6 +835,241 @@ def test_a_refused_write_publishes_nothing(
 
     assert written is False
     assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# The recorder hook — the SUMMARY check, the one branch protection requires
+# ---------------------------------------------------------------------------
+
+
+def test_the_recorder_also_publishes_the_summary_check_for_the_same_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """OP-B3 made ``vnx-gate/review`` a REQUIRED check. Without this wiring the
+    only producer of it is a hand-run CLI, so every merge to ``main`` would
+    forever wait on an operator typing a command — while the check that IS
+    published automatically (``vnx-gate/<gate>``) is required by nothing.
+    """
+    results_dir = tmp_path / "vnx-dev" / "review_gates" / "results"
+    results_dir.mkdir(parents=True)
+    result_path = results_dir / "pr-1811-glm_gate.json"
+    monkeypatch.setattr(fcr, "publish_for_record", lambda *_a, **_k: {})
+
+    _payload, written = gate_recorder.write_result_guarded(
+        result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+    )
+
+    assert written is True
+    assert len(_summary_publication_captured) == 1
+    call = _summary_publication_captured[0]
+    assert call["pr_number"] == 1811
+    assert call["head_sha"] == HEAD, (
+        "de samenvatting hoort bij de kop die de recorder registreerde, nooit bij "
+        "de huidige kop van de PR — een nieuwe push krijgt terecht geen check"
+    )
+    assert call["results_dir"] == results_dir, (
+        "dezelfde opslag als het record dat zojuist geschreven is, zodat de "
+        "samenvatting de records leest die de merge-deur straks toetst"
+    )
+    assert call["branch"] == "dispatch/x"
+
+
+def test_the_terminal_writer_publishes_the_summary_too(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """The other writer (``record_terminal_result``), which free-form gates use.
+    An asymmetric pair of writers would leave whichever lane used the other one
+    unmergeable."""
+    import gate_depth
+
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    monkeypatch.setattr(fcr, "publish_for_record", lambda *_a, **_k: {})
+
+    gate_recorder.record_terminal_result(
+        gate="glm_gate",
+        pr_id="1811",
+        result_path=result_path,
+        payload=_recorder_payload(),
+        execution_depth=gate_depth.single_shot_depth(4096, False),
+    )
+
+    assert [c["head_sha"] for c in _summary_publication_captured] == [HEAD]
+
+
+def test_the_per_gate_publication_goes_first_and_the_summary_after(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """Order is the guarantee: the per-gate publication succeeds or fails on its
+    own merits BEFORE the summary is attempted, so the summary can never be the
+    thing that took it down."""
+    order: List[str] = []
+    monkeypatch.setattr(
+        fcr, "publish_for_record", lambda *_a, **_k: order.append("per-gate") or {}
+    )
+    monkeypatch.setattr(
+        fcr,
+        "publish_review_summary",
+        lambda *_a, **_k: order.append("summary") or {},
+    )
+
+    gate_recorder.write_result_guarded(
+        tmp_path / "pr-1811-glm_gate.json",
+        _recorder_payload(),
+        gate="glm_gate",
+        pr_ref="1811",
+    )
+
+    assert order == ["per-gate", "summary"]
+
+
+def test_a_throwing_summary_leaves_the_per_gate_publication_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The second publication is a SECOND, separate failure handler.
+
+    A 500 on the summary may not undo the per-gate check-run that already went
+    out, may not touch the record on disk, and may not fail the gate run — and
+    it must say so loudly, with the command that repairs it.
+    """
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    per_gate: List[Any] = []
+    monkeypatch.setattr(
+        fcr, "publish_for_record", lambda *a, **_k: per_gate.append(a) or {}
+    )
+
+    def exploding_summary(*_a: Any, **_k: Any) -> Dict[str, Any]:
+        raise fcr.ForgeAPIError("GitHub gaf 500", status=500, body="boom")
+
+    monkeypatch.setattr(fcr, "publish_review_summary", exploding_summary)
+
+    with caplog.at_level(logging.WARNING, logger="gate_recorder"):
+        payload, written = gate_recorder.write_result_guarded(
+            result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+        )
+
+    assert written is True
+    assert payload["status"] == "pass"
+    assert json.loads(result_path.read_text())["status"] == "pass"
+    assert len(per_gate) == 1, "de per-poort-publicatie is geslaagd en blijft geslaagd"
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "forge_gate_publisher.py review --pr 1811" in logged
+    assert "SAMENVATTENDE CHECK" in logged
+    assert "ForgeAPIError" in logged
+
+
+def test_a_throwing_per_gate_publication_still_lets_the_summary_go_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """The reverse direction, and the one that matters for mergeability: the
+    per-gate check is required by nothing, the summary is required by branch
+    protection. A gate-specific failure may not take the required check with
+    it."""
+    def exploding_per_gate(*_a: Any, **_k: Any) -> Dict[str, Any]:
+        raise fcr.ForgeAPIError("GitHub gaf 500", status=500, body="boom")
+
+    monkeypatch.setattr(fcr, "publish_for_record", exploding_per_gate)
+
+    gate_recorder.write_result_guarded(
+        tmp_path / "pr-1811-glm_gate.json",
+        _recorder_payload(),
+        gate="glm_gate",
+        pr_ref="1811",
+    )
+
+    assert [c["head_sha"] for c in _summary_publication_captured] == [HEAD]
+
+
+def test_two_gate_runs_on_the_same_head_publish_the_summary_twice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """Idempotence. Two review peers signing the same head is the normal case,
+    and a check-run POST for a name+sha that already carries one is an update,
+    not a conflict."""
+    monkeypatch.setattr(fcr, "publish_for_record", lambda *_a, **_k: {})
+
+    for gate in ("glm_gate", "kimi_gate"):
+        payload = _recorder_payload()
+        payload["gate"] = gate
+        gate_recorder.write_result_guarded(
+            tmp_path / f"pr-1811-{gate}.json", payload, gate=gate, pr_ref="1811"
+        )
+
+    assert [c["head_sha"] for c in _summary_publication_captured] == [HEAD, HEAD]
+
+
+def test_a_record_without_a_head_publishes_no_summary_either(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """One identity check for both publications: no head, nothing to attach."""
+    monkeypatch.setattr(fcr, "publish_for_record", lambda *_a, **_k: {})
+    payload = _recorder_payload()
+    payload["commit_sha"] = ""
+
+    gate_recorder.write_result_guarded(
+        tmp_path / "pr-1811-glm_gate.json", payload, gate="glm_gate", pr_ref="1811"
+    )
+
+    assert _summary_publication_captured == []
+
+
+def test_a_refused_write_publishes_no_summary_either(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """A refused write left another writer's record standing (OI-1469/OI-1470);
+    a summary computed over it would describe a write that never happened."""
+    result_path = tmp_path / "pr-1811-glm_gate.json"
+    result_path.write_text("{ this is not json", encoding="utf-8")
+    monkeypatch.setattr(fcr, "publish_for_record", lambda *_a, **_k: {})
+
+    _payload, written = gate_recorder.write_result_guarded(
+        result_path, _recorder_payload(), gate="glm_gate", pr_ref="1811"
+    )
+
+    assert written is False
+    assert _summary_publication_captured == []
+
+
+def test_an_unregistered_app_costs_one_info_line_and_no_second_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _summary_publication_captured: List[Dict[str, Any]],
+) -> None:
+    """No App registered is a pending operator step, not a malfunction — and
+    the summary cannot publish without one either. Attempting it anyway would
+    put a second copy of the same line in the log on every single gate write,
+    which is how a reader learns to skip the line that has to be believed on
+    the day the keychain really is locked."""
+    def no_app(*_a: Any, **_k: Any) -> Dict[str, Any]:
+        raise fcr.ForgeAppConfigError("app_id ontbreekt")
+
+    monkeypatch.setattr(fcr, "publish_for_record", no_app)
+
+    with caplog.at_level(logging.INFO, logger="gate_recorder"):
+        gate_recorder.write_result_guarded(
+            tmp_path / "pr-1811-glm_gate.json",
+            _recorder_payload(),
+            gate="glm_gate",
+            pr_ref="1811",
+        )
+
+    assert _summary_publication_captured == []
+    logged = [r.getMessage() for r in caplog.records if "nog niet geregistreerd" in r.getMessage()]
+    assert len(logged) == 1
 
 
 def test_publication_never_shells_out_from_the_recorder_on_import() -> None:

--- a/tests/test_forge_protection_drift.py
+++ b/tests/test_forge_protection_drift.py
@@ -81,12 +81,28 @@ class TestParseProtectionConfig:
         assert config.checks[0].app_id == 15368
         assert config.enforce_admins is True
 
-    def test_the_real_shipped_yaml_parses_and_has_fourteen_checks(self):
-        """The actual scripts/forge/branch_protection.yaml this dispatch ships."""
+    def test_the_real_shipped_yaml_parses_and_has_fifteen_checks(self):
+        """The actual scripts/forge/branch_protection.yaml this dispatch ships.
+
+        Fourteen until OP-B3, fifteen after it: that step moved
+        ``vnx-gate/review`` out of ``pending_checks`` and into ``checks[]``. The
+        blanket ``all(app_id == 15368)`` went with it — the fifteenth check is
+        not a GitHub Actions context but the ``vnx-gate`` App's, bound to the
+        App ID the same file declares under ``app:``. Read, not repeated here:
+        a second literal copy of that number in the test could drift from the
+        one that signs, which is the very thing the YAML comment warns about.
+        """
         path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
         config = fpd.load_protection_config(path)
-        assert len(config.checks) == 14
-        assert all(c.app_id == 15368 for c in config.checks)
+        app_id = yaml.safe_load(path.read_text(encoding="utf-8"))["app"]["app_id"]
+
+        by_context = {c.context: c.app_id for c in config.checks}
+        assert len(config.checks) == 15
+        assert by_context["vnx-gate/review"] == app_id
+        assert all(
+            c.app_id == 15368 for c in config.checks if not c.context.startswith("vnx-gate/")
+        )
+        assert config.pending_checks == ()
         assert config.branch == "main"
         assert config.enforce_admins is True
         assert config.allow_auto_merge is False

--- a/tests/test_forge_protection_drift.py
+++ b/tests/test_forge_protection_drift.py
@@ -180,8 +180,16 @@ class TestParseProtectionConfig:
             with pytest.raises(fpd.ProtectionConfigError, match="vnx-gate/review"):
                 fpd.parse_protection_config(yaml.safe_dump(doc))
 
-        def test_vnx_gate_check_with_a_bound_app_id_is_accepted(self):
-            doc = _base_config_dict()
+        def test_vnx_gate_check_bound_to_the_signing_app_is_accepted(self):
+            """The positive control: the number that signs, accepted.
+
+            This used to accept ``99999`` against a document with no ``app:``
+            block at all -- an arbitrary integer bound to nothing. That made
+            the assertion measure "any integer passes", which is precisely the
+            hole the class below closes; the entry is now bound to the App the
+            same document declares.
+            """
+            doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": 99999})
             doc["required_status_checks"]["checks"].append({"context": "vnx-gate/review", "app_id": 99999})
             config = fpd.parse_protection_config(yaml.safe_dump(doc))
             names = {c.context: c.app_id for c in config.checks}
@@ -195,6 +203,79 @@ class TestParseProtectionConfig:
             config = fpd.parse_protection_config(yaml.safe_dump(doc))
             names = {c.context: c.app_id for c in config.checks}
             assert names["Some Other Check"] is None
+
+    class TestVnxGateAppIdMatchesTheSigningApp:
+        """(OP-B3 fix-forward) a ``vnx-gate/*`` entry must carry the app_id of
+        the App that actually signs -- ``app.app_id`` in the same document.
+
+        Two copies of one number now ship in ``branch_protection.yaml``
+        (``required_status_checks.checks[]`` needs its own binding because that
+        list IS the PUT body; ``app:`` is what ``forge_check_run.py`` signs
+        with). Before this guard only a YAML comment asked an editor to keep
+        them equal. A transposed digit passed the schema reader, passed the
+        merge door -- ``is_weakening`` reads only presence/absence in the
+        checks branch, so a CHANGED app_id is not a weakening -- and applied
+        cleanly, leaving ``main`` requiring a check that no App on earth can
+        satisfy. That is a permanently closed merge door installed by a typo.
+        """
+
+        def test_a_transposed_digit_is_refused(self):
+            doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": 4869217})
+            doc["required_status_checks"]["checks"].append(
+                {"context": "vnx-gate/review", "app_id": 4869271}
+            )
+            with pytest.raises(fpd.ProtectionConfigError) as excinfo:
+                fpd.parse_protection_config(yaml.safe_dump(doc))
+            message = str(excinfo.value)
+            assert "4869271" in message and "4869217" in message, (
+                "de melding hoort beide getallen te noemen, anders moet de lezer "
+                "zelf gaan zoeken welke van de twee fout is"
+            )
+            assert "vnx-gate/review" in message
+
+        def test_a_vnx_gate_check_without_any_app_block_is_refused(self):
+            """No ``app:`` block means no identity to bind to. Accepting the
+            entry would put a required check in the PUT body whose app_id is
+            answerable to nothing in this file."""
+            doc = _base_config_dict()
+            assert "app" not in doc
+            doc["required_status_checks"]["checks"].append(
+                {"context": "vnx-gate/review", "app_id": 4869217}
+            )
+            with pytest.raises(fpd.ProtectionConfigError, match="app"):
+                fpd.parse_protection_config(yaml.safe_dump(doc))
+
+        def test_a_vnx_gate_check_with_a_null_app_block_id_is_refused(self):
+            """``app.app_id: null`` is the pre-registration state (runbook
+            §1/§3). Nothing signs yet, so nothing may be required yet."""
+            doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": None})
+            doc["required_status_checks"]["checks"].append(
+                {"context": "vnx-gate/review", "app_id": 4869217}
+            )
+            with pytest.raises(fpd.ProtectionConfigError, match="app"):
+                fpd.parse_protection_config(yaml.safe_dump(doc))
+
+        def test_a_non_vnx_gate_check_may_carry_any_app_id(self):
+            """The guard binds the ``vnx-gate/*`` namespace only. A GitHub
+            Actions context is satisfied by GitHub's own app (15368) and has no
+            business matching the review App -- refusing that would make the
+            shipped YAML, with its fourteen Actions checks, unparseable."""
+            doc = _base_config_dict(app={"slug": "vnx-gate", "app_id": 4869217})
+            doc["required_status_checks"]["checks"].append(
+                {"context": "Some Actions Check", "app_id": 15368}
+            )
+            config = fpd.parse_protection_config(yaml.safe_dump(doc))
+            names = {c.context: c.app_id for c in config.checks}
+            assert names["Some Actions Check"] == 15368
+
+        def test_the_shipped_yaml_satisfies_the_guard(self):
+            """The file this PR ships, through the guard it adds."""
+            path = VNX_ROOT / "scripts" / "forge" / "branch_protection.yaml"
+            config = fpd.load_protection_config(path)
+            app_id = yaml.safe_load(path.read_text(encoding="utf-8"))["app"]["app_id"]
+
+            bound = {c.app_id for c in config.checks if c.context.startswith("vnx-gate/")}
+            assert bound == {app_id}
 
 
 class TestAppBlock:

--- a/tests/test_forge_review_summary.py
+++ b/tests/test_forge_review_summary.py
@@ -541,12 +541,58 @@ class TestPendingPreview:
         assert {"context": REVIEW_CHECK, "app_id": REAL_APP_ID} in checks
 
     def test_every_currently_required_check_survives_the_promotion(self):
+        """The shipped file, where ``pending_checks`` is empty since OP-B3.
+
+        Kept as the no-op control, and it is honest about being one: with
+        nothing parked, the promotion loop runs zero iterations and this
+        asserts ``X <= X``, which cannot fail. It pins that an EMPTY
+        ``pending_checks`` neither drops nor invents a requirement — nothing
+        more. The test that actually exercises the loop is
+        :meth:`test_a_parked_entry_is_promoted_bound_to_the_signing_app`.
+        """
         config = drift.load_protection_config(YAML_PATH)
 
         payload = fgp.pending_promotion_put_payload(YAML_PATH)
 
         promoted = {c["context"] for c in payload["required_status_checks"]["checks"]}
+        assert config.pending_checks == (), (
+            "dit is de nul-iteratie-controle; met een geparkeerde entry meet hij "
+            "iets anders dan hij zegt"
+        )
         assert {c.context for c in config.checks} <= promoted
+
+    def test_a_parked_entry_is_promoted_bound_to_the_signing_app(self, tmp_path):
+        """The promotion loop itself, on a synthetic parked entry.
+
+        Without this the loop is dead code behind a green suite: OP-B3 emptied
+        ``pending_checks``, so every other test here drives
+        :func:`pending_promotion_put_payload` through zero iterations. The two
+        refusal branches stayed covered; the branch that actually promotes did
+        not. Same technique as
+        :meth:`TestBranchProtectionYaml.test_apply_and_drift_never_see_a_pending_entry`
+        — a synthetic entry on a copy of the real document, so the shipped file
+        is never re-parked to test the mechanism that unparks it.
+        """
+        doc = _real_yaml_doc()
+        doc["pending_checks"] = [SYNTHETIC_PENDING_CHECK]
+        path = tmp_path / "branch_protection.yaml"
+        path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+        before = drift.load_protection_config(path)
+        assert SYNTHETIC_PENDING_CHECK not in {c.context for c in before.checks}
+
+        payload = fgp.pending_promotion_put_payload(path)
+
+        promoted = payload["required_status_checks"]["checks"]
+        by_context = {c["context"]: c["app_id"] for c in promoted}
+        assert {c.context for c in before.checks} <= set(by_context), (
+            "een promotie mag geen bestaande eis laten vallen"
+        )
+        assert by_context[SYNTHETIC_PENDING_CHECK] == REAL_APP_ID, (
+            "de geparkeerde entry komt gebonden aan de tekenende App uit de lus, "
+            "niet als kale context"
+        )
+        assert len(promoted) == len(before.checks) + 1
+        assert "pending_checks" not in payload
 
     def test_the_rehearsal_never_talks_to_github(self, monkeypatch, capsys):
         """No PUT, no POST, no ``gh`` — a rehearsal that writes is not one."""

--- a/tests/test_forge_review_summary.py
+++ b/tests/test_forge_review_summary.py
@@ -408,7 +408,7 @@ class TestReviewPublication:
 
 
 # ---------------------------------------------------------------------------
-# The YAML: pending, not required
+# The YAML: required, and bound to the App that signs
 # ---------------------------------------------------------------------------
 
 
@@ -416,45 +416,113 @@ def _real_yaml_doc() -> Dict[str, Any]:
     return yaml.safe_load(YAML_PATH.read_text(encoding="utf-8"))
 
 
+#: A context that exists NOWHERE — not in ``checks[]``, not in
+#: ``pending_checks``, not on the branch. The parking-slot invariant needs a
+#: pending entry to observe, and after OP-B3 the YAML no longer ships one; a
+#: synthetic name keeps the invariant testable without re-parking the real
+#: check to test it.
+SYNTHETIC_PENDING_CHECK = "vnx-gate/nooit-vereist-alleen-voor-deze-test"
+
+
 class TestBranchProtectionYaml:
-    def test_review_check_is_parked_in_pending_checks(self):
+    """OP-B3 flipped this class. Before it, ``vnx-gate/review`` sat in
+    ``pending_checks`` and the assertions here pinned that it reached neither
+    the apply nor the drift check. That was true of the YAML on ``main`` and is
+    the exact state OP-B3 ends: the entry now lives in
+    ``required_status_checks.checks`` bound to ``app.app_id``, so every
+    assertion about WHERE it sits is inverted on purpose.
+
+    What did NOT change is the parking-slot invariant itself — an entry in
+    ``pending_checks`` still reaches neither apply nor drift. It lost its last
+    real user, not its meaning, so it is pinned below on a synthetic entry
+    (:data:`SYNTHETIC_PENDING_CHECK`) instead of being deleted along with the
+    promotion.
+    """
+
+    def test_review_check_is_no_longer_parked(self):
         config = drift.load_protection_config(YAML_PATH)
 
-        assert REVIEW_CHECK in config.pending_checks
+        assert REVIEW_CHECK not in config.pending_checks
+        assert config.pending_checks == ()
 
-    def test_review_check_is_not_required_yet(self):
+    def test_review_check_is_required_and_bound_to_the_app(self):
+        """Required AND bound. The binding is half the requirement: an unbound
+        ``vnx-gate/*`` context could be satisfied by any app that knows the
+        name, which is why the schema reader refuses one (see
+        :meth:`test_promoting_it_unbound_is_refused`)."""
         config = drift.load_protection_config(YAML_PATH)
 
-        assert REVIEW_CHECK not in {c.context for c in config.checks}
+        assert (REVIEW_CHECK, REAL_APP_ID) in {(c.context, c.app_id) for c in config.checks}
 
-    def test_apply_and_drift_never_see_the_pending_entry(self):
+    def test_apply_and_drift_now_see_it(self):
+        """The inversion that has teeth: it is in the PUT body the apply sends
+        and in the object the drift check compares against live state."""
         config = drift.load_protection_config(YAML_PATH)
 
         normalized = drift.to_normalized_dict(config)
         put_body = apply_bp.build_put_payload(config)
 
-        assert "pending_checks" not in normalized
-        assert REVIEW_CHECK not in json.dumps(normalized)
-        assert REVIEW_CHECK not in json.dumps(put_body)
-
-    def test_promoting_it_with_the_real_app_id_is_accepted(self):
-        doc = _real_yaml_doc()
-        doc["pending_checks"] = []
-        doc["required_status_checks"]["checks"].append(
-            {"context": REVIEW_CHECK, "app_id": REAL_APP_ID}
+        assert {"context": REVIEW_CHECK, "app_id": REAL_APP_ID} in (
+            normalized["required_status_checks"]["checks"]
         )
+        assert {"context": REVIEW_CHECK, "app_id": REAL_APP_ID} in (
+            put_body["required_status_checks"]["checks"]
+        )
+
+    def test_apply_and_drift_never_see_a_pending_entry(self):
+        """The B1 parking-slot invariant, on a synthetic entry.
+
+        ``pending_checks`` remains a slot that requires nothing of ``main``:
+        ``apply_branch_protection.py`` leaves it out of the PUT and
+        ``forge_protection_drift.py`` never compares it. OP-B3 emptied the list
+        but did not remove the mechanism, and the next check to be parked there
+        must inherit the same guarantee.
+        """
+        doc = _real_yaml_doc()
+        doc["pending_checks"] = [SYNTHETIC_PENDING_CHECK]
 
         config = drift.parse_protection_config(yaml.safe_dump(doc))
 
-        assert (REVIEW_CHECK, REAL_APP_ID) in {(c.context, c.app_id) for c in config.checks}
+        normalized = drift.to_normalized_dict(config)
+        put_body = apply_bp.build_put_payload(config)
+
+        assert SYNTHETIC_PENDING_CHECK in config.pending_checks
+        assert "pending_checks" not in normalized
+        assert SYNTHETIC_PENDING_CHECK not in json.dumps(normalized)
+        assert SYNTHETIC_PENDING_CHECK not in json.dumps(put_body)
+
+    def test_the_real_yaml_with_the_bound_entry_is_accepted(self):
+        """What the old ``test_promoting_it_with_the_real_app_id_is_accepted``
+        meant, now that the promotion is on disk.
+
+        It used to build the promoted document by appending the entry to a copy.
+        Appending it now produces a DUPLICATE context, which the schema reader
+        refuses for its own reason — the test would still be red-free but it
+        would be measuring the duplicate guard instead of acceptance. So it
+        reads the shipped file as-is: the real YAML, through the real parser,
+        with the entry it really carries.
+        """
+        config = drift.parse_protection_config(YAML_PATH.read_text(encoding="utf-8"))
+
+        contexts = [c.context for c in config.checks]
+        assert contexts.count(REVIEW_CHECK) == 1
+        assert dict((c.context, c.app_id) for c in config.checks)[REVIEW_CHECK] == REAL_APP_ID
 
     @pytest.mark.parametrize("app_id", [None, drift.ANY_APP_ID])
     def test_promoting_it_unbound_is_refused(self, app_id):
+        """Unbinding the entry that now ships must still be refused.
+
+        Same guarantee as before, reached from the other side: the entry no
+        longer has to be added, it has to be BROKEN. Rewriting the app_id of the
+        real entry to ``null`` / the "any app" sentinel is exactly the edit a
+        future hand could make to the shipped file.
+        """
         doc = _real_yaml_doc()
-        doc["pending_checks"] = []
-        doc["required_status_checks"]["checks"].append(
-            {"context": REVIEW_CHECK, "app_id": app_id}
-        )
+        entries = [
+            c for c in doc["required_status_checks"]["checks"] if c["context"] == REVIEW_CHECK
+        ]
+        assert len(entries) == 1, "de promotie hoort precies een entry op te leveren"
+        entries[0]["app_id"] = app_id
 
         with pytest.raises(drift.ProtectionConfigError):
             drift.parse_protection_config(yaml.safe_dump(doc))
@@ -534,13 +602,24 @@ class TestPendingPreview:
         assert "Traceback" not in captured.err
 
     def test_a_pending_entry_already_required_is_refused(self, tmp_path):
+        """A context that is parked AND required refuses in the rehearsal.
+
+        Before OP-B3 this test appended the entry to ``checks[]`` itself. After
+        it, ``checks[]`` already carries ``vnx-gate/review``, so appending would
+        make the document hold the context TWICE — and the schema reader refuses
+        that for its own, earlier reason ("bevat 'vnx-gate/review' dubbel",
+        measured). The test would stay green while
+        :func:`pending_promotion_put_payload`'s own ``context in required``
+        refusal went unexercised. Re-parking the already-required entry is what
+        reaches that branch now.
+        """
         doc = _real_yaml_doc()
         doc["pending_checks"] = [REVIEW_CHECK]
-        doc["required_status_checks"]["checks"].append(
-            {"context": REVIEW_CHECK, "app_id": REAL_APP_ID}
-        )
+        assert REVIEW_CHECK in {
+            c["context"] for c in doc["required_status_checks"]["checks"]
+        }, "checks[] hoort de entry na OP-B3 al te dragen; anders test dit iets anders"
         path = tmp_path / "branch_protection.yaml"
         path.write_text(yaml.safe_dump(doc), encoding="utf-8")
 
-        with pytest.raises(fgp.ForgePublishRefused):
+        with pytest.raises(fgp.ForgePublishRefused, match="zowel in pending_checks als in"):
             fgp.pending_promotion_put_payload(path)

--- a/tests/test_pr_merge_branch_protection.py
+++ b/tests/test_pr_merge_branch_protection.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pytest
+import yaml
 
 VNX_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = VNX_ROOT / "scripts"
@@ -402,12 +403,24 @@ class TestRunBranchProtectionGate:
             assert "niet-lege reden" in result["message"]
 
         def test_removing_a_vnx_gate_check_is_refused_without_allow_weaken(self, monkeypatch):
-            main_text = _real_yaml_text().replace(
-                "    - {context: \"vnx doctor smoke\", app_id: 15368}\n",
-                "    - {context: \"vnx doctor smoke\", app_id: 15368}\n"
-                "    - {context: \"vnx-gate/review\", app_id: 424242}\n",
-            )
-            pr_text = _real_yaml_text()  # PR-side lacks the vnx-gate/* entry main now has
+            """The FORGE_GATE.md §7 terugweg, as the merge door sees it.
+
+            This used to synthesize main's side by inserting a ``vnx-gate/*``
+            entry the shipped YAML did not have. Since OP-B3 it has one, and
+            inserting a second would only produce the duplicate context the
+            schema reader refuses — the test would go red on the wrong error.
+            So main is now the real file and the PR side is the file with the
+            entry taken OUT, which is exactly what the rollback PR in §7 looks
+            like: a weakening, blocked without ``--allow-weaken``.
+            """
+            main_text = _real_yaml_text()
+            pr_doc = yaml.safe_load(main_text)
+            pr_doc["required_status_checks"]["checks"] = [
+                c for c in pr_doc["required_status_checks"]["checks"]
+                if not c["context"].startswith("vnx-gate/")
+            ]
+            pr_text = yaml.safe_dump(pr_doc)
+            assert "vnx-gate/review" in main_text and "vnx-gate/review" not in pr_text
 
             def fake_fetch(project_root, ref, *a, **k):
                 if ref == "main":

--- a/tests/test_pr_merge_branch_protection.py
+++ b/tests/test_pr_merge_branch_protection.py
@@ -435,6 +435,12 @@ class TestRunBranchProtectionGate:
 
             assert result["verdict"] == "NO-GO"
             assert "vnx-gate/review" in result["message"]
+            # The context name alone does not identify which check said no:
+            # step (c) (live vs main's YAML) reports the same field in its own
+            # NO-GO. ``allow-weaken`` appears only in the PR-side weakening
+            # message, so it is what pins this on step (d) — the same pair the
+            # enforce_admins sister test above asserts on.
+            assert "allow-weaken" in result["message"]
 
     def test_door_hash_check_no_go_propagates(self, monkeypatch):
         self._stub_main_matches_live(monkeypatch)


### PR DESCRIPTION
**Dispatch-ID**: 20260908-opb3-promotie-review-verplicht
**Track**: gate-enforcement-to-forge · **Plan**: `claudedocs/plans/2026-09-06-golf-B-forge-dwingt-af.md`, OP-B3

Configuratie-PR met de testklasse eraan vast. Geen nieuwe runtime-code. `apply_branch_protection.py` is niet gedraaid, in geen enkele vorm, en er is geen check-run gepubliceerd.

## Wat er verandert

`vnx-gate/review` gaat uit `pending_checks:` (die lijst wordt `[]`) en komt als vijftiende entry in `required_status_checks.checks`, gebonden aan `app_id: 4869217`. Apply en drift zien hem daarmee wel.

Het app_id staat hier **wel** per entry en in `pending_checks` bewust niet. `checks[]` IS het PUT-object en GitHub eist de binding per entry; zonder app_id in de entry zou elke app deze status mogen zetten, en precies daarom weigert de schemalezer zo'n entry. Een pending-entry gaat nooit de deur uit en wordt op leestijd aan `app.app_id` gebonden, dus daar was een tweede kopie overbodig.

## De omgedraaide asserts

`TestBranchProtectionYaml` pinde precies het tegenovergestelde vast. Wat er veranderde op main is de plek van de entry, dus elke assert over WAAR hij staat is omgedraaid:

| Was | Is |
|---|---|
| `test_review_check_is_parked_in_pending_checks` | `test_review_check_is_no_longer_parked` — plus `pending_checks == ()` |
| `test_review_check_is_not_required_yet` | `test_review_check_is_required_and_bound_to_the_app` |
| `test_apply_and_drift_never_see_the_pending_entry` (echte entry) | `test_apply_and_drift_now_see_it` + `test_apply_and_drift_never_see_a_pending_entry` op een **synthetische** entry |
| `test_promoting_it_with_the_real_app_id_is_accepted` (bouwde de promotie na) | `test_the_real_yaml_with_the_bound_entry_is_accepted` (leest de echte YAML) |
| `test_promoting_it_unbound_is_refused` (entry toevoegen) | idem, maar de bestaande entry wordt **gebroken** (`null` / `-1`) |

De parkeerplaats-invariant is niet vervallen, hij verloor zijn laatste echte gebruiker. Daarom staat hij nog, op `vnx-gate/nooit-vereist-alleen-voor-deze-test`.

## Buurtests die de echte YAML lezen

Drie gingen rood op de promotie, alle drie op de telling of op een synthetische invoeging:

- `test_the_real_shipped_yaml_parses_and_has_fourteen_checks` → `..._fifteen_checks`. De blanket `all(app_id == 15368)` kon niet blijven: de vijftiende is geen Actions-context. Het App ID wordt uit het `app:`-blok van hetzelfde bestand gelezen, niet als literal herhaald.
- `test_dry_run_never_calls_gh_writes_and_prints_the_full_payload`: 14 → 15, geteld tegen de geladen config.
- `test_removing_a_vnx_gate_check_is_refused_without_allow_weaken`: bouwde main's zijde door een `vnx-gate/*`-entry IN te voegen, wat nu een dubbele context geeft. Main is nu het echte bestand en de PR-zijde is dat bestand met de entry ERUIT — precies de terugweg van §7.

## Runbook

- §0: statusregels naar wat er op main staat (B2a/B2b/B3 gemerged, OP-B3 half: YAML wel, apply niet).
- §5 stap 1 is de werkelijke promotie, en de migratiestap draagt het echte commando in plaats van een ontwerp-placeholder.
- Twee gemeten feiten toegevoegd: de merge-deur staat tussen deze merge en de apply dicht op drift zonder override (met de exacte melding), en na de apply leest een head zonder gepubliceerd oordeel als `SKIPPED_UNVERIFIED` met een melding die naar een kapotte workflow-graaf wijst in plaats van naar de publisher.
- **§4 draagt nu een waarschuwing**: een kale `apply_branch_protection.py` is sinds deze merge geen no-op meer maar de OP-B3-mutatie zelf. Zonder die regel zou het runbook een operator naar de zwaarste mutatie van de golf leiden zonder de leeszetel uit §5.

## Verificatie

- Rood eerst: `TestBranchProtectionYaml` 6 failed / 1 passed tegen de ongewijzigde YAML.
- Groen na: `230 passed` over `test_forge_protection_drift.py test_apply_branch_protection.py test_pr_merge_branch_protection.py test_vnx_doctor_branch_protection.py test_forge_check_run_client.py test_forge_review_summary.py`.
- Bredere sweep op alles wat branch-protection noemt: `139 passed`.
- `pending-preview`: nog steeds 15 checks, `vnx-gate/review` op 4869217 (de promotie zit nu al in `checks[]`, `pending_checks` is leeg).
- `parse_protection_config` over de nieuwe YAML: 15 contexten, 14× 15368 en 1× 4869217, `pending_checks: ()`.

## Open

De apply moet nog gebeuren en tot dat moment staat de merge-deur dicht. Zie §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)