### PR TITLE
docs(forge-gate): de lezer-voor-veld-eis van de branch-protection-preflight vastgelegd (golf Bx, D6, OI-1672)

### DIFF
--- a/docs/operations/FORGE_GATE.md
+++ b/docs/operations/FORGE_GATE.md
@@ -291,9 +291,34 @@ Deze volgorde werkt wél, en hij bevat **precies één ongegovernde stap**: stap
 
 Letterlijk uit het plan (`claudedocs/plans/2026-09-06-golf-B-forge-dwingt-af.md`, sectie "Geaccepteerd restrisico"): de bescherming is bewerkbaar door precies de operator die hem bindt, en op een persoonlijk account is er geen audit-log-API — een protection-wijziging gevolgd door een kale merge laat niets opvraagbaars achter. Wie de private key in de keychain heeft, kan bovendien met een paar regels `curl` een `success` op elke sha zetten, langs `forge_check_run.py` heen; dezelfde operator, hetzelfde risico. Compenserende maatregelen: de drift in de deur (`pr_merge.py`) en in `vnx doctor` (§4, §8), en de receipt die apply en terugweg zelf schrijven (§4, §7). Wat overblijft is een operator die bewust drie stappen zet; dat risico is aanvaard en staat hier opgeschreven, niet weggewerkt.
 
+## 10. Contract: `branch_protection.yaml` uitbreiden gaat in twee PR's (OI-1672)
+
+**Gemeten, twee keer live.** `scripts/pr_merge.py::_run_branch_protection_gate` stap (d) leest de YAML van de PR-head via de contents-API, maar parseert die met `parse_protection_config` uit `scripts/lib/forge_protection_drift.py` **zoals dat bestand in de lokale checkout staat** — en stap (a), vlak daarvoor in dezelfde poort, heeft net bewezen dat die lokale checkout byte-identiek is aan `main`. De lezer die over de YAML van de PR-head oordeelt is dus altijd `main`'s lezer, nooit die van de PR zelf.
+
+Gevolg: een PR die tegelijk een nieuw veld in `branch_protection.yaml` toevoegt ÉN de lezer uitbreidt zodat die het veld kent, kan nooit door stap (d). `main`'s lezer — de enige die op dat moment draait — kent het nieuwe veld per definitie nog niet. Een PR mag zijn eigen bewaker niet leveren.
+
+**De eis.** Een uitbreiding van het schema van `scripts/forge/branch_protection.yaml` (nieuw top-level veld, nieuw sub-veld, nieuwe toegestane waarde) gaat altijd in twee PR's, in deze volgorde:
+
+1. **Eerst de lezer.** `forge_protection_drift.py` (en elke andere plek die het schema parseert) leert het nieuwe veld kennen. De YAML op `main` verandert in deze PR NIET.
+2. **Dan pas het veld.** Een tweede PR voegt het veld daadwerkelijk toe aan `scripts/forge/branch_protection.yaml`. Stap (d) draait nu tegen een `main`-lezer die het veld al kent, en laat de PR door.
+
+**De exacte weigerboodschap**, zodat een lezer die erop stuit hem herkent:
+
+```
+branch-protection-YAML op de PR-head ongeldig: branch_protection.yaml heeft onbekende velden: [<veld>]
+```
+
+**Twee gemeten gevallen:**
+
+- **2026-09-07 23:52, PR #1808**: voegde in één PR een `app:`-blok toe aan `scripts/forge/branch_protection.yaml` én breidde `forge_protection_drift.py` uit zodat de lezer dat blok kende (172 tests groen op de PR-head). De deur weigerde alsnog met exact de bovenstaande boodschap (`[app]`). Alle andere poorten stonden groen; alleen stap (d) blokkeerde.
+- **2026-09-08, OP-B3 (#1815)**: opnieuw bevestigd door T0. De promotie van `vnx-gate/review` van `pending_checks` naar `required_status_checks.checks` (§5) is daarom bewust gedaan **zonder** een nieuw schemaveld — die PR wijzigde alleen bestaande, al-bekende structuur.
+
+Zie ook de docstring van `_run_branch_protection_gate` (stap d) in `scripts/pr_merge.py` voor de codekant van dit contract.
+
 ## Cross-references
 
 - Plan: `claudedocs/plans/2026-09-06-golf-B-forge-dwingt-af.md`
 - Merge-deur en zijn gates: `docs/core/DISPATCH_RULES.md` §2
 - Code op `main`: `scripts/forge/branch_protection.yaml`, `scripts/forge/apply_branch_protection.py`, `scripts/lib/forge_protection_drift.py`, `scripts/pr_merge.py::_run_branch_protection_gate`, `scripts/vnx_doctor.py::check_branch_protection_drift`
 - Publicatielaag op `main`: `scripts/lib/forge_check_run.py` (client), `scripts/lib/forge_gate_publisher.py` (afbeelding, samenvattende check, CLI), `tests/test_forge_check_run_client.py`, `tests/test_forge_review_summary.py`
+- Lezer-voor-veld-contract (OI-1672): §10 hierboven, bewaakt door `tests/test_branch_protection_gate_reader_for_field_doc.py`

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -648,6 +648,17 @@ def _run_branch_protection_gate(
         as the ultimate weakening. Blocks without ``--allow-weaken
         "<reason>"`` (empty reason refused, no silent bypass).
 
+        Reader-for-field contract: the parser used here (``parse_protection_config``)
+        is the LOCAL checkout's code, which step (a) has just proven
+        byte-identical to main — never the PR's own copy. A PR that adds a
+        new schema field to ``branch_protection.yaml`` AND teaches the
+        reader that field in the same PR can therefore never pass this
+        step: main's reader, the only one running, does not know the field
+        yet. Extending the schema is always two PRs, reader first, field
+        second. See docs/operations/FORGE_GATE.md § "Contract:
+        branch_protection.yaml uitbreiden gaat in twee PR's (OI-1672)" for
+        the measured cases and the exact refusal text.
+
     No override besides ``--allow-weaken`` — a drift found in (c) or an
     unreadable/unparseable state anywhere has no escape hatch.
     """

--- a/tests/test_branch_protection_gate_reader_for_field_doc.py
+++ b/tests/test_branch_protection_gate_reader_for_field_doc.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Guards the cross-reference between `_run_branch_protection_gate`'s
+docstring (step d) and docs/operations/FORGE_GATE.md (OI-1672, golf Bx D6).
+
+The reader-for-field contract — extending ``branch_protection.yaml``'s
+schema always takes two PRs, reader first, field second — is documented
+prose, not enforced code. Nothing else in the suite reads docstrings, so a
+future rewrite of the docstring or of FORGE_GATE.md could silently drop the
+link between them. This test fails when either half disappears: the
+reference in the docstring, or the anchored section in FORGE_GATE.md.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge  # noqa: E402
+
+FORGE_GATE_DOC = VNX_ROOT / "docs" / "operations" / "FORGE_GATE.md"
+ANCHOR = "OI-1672"
+
+
+def _docstring() -> str:
+    doc = inspect.getdoc(pr_merge._run_branch_protection_gate)
+    assert doc, "_run_branch_protection_gate has no docstring"
+    return doc
+
+
+def test_docstring_references_forge_gate_doc_and_anchor() -> None:
+    doc = _docstring()
+    assert "docs/operations/FORGE_GATE.md" in doc, (
+        "step (d) docstring lost its cross-reference to "
+        "docs/operations/FORGE_GATE.md (the reader-for-field contract, OI-1672)"
+    )
+    assert ANCHOR in doc, (
+        f"step (d) docstring lost its {ANCHOR} anchor — the link to the "
+        "FORGE_GATE.md section documenting the two-PR schema-extension contract"
+    )
+
+
+def test_forge_gate_doc_has_the_anchored_section() -> None:
+    assert FORGE_GATE_DOC.exists(), f"{FORGE_GATE_DOC} is missing"
+    text = FORGE_GATE_DOC.read_text(encoding="utf-8")
+    headings_with_anchor = [
+        line
+        for line in text.splitlines()
+        if re.match(r"^#{1,6}\s", line) and ANCHOR in line
+    ]
+    assert headings_with_anchor, (
+        f"docs/operations/FORGE_GATE.md no longer has a heading carrying {ANCHOR} "
+        "— the section the pr_merge.py docstring points at is gone or was "
+        "renamed without updating the anchor"
+    )


### PR DESCRIPTION
## Summary
- `scripts/pr_merge.py::_run_branch_protection_gate` stap (d) parseert de YAML van de PR-head met de schema-lezer uit de LOKALE checkout, die stap (a) net byte-identiek aan main heeft bewezen. Een PR die tegelijk een nieuw YAML-veld en de lezer ervoor toevoegt kan daardoor nooit door stap (d): main's lezer kent het veld nog niet.
- Twee keer live gemeten: PR #1808 (07-09, `app:`-blok + lezer tegelijk, 172 tests groen op de PR-head, deur weigerde met "onbekende velden: [app]") en OP-B3/#1815 (08-09, opnieuw bevestigd door T0, promotie bewust zonder nieuwe velden gedaan).
- Legt de eis vast: uitbreiding van `scripts/forge/branch_protection.yaml`'s schema gaat altijd in twee PR's — eerst de lezer, dan het veld.

## Changes
- `docs/operations/FORGE_GATE.md`: nieuwe §10 "Contract: `branch_protection.yaml` uitbreiden gaat in twee PR's (OI-1672)" met de reden, de exacte weigerboodschap, en de twee gemeten gevallen als bewijs. Cross-references-sectie wijst er nu ook naartoe.
- `scripts/pr_merge.py`: uitsluitend de docstring van `_run_branch_protection_gate` uitgebreid met een alinea die stap (d) expliciet als dit contract benoemt en naar FORGE_GATE.md §10 verwijst. Geen code aangeraakt (`git diff HEAD -- scripts/pr_merge.py` bevat alleen toegevoegde docstring-regels).
- `tests/test_branch_protection_gate_reader_for_field_doc.py` (nieuw): bewaakt de verwijzing. Faalt als de docstring de referentie naar `docs/operations/FORGE_GATE.md` of het `OI-1672`-anker verliest, EN faalt onafhankelijk als de geankerde sectie uit FORGE_GATE.md verdwijnt.

## Verification
- Rode test eerst: de test is geschreven vóór de doc/docstring-wijzigingen en faalde toen op beide asserts (`AssertionError: step (d) docstring lost its cross-reference...` en `...no longer has a heading carrying OI-1672`). Na de wijzigingen: `2 passed`.
- `python3 -m pytest tests/test_pr_merge_branch_protection.py tests/test_branch_protection_gate_reader_for_field_doc.py -v` → **33 passed**.
- `git diff HEAD` is leeg (werkboom schoon na commit); `git diff HEAD -- scripts/pr_merge.py` bevat uitsluitend toegevoegde docstring-regels (geen code-wijziging).

## Test plan
- [x] Rode run vóór de implementatie, letterlijk getoond in het rapport
- [x] Groene run erna: `tests/test_branch_protection_gate_reader_for_field_doc.py` + `tests/test_pr_merge_branch_protection.py` (33 passed)
- [x] `git diff HEAD -- scripts/pr_merge.py` bevat alleen docstring-regels

Dispatch-ID: 20260908-bx-d6-lezer-voor-veld
🤖 Generated with [Claude Code](https://claude.com/claude-code)