### PR TITLE
fix(gate-runner): ~/.local/bin in het plist-sjabloon en de provider_not_installed-opruiming uitgebreid (golf Bx, D1, OI-1663)

### DIFF
--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -993,7 +993,106 @@ class GateResultIndex(NamedTuple):
     by_pr: Dict[Tuple[int, str], List[Tuple[Path, Dict[str, Any]]]]
 
 
-def _sweep_stale_provider_not_installed_results(state_dir: Path) -> List[str]:
+class ProviderNotInstalledSweepResult(NamedTuple):
+    """Outcome of one :func:`_sweep_stale_provider_not_installed_results` call
+    (golf Bx, D1 — codex findings on PR #1817, the PR that introduced the
+    sweep itself).
+
+    ``removed`` — filenames of records actually unlinked (unchanged OI-1663
+    behaviour). ``unreadable`` — absolute paths of records the sweep could
+    not even parse (``OSError``/``json.JSONDecodeError``). These are left ON
+    DISK, never removed: a record that cannot be read cannot be verified
+    against the narrow ``status=not_executable`` + ``reason=
+    provider_not_installed`` predicate this sweep targets, and deleting on
+    evidence the sweep never actually read could destroy a genuine gate
+    verdict that merely failed to parse (a corrupt write, a write caught
+    mid-flush) — the exact silent-outcome failure mode golf Bx exists to
+    close, so each one is also logged loudly rather than folded into a bare
+    ``continue``.
+    """
+
+    removed: List[str]
+    unreadable: List[str]
+
+
+def _audit_log_provider_not_installed_removal(
+    state_dir: Path, entry: Path, record: Dict[str, Any],
+) -> None:
+    """Append a removal entry to the governance audit trail (ADR-005).
+
+    ``entry.unlink()`` alone erases a governance record with nothing left
+    behind to show it ever existed. This reuses the repo's EXISTING
+    general-purpose governance audit trail
+    (``scripts/lib/governance_audit.py`` → ``governance_audit.ndjson``)
+    rather than introducing a new file: ``cleanup_orphan_gates.py`` already
+    calls the identical ``log_enforcement`` for the same shape of action (a
+    stale gate record cleaned up, logged under its own ``check_name``).
+    ``gate_recorder.write_skip_rationale`` (``gate_execution_audit.ndjson``,
+    GATE-9) was considered and rejected: its schema is a fixed
+    ``provider_check`` block answering "why was this gate never requested",
+    not "an existing record was deleted" — forcing this event through it
+    would mean inventing fields that schema was never designed to carry.
+
+    ``log_enforcement`` only stores a few fields as top-level plaintext
+    (``pr_number``, ``dispatch_id``, ``message``) — everything else passed
+    via ``context`` is HASHED, not kept in the clear (see
+    ``governance_audit._context_hash``). The dispatch's minimum bar — path,
+    gate, PR number, the reason the record carried, and why it was removed —
+    is therefore put directly into ``message`` (always recoverable in
+    plaintext from the audit line itself), with ``pr_number``/``dispatch_id``
+    additionally carried as their own dedicated top-level fields.
+
+    ``governance_audit._data_dir()`` resolves ``VNX_DATA_DIR`` from the
+    AMBIENT environment, never from an argument. Pinning it here to this
+    sweep's own ``state_dir`` mirrors ``_build_manager``'s identical pin
+    a few hundred lines below — the same fix for the same class of bug: a
+    store-scoped write must never depend on whatever ``VNX_DATA_DIR``
+    happens to be set to elsewhere in the process (Codex Defense Checklist:
+    state dir override must come from the explicit argument, never ambient
+    env).
+
+    Best-effort: an audit-write failure must never re-open the (already
+    correct, already-completed) removal decision — logged loudly via
+    ``_LOG.warning``, never raised, mirroring ``cleanup_orphan_gates.py``'s
+    identical tolerance for this exact class of write.
+    """
+    try:
+        os.environ["VNX_DATA_DIR"] = str(Path(state_dir).parent)
+        from governance_audit import log_enforcement  # noqa: PLC0415
+
+        dispatch_id = record.get("dispatch_id") or None
+        pr_number = record.get("pr_number")
+        context: Dict[str, Any] = {
+            "path": str(entry),
+            "gate": record.get("gate"),
+            "reason": record.get("reason"),
+        }
+        if isinstance(pr_number, int):
+            context["pr_number"] = pr_number
+        log_enforcement(
+            check_name="provider_not_installed_sweep",
+            level=1,
+            result=True,
+            context=context,
+            message=(
+                f"removed stale provider_not_installed result {entry.name} "
+                f"(path={entry}, gate={record.get('gate')!r}, "
+                f"reason={record.get('reason')!r}): provider availability is "
+                "an environment fact about whichever process wrote it, "
+                "never PR evidence (OI-1469/OI-1663)"
+            ),
+            dispatch_id=dispatch_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — audit-write failure must not unwind the sweep
+        _LOG.warning(
+            "gate_obligation_runner: could not write governance_audit entry "
+            "for removed %s: %s", entry, exc,
+        )
+
+
+def _sweep_stale_provider_not_installed_results(
+    state_dir: Path,
+) -> ProviderNotInstalledSweepResult:
     """Remove every ``provider_not_installed`` result record on disk,
     regardless of which process wrote it (OI-1663).
 
@@ -1026,18 +1125,32 @@ def _sweep_stale_provider_not_installed_results(state_dir: Path) -> List[str]:
     Called once per :func:`run`, over the WHOLE ``review_gates/results``
     directory — not scoped to this run's own obligations — so a stale record
     is swept on the very next launchd tick (900s) regardless of whether any
-    obligation still references the PR it names. Returns the list of removed
-    filenames (empty when nothing was stale), logged loudly per removal so
-    the sweep itself stays visible in the runner's own log.
+    obligation still references the PR it names. Returns a
+    :class:`ProviderNotInstalledSweepResult` — ``removed`` filenames (empty
+    when nothing was stale), each also logged loudly and given a matching
+    ``governance_audit.ndjson`` entry (:func:`_audit_log_provider_not_installed_removal`,
+    ADR-005) so a deleted governance record leaves a trace behind; and
+    ``unreadable`` paths for anything the sweep could not even parse — never
+    deleted, always logged loudly, never folded silently into the same
+    ``continue`` a genuinely-uninteresting record takes (golf Bx, D1).
     """
     results_dir = Path(state_dir) / "review_gates" / "results"
     removed: List[str] = []
+    unreadable: List[str] = []
     if not results_dir.is_dir():
-        return removed
+        return ProviderNotInstalledSweepResult(removed=removed, unreadable=unreadable)
     for entry in sorted(results_dir.glob("*.json")):
         try:
             record = json.loads(entry.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as exc:
+            unreadable.append(str(entry))
+            _LOG.warning(
+                "gate_obligation_runner: could not read %s during the "
+                "provider_not_installed sweep (%s) — leaving it in place; "
+                "a record this sweep could not verify is never removed "
+                "(golf Bx, D1)",
+                entry, exc,
+            )
             continue
         if not isinstance(record, dict):
             continue
@@ -1060,7 +1173,8 @@ def _sweep_stale_provider_not_installed_results(state_dir: Path) -> List[str]:
             "fact, never PR evidence (OI-1469/OI-1663)",
             entry.name,
         )
-    return removed
+        _audit_log_provider_not_installed_removal(state_dir, entry, record)
+    return ProviderNotInstalledSweepResult(removed=removed, unreadable=unreadable)
 
 
 def _index_gate_results(state_dir: Path) -> GateResultIndex:
@@ -2692,7 +2806,12 @@ def run(
     # building the evidence index, so a swept record can never be read back
     # as a candidate. write=False (dry run) must never mutate anything, so
     # the sweep — like the fulfilment loop itself — only runs when write=True.
-    swept_provider_not_installed = _sweep_stale_provider_not_installed_results(state_dir) if write else []
+    sweep_result = (
+        _sweep_stale_provider_not_installed_results(state_dir)
+        if write
+        else ProviderNotInstalledSweepResult(removed=[], unreadable=[])
+    )
+    swept_provider_not_installed = sweep_result.removed
     # OI-1388 defect 2: built once per run, not per obligation, and shared by
     # both the write path and the dry-run path — the same index feeds the
     # same decision tree (_pre_execution_decision) either way, so the two
@@ -2745,6 +2864,8 @@ def run(
         "terminal_evidence_contradictions": contradictions,
         "terminal_evidence_contradiction_count": len(contradictions),
         "swept_provider_not_installed": swept_provider_not_installed,
+        "provider_not_installed_sweep_unreadable": sweep_result.unreadable,
+        "provider_not_installed_sweep_unreadable_count": len(sweep_result.unreadable),
     }
 
 

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -993,6 +993,76 @@ class GateResultIndex(NamedTuple):
     by_pr: Dict[Tuple[int, str], List[Tuple[Path, Dict[str, Any]]]]
 
 
+def _sweep_stale_provider_not_installed_results(state_dir: Path) -> List[str]:
+    """Remove every ``provider_not_installed`` result record on disk,
+    regardless of which process wrote it (OI-1663).
+
+    The OI-1469 cleanup inside :func:`fulfill_obligation` only removes a
+    record THIS runner's own ``request_and_execute`` call just caused the
+    engine to write, in the same process, in the same call — it has no way
+    to see a record written by a SEPARATE process. Measured live on vnx-dev
+    (2026-09-08): 97 ``provider_not_installed`` records survived on disk
+    weeks after OI-1469 closed, including ``pr-1809-codex_gate.json`` and
+    ``pr-1802-codex_gate.json`` (2026-09-07, golf-B PRs) and
+    ``pr-1792-gemini_review.json`` (2026-09-06, no ``dispatch_id`` field at
+    all). All three carry the signature of ``scripts/review_gate_manager.py``
+    ``request-and-execute`` invoked directly — documented at
+    ``templates/terminals/T0.md`` as T0's own PR-review-gate workflow ("PR
+    review gate ... scripts/review_gate_manager.py request-and-execute (or
+    scripts/t0_gate_enforcement.sh wrapper)") — a process this runner never
+    shares state with.
+
+    Deliberately narrow: only ``status == not_executable`` AND
+    ``reason == "provider_not_installed"`` is removed, the exact same
+    predicate OI-1469 already established as "never PR evidence, always an
+    environment fact about whichever process wrote it" (see the
+    ``test_runner_removes_provider_not_installed_result_record`` docstring).
+    A decided pass/fail, or a ``not_executable`` for any OTHER reason (e.g.
+    ``provider_disabled`` — a config decision, not an environment gap), is
+    left untouched; the guard the request-time writer already goes through
+    (``gate_recorder.write_result_guarded``) means a record that clears this
+    predicate was never protecting real evidence in the first place.
+
+    Called once per :func:`run`, over the WHOLE ``review_gates/results``
+    directory — not scoped to this run's own obligations — so a stale record
+    is swept on the very next launchd tick (900s) regardless of whether any
+    obligation still references the PR it names. Returns the list of removed
+    filenames (empty when nothing was stale), logged loudly per removal so
+    the sweep itself stays visible in the runner's own log.
+    """
+    results_dir = Path(state_dir) / "review_gates" / "results"
+    removed: List[str] = []
+    if not results_dir.is_dir():
+        return removed
+    for entry in sorted(results_dir.glob("*.json")):
+        try:
+            record = json.loads(entry.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        if record.get("status") != STATUS_NOT_EXECUTABLE:
+            continue
+        if record.get("reason") != "provider_not_installed":
+            continue
+        try:
+            entry.unlink()
+        except OSError as exc:
+            _LOG.debug(
+                "gate_obligation_runner: could not sweep stale provider_not_installed "
+                "result %s: %s", entry, exc,
+            )
+            continue
+        removed.append(entry.name)
+        _LOG.warning(
+            "gate_obligation_runner: swept stale provider_not_installed result %s "
+            "written by another process — provider availability is an environment "
+            "fact, never PR evidence (OI-1469/OI-1663)",
+            entry.name,
+        )
+    return removed
+
+
 def _index_gate_results(state_dir: Path) -> GateResultIndex:
     """Index ``review_gates/results`` records by ``(dispatch_id, gate)`` AND
     by ``(pr_number, gate)`` — see :class:`GateResultIndex`.
@@ -2617,6 +2687,12 @@ def run(
         for path, record in obligations
         if _in_scope(path, record, since=since, dispatch_prefix=dispatch_prefix)
     ]
+    # OI-1663: sweep every stale provider_not_installed result left by ANY
+    # process (not just this runner's own fulfilment calls below) before
+    # building the evidence index, so a swept record can never be read back
+    # as a candidate. write=False (dry run) must never mutate anything, so
+    # the sweep — like the fulfilment loop itself — only runs when write=True.
+    swept_provider_not_installed = _sweep_stale_provider_not_installed_results(state_dir) if write else []
     # OI-1388 defect 2: built once per run, not per obligation, and shared by
     # both the write path and the dry-run path — the same index feeds the
     # same decision tree (_pre_execution_decision) either way, so the two
@@ -2668,6 +2744,7 @@ def run(
         "action_counts": action_counts,
         "terminal_evidence_contradictions": contradictions,
         "terminal_evidence_contradiction_count": len(contradictions),
+        "swept_provider_not_installed": swept_provider_not_installed,
     }
 
 

--- a/scripts/launchd/com.vnx.gate-obligation-runner.plist
+++ b/scripts/launchd/com.vnx.gate-obligation-runner.plist
@@ -56,12 +56,30 @@
     the producer-freshness monitor's launchd harvest; obligations pending
     longer than a day are flagged per gate key by the same monitor's
     review_gate_obligations producer.
+
+    OI-1663 (golf Bx, D1, 2026-09-08): the declared static PATH below
+    (/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin) never included
+    ~/.local/bin, where pipx-style CLI installs (codex, measured live)
+    actually live — every gate whose provider binary lands there was
+    unconditionally booked provider_not_installed by this job, regardless of
+    whether the binary was actually installed. ~/.local/bin cannot be baked
+    into the EnvironmentVariables.PATH string above as a literal "~" —
+    launchd sets environment variable VALUES verbatim, with no shell running
+    over them to expand a tilde — and there is no existing ${...}
+    install-time substitution for a per-user home directory (only
+    ${VNX_HOME}/${VNX_PROJECT_ID}, both project-scoped, are substituted by
+    vnx_cli/commands/init_cmd.py::_install_launchd_agent). The
+    ProgramArguments command IS run through /bin/bash -c, which performs
+    real shell expansion at RUN time — "$HOME/.local/bin:$PATH" above
+    prepends the user's actual local bin directory to the declared PATH
+    using $HOME, which launchd sets for every user LaunchAgent regardless of
+    what EnvironmentVariables declares (only PATH is overridden here).
   -->
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-c</string>
-    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/gate_obligation_runner.py</string>
+    <string>cd ${VNX_HOME} &amp;&amp; PATH="$HOME/.local/bin:$PATH" exec python3 scripts/gate_obligation_runner.py</string>
   </array>
   <key>StartInterval</key>
   <integer>900</integer>

--- a/scripts/launchd/com.vnx.gate-obligation-runner.plist
+++ b/scripts/launchd/com.vnx.gate-obligation-runner.plist
@@ -70,16 +70,27 @@
     ${VNX_HOME}/${VNX_PROJECT_ID}, both project-scoped, are substituted by
     vnx_cli/commands/init_cmd.py::_install_launchd_agent). The
     ProgramArguments command IS run through /bin/bash -c, which performs
-    real shell expansion at RUN time — "$HOME/.local/bin:$PATH" above
-    prepends the user's actual local bin directory to the declared PATH
+    real shell expansion at RUN time — "$PATH:$HOME/.local/bin" above
+    appends the user's actual local bin directory to the declared PATH
     using $HOME, which launchd sets for every user LaunchAgent regardless of
     what EnvironmentVariables declares (only PATH is overridden here).
+
+    Append, never prepend (golf Bx, D1 codex finding, 2026-09-08): this job
+    runs as the same user who owns ~/.local/bin, so there is no privilege
+    boundary being crossed either way — but PREPENDING would let any
+    executable name that also exists in ~/.local/bin shadow the system
+    version of the same name for every OTHER tool this job invokes (e.g. a
+    ~/.local/bin/python3 silently taking over from the system python3 that
+    "exec python3 scripts/gate_obligation_runner.py" below actually depends
+    on). codex itself does not exist anywhere in the static PATH above, so
+    appending finds it exactly as reliably as prepending would, with zero
+    shadowing risk for every other binary on the declared static PATH.
   -->
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-c</string>
-    <string>cd ${VNX_HOME} &amp;&amp; PATH="$HOME/.local/bin:$PATH" exec python3 scripts/gate_obligation_runner.py</string>
+    <string>cd ${VNX_HOME} &amp;&amp; PATH="$PATH:$HOME/.local/bin" exec python3 scripts/gate_obligation_runner.py</string>
   </array>
   <key>StartInterval</key>
   <integer>900</integer>

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -866,6 +866,85 @@ def test_runner_removes_provider_not_installed_result_record(tmp_path, monkeypat
     )
 
 
+def test_runner_sweeps_provider_not_installed_result_written_by_another_process(tmp_path, monkeypatch):
+    """OI-1663: OI-1469's cleanup above only fires INSIDE fulfill_obligation,
+    right after ITS OWN request_and_execute call just caused the engine to
+    write the record — it never sees a provider_not_installed record written
+    by a SEPARATE process. Measured live on vnx-dev (2026-09-08): 97 such
+    records survived on disk weeks after OI-1469 closed, including
+    pr-1809-codex_gate.json and pr-1802-codex_gate.json (2026-09-07) and
+    pr-1792-gemini_review.json (2026-09-06, no dispatch_id field at all).
+    All three carry the signature of scripts/review_gate_manager.py's
+    ``request-and-execute`` subcommand invoked directly -- documented at
+    templates/terminals/T0.md as T0's own PR-review-gate workflow ("PR review
+    gate ... scripts/review_gate_manager.py request-and-execute (or
+    scripts/t0_gate_enforcement.sh wrapper)") -- a SEPARATE OS process from
+    this runner, so the in-process OI-1469 cleanup step never runs for it.
+
+    This test writes such a record directly to disk with NO obligation
+    registered for it at all (simulating that separate writer, and proving
+    the sweep is not coupled to this run's own obligation-fulfilment loop),
+    then asserts a plain runner.run() call removes it anyway."""
+    state_dir = _make_state_dir(tmp_path)
+    results_dir = state_dir / "review_gates" / "results"
+    stale_record = {
+        "gate": "codex_gate",
+        "pr_id": "1809",
+        "pr_number": 1809,
+        "status": STATUS_NOT_EXECUTABLE,
+        "reason": "provider_not_installed",
+        "reason_detail": "codex binary not found in PATH",
+        "failure_reason": "codex binary not found in PATH",
+        "summary": "codex_gate not executable: codex binary not found in PATH",
+        "contract_hash": "",
+        "branch": "dispatch/20260907-golfb-b4-runbook",
+        "report_path": "",
+        "recorded_at": "2026-09-07T16:44:26Z",
+        "dispatch_id": "20260907-golfb-b4-runbook",
+    }
+    result_file = results_dir / "pr-1809-codex_gate.json"
+    result_file.write_text(json.dumps(stale_record), encoding="utf-8")
+
+    summary = runner.run(state_dir)
+
+    assert not result_file.exists(), (
+        "a provider_not_installed result written by ANY process must not "
+        "survive a runner.run() call, not just one this runner's own "
+        "fulfilment attempt just wrote itself (OI-1663)"
+    )
+    assert summary["obligations_seen"] == 0
+
+
+def test_runner_sweep_leaves_decided_results_untouched(tmp_path, monkeypatch):
+    """The sweep must be narrowly targeted: status=not_executable AND
+    reason=provider_not_installed, nothing broader. A decided pass/fail (real
+    PR evidence) and an unrelated not_executable reason (e.g. a genuine
+    config-disabled parking) must both survive the sweep untouched."""
+    state_dir = _make_state_dir(tmp_path)
+    results_dir = state_dir / "review_gates" / "results"
+    pass_record = {
+        "gate": "codex_gate", "pr_number": 1700, "status": "pass",
+        "contract_hash": "abc123", "report_path": "/tmp/report.md",
+    }
+    pass_file = results_dir / "pr-1700-codex_gate.json"
+    pass_file.write_text(json.dumps(pass_record), encoding="utf-8")
+
+    disabled_record = {
+        "gate": "ci_gate", "pr_number": 1701, "status": STATUS_NOT_EXECUTABLE,
+        "reason": "provider_disabled", "reason_detail": "VNX_CI_GATE_REQUIRED is set to 0",
+        "contract_hash": "", "report_path": "",
+    }
+    disabled_file = results_dir / "pr-1701-ci_gate.json"
+    disabled_file.write_text(json.dumps(disabled_record), encoding="utf-8")
+
+    runner.run(state_dir)
+
+    assert pass_file.exists()
+    assert json.loads(pass_file.read_text(encoding="utf-8")) == pass_record
+    assert disabled_file.exists()
+    assert json.loads(disabled_file.read_text(encoding="utf-8")) == disabled_record
+
+
 def test_runner_leaves_pre_existing_pass_untouched_on_provider_not_installed(tmp_path, monkeypatch):
     """OI-1469/OI-1470 composition: if the slot already carries a real,
     evidenced pass, gate_recorder's overwrite guard (OI-1470/OI-1471)

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -945,6 +945,77 @@ def test_runner_sweep_leaves_decided_results_untouched(tmp_path, monkeypatch):
     assert json.loads(disabled_file.read_text(encoding="utf-8")) == disabled_record
 
 
+def test_runner_sweep_writes_governance_audit_entry_for_removed_record(tmp_path, monkeypatch):
+    """golf Bx, D1 (PR #1817 codex finding 1): ``entry.unlink()`` alone erases
+    a governance record with nothing left to show it ever existed. The sweep
+    must append an audit-trail entry -- path, gate, PR number (when the
+    record carries one), the reason it was removed for, and why -- to the
+    repo's EXISTING general-purpose governance audit trail
+    (governance_audit.ndjson), not a new file."""
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    state_dir = _make_state_dir(tmp_path)
+    results_dir = state_dir / "review_gates" / "results"
+    stale_record = {
+        "gate": "codex_gate",
+        "pr_number": 1809,
+        "status": STATUS_NOT_EXECUTABLE,
+        "reason": "provider_not_installed",
+        "reason_detail": "codex binary not found in PATH",
+        "dispatch_id": "20260907-golfb-b4-runbook",
+    }
+    result_file = results_dir / "pr-1809-codex_gate.json"
+    result_file.write_text(json.dumps(stale_record), encoding="utf-8")
+
+    runner.run(state_dir)
+
+    assert not result_file.exists()
+    audit_path = state_dir / "governance_audit.ndjson"
+    assert audit_path.exists(), "the sweep must leave an audit trail behind a removed record"
+    entries = [
+        json.loads(line)
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    matches = [e for e in entries if e.get("check_name") == "provider_not_installed_sweep"]
+    assert len(matches) == 1, f"expected exactly one sweep audit entry, got: {entries}"
+    entry = matches[0]
+    assert entry["pr_number"] == 1809
+    assert entry["dispatch_id"] == "20260907-golfb-b4-runbook"
+    message = entry["message"]
+    assert str(result_file) in message, message
+    assert "codex_gate" in message, message
+    assert "provider_not_installed" in message, message
+    assert "OI-1469" in message and "OI-1663" in message, message
+
+
+def test_runner_sweep_leaves_corrupt_record_and_logs_loudly(tmp_path, monkeypatch, caplog):
+    """golf Bx, D1 (PR #1817 codex finding 2): a corrupt/unreadable result
+    record must never silently disappear from the sweep's accounting. It
+    must stay ON DISK -- never deleted on evidence the sweep could not even
+    read -- be logged loudly with its path and the read error, and be
+    counted in run()'s summary next to swept_provider_not_installed."""
+    import logging
+
+    state_dir = _make_state_dir(tmp_path)
+    results_dir = state_dir / "review_gates" / "results"
+    corrupt_file = results_dir / "pr-1810-codex_gate.json"
+    corrupt_file.write_text("{not valid json", encoding="utf-8")
+
+    caplog.set_level(logging.WARNING, logger="gate_obligation_runner")
+
+    summary = runner.run(state_dir)
+
+    assert corrupt_file.exists(), "a record the sweep could not read must never be deleted"
+    assert corrupt_file.read_text(encoding="utf-8") == "{not valid json"
+    assert summary["provider_not_installed_sweep_unreadable_count"] == 1
+    assert str(corrupt_file) in summary["provider_not_installed_sweep_unreadable"]
+    assert summary["swept_provider_not_installed"] == []
+    assert any(
+        str(corrupt_file) in record.message or corrupt_file.name in record.message
+        for record in caplog.records
+    ), f"expected a loud log line naming the corrupt path, got: {[r.message for r in caplog.records]}"
+
+
 def test_runner_leaves_pre_existing_pass_untouched_on_provider_not_installed(tmp_path, monkeypatch):
     """OI-1469/OI-1470 composition: if the slot already carries a real,
     evidenced pass, gate_recorder's overwrite guard (OI-1470/OI-1471)

--- a/tests/test_launchd_plist_guard.py
+++ b/tests/test_launchd_plist_guard.py
@@ -26,7 +26,9 @@ this file is the broader, whole-directory sweep plus the XML check.
 """
 from __future__ import annotations
 
+import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -36,6 +38,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
 import path_parity  # noqa: E402
 
 LAUNCHD_TEMPLATES_DIR = REPO_ROOT / "scripts" / "launchd"
+GATE_OBLIGATION_RUNNER_PLIST = LAUNCHD_TEMPLATES_DIR / "com.vnx.gate-obligation-runner.plist"
 
 
 def _real_requires_python() -> Optional[str]:
@@ -227,3 +230,77 @@ def test_real_repo_launchd_templates_clear_the_guard(monkeypatch) -> None:
     for c in result["consumers"]:
         if c["label"] in (gate_obligation_runner_label, "com.vnx.ledger-health"):
             assert c["in_range"] is True, c
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# OI-1663: com.vnx.gate-obligation-runner's declared PATH
+# (/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin) never includes
+# ~/.local/bin, where pipx-style CLI installs actually live — measured live:
+# `which codex` -> /Users/vincentvandeth/.local/bin/codex, but
+# gate_result_parser._classify_unavailable's shutil.which(binary_name) runs
+# in the RUNNER's own process PATH, which is always this bare launchd
+# default. The gate is therefore always booked provider_not_installed
+# regardless of whether codex is actually installed.
+#
+# A literal ``~`` is never expanded inside a launchd EnvironmentVariables
+# string value (no shell runs over it), so this test executes the plist's
+# own ProgramArguments command through the SAME /bin/bash -c launchd itself
+# invokes it with — the one place in the template that already does real,
+# runtime shell expansion (of ${VNX_HOME} pre-substitution, then of any
+# shell variable at execution time) — with a fake HOME carrying a
+# ``.local/bin/codex`` stub and the declared static PATH, and asserts the
+# spawned process can resolve it. This is GEDRAG, not string matching: it
+# proves what a real launchd-launched process would see.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _extract_program_arguments_last_string(plist_path: Path) -> str:
+    """Return the final ``<string>`` in a launchd plist's ProgramArguments
+    array — the bash -c payload for every template in this directory."""
+    tree = ET.parse(plist_path)
+    top_dict = tree.getroot().find("dict")
+    assert top_dict is not None, f"{plist_path} has no top-level <dict>"
+    children = list(top_dict)
+    for i, el in enumerate(children):
+        if el.tag == "key" and el.text == "ProgramArguments":
+            array = children[i + 1]
+            assert array.tag == "array", f"ProgramArguments in {plist_path} is not an array"
+            strings = [child.text for child in array if child.tag == "string"]
+            assert strings, f"ProgramArguments in {plist_path} has no <string> entries"
+            return strings[-1]
+    raise AssertionError(f"no ProgramArguments key found in {plist_path}")
+
+
+def test_gate_obligation_runner_plist_resolves_local_bin_codex_on_path(tmp_path: Path) -> None:
+    script = _extract_program_arguments_last_string(GATE_OBLIGATION_RUNNER_PLIST)
+
+    fake_home = tmp_path / "home"
+    local_bin = fake_home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    codex_stub = local_bin / "codex"
+    codex_stub.write_text("#!/bin/bash\necho fake-codex\n")
+    codex_stub.chmod(0o755)
+
+    fake_vnx_home = tmp_path / "repo"
+    scripts_dir = fake_vnx_home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "gate_obligation_runner.py").write_text(
+        "import shutil, sys\nsys.stdout.write(shutil.which('codex') or '')\n"
+    )
+
+    resolved_script = script.replace("${VNX_HOME}", str(fake_vnx_home))
+    static_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+    env = {"HOME": str(fake_home), "PATH": static_path}
+
+    proc = subprocess.run(
+        ["/bin/bash", "-c", resolved_script],
+        capture_output=True, text=True, env=env, timeout=10, check=False,
+    )
+
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert proc.stdout.strip() == str(codex_stub), (
+        "the runner process, launched exactly as launchd would launch it "
+        "(bash -c over the plist's own ProgramArguments string, with only "
+        "HOME and the declared static PATH set), could not resolve codex "
+        f"on PATH -- stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )


### PR DESCRIPTION
## Summary
- `scripts/launchd/com.vnx.gate-obligation-runner.plist`: de ProgramArguments bash-c-string zet nu `PATH="$HOME/.local/bin:$PATH"` voor de exec, zodat pipx-stijl installs (codex, gemeten: `/Users/vincentvandeth/.local/bin/codex`) resolven. Geen tilde-expansie gebruikt (werkt niet in een launchd EnvironmentVariables-waarde); `$HOME` wordt door bash zelf geëxpandeerd op het moment dat launchd de ProgramArguments-command draait.
- `scripts/gate_obligation_runner.py`: nieuwe `_sweep_stale_provider_not_installed_results()`, aangeroepen aan het begin van `run()` (alleen bij `write=True`), die de VOLLEDIGE `review_gates/results/`-directory sweept op `status=not_executable, reason=provider_not_installed` — ongeacht welk proces het record schreef en ongeacht of er een obligation voor bestaat.

## Changes
- `scripts/launchd/com.vnx.gate-obligation-runner.plist` — PATH-fix + inline OI-1663-documentatie in het bestaande commentaarblok
- `scripts/gate_obligation_runner.py` — `_sweep_stale_provider_not_installed_results()` + aanroep in `run()` + `swept_provider_not_installed` in de summary
- `tests/test_launchd_plist_guard.py` — nieuwe test die het plist-sjabloon via een echte `/bin/bash -c` aanroep uitvoert (met fake HOME + codex-stub) en bewijst dat codex resolveerbaar is
- `tests/test_gate_obligations.py` — twee nieuwe tests: de sweep verwijdert een record van een ANDER (niet-geregistreerd) proces, en laat een decided pass + een `provider_disabled`-record ongemoeid

## Verification

**Punt 1 (plist) — rood eerst, gedrag:**
```
$ python3 -m pytest tests/test_launchd_plist_guard.py::test_gate_obligation_runner_plist_resolves_local_bin_codex_on_path -v
FAILED ... AssertionError: ... could not resolve codex on PATH -- stdout='' stderr=''
```
Na de fix: PASSED.

**Punt 2 (sweep) — rood eerst, gedrag:**
```
$ python3 -m pytest tests/test_gate_obligations.py::test_runner_sweeps_provider_not_installed_result_written_by_another_process -v
FAILED ... AssertionError: a provider_not_installed result written by ANY process must not survive a runner.run() call ...
assert not True
```
Na de fix: PASSED (68/68 in test_gate_obligations.py).

**Live demo, tijdelijke state-dir, geen live store geraakt:**
```
=== before run() ===
['pr-9999-codex_gate.json']
=== run() summary ===
swept_provider_not_installed: ['pr-9999-codex_gate.json']
obligations_seen: 0
exit code: 0
=== after run() ===
[]
record_path.exists(): False
```

**Volledige targeted run:**
```
$ python3 -m pytest tests/test_launchd_plist_guard.py tests/test_gate_obligations.py tests/test_oi1490_gate_provider_registry.py tests/test_gate_obligation_runner.py
147 passed in 17.46s
```
(`tests/test_gate_result_parser.py` zoals genoemd in de dispatch bestaat niet; `gate_result_parser.py`'s eigen dekking zit in `test_oi1490_gate_provider_registry.py`, meegenomen. `gate_result_parser.py`/`gate_obligations.py` zelf zijn ongewijzigd — de fix hoefde er niet in.)

`git diff HEAD` leeg na commit.

## Open Items
- De schrijver die de 97 bestaande records produceerde is `scripts/review_gate_manager.py request-and-execute`, rechtstreeks aangeroepen door T0 (`templates/terminals/T0.md`) of via `scripts/t0_gate_enforcement.sh`/`vnx gate` — een apart OS-proces, buiten de bestandsgrens van deze dispatch.
- De 97 bestaande records op `~/.vnx-data/vnx-dev/state/review_gates/results/` zijn NIET aangeraakt door deze PR (geen `.vnx-data/`-writes toegestaan). De volgende live `com.vnx.gate-obligation-runner`-run (na de operator-herinstallatie hieronder) sweept ze automatisch weg — geen aparte opruimactie nodig, tenzij de operator ze als historie wil bewaren.
- **Live plist-herstel is een operator-handeling, niet onderdeel van deze PR.** Huidig live bestand (`~/Library/LaunchAgents/com.vnx.gate-obligation-runner.vnx-dev.plist`) draagt nog de oude command-string zonder de PATH-fix. Herstelcommando na merge:
  ```
  launchctl unload ~/Library/LaunchAgents/com.vnx.gate-obligation-runner.vnx-dev.plist
  bash scripts/launchd/reload_plist.sh com.vnx.gate-obligation-runner
  ```

---

**Dispatch-ID**: 20260908-bx-d1-runner-path
**Model**: sonnet
**Provider**: claude