### PR TITLE
feat(horizon): objective unlink-pr, operator-gated met receipt en tenancy-isolatie (golf Bx, D5b, OI-1664)

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -835,6 +835,48 @@ def _merge_pr_refs(existing: Optional[str], incoming: list[str]) -> tuple[Option
     return new_ref, added, already
 
 
+def _remove_pr_refs(existing: Optional[str], to_remove: list[str]) -> tuple[Optional[str], list[str], list[str]]:
+    """Remove PR refs from an existing comma-separated pr_ref (inverse of `_merge_pr_refs`).
+
+    Returns (new_pr_ref, removed_refs, not_present_refs). Preserves the order of
+    `existing`; `removed_refs` lists refs in that same order, `not_present_refs`
+    lists requested-but-absent refs in request order. Deduplicates by PR number
+    on both sides. `new_pr_ref` is None when nothing remains (mirrors
+    `_merge_pr_refs`'s empty-is-None convention).
+    """
+    current: list[str] = []
+    seen: set[int] = set()
+    for tok in str(existing or "").split(","):
+        norm = _normalize_pr_ref(tok.strip())
+        if norm is None:
+            continue
+        n = int(norm.lstrip("#"))
+        if n in seen:
+            continue
+        seen.add(n)
+        current.append(norm)
+
+    remove_set: set[int] = set()
+    requested_order: list[int] = []
+    for raw in to_remove:
+        for tok in str(raw).split(","):
+            norm = _normalize_pr_ref(tok.strip())
+            if norm is None:
+                continue
+            n = int(norm.lstrip("#"))
+            if n not in remove_set:
+                remove_set.add(n)
+                requested_order.append(n)
+
+    present_nums = {int(ref.lstrip("#")) for ref in current}
+    removed = [ref for ref in current if int(ref.lstrip("#")) in remove_set]
+    remaining = [ref for ref in current if int(ref.lstrip("#")) not in remove_set]
+    not_present = [f"#{n}" for n in requested_order if n not in present_nums]
+
+    new_ref = ",".join(remaining) if remaining else None
+    return new_ref, removed, not_present
+
+
 # OI-1167: link-pr's pr_ref write and its delivery-marking write are two
 # separate facts. Linking the PR reference genuinely succeeds even when
 # track_pr_delivery is absent (pre-0032 store) -- that is legitimate
@@ -1017,6 +1059,104 @@ def cmd_objective_link_pr(args: argparse.Namespace) -> int:
             print(f"  delivery ({delivery_kind}) recorded for: {', '.join(f'#{n}' for n in touched_prs)}")
         else:
             print(f"  ERROR: {_DELIVERY_TABLE_MISSING_MSG}", file=sys.stderr)
+        print()
+    return 0
+
+
+def cmd_objective_unlink_pr(args: argparse.Namespace) -> int:
+    """Manually unlink PR ref(s) from a track (inverse of `link-pr`; operator-gated; audited).
+
+    Removes PR reference(s) from `tracks.pr_ref`, scoped to (track_id, project_id)
+    per ADR-007 -- same scoping shape as `link-pr`'s write. Unlink is more
+    destructive than link (it removes evidence), so a non-empty --reason is
+    REQUIRED: an empty reason is a refusal, not a silent bypass, mirroring
+    `pr_merge.py`'s `--override-contract-invalid` shape. Unlinking a PR that
+    is not currently present is a no-op that says so -- not an error.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+    reason = (args.reason or "").strip()
+
+    if not reason:
+        print(
+            "objective unlink-pr: --reason is required and must not be empty "
+            "(no silent bypass). No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"objective unlink-pr: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    existing = track.get("pr_ref")
+    new_ref, removed, not_present = _remove_pr_refs(existing, list(args.pr))
+
+    if not removed:
+        payload = {
+            "track_id": track_id,
+            "project_id": project_id,
+            "pr_ref": existing or "",
+            "removed": removed,
+            "not_present": not_present,
+            "reason": reason,
+            "action": "noop_not_present",
+            "applied": False,
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective unlink-pr — {track_id} (project '{project_id}')")
+            print(f"  pr_ref: {existing or ''}")
+            print(f"  none of the provided PR refs are present; no change made.\n")
+        return 0
+
+    # ADR-007: write is scoped to (track_id, project_id) -- same shape as link-pr.
+    conn = _db_conn(state_dir)
+    try:
+        conn.execute(
+            "UPDATE tracks SET pr_ref = ? WHERE track_id = ? AND project_id = ?",
+            (new_ref, track_id, project_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # ADR-005 audit event: specific operator action, reason recorded.
+    tracks_lib._emit_track_event(
+        state_dir,
+        "track_pr_unlinked",
+        track_id,
+        project_id,
+        "operator",
+        {"removed": removed, "not_present": not_present, "pr_ref": new_ref, "reason": reason},
+    )
+
+    payload = {
+        "track_id": track_id,
+        "project_id": project_id,
+        "pr_ref": new_ref,
+        "removed": removed,
+        "not_present": not_present,
+        "reason": reason,
+        "action": "unlinked",
+        "applied": True,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        print(f"\nvnx objective unlink-pr — {track_id} (project '{project_id}')")
+        print(f"  pr_ref: {new_ref or '(none)'}")
+        print(f"  - removed: {', '.join(removed)}")
+        if not_present:
+            print(f"  = not present: {', '.join(not_present)}")
+        print(f"  reason: {reason}")
         print()
     return 0
 
@@ -4814,6 +4954,23 @@ def _build_parser() -> argparse.ArgumentParser:
              "so; apply 0032 and re-run to record it)",
     )
     p_link_pr.set_defaults(func=cmd_objective_link_pr)
+
+    p_unlink_pr = obj_sub.add_parser(
+        "unlink-pr",
+        help="manually unlink PR ref(s) from a track (inverse of link-pr; operator-gated; audited)",
+    )
+    _common(p_unlink_pr)
+    p_unlink_pr.add_argument("track_id")
+    p_unlink_pr.add_argument(
+        "pr", nargs="+",
+        help="PR reference(s) as #NNN or NNN; comma-separated or repeated",
+    )
+    p_unlink_pr.add_argument(
+        "--reason", default="",
+        help="REQUIRED, non-empty: why this PR reference is being removed (audited; "
+             "no silent bypass -- an empty reason is refused)",
+    )
+    p_unlink_pr.set_defaults(func=cmd_objective_unlink_pr)
 
     p_reopen = obj_sub.add_parser(
         "reopen",

--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -345,7 +345,7 @@ def test_horizon_help_lists_full_surface(monkeypatch, capsys):
     for verb in (
         "add", "list", "show", "sync", "drift", "reconcile",
         "reconcile-review", "reconcile-streak", "close", "reopen",
-        "link-pr", "set-lane-hint", "set-goal",
+        "link-pr", "unlink-pr", "set-lane-hint", "set-goal",
         "deliverable", "plan-gate",
     ):
         assert verb in out, f"missing verb in `vnx horizon --help`: {verb}"
@@ -357,7 +357,7 @@ def test_objective_and_deliverable_alias_help(monkeypatch, capsys):
     for verb in (
         "add", "list", "show", "sync", "drift", "reconcile",
         "reconcile-review", "reconcile-streak", "close", "reopen",
-        "link-pr", "set-lane-hint", "set-goal",
+        "link-pr", "unlink-pr", "set-lane-hint", "set-goal",
     ):
         assert verb in out
     # objective is the OBJECTIVE-domain alias only — deliverable/plan-gate stay
@@ -520,12 +520,10 @@ def test_link_pr_and_set_lane_hint_resolve_through_verb_dispatch():
 def test_unlink_pr_resolves_through_verb_dispatch():
     """`unlink-pr` (golf Bx, D5b, OI-1664) is registered in _VERB_DISPATCH and
     delegates to the real planning_cli.cmd_objective_unlink_pr (not
-    reimplemented) -- same wiring shape as link-pr above. NOTE: unlike
-    link-pr, this verb is not yet reachable through `vnx_cli.main`'s argparse
-    (out of this dispatch's file boundary -- vnx_cli/main.py); this test only
-    verifies the horizon.py-layer dispatch wiring, matching the OI-1063
-    precedent where the engine verb landed before the pip-CLI parser surface
-    caught up."""
+    reimplemented) -- same wiring shape as link-pr above. Reachable through
+    `vnx_cli.main`'s argparse as of golf Bx D5b fix-forward (20260908-bx-d5b-
+    ff-cli-oppervlak) -- see the round-trip/help tests below for the parser
+    surface itself."""
     assert _horizon._VERB_DISPATCH["unlink-pr"] is _horizon._cmd_unlink_pr
     assert hasattr(planning_cli, "cmd_objective_unlink_pr")
 
@@ -586,6 +584,85 @@ def test_horizon_link_pr_rejects_unknown_delivery(project, monkeypatch, capsys):
         "--project-id", "horizon-test", "--project-dir", str(project_dir),
     ])
     assert rc == 2
+
+
+def test_horizon_unlink_pr_round_trips_track_prs_and_reason(project, monkeypatch, capsys):
+    """`vnx horizon unlink-pr <track> <pr> <pr> --reason ...` parses multiple
+    PR refs and forwards --reason (golf Bx, D5b, OI-1664 fix-forward: the
+    argparse surface for the parser-side of unlink-pr, mirroring link-pr's
+    round-trip test above)."""
+    project_dir, _ = project
+    captured = _capture_delegate(monkeypatch, "cmd_objective_unlink_pr")
+
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "unlink-pr", "feat-unlink", "#1234", "#1235",
+        "--reason", "superseded by #1240",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    args = captured["args"]
+    assert args.track_id == "feat-unlink"
+    assert args.pr == ["#1234", "#1235"]
+    assert args.reason == "superseded by #1240"
+    assert args.project_id == "horizon-test"
+    assert args.state_dir == str(_engine.resolve_data_root(Path(project_dir)) / "state")
+
+
+def test_objective_unlink_pr_round_trips_track_prs_and_reason(project, monkeypatch, capsys):
+    """Same round trip via the `vnx objective` alias entrance -- proves both
+    surfaces (`vnx horizon` and `vnx objective`) reach the new subparser, not
+    just one."""
+    project_dir, _ = project
+    captured = _capture_delegate(monkeypatch, "cmd_objective_unlink_pr")
+
+    rc, _, err = _run(monkeypatch, capsys, [
+        "objective", "unlink-pr", "feat-unlink", "#4321",
+        "--reason", "linked in error",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    args = captured["args"]
+    assert args.track_id == "feat-unlink"
+    assert args.pr == ["#4321"]
+    assert args.reason == "linked in error"
+
+
+def test_horizon_unlink_pr_empty_reason_is_refused_by_the_real_handler(project, monkeypatch, capsys):
+    """A real (non-stubbed) dry-run call with no --reason falls through to
+    planning_cli.cmd_objective_unlink_pr's own empty-reason refusal (exit 2,
+    no silent bypass) -- proves the validation shipped in the prior commit
+    still fires when reached through this new argparse entrance, not just
+    when planning_cli.py's own standalone parser is used directly. The
+    refusal happens before any track lookup, so no track needs to exist."""
+    project_dir, _ = project
+    rc, _, err = _run(monkeypatch, capsys, [
+        "objective", "unlink-pr", "feat-does-not-exist", "#1",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 2
+    assert "reason" in err
+
+
+def test_horizon_unlink_pr_help_matches_engine_arg_surface(monkeypatch, capsys):
+    """`vnx horizon unlink-pr --help` accepts the same arguments as the
+    planning_cli engine's own standalone parser (TRACK_ID, PR with
+    nargs='+', --reason)."""
+    rc, out, _ = _run(monkeypatch, capsys, ["horizon", "unlink-pr", "--help"])
+    assert rc == 0
+    assert "TRACK_ID" in out
+    assert "PR" in out
+    assert "--reason" in out
+
+
+def test_objective_unlink_pr_help_matches_engine_arg_surface(monkeypatch, capsys):
+    """Same help surface via the `vnx objective` alias entrance."""
+    rc, out, _ = _run(monkeypatch, capsys, ["objective", "unlink-pr", "--help"])
+    assert rc == 0
+    assert "TRACK_ID" in out
+    assert "PR" in out
+    assert "--reason" in out
 
 
 def test_horizon_set_lane_hint_round_trips_choices(project, monkeypatch, capsys):

--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -517,6 +517,19 @@ def test_link_pr_and_set_lane_hint_resolve_through_verb_dispatch():
     assert hasattr(planning_cli, "cmd_objective_set_lane_hint")
 
 
+def test_unlink_pr_resolves_through_verb_dispatch():
+    """`unlink-pr` (golf Bx, D5b, OI-1664) is registered in _VERB_DISPATCH and
+    delegates to the real planning_cli.cmd_objective_unlink_pr (not
+    reimplemented) -- same wiring shape as link-pr above. NOTE: unlike
+    link-pr, this verb is not yet reachable through `vnx_cli.main`'s argparse
+    (out of this dispatch's file boundary -- vnx_cli/main.py); this test only
+    verifies the horizon.py-layer dispatch wiring, matching the OI-1063
+    precedent where the engine verb landed before the pip-CLI parser surface
+    caught up."""
+    assert _horizon._VERB_DISPATCH["unlink-pr"] is _horizon._cmd_unlink_pr
+    assert hasattr(planning_cli, "cmd_objective_unlink_pr")
+
+
 def _capture_delegate(monkeypatch, name):
     """Stub a planning_cli cmd_* function and capture the args it receives."""
     captured = {}

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -319,6 +319,7 @@ _OBJECTIVE_ARGV = {
     "close": ["delegate-track"],
     "reopen": ["delegate-track"],
     "link-pr": ["delegate-track", "#1234", "#1235", "--delivery", "complete"],
+    "unlink-pr": ["delegate-track", "#1234", "#1235", "--reason", "superseded by #1240"],
     "set-lane-hint": ["delegate-track", "governed"],
     "set-goal": ["delegate-track", "Delegate goal state"],
 }

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -381,6 +381,129 @@ def test_link_pr_wrong_project_id_does_not_write(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# unlink-pr (golf Bx, D5b, OI-1664) — inverse of link-pr, operator-gated
+# ---------------------------------------------------------------------------
+
+def _unlink_pr_args(
+    state_dir: Path,
+    track_id: str,
+    *prs: str,
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+    reason: str = "",
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=project_id,
+        track_id=track_id,
+        pr=list(prs),
+        json=json,
+        reason=reason,
+    )
+
+
+def test_unlink_pr_removes_present_pr_and_writes_audit_event(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(
+        sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="#100,#1790,#200"
+    )
+    rc = planning_cli.cmd_objective_unlink_pr(
+        _unlink_pr_args(sd, "T", "#1790", reason="herkomst onbekend, OI-1664")
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "T") == "#100,#200"
+
+    events = _track_events(sd, "T", "track_pr_unlinked")
+    assert len(events) == 1
+    details = events[0]["details"]
+    assert details["removed"] == ["#1790"]
+    assert details["not_present"] == []
+    assert details["pr_ref"] == "#100,#200"
+    assert details["reason"] == "herkomst onbekend, OI-1664"
+
+
+def test_unlink_pr_removing_all_refs_leaves_pr_ref_empty(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="#1790")
+    rc = planning_cli.cmd_objective_unlink_pr(_unlink_pr_args(sd, "T", "#1790", reason="only ref"))
+    assert rc == 0
+    assert _pr_ref(sd, "T") == ""
+
+
+def test_unlink_pr_not_present_is_clean_noop_not_an_error(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="#100")
+    rc = planning_cli.cmd_objective_unlink_pr(
+        _unlink_pr_args(sd, "T", "#999", reason="not linked here")
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "T") == "#100"  # unchanged
+    # a no-op writes no audit event -- nothing to attest to.
+    assert _track_events(sd, "T", "track_pr_unlinked") == []
+
+
+def test_unlink_pr_on_missing_track_is_clean_error(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    rc = planning_cli.cmd_objective_unlink_pr(_unlink_pr_args(sd, "missing", "#1", reason="x"))
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "not found" in (captured.out + captured.err)
+
+
+def test_unlink_pr_empty_reason_is_refused(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="#100")
+    rc = planning_cli.cmd_objective_unlink_pr(_unlink_pr_args(sd, "T", "#100", reason=""))
+    assert rc == 2
+    assert _pr_ref(sd, "T") == "#100"  # unchanged -- no silent bypass
+    assert _track_events(sd, "T", "track_pr_unlinked") == []
+
+
+def test_unlink_pr_whitespace_only_reason_is_refused(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="#100")
+    rc = planning_cli.cmd_objective_unlink_pr(_unlink_pr_args(sd, "T", "#100", reason="   "))
+    assert rc == 2
+    assert _pr_ref(sd, "T") == "#100"
+
+
+def test_unlink_pr_wrong_project_id_does_not_write(tmp_path):
+    """Builds on the SAME wrong-project guard as link-pr
+    (`test_link_pr_wrong_project_id_does_not_write`): `get_track` is scoped to
+    (track_id, project_id), so a track that exists only under PROJECT_ID is
+    invisible under a different project_id -- the command errors out via the
+    "track not found" path before any write is attempted, never via a
+    second/duplicate scoping check."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="#1")
+    rc = planning_cli.cmd_objective_unlink_pr(
+        _unlink_pr_args(sd, "T", "#1", project_id="other-proj", reason="x")
+    )
+    assert rc == 1
+    assert _pr_ref(sd, "T", PROJECT_ID) == "#1"  # untouched
+
+
+def test_unlink_pr_isolation_same_track_id_two_projects(tmp_path):
+    """Tenancy requirement (golf Bx D5b, ADR-007): the SAME track_id under two
+    different project_ids are two different rows -- unlinking in project A
+    must never touch project B's row."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", "proj-a", title="x", goal_state="y", phase="queued", pr_ref="#1790")
+    tracks_lib.create_track(sd, "T", "proj-b", title="x", goal_state="y", phase="queued", pr_ref="#1790")
+
+    rc = planning_cli.cmd_objective_unlink_pr(
+        _unlink_pr_args(sd, "T", "#1790", project_id="proj-a", reason="isolation test")
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "T", project_id="proj-a") == ""
+    assert _pr_ref(sd, "T", project_id="proj-b") == "#1790"  # untouched
+
+    events_a = _track_events(sd, "T", "track_pr_unlinked")
+    assert len(events_a) == 1
+    assert events_a[0]["project_id"] == "proj-a"
+
+
+# ---------------------------------------------------------------------------
 # link-pr --delivery — OI-829 fail-closed auto-close gate
 # ---------------------------------------------------------------------------
 

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -189,6 +189,12 @@ def _cmd_link_pr(args: Any) -> int:
     return pc.cmd_objective_link_pr(args)
 
 
+def _cmd_unlink_pr(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_unlink_pr(args)
+
+
 def _cmd_set_lane_hint(args: Any) -> int:
     pc = _require_planning_cli()
     _prep(args)
@@ -213,6 +219,7 @@ _VERB_DISPATCH: dict[str, Callable[[Any], int]] = {
     "close": _cmd_close,
     "reopen": _cmd_reopen,
     "link-pr": _cmd_link_pr,
+    "unlink-pr": _cmd_unlink_pr,
     "set-lane-hint": _cmd_set_lane_hint,
     "set-goal": _cmd_set_goal,
 }

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -755,6 +755,23 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
              "OI-829 auto-close requires >=1 linked PR marked 'complete')",
     )
 
+    p_unlink_pr = subs.add_parser(
+        "unlink-pr",
+        help="manually unlink PR ref(s) from a track (operator-gated inverse of "
+             "link-pr; audited)",
+    )
+    _common_horizon_args(p_unlink_pr)
+    p_unlink_pr.add_argument("track_id", metavar="TRACK_ID")
+    p_unlink_pr.add_argument(
+        "pr", nargs="+", metavar="PR",
+        help="PR reference(s) as #NNN or NNN; comma-separated or repeated",
+    )
+    p_unlink_pr.add_argument(
+        "--reason", default="",
+        help="REQUIRED, non-empty: why this PR reference is being removed "
+             "(audited; no silent bypass — an empty reason is refused)",
+    )
+
     p_lane_hint = subs.add_parser(
         "set-lane-hint",
         help="set the descriptive dispatch lane_hint (governed|direct|unset) on a track",


### PR DESCRIPTION
## Summary
- `vnx objective unlink-pr <track_id> <pr>...` — inverse of `link-pr`, operator-gated (`--reason` required, empty is refused), ADR-007-scoped write on `(track_id, project_id)`, emits `track_pr_unlinked` (ADR-005).
- D5a (T0, `claudedocs/2026-09-08-D5a-herkomst-pr1790.md`) excluded both known write paths for the stray `#1790` link on `gate-enforcement-to-forge` with evidence — there is no rule to tighten, so this deliverable only builds the unlink escape hatch.
- Unlinking a not-present PR is a clean no-op (exit 0), not an error.
- Tenancy: reuses `get_track()`'s existing `(track_id, project_id)` scoping — the same guard `test_link_pr_wrong_project_id_does_not_write` exercises — plus a dedicated isolation test (same track_id under two project_ids, unlink in one leaves the other untouched).
- `vnx_cli/commands/horizon.py` gets the tenant-safe dispatch wrapper (`_cmd_unlink_pr`); `vnx_cli/main.py`'s own argparse surface is out of this dispatch's file boundary and does not get the subparser yet (same order as OI-1063: engine verb first, pip-CLI parser later — flagged in Open Items).
- Production step: `#1790` unlinked from `gate-enforcement-to-forge` (reason: unknown provenance, OI-1664/D5a); `objective reconcile` (check-only) does not re-link it afterward.

## Changes
- `scripts/planning_cli.py`: `_remove_pr_refs()` helper (inverse of `_merge_pr_refs`), `cmd_objective_unlink_pr()`, `unlink-pr` argparse subcommand.
- `vnx_cli/commands/horizon.py`: `_cmd_unlink_pr()` wrapper + `_VERB_DISPATCH["unlink-pr"]` entry.
- `tests/test_planning_cli.py`: 8 new tests (remove present, remove-all-leaves-empty, not-present no-op, missing track, empty reason, whitespace-only reason, wrong-project-id, cross-project isolation).
- `tests/test_horizon_cli.py`: 1 new wiring test (`_VERB_DISPATCH` entry resolves to the real `cmd_objective_unlink_pr`).

## Verification
Red run (implementation reverted via patch, tests kept) — all 9 new tests failed on behavior (`AttributeError`/`KeyError`, not import errors):
```
FAILED tests/test_planning_cli.py::test_unlink_pr_removes_present_pr_and_writes_audit_event
FAILED tests/test_planning_cli.py::test_unlink_pr_removing_all_refs_leaves_pr_ref_empty
FAILED tests/test_planning_cli.py::test_unlink_pr_not_present_is_clean_noop_not_an_error
FAILED tests/test_planning_cli.py::test_unlink_pr_on_missing_track_is_clean_error
FAILED tests/test_planning_cli.py::test_unlink_pr_empty_reason_is_refused
FAILED tests/test_planning_cli.py::test_unlink_pr_whitespace_only_reason_is_refused
FAILED tests/test_planning_cli.py::test_unlink_pr_wrong_project_id_does_not_write
FAILED tests/test_planning_cli.py::test_unlink_pr_isolation_same_track_id_two_projects
FAILED tests/test_horizon_cli.py::test_unlink_pr_resolves_through_verb_dispatch
9 failed, 77 deselected
```

Green run (implementation restored):
```
9 passed, 77 deselected
```

Full targeted runs after restore:
- `pytest tests/test_planning_cli.py -k "link_pr or unlink_pr"` → 18 passed
- `pytest tests/test_horizon_cli.py` → 27 passed
- `pytest tests/test_receipt_provenance.py` → 78 passed, 3 pre-existing unrelated failures (chain_status enum drift, confirmed present on a clean HEAD checkout before this branch touched anything)

Production unlink (real run, `vnx-dev` project):
```json
{
  "track_id": "gate-enforcement-to-forge",
  "project_id": "vnx-dev",
  "pr_ref": "#1804,#1805,#1806,#1807,#1809,#1810,#1808,#1811,#1812,#1813,#1814,#1815,#1816",
  "removed": ["#1790"],
  "not_present": [],
  "reason": "OI-1664/D5a: herkomst van de #1790-koppeling op deze track kon niet worden vastgesteld ...",
  "action": "unlinked",
  "applied": true
}
```
`tracks.pr_ref` before: `#1790,#1804,#1805,#1806,#1807,#1809,#1810,#1808,#1811,#1812,#1813,#1814,#1815,#1816`
`tracks.pr_ref` after: `#1804,#1805,#1806,#1807,#1809,#1810,#1808,#1811,#1812,#1813,#1814,#1815,#1816`
`objective reconcile` (check-only, no `--apply`) afterward: `gate-enforcement-to-forge` shows `pr_ref: #1804,...,#1816` — `#1790` not re-linked.

`git diff HEAD` empty before push.

## Open Items
None on the implementation. Two flagged for the operator/T0:
1. **Herkomst van de #1790-koppeling blijft onbekend.** D5a sloot zowel de reconciler-route als de handmatige `link-pr`-route uit met bewijs. Er bestaat dus een schrijver van `tracks.pr_ref` die geen `track_pr_linked`-gebeurtenis nalaat — niet gevonden in dit deliverable, en niet in scope om te zoeken (D5b bouwt alleen de unlink).
2. `vnx_cli/main.py` has no `unlink-pr` subparser yet — out of this dispatch's file boundary (`scripts/planning_cli.py`, `scripts/lib/tracks.py`, `vnx_cli/commands/horizon.py`, `tests/`). The horizon.py dispatch-layer wiring is in place and unit-tested; the pip-CLI argparse surface needs a follow-up (mirrors the OI-1063 precedent for `link-pr`).
3. `scripts/lib/tracks.py` was in the file boundary but ended up untouched — the unlink write mirrors `link-pr`'s existing inline-in-`planning_cli.py` shape (no new `tracks.py` primitive was needed; `_emit_track_event` was reused as-is).

**Dispatch-ID**: 20260908-bx-d5b-unlink-pr
**Model**: sonnet
**Provider**: claude