### PR TITLE
fix(hooks): de t0_state-hook hing aan een VNX_HOME die een SessionStart-hook nooit erft (OI-1552)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,11 +61,11 @@
         ]
       },
       {
-        "matcher": "terminals/T0",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'if [ -n \"${VNX_HOME:-}\" ] && [ -f \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\" ]; then exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"; else printf \"[vnx] build_t0_state_hook artifact MISSING (VNX_HOME unset or hook absent); t0_state.json will not refresh\\n\" >&2; exit 0; fi'"
+            "command": "bash -c 'VNX_HOME=\"${VNX_HOME:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}\"; if [ -f \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\" ]; then exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"; else printf \"[vnx] build_t0_state_hook artifact MISSING (no scripts/hooks/build_t0_state_hook.sh under %s); t0_state.json will not refresh\\n\" \"${VNX_HOME}\" >&2; exit 0; fi'"
           }
         ]
       },

--- a/tests/test_build_t0_state_freshness.py
+++ b/tests/test_build_t0_state_freshness.py
@@ -384,24 +384,30 @@ def test_autoclose_degraded_when_counts_malformed(tmp_path):
 # ---------------------------------------------------------------------------
 
 def _t0_sessionstart_command() -> str:
+    """Locate the state-builder registration by SUBSTRING on its command.
+
+    OI-1552: this used to look the group up by ``matcher == "terminals/T0"``.
+    That matcher was itself the bug — a SessionStart matcher matches the session
+    SOURCE (startup/resume/clear/compact) or is empty, never a path, so the group
+    never fired. Keying the lookup on the matcher meant these assertions moved
+    with the defect instead of catching it. Substring on the command is how
+    ``scripts/lib/t0_state_health.py`` detects the same hook.
+    """
     settings = json.loads((_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
     for entry in settings["hooks"]["SessionStart"]:
-        if entry.get("matcher") == "terminals/T0":
-            return entry["hooks"][0]["command"]
-    raise AssertionError("T0 SessionStart hook not found")
+        for hook in entry.get("hooks", []):
+            if "build_t0_state_hook" in hook.get("command", ""):
+                return hook["command"]
+    raise AssertionError("no SessionStart hook registers build_t0_state_hook")
 
 
 def _t0_sessionstart_wrapper() -> str:
-    settings = json.loads((_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
-    for entry in settings["hooks"]["SessionStart"]:
-        if entry.get("matcher") == "terminals/T0":
-            command = entry["hooks"][0]["command"]
-            body = shlex.split(command)[2]
-            match = re.search(r"scripts/hooks/([\w._-]+\.sh)", body)
-            if not match:
-                raise AssertionError(f"T0 SessionStart hook does not delegate to a wrapper: {command}")
-            return (_ROOT / "scripts" / "hooks" / match.group(1)).read_text(encoding="utf-8")
-    raise AssertionError("T0 SessionStart hook not found")
+    command = _t0_sessionstart_command()
+    body = shlex.split(command)[2]
+    match = re.search(r"scripts/hooks/([\w._-]+\.sh)", body)
+    if not match:
+        raise AssertionError(f"T0 SessionStart hook does not delegate to a wrapper: {command}")
+    return (_ROOT / "scripts" / "hooks" / match.group(1)).read_text(encoding="utf-8")
 
 
 def test_sessionstart_hook_is_valid_bash_and_visible_failure():

--- a/tests/test_sessionstart_hook_t0state_fires.py
+++ b/tests/test_sessionstart_hook_t0state_fires.py
@@ -1,0 +1,210 @@
+"""tests/test_sessionstart_hook_t0state_fires.py — OI-1552 / D1: the SessionStart
+hook that rebuilds ``t0_state.json`` must actually FIRE and actually REACH its
+artefact. It did neither, for two independent reasons, and both failed SILENTLY
+(exit 0, no signal) — the exact class this file exists to keep closed.
+
+MEASURED 2026-09-08 on claude 2.1.263, main ``015f3cf2``. This module docstring
+is the record of that measurement: ``.claude/settings.json`` is strict JSON and
+cannot carry a comment, so the finding is kept here, next to the tests that
+enforce it.
+
+Cause 1 — the gate could never open.
+    The registration read::
+
+        bash -c 'if [ -n "${VNX_HOME:-}" ] && [ -f "${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh" ]; then ...'
+
+    ``VNX_HOME`` is a RUNTIME variable. A SessionStart hook does not inherit it:
+    measured with a probe hook that dumped its own environment, ``VNX_HOME`` came
+    back ``UNSET``. So ``[ -n "${VNX_HOME:-}" ]`` was false in EVERY session, the
+    ``else`` branch printed "MISSING" and exited 0, and the projection never
+    refreshed. The six sibling SessionStart hooks in the same file already anchor
+    on ``$(git rev-parse --show-toplevel 2>/dev/null || echo .)`` and do run.
+
+    The anchor is safe here because a SessionStart hook runs with cwd set to the
+    session's project directory (measured: the harness passes ``cwd`` on stdin and
+    the hook's ``$PWD`` matched it), so ``git rev-parse`` resolves inside the repo.
+    ``VNX_HOME`` is kept as the PRIMARY anchor when it is set (OI-1089 finding 2),
+    and the ``[ -f ]`` guard stays as the fail-loud net for a consumer/pip tree
+    that has no ``scripts/`` next to its project root.
+
+Cause 2 — the hook group was never dispatched at all.
+    The group carried ``"matcher": "terminals/T0"``. A SessionStart matcher does
+    not match a path; it matches the session SOURCE (``startup``, ``resume``,
+    ``clear``, ``compact``), or is empty for "always". Measured with three probe
+    groups in one settings file, each touching a distinct marker file:
+
+        matcher ""             -> marker written   (fires)
+        matcher "startup"      -> marker written   (fires)
+        matcher "terminals/T0" -> NO marker        (never fires)
+
+    So the group was dead independently of ``VNX_HOME``: fixing only the gate
+    would have left the projection just as frozen. Both causes are covered below.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SETTINGS = _ROOT / ".claude" / "settings.json"
+
+# A SessionStart matcher the harness can actually dispatch: empty/"*" mean
+# "always", otherwise it is built from the documented session-source tokens.
+# Anything else (notably a path like "terminals/T0") silently never fires.
+_VALID_SOURCES = {"startup", "resume", "clear", "compact"}
+
+
+def _load_settings() -> dict:
+    return json.loads(_SETTINGS.read_text(encoding="utf-8"))
+
+
+def _t0_state_hook_entry() -> dict:
+    """The SessionStart group that registers the state builder.
+
+    Located by SUBSTRING on the command — the same way
+    ``scripts/lib/t0_state_health.py`` detects it — so this helper keeps
+    working when the group's matcher changes.
+    """
+    for entry in _load_settings()["hooks"]["SessionStart"]:
+        for hook in entry.get("hooks", []):
+            if "build_t0_state_hook" in hook.get("command", ""):
+                return entry
+    raise AssertionError("no SessionStart hook registers build_t0_state_hook")
+
+
+def _t0_state_hook_command() -> str:
+    entry = _t0_state_hook_entry()
+    for hook in entry.get("hooks", []):
+        if "build_t0_state_hook" in hook.get("command", ""):
+            return hook["command"]
+    raise AssertionError("unreachable: entry matched but command not found")
+
+
+def _stage_engine(tmp_path: Path, *, with_hook: bool) -> tuple[Path, Path]:
+    """A throwaway git repo standing in for the session's project root.
+
+    The hook artefact is a STUB that records that it ran. The point of these
+    tests is the INVOCATION contract (does the registered command reach the
+    artefact), so they must not run the real 9.6s builder or touch the live
+    central store.
+    """
+    repo = tmp_path / "engine"
+    (repo / "scripts" / "hooks").mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "-q"], cwd=repo, check=True, capture_output=True
+    )
+    marker = tmp_path / "hook_ran.marker"
+    if with_hook:
+        artefact = repo / "scripts" / "hooks" / "build_t0_state_hook.sh"
+        artefact.write_text(
+            '#!/usr/bin/env bash\nprintf ran > "$VNX_TEST_MARKER"\nexit 0\n',
+            encoding="utf-8",
+        )
+        artefact.chmod(0o755)
+    return repo, marker
+
+
+def _run_registered_command(repo: Path, marker: Path, **env_overrides) -> subprocess.CompletedProcess:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", str(repo)),
+        "VNX_TEST_MARKER": str(marker),
+    }
+    for key, value in env_overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+    return subprocess.run(
+        shlex.split(_t0_state_hook_command()),
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cause 2: the group must carry a matcher the harness actually dispatches.
+# ---------------------------------------------------------------------------
+
+def test_t0_state_hook_matcher_can_actually_fire():
+    matcher = _t0_state_hook_entry().get("matcher", "")
+    if matcher in ("", "*"):
+        return
+    tokens = {t.strip() for t in matcher.split("|") if t.strip()}
+    unknown = tokens - _VALID_SOURCES
+    assert not unknown, (
+        f"SessionStart matcher {matcher!r} contains {sorted(unknown)}, which the "
+        "harness never matches — a SessionStart matcher matches the session "
+        f"SOURCE ({sorted(_VALID_SOURCES)}) or is empty for 'always'. Measured "
+        "2026-09-08: a group matched on 'terminals/T0' never fired at all, so "
+        "t0_state.json froze no matter what the hook command did."
+    )
+
+
+def test_t0_state_hook_matcher_is_not_a_path():
+    """The specific regression: a path-shaped matcher reads plausible and is dead."""
+    matcher = _t0_state_hook_entry().get("matcher", "")
+    assert "/" not in matcher, (
+        f"SessionStart matcher {matcher!r} looks like a path. Matchers are not "
+        "paths; this group would never be dispatched (OI-1552)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cause 1: with VNX_HOME absent — the real SessionStart condition — the
+# registered command must still REACH the artefact.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("vnx_home", [None, ""], ids=["unset", "empty"])
+def test_registered_command_reaches_artefact_without_vnx_home(tmp_path, vnx_home):
+    repo, marker = _stage_engine(tmp_path, with_hook=True)
+    result = _run_registered_command(repo, marker, VNX_HOME=vnx_home)
+    assert result.returncode == 0, result.stderr
+    assert marker.exists(), (
+        "the registered SessionStart command did not reach "
+        "build_t0_state_hook.sh with VNX_HOME "
+        f"{'unset' if vnx_home is None else 'empty'} — which is how EVERY "
+        "SessionStart hook runs, since VNX_HOME is a runtime variable a hook "
+        f"does not inherit. stderr: {result.stderr!r}"
+    )
+
+
+def test_vnx_home_still_wins_when_it_is_set(tmp_path):
+    """OI-1089 finding 2 stays intact: an explicit VNX_HOME is the primary anchor."""
+    repo, marker = _stage_engine(tmp_path, with_hook=True)
+    other = tmp_path / "elsewhere"
+    (other / "scripts" / "hooks").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=other, check=True, capture_output=True)
+    explicit_marker = tmp_path / "explicit.marker"
+    artefact = other / "scripts" / "hooks" / "build_t0_state_hook.sh"
+    artefact.write_text(
+        f'#!/usr/bin/env bash\nprintf ran > "{explicit_marker}"\nexit 0\n',
+        encoding="utf-8",
+    )
+    artefact.chmod(0o755)
+
+    result = _run_registered_command(repo, marker, VNX_HOME=str(other))
+    assert result.returncode == 0, result.stderr
+    assert explicit_marker.exists(), "an explicit VNX_HOME must take precedence"
+    assert not marker.exists(), "VNX_HOME must win over the git anchor"
+
+
+def test_missing_artefact_still_fails_loud_and_non_blocking(tmp_path):
+    """Negative path: a tree without the artefact must SAY so, and not block."""
+    repo, marker = _stage_engine(tmp_path, with_hook=False)
+    result = _run_registered_command(repo, marker, VNX_HOME=None)
+    assert result.returncode == 0, "a missing artefact must never block a session"
+    assert not marker.exists()
+    assert "MISSING" in result.stderr, (
+        "a tree with no build_t0_state_hook.sh must announce it on stderr "
+        f"(OI-1073 defect 2), got: {result.stderr!r}"
+    )

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -6044,10 +6044,25 @@ class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
         self.assertIn("${VNX_HOME:-", command, "VNX_HOME must be the primary anchor")
         self.assertIn("scripts/hooks/build_t0_state_hook.sh", command)
         self.assertIn("MISSING", command, "fail-loud guard must be present")
-        self.assertNotIn(
-            "git rev-parse --show-toplevel",
+        # OI-1552 amends this assertion. It used to forbid `git rev-parse
+        # --show-toplevel` outright, to stop the builder resolving against a
+        # CONSUMER git top-level that has no scripts/ next to it. That banned
+        # the mechanism instead of the outcome, and the only remaining anchor
+        # was VNX_HOME — a RUNTIME variable a SessionStart hook does not
+        # inherit (measured 2026-09-08: it comes back UNSET). The gate was
+        # therefore false in every session and t0_state.json froze.
+        #
+        # What OI-1089 actually wanted is preserved and still asserted above:
+        # VNX_HOME is the PRIMARY anchor when set, and a tree without the
+        # artifact fails LOUD. The git top-level is only the FALLBACK, and it
+        # is safe precisely because the `[ -f ... ]` guard below still stands
+        # between it and execution: in a consumer tree the file is absent, so
+        # the command prints MISSING instead of silently doing nothing.
+        self.assertIn(
+            '[ -f "${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh" ]',
             command,
-            "must not resolve against a consumer git top-level",
+            "the artifact guard must gate execution, so a consumer git "
+            "top-level fallback can only ever fail loud, never silently no-op",
         )
 
     def test_write_hook_settings_merges_existing_and_is_idempotent(self):


### PR DESCRIPTION
## Wat er mis was

`t0_state.json` ververste niet. Twee ONAFHANKELIJKE oorzaken, allebei stil (exit 0, geen signaal). Alleen de eerste repareren had niets opgelost.

**Oorzaak 1 — de poort kon nooit open.** De registratie testte `[ -n "${VNX_HOME:-}" ]`. `VNX_HOME` is een runtime-variabele die een SessionStart-hook niet erft. Gemeten met een probe-hook die zijn eigen omgeving dumpte: `VNX_HOME=[UNSET]`. De `else`-tak printte "MISSING" en gaf exit 0, in elke sessie.

**Oorzaak 2 — de hookgroep werd nooit aangeroepen.** De groep droeg `"matcher": "terminals/T0"`. Een SessionStart-matcher matcht de sessie-BRON, niet een pad. Gemeten met drie probe-groepen in één settings-bestand, elk met een eigen marker:

| matcher | resultaat |
|---|---|
| `""` | marker geschreven (vuurt) |
| `"startup"` | marker geschreven (vuurt) |
| `"terminals/T0"` | GEEN marker (vuurt nooit) |

De groep was dus dood los van `VNX_HOME`.

## De reparatie

`VNX_HOME` blijft de primaire ankerwaarde en valt terug op de vorm die de zes sibling-hooks al gebruiken. De `[ -f ]`-controle blijft staan, dus een consumer-boom zonder het artefact faalt luid in plaats van stil. De matcher gaat naar `""`, gelijk aan de zes siblings.

Een SessionStart-hook draait met cwd = de projectmap van de sessie (gemeten: de harness geeft `cwd` op stdin, en `$PWD` van de hook kwam overeen), dus `git rev-parse` lost binnen de repo op.

## Verificatie

Rode test eerst, op gedrag: **4 failed, 2 passed** vóór de fix, **6 passed** erna. De test leest het commando uit het echte `.claude/settings.json`, niet uit een kopie.

Eind-tot-eind met het echte commando, vanuit een T0-terminal-cwd, `VNX_HOME` uitgezet:

```
generated_at VOOR : 2026-09-08T10:59:04Z
generated_at NA   : 2026-09-08T11:04:20Z   rc=0
```

`.claude/settings.json` blijft geldige JSON, nog steeds 7 SessionStart-groepen, alleen matcher + commando van de bouwer gewijzigd (diff: 2 regels).

Testtotalen: **455 passed, 0 failed** over de aangeraakte bestanden plus buren.

## Twee bestaande tests keken de verkeerde kant op

- `test_build_t0_state_freshness` zocht de groep OP de kapotte matcher, waardoor de assertions met het defect meebewogen in plaats van het te vangen. Lookup gaat nu op substring van het commando, zoals `scripts/lib/t0_state_health.py` het ook doet.
- De OI-1089-assertie in `test_tmux_interactive_dispatch` verbood `git rev-parse --show-toplevel` als mechanisme. Dat verbood de vorm in plaats van de uitkomst, en liet `VNX_HOME` als enig anker over — precies de variabele die een hook niet erft. De assertie bewaakt nu wat OI-1089 werkelijk wilde: de `[ -f ]`-guard staat vóór uitvoering, dus een consumer-terugval kan alleen luid falen.

## Openstaand (buiten de bestandsgrens, NIET aangeraakt)

`vnx regen-settings` zet deze fix terug. `scripts/vnx_settings_merge.py::merge_settings` doet `result["hooks"] = vnx_template["hooks"]` ("Replace hooks (VNX-owned entirely)"), en de drie templates dragen nog de dode matcher:

- `templates/settings_vnx_keys.json.tmpl:86`
- `templates/init/default/settings.json.j2:61`
- `templates/init/minimal/settings.json.j2:55`

Dat betekent ook dat elke consumer-installatie dezelfde dode hook heeft. Details in het rapport.

Dispatch-ID: 20260908-b5-hookfix-t0state