### PR TITLE
feat(pr-merge): de vijf preflight-oordelen landen in het grootboek, ook bij een weigering (golf Bx, D3, OI-1665)

### DIFF
--- a/scripts/build_t0_quality_digest.py
+++ b/scripts/build_t0_quality_digest.py
@@ -82,6 +82,24 @@ def _load_recent_receipts(state_dir: Path, hours: int = LOOKBACK_HOURS) -> List[
     return receipts
 
 
+#: Event types whose failure-shaped status records a governed REFUSAL, not a
+#: failed dispatch. ``pr_merge_refused`` (Golf Bx, D3) carries
+#: ``status="blocked"`` — the canonical governed-failure literal, chosen there
+#: because inventing a "refused" status would be a fleet-wide vocabulary change
+#: — plus the dispatch_id of the work it refused. Without this exemption the
+#: merge door refusing PR #N would mark dispatch N failed for 24 hours, even
+#: once the gate cleared and the PR merged that same day.
+#:
+#: An event_type filter rather than "a later success outranks an earlier
+#: failure": that alternative would change how EVERY event type in the ledger
+#: is counted, dropping real failures behind any later success, which is a far
+#: larger change to a governance metric than the defect being repaired. This
+#: exemption is scoped to the one receipt that means "the door said no".
+#: Absence of a readable event_type is not an exemption — an unclassified
+#: failure stays a failure.
+NON_FAILURE_EVENT_TYPES = frozenset({"pr_merge_refused"})
+
+
 def _build_evidence_map(receipts: List[Dict]) -> Dict[str, Any]:
     """Build dispatch-level evidence maps from recent receipts."""
     dispatch_ids: List[str] = []
@@ -90,9 +108,16 @@ def _build_evidence_map(receipts: List[Dict]) -> Dict[str, Any]:
     for r in receipts:
         did = r.get("dispatch_id") or r.get("task_id") or ""
         status = str(r.get("status", "")).lower()
+        # ``event`` is the legacy alias for ``event_type`` on older ledger
+        # lines; both are resolved, matching outcome_identity's reader.
+        event_type = str(r.get("event_type") or r.get("event") or "")
         if did and did not in dispatch_ids:
             dispatch_ids.append(did)
-        if did and status in ("failed", "fail", "error", "blocked"):
+        if (
+            did
+            and status in ("failed", "fail", "error", "blocked")
+            and event_type not in NON_FAILURE_EVENT_TYPES
+        ):
             if did not in failed_ids:
                 failed_ids.append(did)
 

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -212,6 +212,15 @@ PREFLIGHT_ORDER: tuple[str, ...] = (
 #: is indistinguishable from one that approved (OI-1665).
 VERDICT_NOT_EVALUATED = "not_evaluated"
 
+#: The ``not_evaluated`` message for a merge whose CALLER never ran the door's
+#: preflights at all (``merge_pr`` invoked directly, not via ``main()``). The
+#: same principle one level up: a ``pr_merged`` receipt that simply OMITS
+#: ``preflight_gates`` is indistinguishable from the ~23k receipts written
+#: before the field existed, so the first reader has to fail open on both. The
+#: key is therefore always written, and this message is what separates "no gate
+#: ran, ever" from the short-circuit padding a refusal produces.
+GATES_NOT_RUN_MESSAGE = "niet uitgevoerd: deze aanroep draaide de preflights van de deur niet"
+
 
 def _preflight_record(name: str, gate: Dict[str, Any], head_sha: str = "") -> Dict[str, Any]:
     """One preflight's outcome, in the shape the ledger stores it.
@@ -235,6 +244,7 @@ def _preflight_ledger(
     evaluated: list[Dict[str, Any]],
     *,
     refused_by: str = "",
+    unevaluated_message: str = "",
 ) -> list[Dict[str, Any]]:
     """The five preflights in ``PREFLIGHT_ORDER``: those that ran, plus those
     that never got a turn marked ``not_evaluated``.
@@ -244,9 +254,19 @@ def _preflight_ledger(
     reconstruct WHY a gate has no verdict. On the merge branch all five have
     run and this pads nothing.
 
+    ``unevaluated_message`` overrides that text for a caller whose gates did
+    not run for a different reason than a short-circuit — see
+    ``GATES_NOT_RUN_MESSAGE``. Both shapes use the same ``not_evaluated``
+    verdict, so the message is what tells the two apart.
+
     A gate that did not run judged no commit, so its ``head_sha`` is empty —
     deliberately not the PR head, which would suggest it looked at it.
     """
+    default_message = (
+        f"niet uitgevoerd: de deur stopte op de {refused_by}-preflight"
+        if refused_by
+        else "niet uitgevoerd"
+    )
     by_name = {record["gate"]: record for record in evaluated}
     ledger: list[Dict[str, Any]] = []
     for name in PREFLIGHT_ORDER:
@@ -257,11 +277,7 @@ def _preflight_ledger(
         ledger.append({
             "gate": name,
             "verdict": VERDICT_NOT_EVALUATED,
-            "message": (
-                f"niet uitgevoerd: de deur stopte op de {refused_by}-preflight"
-                if refused_by
-                else "niet uitgevoerd"
-            ),
+            "message": unevaluated_message or default_message,
             "head_sha": "",
             "overridden": False,
         })
@@ -995,8 +1011,17 @@ def _emit_receipt(
 
     ``preflight_gates`` (Golf Bx, D3): the five preflight verdicts that
     approved this merge, on THIS receipt rather than in a second gate
-    registration beside it — one merge, one evidence record. ``None`` omits
-    the field, for callers that merge without running the door's gates.
+    registration beside it — one merge, one evidence record.
+
+    The key is written ALWAYS, never omitted. Omitting it on a caller that ran
+    no gates gave the absence three readings at once — a merge from before this
+    field existed, a caller that skipped the door, and an empty list — over a
+    ledger holding ~23k older ``pr_merged`` lines that carry none of it. That
+    is the same argument ``VERDICT_NOT_EVALUATED`` exists for, applied to the
+    list itself instead of only to entries inside it. A gateless caller gets
+    the full five-record ledger with every verdict ``not_evaluated`` and
+    ``GATES_NOT_RUN_MESSAGE`` as the reason, so a reader sees one uniform shape
+    and field-presence alone separates a post-D3 receipt from a pre-D3 one.
     """
     kwargs: Dict[str, Any] = {
         "pr_number": pr_number,
@@ -1013,8 +1038,9 @@ def _emit_receipt(
         kwargs["dispatch_id"] = dispatch_id
     if contract_invalid_override:
         kwargs["contract_invalid_override"] = contract_invalid_override
-    if preflight_gates:
-        kwargs["preflight_gates"] = preflight_gates
+    kwargs["preflight_gates"] = preflight_gates or _preflight_ledger(
+        [], unevaluated_message=GATES_NOT_RUN_MESSAGE,
+    )
     return emit_governance_receipt(
         "pr_merged",
         receipt_kind="state_mutation",
@@ -1048,6 +1074,38 @@ def _emit_refusal_receipt(
     fleet-wide vocabulary change, not a merge-door change.
     ``receipt_kind="state_mutation"`` matches the ``pr_merged`` sibling — the
     merge door's attempt to mutate main, here with its outcome being "no".
+
+    ``commit_sha`` and ``gate`` carry ADR-038 outcome identity. That ADR
+    identifies an outcome by
+    ``(dispatch_id, event_type, status, commit_sha, gate, pr_number)``
+    (``outcome_identity.OUTCOME_ID_FIELDS``) and dedups against a durable index
+    spanning the WHOLE ledger, not a time window. This receipt first shipped
+    carrying only ``head_sha`` and ``refused_by`` — neither is in that tuple —
+    with a constant ``status="blocked"``, so every refusal of one PR under one
+    dispatch collapsed onto a single identity and ``_write_receipt_under_lock``
+    dropped all but the first. Measured on an isolated ledger: a CI refusal on
+    head aaa111 appended, a branch-protection refusal on head bbb222 returned
+    ``duplicate``, one line total.
+
+    ``commit_sha`` repeats ``head_sha`` deliberately rather than replacing it.
+    ``head_sha`` is this record's own field, asserted by the D3 tests and
+    echoed in the CLI's JSON; ``commit_sha`` is the fleet-canonical name that
+    ``closure_verifier``, ``gate_recorder``, ``receipt_provenance`` and
+    ``forge_gate_publisher`` already read, and the name ADR-038 hashes.
+
+    ``gate`` is stamped ONLY alongside a real dispatch_id, and that condition
+    is load-bearing in both directions. ``ghost_receipt_filter.is_gate_event``
+    treats ANY non-empty ``gate`` as a headless gate event, and
+    ``should_route_to_gate_stream`` then diverts the receipt to
+    ``gate_events.ndjson`` whenever the dispatch_id is a ghost value — and
+    ``""`` is one, which is exactly what ``_lookup_dispatch_id_by_pr_number``
+    returns on a miss. Stamping it unconditionally would push the least
+    traceable refusals straight out of the ledger this record exists to land
+    in (measured: reroute False today, True with an unconditional ``gate``).
+    Nothing is lost by the condition: ADR-038's durable check only runs when
+    ``has_outcome_identity`` sees a real dispatch_id, so ``gate`` adds
+    discrimination in precisely the case where discrimination is consulted.
+    ``refused_by`` carries the same gate name unconditionally for readers.
     """
     kwargs: Dict[str, Any] = {
         "pr_number": pr_number,
@@ -1055,9 +1113,11 @@ def _emit_refusal_receipt(
         "refused_by": refused_by,
         "preflight_gates": preflight_gates,
         "head_sha": head_sha or "",
+        "commit_sha": head_sha or "",
     }
     if dispatch_id:
         kwargs["dispatch_id"] = dispatch_id
+        kwargs["gate"] = refused_by
     return emit_governance_receipt(
         "pr_merge_refused",
         receipt_kind="state_mutation",
@@ -1092,6 +1152,19 @@ def _refuse_merge(
     failing emit is reported loudly on stderr and the refusal still exits
     EXIT_ERROR. The receipt's status travels back in the JSON payload so an
     unwritten record is visible to a machine reader too, not just in the log.
+
+    ``duplicate`` stays inside ``_RECEIPT_OK_STATUSES`` here, and that is a
+    decision rather than an oversight. Before ADR-038 identity was stamped on
+    this receipt (see ``_emit_refusal_receipt``), ``duplicate`` was reachable
+    for any second refusal of the same PR and meant "an unrelated earlier
+    refusal swallowed this one" — a silent evidence loss that the OK-list was
+    hiding. With ``commit_sha`` and ``gate`` on the tuple it is reachable only
+    when dispatch_id, PR, gate, head AND status are all identical, i.e. the
+    operator re-ran the door and got the very same refusal back. The ledger
+    already holds a byte-equivalent evidence line for that outcome, so ADR-038
+    suppressing the copy is the correct one-outcome-one-line behaviour and not
+    a fault to warn about. It remains visible to a machine reader either way:
+    ``refusal_receipt_status`` reports it verbatim in the JSON payload.
     """
     ledger = _preflight_ledger(evaluated, refused_by=gate_name)
 

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -79,10 +79,48 @@ Receipt written to t0_receipts.ndjson:
     merge_method: "squash" | "merge" | "rebase"
     pr_title    : <from gh api>
     branch      : <from gh api>
+    preflight_gates: <list of 5 dicts — every preflight's own verdict; see
+                                 "Preflight ledger" below>
     contract_invalid_override: <dict, optional — {"flag", "reason"}, only
                                  present when --override-contract-invalid
                                  was used to bypass a contract_invalid latest
                                  receipt>
+
+Preflight ledger (Golf Bx, D3 / OI-1665): the five preflights above each
+printed a verdict to the terminal and none of them reached the ledger, so
+"which gate approved this merge" survived only as long as the pane did, and a
+REFUSED merge left no record at all — the five ``return EXIT_ERROR`` branches
+in ``main()`` wrote nothing. Both branches now carry the same field,
+``preflight_gates``: one record per gate in ``PREFLIGHT_ORDER``, each
+``{"gate", "verdict", "message", "head_sha", "overridden"}``.
+
+The door SHORT-CIRCUITS on the first NO-GO (each preflight returns
+EXIT_ERROR on its own, before the next one runs) and that stays exactly as
+it was — it is the fail-closed property golf A and B built. So a refusal can
+never carry five real verdicts: the gates after the deciding one never ran.
+They are recorded as ``verdict: "not_evaluated"`` naming the gate that
+stopped the door, which is the point of the field — without it a gate that
+never ran is simply absent from the record, and absence reads as silent
+approval.
+
+Refusal receipt written to t0_receipts.ndjson (a refused merge):
+    event_type  : "pr_merge_refused"
+    status      : "blocked"
+    pr_number   : <int>
+    dispatch_id : <str, optional — --dispatch-id, else resolved from the PR>
+    conclusion  : "refused"
+    refused_by  : <str — the gate whose NO-GO stopped the merge>
+    head_sha    : <str — the head the gates judged, "" when unresolvable>
+    preflight_gates: <list of 5 dicts, as above>
+
+Its own event_type, NOT a ``pr_merged`` carrying ``conclusion: "refused"``:
+every merged-PR reader in the tree filters on the literal string
+``pr_merged`` and none of them reads ``conclusion`` (track_reconciler.py:320,
+build_feature_plan.py:212, build_t0_state.py:999, pr_queue_state.py:128,
+traceability_audit.py:610, digest/collectors/progress.py:63), so reusing the
+event type would make every one of them count a refused merge as a merge.
+``--dry-run`` writes no refusal receipt: that flag is documented as "no
+merge, no write", and a governance record is a write.
 
 Register event written to dispatch_register.ndjson:
     event       : "pr_merged"
@@ -156,6 +194,78 @@ _PR_LABEL_RE = re.compile(r"\bPR-([A-Z0-9]+(?:-[A-Z0-9]+)*)\b", re.IGNORECASE)
 # here together: _emit_receipt raising, and _emit_receipt returning a status
 # that is not recognized. Both must make the CLI exit non-zero.
 _RECEIPT_OK_STATUSES = frozenset({"appended", "duplicate"})
+
+#: The five preflights, in the exact order ``main()`` runs them. This order is
+#: what makes a refusal record readable: the door short-circuits on the first
+#: NO-GO, so everything at a later position never ran.
+PREFLIGHT_ORDER: tuple[str, ...] = (
+    "ci",
+    "review",
+    "adr",
+    "contract_invalid",
+    "branch_protection",
+)
+
+#: Third verdict value beside "GO" and "NO-GO" on a preflight record: this gate
+#: never got a turn because an earlier one refused. It is written EXPLICITLY
+#: rather than left out, because a gate that is simply missing from the record
+#: is indistinguishable from one that approved (OI-1665).
+VERDICT_NOT_EVALUATED = "not_evaluated"
+
+
+def _preflight_record(name: str, gate: Dict[str, Any], head_sha: str = "") -> Dict[str, Any]:
+    """One preflight's outcome, in the shape the ledger stores it.
+
+    Read straight off the gate result the door already holds — no gate is ever
+    re-run to fill this in (see ``TestShortCircuitUnchanged``). ``head_sha`` is
+    the commit that gate judged; it is the same head for all five (established
+    once by ``_run_ci_gate``) and is carried per record so a single record is
+    self-contained evidence rather than a pointer to a sibling field.
+    """
+    return {
+        "gate": name,
+        "verdict": str(gate.get("verdict") or "unknown"),
+        "message": str(gate.get("message") or ""),
+        "head_sha": head_sha or "",
+        "overridden": bool(gate.get("overridden")),
+    }
+
+
+def _preflight_ledger(
+    evaluated: list[Dict[str, Any]],
+    *,
+    refused_by: str = "",
+) -> list[Dict[str, Any]]:
+    """The five preflights in ``PREFLIGHT_ORDER``: those that ran, plus those
+    that never got a turn marked ``not_evaluated``.
+
+    ``refused_by`` names the gate whose NO-GO stopped the door; it goes into
+    the message of every unevaluated record so a reader never has to
+    reconstruct WHY a gate has no verdict. On the merge branch all five have
+    run and this pads nothing.
+
+    A gate that did not run judged no commit, so its ``head_sha`` is empty —
+    deliberately not the PR head, which would suggest it looked at it.
+    """
+    by_name = {record["gate"]: record for record in evaluated}
+    ledger: list[Dict[str, Any]] = []
+    for name in PREFLIGHT_ORDER:
+        record = by_name.get(name)
+        if record is not None:
+            ledger.append(record)
+            continue
+        ledger.append({
+            "gate": name,
+            "verdict": VERDICT_NOT_EVALUATED,
+            "message": (
+                f"niet uitgevoerd: de deur stopte op de {refused_by}-preflight"
+                if refused_by
+                else "niet uitgevoerd"
+            ),
+            "head_sha": "",
+            "overridden": False,
+        })
+    return ledger
 
 
 def _extract_pr_id(subject: str) -> Optional[str]:
@@ -871,6 +981,7 @@ def _emit_receipt(
     pr_id_resolution: str = "",
     receipts_file: Optional[str] = None,
     contract_invalid_override: Optional[Dict[str, Any]] = None,
+    preflight_gates: Optional[list[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Write pr_merged receipt to t0_receipts.ndjson with dual-scheme linkage.
 
@@ -881,6 +992,11 @@ def _emit_receipt(
     this receipt when ``--override-contract-invalid`` was used to bypass a
     contract_invalid latest receipt — ``{"flag": "--override-contract-invalid",
     "reason": <str>}``. ``None`` (the normal case) omits the field entirely.
+
+    ``preflight_gates`` (Golf Bx, D3): the five preflight verdicts that
+    approved this merge, on THIS receipt rather than in a second gate
+    registration beside it — one merge, one evidence record. ``None`` omits
+    the field, for callers that merge without running the door's gates.
     """
     kwargs: Dict[str, Any] = {
         "pr_number": pr_number,
@@ -897,6 +1013,8 @@ def _emit_receipt(
         kwargs["dispatch_id"] = dispatch_id
     if contract_invalid_override:
         kwargs["contract_invalid_override"] = contract_invalid_override
+    if preflight_gates:
+        kwargs["preflight_gates"] = preflight_gates
     return emit_governance_receipt(
         "pr_merged",
         receipt_kind="state_mutation",
@@ -906,6 +1024,114 @@ def _emit_receipt(
         receipts_file=receipts_file,
         **kwargs,
     )
+
+
+def _emit_refusal_receipt(
+    *,
+    pr_number: int,
+    dispatch_id: str,
+    preflight_gates: list[Dict[str, Any]],
+    refused_by: str,
+    head_sha: str = "",
+    receipts_file: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Write the ``pr_merge_refused`` receipt for a merge the door refused.
+
+    Its OWN event_type, not a ``pr_merged`` with ``conclusion: "refused"`` —
+    see the module docstring for the six readers that filter on the literal
+    ``pr_merged`` and would each count a refusal as a merge.
+
+    ``status="blocked"`` is taken from the canonical vocabulary in
+    ``event_outcome_semantics`` (a governed failure literal) rather than a new
+    literal like "refused": a status this ledger has never seen is refused by
+    ``resolve_status_category`` on the write side, and adding one is a
+    fleet-wide vocabulary change, not a merge-door change.
+    ``receipt_kind="state_mutation"`` matches the ``pr_merged`` sibling — the
+    merge door's attempt to mutate main, here with its outcome being "no".
+    """
+    kwargs: Dict[str, Any] = {
+        "pr_number": pr_number,
+        "conclusion": "refused",
+        "refused_by": refused_by,
+        "preflight_gates": preflight_gates,
+        "head_sha": head_sha or "",
+    }
+    if dispatch_id:
+        kwargs["dispatch_id"] = dispatch_id
+    return emit_governance_receipt(
+        "pr_merge_refused",
+        receipt_kind="state_mutation",
+        status="blocked",
+        terminal="T0",
+        source="pr_merge",
+        receipts_file=receipts_file,
+        **kwargs,
+    )
+
+
+def _refuse_merge(
+    *,
+    pr_number: int,
+    dispatch_id: str,
+    gate_name: str,
+    gate: Dict[str, Any],
+    evaluated: list[Dict[str, Any]],
+    head_sha: str,
+    json_output: bool,
+    json_key: str,
+    dry_run: bool,
+    receipts_file: Optional[str] = None,
+) -> int:
+    """Record a refused merge and return the CLI's exit code.
+
+    Called from every one of the five NO-GO branches in ``main()``; each of
+    them still does its own ``return`` on the value this produces, so the
+    short-circuit is untouched — this function never runs a gate.
+
+    Writing the record must not be able to turn a refusal into a crash: a
+    failing emit is reported loudly on stderr and the refusal still exits
+    EXIT_ERROR. The receipt's status travels back in the JSON payload so an
+    unwritten record is visible to a machine reader too, not just in the log.
+    """
+    ledger = _preflight_ledger(evaluated, refused_by=gate_name)
+
+    receipt_status = "skipped: dry-run"
+    if not dry_run:
+        resolved_dispatch_id = dispatch_id or _lookup_dispatch_id_by_pr_number(pr_number)
+        try:
+            receipt = _emit_refusal_receipt(
+                pr_number=pr_number,
+                dispatch_id=resolved_dispatch_id,
+                preflight_gates=ledger,
+                refused_by=gate_name,
+                head_sha=head_sha,
+                receipts_file=receipts_file,
+            )
+            receipt_status = (receipt or {}).get("append_status", "unknown")
+        # Broad by intent: a failed record must never mask the refusal itself.
+        except Exception as exc:
+            receipt_status = f"error: {exc}"
+        if receipt_status not in _RECEIPT_OK_STATUSES:
+            print(
+                f"WARN: PR #{pr_number} was refused by the {gate_name} preflight, but the "
+                f"pr_merge_refused record did NOT land (append_status={receipt_status!r}). "
+                f"The refusal itself stands; only its audit-trail evidence is missing.",
+                file=sys.stderr,
+            )
+
+    if json_output:
+        print(json.dumps({
+            "success": False,
+            "pr_number": pr_number,
+            "error": gate["message"],
+            json_key: gate,
+            "refused_by": gate_name,
+            "preflight_gates": ledger,
+            "refusal_receipt_status": receipt_status,
+        }, indent=2))
+    else:
+        print(f"NO-GO: {gate['message']}", file=sys.stderr)
+    return EXIT_ERROR
 
 
 def _emit_register_event(
@@ -938,6 +1164,7 @@ def merge_pr(
     head_sha: str = "",
     pr_data: Optional[Dict[str, Any]] = None,
     contract_invalid_override: Optional[Dict[str, Any]] = None,
+    preflight_gates: Optional[list[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Merge a PR and emit audit trail.
 
@@ -946,6 +1173,10 @@ def merge_pr(
     see ``_emit_receipt`` and ``_run_contract_invalid_gate``. ``None``
     (default) omits the field, matching a merge whose contract_invalid gate
     was never overridden.
+
+    ``preflight_gates`` (Golf Bx, D3): the five preflight verdicts ``main()``
+    collected on the way here, forwarded onto the ``pr_merged`` receipt.
+    ``None`` (default) omits the field for callers that never ran the gates.
 
     ``head_sha`` is the exact commit the gates approved; it is threaded into
     ``gh pr merge --match-head-commit`` so the merge refuses any other commit.
@@ -1045,6 +1276,7 @@ def merge_pr(
             pr_id_resolution="" if pr_id else "unmatched",
             receipts_file=receipts_file,
             contract_invalid_override=contract_invalid_override,
+            preflight_gates=preflight_gates,
         )
         append_status = (receipt or {}).get("append_status", "unknown")
         result["receipt_status"] = append_status
@@ -1114,19 +1346,34 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     method = args.merge_method or "squash"
 
+    # Golf Bx, D3: every preflight's own verdict, appended as it is decided.
+    # The door still returns on the FIRST NO-GO — this list is what the gates
+    # after that one are recorded as `not_evaluated` from, never a reason to
+    # keep running them.
+    evaluated: list[Dict[str, Any]] = []
+
     # ── Merge gate: VNX CI conclusion=success for the exact PR head ──────
     gate, pr_data = _run_ci_gate(args.pr, override_reason=args.override_reason)
+    # The head SHA the gates approve is established once, here: the merge is
+    # pinned to it (--match-head-commit) and every preflight record names it.
+    head_sha = (pr_data or {}).get("headRefOid") or ""
+    evaluated.append(_preflight_record("ci", gate, head_sha))
+
+    def refuse(gate_name: str, gate_result: Dict[str, Any], json_key: str) -> int:
+        return _refuse_merge(
+            pr_number=args.pr,
+            dispatch_id=args.dispatch_id or "",
+            gate_name=gate_name,
+            gate=gate_result,
+            evaluated=evaluated,
+            head_sha=head_sha,
+            json_output=args.json,
+            json_key=json_key,
+            dry_run=args.dry_run,
+        )
+
     if gate["verdict"] != "GO":
-        if args.json:
-            print(json.dumps({
-                "success": False,
-                "pr_number": args.pr,
-                "error": gate["message"],
-                "ci_gate": gate,
-            }, indent=2))
-        else:
-            print(f"NO-GO: {gate['message']}", file=sys.stderr)
-        return EXIT_ERROR
+        return refuse("ci", gate, "ci_gate")
     if gate.get("overridden"):
         print(f"OVERRIDE: {gate['message']}")
     else:
@@ -1134,17 +1381,9 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     # ── Review gate: a passing, evidenced review-gate result must exist ────
     review_gate, _ = _run_review_gate(args.pr, override_reason=args.override_reason)
+    evaluated.append(_preflight_record("review", review_gate, head_sha))
     if review_gate["verdict"] != "GO":
-        if args.json:
-            print(json.dumps({
-                "success": False,
-                "pr_number": args.pr,
-                "error": review_gate["message"],
-                "review_gate": review_gate,
-            }, indent=2))
-        else:
-            print(f"NO-GO: {review_gate['message']}", file=sys.stderr)
-        return EXIT_ERROR
+        return refuse("review", review_gate, "review_gate")
     if review_gate.get("overridden"):
         print(f"OVERRIDE: {review_gate['message']}")
     else:
@@ -1153,13 +1392,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     # ── ADR-number preflight: an added ADR file must not collide with a ────
     # number already on main (Golf B, B6). No override — always a refusal.
     adr_gate = _run_adr_gate(args.pr, pr_data=pr_data)
+    evaluated.append(_preflight_record("adr", adr_gate, head_sha))
     if adr_gate["verdict"] != "GO":
-        if args.json:
-            print(json.dumps({"success": False, "pr_number": args.pr,
-                               "error": adr_gate["message"], "adr_gate": adr_gate}, indent=2))
-        else:
-            print(f"NO-GO: {adr_gate['message']}", file=sys.stderr)
-        return EXIT_ERROR
+        return refuse("adr", adr_gate, "adr_gate")
     print(f"ADR gate: {adr_gate['message']}")
 
     # ── contract_invalid gate: the latest OUTCOME receipt for the dispatch ──
@@ -1170,16 +1405,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         pr_number=args.pr,
         override_reason=args.override_contract_invalid,
     )
+    evaluated.append(_preflight_record("contract_invalid", contract_gate, head_sha))
     if contract_gate["verdict"] != "GO":
-        if args.json:
-            print(json.dumps({
-                "success": False, "pr_number": args.pr,
-                "error": contract_gate["message"],
-                "contract_invalid_gate": contract_gate,
-            }, indent=2))
-        else:
-            print(f"NO-GO: {contract_gate['message']}", file=sys.stderr)
-        return EXIT_ERROR
+        return refuse("contract_invalid", contract_gate, "contract_invalid_gate")
     if contract_gate.get("overridden"):
         print(f"OVERRIDE: {contract_gate['message']}")
     else:
@@ -1192,24 +1420,16 @@ def main(argv: Optional[list[str]] = None) -> int:
     protection_gate = _run_branch_protection_gate(
         args.pr, pr_data=pr_data, allow_weaken_reason=args.allow_weaken,
     )
+    evaluated.append(_preflight_record("branch_protection", protection_gate, head_sha))
     if protection_gate["verdict"] != "GO":
-        if args.json:
-            print(json.dumps({
-                "success": False, "pr_number": args.pr,
-                "error": protection_gate["message"],
-                "branch_protection_gate": protection_gate,
-            }, indent=2))
-        else:
-            print(f"NO-GO: {protection_gate['message']}", file=sys.stderr)
-        return EXIT_ERROR
+        return refuse("branch_protection", protection_gate, "branch_protection_gate")
     if protection_gate.get("overridden"):
         print(f"OVERRIDE: {protection_gate['message']}")
     else:
         print(f"Branch-protection gate: {protection_gate['message']}")
 
-    # The head SHA the gates approved is established once in _run_ci_gate; the
-    # merge is pinned to it (--match-head-commit) so a post-gate push is refused.
-    head_sha = (pr_data or {}).get("headRefOid") or ""
+    # All five ran and approved: the ledger pads nothing here.
+    preflight_gates = _preflight_ledger(evaluated)
 
     contract_invalid_override = (
         {"flag": "--override-contract-invalid", "reason": contract_gate["override_reason"]}
@@ -1224,6 +1444,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         head_sha=head_sha,
         pr_data=pr_data,
         contract_invalid_override=contract_invalid_override,
+        preflight_gates=preflight_gates,
     )
 
     if args.json:

--- a/tests/test_pr_merge_preflight_ledger.py
+++ b/tests/test_pr_merge_preflight_ledger.py
@@ -465,3 +465,183 @@ class TestShortCircuitUnchanged:
 
         assert rc == pr_merge.EXIT_OK
         assert counts == {"adr": 1, "contract_invalid": 1, "branch_protection": 1}
+
+
+# ---------------------------------------------------------------------------
+# 4. ADR-038 outcome identity: a second refusal must not be swallowed
+# ---------------------------------------------------------------------------
+
+class TestRefusalOutcomeIdentity:
+    """ADR-038 gives an outcome a durable identity over
+    ``(dispatch_id, event_type, status, commit_sha, gate, pr_number)``
+    (``outcome_identity.OUTCOME_ID_FIELDS``) and dedups against a whole-ledger
+    index, not a time window. The refusal receipt as first shipped carried
+    ``head_sha`` and ``refused_by`` — neither is in that tuple — with a
+    constant ``status="blocked"``, so every refusal of one PR by one dispatch
+    hashed to ONE identity and every refusal after the first was dropped by
+    ``idempotency._write_receipt_under_lock``.
+    """
+
+    def _refuse_once(self, monkeypatch, *, ci=None, review=None, head, dispatch_id):
+        pr_data = dict(PR_DATA, headRefOid=head)
+        _stub_gh_gates(monkeypatch, ci=ci, review=review, pr_data=pr_data)
+        _track_do_merge(monkeypatch)
+        return pr_merge.main(["--pr", "7", "--dispatch-id", dispatch_id])
+
+    def test_two_refusals_by_different_gates_leave_two_records(
+        self, vnx_env, monkeypatch,
+    ):
+        """The failing case: CI refuses on one head, the operator pushes a fix,
+        the review gate refuses on the next head. Two distinct governance
+        outcomes, two ledger lines."""
+        head_one = "a" * 40
+        head_two = "b" * 40
+
+        rc1 = self._refuse_once(
+            monkeypatch, ci=_no_go("CI rood"),
+            head=head_one, dispatch_id="20260908-d3-dedup",
+        )
+        rc2 = self._refuse_once(
+            monkeypatch, review=_no_go("geen gate-verdict"),
+            head=head_two, dispatch_id="20260908-d3-dedup",
+        )
+
+        assert rc1 == pr_merge.EXIT_ERROR
+        assert rc2 == pr_merge.EXIT_ERROR
+
+        refusals = _receipts_of(vnx_env["receipts_path"], "pr_merge_refused")
+        assert len(refusals) == 2, (
+            "the second refusal was swallowed by the ADR-038 outcome index — "
+            f"got {[r.get('refused_by') for r in refusals]}"
+        )
+        assert [r["refused_by"] for r in refusals] == ["ci", "review"]
+        assert [r["commit_sha"] for r in refusals] == [head_one, head_two]
+
+    def test_two_refusals_by_different_gates_on_the_same_head(
+        self, vnx_env, monkeypatch,
+    ):
+        """``commit_sha`` alone does not carry it: an operator who fixes gate
+        state WITHOUT pushing (a review verdict landing, a protection drift
+        repaired) retries on the very same head and is refused by a later
+        gate. ``gate`` is what discriminates there."""
+        rc1 = self._refuse_once(
+            monkeypatch, ci=_no_go("CI rood"),
+            head=SHA, dispatch_id="20260908-d3-samehead",
+        )
+        rc2 = self._refuse_once(
+            monkeypatch, review=_no_go("geen gate-verdict"),
+            head=SHA, dispatch_id="20260908-d3-samehead",
+        )
+
+        assert (rc1, rc2) == (pr_merge.EXIT_ERROR, pr_merge.EXIT_ERROR)
+        refusals = _receipts_of(vnx_env["receipts_path"], "pr_merge_refused")
+        assert [r["refused_by"] for r in refusals] == ["ci", "review"]
+
+    def test_the_identity_tuple_actually_discriminates(self, vnx_env, monkeypatch):
+        """Asserted on ADR-038's own hash rather than on the line count, so this
+        test names the mechanism it defends and not just its symptom."""
+        from append_receipt_internals.outcome_identity import compute_outcome_id
+
+        self._refuse_once(
+            monkeypatch, ci=_no_go("CI rood"),
+            head="a" * 40, dispatch_id="20260908-d3-hash",
+        )
+        self._refuse_once(
+            monkeypatch, review=_no_go("geen gate-verdict"),
+            head="b" * 40, dispatch_id="20260908-d3-hash",
+        )
+
+        ids = {
+            compute_outcome_id(r)
+            for r in _receipts_of(vnx_env["receipts_path"], "pr_merge_refused")
+        }
+        assert len(ids) == 2
+
+    def test_an_identical_repeat_refusal_is_a_duplicate_and_stays_quiet(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        """The other side of the decision: after the fix, ``duplicate`` on this
+        event type can ONLY mean the same dispatch was refused by the same gate
+        on the same head with the same status — a genuine re-run of the door
+        whose evidence line is already on record. ADR-038 suppressing the
+        second copy is correct, so ``duplicate`` stays in
+        ``_RECEIPT_OK_STATUSES`` and the "record did NOT land" WARN must NOT
+        fire."""
+        for _ in range(2):
+            rc = self._refuse_once(
+                monkeypatch, ci=_no_go("CI rood"),
+                head=SHA, dispatch_id="20260908-d3-repeat",
+            )
+            assert rc == pr_merge.EXIT_ERROR
+
+        refusals = _receipts_of(vnx_env["receipts_path"], "pr_merge_refused")
+        assert len(refusals) == 1
+        assert "did NOT land" not in capsys.readouterr().err
+
+    def test_refusal_without_a_resolvable_dispatch_id_stays_in_the_ledger(
+        self, vnx_env, monkeypatch,
+    ):
+        """Guard on the fix itself. ``ghost_receipt_filter.is_gate_event``
+        treats ANY non-empty ``gate`` field as a headless gate event, and
+        ``should_route_to_gate_stream`` then diverts it to
+        ``gate_events.ndjson`` whenever the dispatch_id is a ghost value
+        (``""`` is one). Stamping ``gate`` unconditionally would therefore push
+        exactly the refusals that are hardest to trace OUT of the ledger this
+        PR exists to land them in."""
+        monkeypatch.setattr(pr_merge, "_lookup_dispatch_id_by_pr_number", lambda n: "")
+        self._refuse_once(
+            monkeypatch, ci=_no_go("CI rood"), head=SHA, dispatch_id="",
+        )
+
+        assert len(_receipts_of(vnx_env["receipts_path"], "pr_merge_refused")) == 1
+        assert not (vnx_env["state_dir"] / "gate_events.ndjson").exists()
+
+
+# ---------------------------------------------------------------------------
+# 5. A pr_merged without preflight_gates has three meanings
+# ---------------------------------------------------------------------------
+
+class TestMergedReceiptAlwaysCarriesTheKey:
+    """The ``not_evaluated`` principle applied to the LIST, not only inside it.
+
+    Omitting ``preflight_gates`` made "this caller never ran the door's gates"
+    indistinguishable from the ~23k ``pr_merged`` lines written before this
+    field existed. The first reader would have to fail open on both.
+    """
+
+    def test_a_merge_without_gates_still_writes_the_key(self, vnx_env, monkeypatch):
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: dict(PR_DATA))
+        _track_do_merge(monkeypatch)
+        monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **k: True)
+
+        pr_merge.merge_pr(7, dispatch_id="20260908-d3-nogates")
+
+        merged = _receipts_of(vnx_env["receipts_path"], "pr_merged")
+        assert len(merged) == 1
+        assert "preflight_gates" in merged[0], (
+            "absence is indistinguishable from a pre-D3 merge receipt"
+        )
+
+    def test_the_key_names_all_five_gates_as_not_evaluated(self, vnx_env, monkeypatch):
+        monkeypatch.setattr(pr_merge, "_query_pr", lambda n: dict(PR_DATA))
+        _track_do_merge(monkeypatch)
+        monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **k: True)
+
+        pr_merge.merge_pr(7, dispatch_id="20260908-d3-nogates-shape")
+
+        gates = _receipts_of(vnx_env["receipts_path"], "pr_merged")[0]["preflight_gates"]
+        assert [g["gate"] for g in gates] == list(pr_merge.PREFLIGHT_ORDER)
+        for g in gates:
+            assert g["verdict"] == pr_merge.VERDICT_NOT_EVALUATED, g
+            assert g["message"] == pr_merge.GATES_NOT_RUN_MESSAGE, g
+
+    def test_a_gateless_merge_reads_differently_from_a_refusal_padding(self):
+        """Both use ``not_evaluated``; the message is what tells a reader which
+        of the two it is looking at."""
+        gateless = pr_merge._preflight_ledger(
+            [], unevaluated_message=pr_merge.GATES_NOT_RUN_MESSAGE,
+        )
+        short_circuited = pr_merge._preflight_ledger([], refused_by="ci")
+
+        assert gateless[0]["message"] != short_circuited[0]["message"]
+        assert "ci" in short_circuited[0]["message"]

--- a/tests/test_pr_merge_preflight_ledger.py
+++ b/tests/test_pr_merge_preflight_ledger.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Golf Bx, D3 (OI-1665): the five preflight verdicts land in the ledger — on
+the merge AND on a refusal.
+
+Measured on main before this change: ``pr_merge.py`` printed five preflight
+verdicts (CI, review, ADR, contract_invalid, branch-protection) to the
+terminal and the ``pr_merged`` receipt knew none of them. A refused merge left
+no record at all: the five ``return EXIT_ERROR`` branches in ``main()`` write
+nothing, so "this door refused PR #N and this gate is why" existed only in a
+terminal that is gone the moment the pane closes.
+
+The door SHORT-CIRCUITS on the first NO-GO, and that is deliberate
+(fail-closed, golf A/B). So "all five verdicts after a refusal" is not
+achievable and is not what these tests demand. What they demand is that a
+reader can tell three states apart:
+
+  GO             — this gate ran and approved
+  NO-GO          — this gate ran and refused
+  not_evaluated  — this gate never ran, because an earlier one refused
+
+The third value is the deliverable: without it, a gate that never ran is
+absent from the record, and absence reads as silent approval.
+
+Three test groups, matching the dispatch's three red tests:
+
+1. ``TestRefusalRecord`` — a NO-GO leaves a readable record whose boundary
+   MOVES with the failing gate's position in the chain (three different
+   failing positions covered: 1, 2 and 4).
+2. ``TestMergedReceiptCarriesAllFive`` — a merge stamps all five verdicts on
+   the existing ``pr_merged`` receipt (no second evidence place beside it).
+3. ``TestShortCircuitUnchanged`` — after a NO-GO on gate two, gate three is
+   provably never called. This test exists to stop a later hand from making
+   the refusal record "more complete" by removing the short-circuit.
+
+Only the two gh-driven gates (``_run_ci_gate``/``_run_review_gate``) and
+``_do_merge`` are stubbed. The ADR gate, the contract_invalid gate and the
+branch-protection gate run for real against the conftest network stubs and an
+isolated tmp ``VNX_STATE_DIR``, so the ledger records come out of the real
+gate functions.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+
+
+SHA = "c" * 40
+
+PR_DATA = {
+    "number": 7,
+    "title": "PR-D3 preflight ledger",
+    "state": "OPEN",
+    "headRefName": "feature/d3",
+    "baseRefName": "main",
+    "headRefOid": SHA,
+}
+
+
+@pytest.fixture()
+def vnx_env(tmp_path, monkeypatch):
+    """Isolated VNX state dir — no receipt from this file touches the real store."""
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    (data_dir / "dispatches").mkdir(parents=True, exist_ok=True)
+    return {
+        "state_dir": state_dir,
+        "data_dir": data_dir,
+        "receipts_path": state_dir / "t0_receipts.ndjson",
+    }
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _write_receipts(path: Path, records: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _load_receipts(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _receipts_of(path: Path, event_type: str) -> List[Dict[str, Any]]:
+    return [r for r in _load_receipts(path) if r.get("event_type") == event_type]
+
+
+def _go(**kw) -> Dict[str, Any]:
+    gate = {"verdict": "GO", "message": "ok", "overridden": False, "override_reason": None}
+    gate.update(kw)
+    return gate
+
+
+def _no_go(message: str, **kw) -> Dict[str, Any]:
+    gate = {"verdict": "NO-GO", "message": message, "overridden": False, "override_reason": None}
+    gate.update(kw)
+    return gate
+
+
+_DEFAULT_PR_DATA = object()
+
+
+def _stub_gh_gates(monkeypatch, *, ci=None, review=None, pr_data=_DEFAULT_PR_DATA):
+    """CI + review gates are the two that need gh; everything else runs for real.
+
+    ``pr_data=None`` is a real case (``gh pr view`` failed), so it is passed
+    through as None rather than treated as "use the default".
+    """
+    data = dict(PR_DATA) if pr_data is _DEFAULT_PR_DATA else pr_data
+    monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (ci or _go(), data))
+    monkeypatch.setattr(pr_merge, "_run_review_gate", lambda pr, **k: (review or _go(), data))
+    monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **k: True)
+
+
+def _track_do_merge(monkeypatch):
+    calls: List[Any] = []
+    monkeypatch.setattr(
+        pr_merge, "_do_merge",
+        lambda n, m, h="": calls.append((n, m, h)) or (True, ""),
+    )
+    return calls
+
+
+def _by_gate(gates: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {g["gate"]: g for g in gates}
+
+
+def _refusal(receipts_path: Path) -> Dict[str, Any]:
+    refusals = _receipts_of(receipts_path, "pr_merge_refused")
+    assert len(refusals) == 1, f"expected exactly one refusal record, got {len(refusals)}"
+    return refusals[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. A refusal leaves a readable record; the boundary moves with the position
+# ---------------------------------------------------------------------------
+
+class TestRefusalRecord:
+    def test_no_go_on_gate_one_marks_the_other_four_not_evaluated(
+        self, vnx_env, monkeypatch,
+    ):
+        _stub_gh_gates(monkeypatch, ci=_no_go("CI-run niet groen op deze head"))
+        merges = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-ci-nogo"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not merges
+
+        rec = _refusal(vnx_env["receipts_path"])
+        assert rec["refused_by"] == "ci"
+        assert rec["conclusion"] == "refused"
+        assert rec["pr_number"] == 7
+        assert rec["dispatch_id"] == "20260908-d3-ci-nogo"
+
+        gates = _by_gate(rec["preflight_gates"])
+        assert list(gates) == list(pr_merge.PREFLIGHT_ORDER)
+        assert gates["ci"]["verdict"] == "NO-GO"
+        assert "CI-run niet groen" in gates["ci"]["message"]
+        for later in ("review", "adr", "contract_invalid", "branch_protection"):
+            assert gates[later]["verdict"] == pr_merge.VERDICT_NOT_EVALUATED, later
+
+    def test_no_go_on_gate_two_keeps_gate_one_go_and_marks_three_onwards(
+        self, vnx_env, monkeypatch,
+    ):
+        _stub_gh_gates(
+            monkeypatch,
+            ci=_go(message=f"VNX CI groen op {SHA[:7]}"),
+            review=_no_go("geen review-gate-verplichting gevonden voor PR #7"),
+        )
+        merges = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-review-nogo"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not merges
+
+        gates = _by_gate(_refusal(vnx_env["receipts_path"])["preflight_gates"])
+        assert gates["ci"]["verdict"] == "GO"
+        assert gates["review"]["verdict"] == "NO-GO"
+        assert "review-gate-verplichting" in gates["review"]["message"]
+        for later in ("adr", "contract_invalid", "branch_protection"):
+            assert gates[later]["verdict"] == pr_merge.VERDICT_NOT_EVALUATED, later
+
+    def test_no_go_on_gate_four_leaves_only_gate_five_not_evaluated(
+        self, vnx_env, monkeypatch,
+    ):
+        """The fourth gate refuses for real (a contract_invalid outcome receipt
+        on the chain) — only branch-protection is left unevaluated."""
+        did = "20260908-d3-contract-nogo"
+        _write_receipts(vnx_env["receipts_path"], [
+            {"timestamp": "2026-09-07T10:00:00Z", "event_type": "task_complete",
+             "status": "contract_invalid", "dispatch_id": did},
+        ])
+        _stub_gh_gates(monkeypatch)
+        merges = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not merges
+
+        rec = _refusal(vnx_env["receipts_path"])
+        assert rec["refused_by"] == "contract_invalid"
+        gates = _by_gate(rec["preflight_gates"])
+        for earlier in ("ci", "review", "adr"):
+            assert gates[earlier]["verdict"] == "GO", earlier
+        assert gates["contract_invalid"]["verdict"] == "NO-GO"
+        assert did in gates["contract_invalid"]["message"]
+        assert gates["branch_protection"]["verdict"] == pr_merge.VERDICT_NOT_EVALUATED
+
+    def test_not_evaluated_names_the_gate_that_stopped_the_door(
+        self, vnx_env, monkeypatch,
+    ):
+        """A reader must not have to reconstruct WHY a gate did not run."""
+        _stub_gh_gates(monkeypatch, review=_no_go("geen gate-verdict"))
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-why"])
+
+        gates = _by_gate(_refusal(vnx_env["receipts_path"])["preflight_gates"])
+        assert "review" in gates["adr"]["message"]
+
+    def test_refusal_is_its_own_event_type_and_writes_no_pr_merged(
+        self, vnx_env, monkeypatch,
+    ):
+        """Design choice under test: a refusal is ``pr_merge_refused``, NEVER a
+        ``pr_merged`` carrying conclusion=refused. Every merged-PR reader in
+        the tree filters on the literal string ``pr_merged``
+        (track_reconciler.py:320, build_feature_plan.py:212,
+        build_t0_state.py:999, pr_queue_state.py:128, traceability_audit.py:610,
+        digest/collectors/progress.py:63) and none of them reads
+        ``conclusion`` — so reusing the event type would make every one of them
+        count a refused merge as a merge."""
+        _stub_gh_gates(monkeypatch, ci=_no_go("niet toetsbaar"))
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-eventtype"])
+
+        assert _receipts_of(vnx_env["receipts_path"], "pr_merged") == []
+        assert len(_receipts_of(vnx_env["receipts_path"], "pr_merge_refused")) == 1
+
+    def test_refusal_record_carries_the_head_it_judged(self, vnx_env, monkeypatch):
+        _stub_gh_gates(monkeypatch, review=_no_go("geen gate-verdict"))
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-head"])
+
+        rec = _refusal(vnx_env["receipts_path"])
+        assert rec["head_sha"] == SHA
+        gates = _by_gate(rec["preflight_gates"])
+        assert gates["ci"]["head_sha"] == SHA
+        assert gates["review"]["head_sha"] == SHA
+        # A gate that never ran judged no commit at all.
+        assert gates["adr"]["head_sha"] == ""
+
+    def test_unresolvable_head_still_leaves_a_record(self, vnx_env, monkeypatch):
+        """Negative path: the CI gate's own "head not determinable" refusal has
+        no sha to record, and must still produce a readable refusal."""
+        _stub_gh_gates(
+            monkeypatch,
+            ci=_no_go("PR-head (sha/branch) kon niet worden bepaald voor #7"),
+            pr_data=None,
+        )
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-nohead"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        rec = _refusal(vnx_env["receipts_path"])
+        assert rec["head_sha"] == ""
+        assert rec["refused_by"] == "ci"
+
+    def test_dry_run_refusal_writes_nothing(self, vnx_env, monkeypatch):
+        """``--dry-run`` is documented as "no merge, no write" — a refusal in
+        dry-run mode must not append a governance record either."""
+        _stub_gh_gates(monkeypatch, ci=_no_go("CI niet groen"))
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-dry", "--dry-run"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert _receipts_of(vnx_env["receipts_path"], "pr_merge_refused") == []
+
+    def test_json_output_carries_the_ledger(self, vnx_env, monkeypatch, capsys):
+        _stub_gh_gates(monkeypatch, review=_no_go("geen gate-verdict"))
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-json", "--json"])
+
+        # The door prints its per-gate progress lines to stdout before the JSON
+        # payload (pre-existing behaviour, unchanged here), so parse from the
+        # first brace rather than the first byte.
+        out = capsys.readouterr().out
+        payload = json.loads(out[out.index("{"):])
+        assert payload["refused_by"] == "review"
+        assert _by_gate(payload["preflight_gates"])["adr"]["verdict"] == (
+            pr_merge.VERDICT_NOT_EVALUATED
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. The merge branch: all five verdicts on the existing pr_merged receipt
+# ---------------------------------------------------------------------------
+
+class TestMergedReceiptCarriesAllFive:
+    def test_all_five_verdicts_land_on_the_pr_merged_receipt(
+        self, vnx_env, monkeypatch,
+    ):
+        _stub_gh_gates(monkeypatch)
+        merges = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-merge"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert merges
+
+        merged = _receipts_of(vnx_env["receipts_path"], "pr_merged")
+        assert len(merged) == 1
+        gates = merged[0]["preflight_gates"]
+        assert [g["gate"] for g in gates] == list(pr_merge.PREFLIGHT_ORDER)
+        for g in gates:
+            assert g["verdict"] == "GO", g
+            assert g["message"], f"{g['gate']} has no message"
+            assert g["head_sha"] == SHA, g
+
+    def test_no_separate_gate_registration_beside_the_merged_receipt(
+        self, vnx_env, monkeypatch,
+    ):
+        """One evidence place, not two: the merge branch writes the ``pr_merged``
+        receipt and nothing else."""
+        _stub_gh_gates(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-one-place"])
+
+        kinds = {r.get("event_type") for r in _load_receipts(vnx_env["receipts_path"])}
+        assert kinds == {"pr_merged"}
+
+    def test_an_overridden_gate_is_visible_as_overridden(self, vnx_env, monkeypatch):
+        _stub_gh_gates(
+            monkeypatch,
+            ci=_go(message="OVERRIDE: CI-check overgeslagen (gate flaked)",
+                   overridden=True, override_reason="gate flaked"),
+        )
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-override"])
+
+        gates = _by_gate(_receipts_of(vnx_env["receipts_path"], "pr_merged")[0]["preflight_gates"])
+        assert gates["ci"]["overridden"] is True
+        assert gates["review"]["overridden"] is False
+
+    def test_bootstrap_branch_protection_go_is_recorded_as_go(
+        self, vnx_env, monkeypatch,
+    ):
+        """The branch-protection gate's bootstrap no-op is a GO with its own
+        message — the record must carry that message, not an empty verdict."""
+        _stub_gh_gates(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-bootstrap"])
+
+        gates = _by_gate(_receipts_of(vnx_env["receipts_path"], "pr_merged")[0]["preflight_gates"])
+        assert gates["branch_protection"]["verdict"] == "GO"
+        assert "preflight overgeslagen" in gates["branch_protection"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# 3. The short-circuit is UNCHANGED
+# ---------------------------------------------------------------------------
+
+class TestShortCircuitUnchanged:
+    def _count_downstream(self, monkeypatch):
+        counts = {"adr": 0, "contract_invalid": 0, "branch_protection": 0}
+        real_adr = pr_merge._run_adr_gate
+        real_contract = pr_merge._run_contract_invalid_gate
+        real_protection = pr_merge._run_branch_protection_gate
+
+        def adr(*a, **k):
+            counts["adr"] += 1
+            return real_adr(*a, **k)
+
+        def contract(*a, **k):
+            counts["contract_invalid"] += 1
+            return real_contract(*a, **k)
+
+        def protection(*a, **k):
+            counts["branch_protection"] += 1
+            return real_protection(*a, **k)
+
+        monkeypatch.setattr(pr_merge, "_run_adr_gate", adr)
+        monkeypatch.setattr(pr_merge, "_run_contract_invalid_gate", contract)
+        monkeypatch.setattr(pr_merge, "_run_branch_protection_gate", protection)
+        return counts
+
+    def test_no_go_on_gate_two_never_calls_gate_three(self, vnx_env, monkeypatch):
+        """The refusal record must NOT be bought by running the remaining gates
+        anyway. Gate three (ADR) is provably never called."""
+        _stub_gh_gates(monkeypatch, review=_no_go("geen gate-verdict"))
+        counts = self._count_downstream(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-shortcircuit"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert counts == {"adr": 0, "contract_invalid": 0, "branch_protection": 0}
+
+    def test_no_go_on_gate_one_never_calls_gate_two(self, vnx_env, monkeypatch):
+        calls: List[int] = []
+
+        def review(pr, **k):
+            calls.append(pr)
+            return _go(), dict(PR_DATA)
+
+        monkeypatch.setattr(pr_merge, "_run_ci_gate", lambda pr, **k: (_no_go("CI rood"), dict(PR_DATA)))
+        monkeypatch.setattr(pr_merge, "_run_review_gate", review)
+        monkeypatch.setattr(pr_merge, "_emit_register_event", lambda **k: True)
+        counts = self._count_downstream(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-sc1"])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert calls == [], "review gate must not run after a CI NO-GO"
+        assert counts == {"adr": 0, "contract_invalid": 0, "branch_protection": 0}
+
+    def test_every_gate_runs_exactly_once_on_a_clean_merge(self, vnx_env, monkeypatch):
+        """The ledger is built from the gate results the door already has — it
+        must not re-run a gate to fill a field."""
+        _stub_gh_gates(monkeypatch)
+        counts = self._count_downstream(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d3-once"])
+
+        assert rc == pr_merge.EXIT_OK
+        assert counts == {"adr": 1, "contract_invalid": 1, "branch_protection": 1}

--- a/tests/test_quality_digest_refusal_not_a_failure.py
+++ b/tests/test_quality_digest_refusal_not_a_failure.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Golf Bx, D3 fix-forward: a refused merge is not a failed dispatch.
+
+``build_t0_quality_digest._build_evidence_map`` classifies a dispatch as failed
+on the receipt's ``status`` alone — ``failed``/``fail``/``error``/``blocked``,
+with no ``event_type`` filter. The ``pr_merge_refused`` receipt introduced by
+D3 carries ``status="blocked"`` (the canonical governed-failure literal; a new
+literal like "refused" would be a fleet-wide vocabulary change) plus the
+dispatch_id. From the merge door's first refusal onward, the nightly digest
+would therefore count a dispatch whose door said "not yet" as a dispatch that
+failed — a different population than it counted before this PR.
+
+The concrete case: dispatch X is refused on the review preflight at 10:00, the
+review verdict lands at 11:00, the PR merges at 11:30. All three receipts fall
+inside the digest's 24h lookback and X is a success, yet it appears in
+``failed_dispatch_ids``.
+
+MEASURED, and why these tests drive ``_build_evidence_map`` directly rather
+than through ``_load_recent_receipts``: that loader cannot parse the canonical
+receipt timestamp. ``governance_receipts.utc_now_iso()`` emits whole seconds
+with a ``Z`` suffix (``2026-09-08T12:00:00Z``), and the loader rewrites it to
+``2026-09-08T12:00:00+00:00+00:00`` (``replace("Z", "+00:00")`` then
+``split(".")[0] + "+00:00"``), which ``fromisoformat`` rejects into a
+swallowed ``ValueError``. Over the live ledger on 2026-09-08 that silently
+drops 22.598 of 29.536 lines; only the 6.934 sub-second timestamps survive.
+A test that fed this classifier a canonically stamped refusal would therefore
+pass no matter what the classifier did — it would never reach it. That loader
+defect is a SEPARATE defect from the one this file pins, it is recorded as an
+open item, and it is deliberately not fixed here: repairing it changes the
+digest's input population fourfold, which is its own measurement and not a
+rider on a one-line classification fix.
+
+So the coupling under test is producer -> classifier: the refusal receipt is
+built by the REAL ``pr_merge._emit_refusal_receipt`` and read back off disk,
+so this file tracks the receipt shape ``pr_merge`` actually writes.
+
+``scripts/learning_loop.py:424`` has the same status-only shape. It is dormant
+and out of this PR's scope; it is recorded as an open item, not changed here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import pr_merge
+
+digest = importlib.import_module("build_t0_quality_digest")
+
+
+@pytest.fixture()
+def state_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _real_refusal(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
+    """A refusal receipt as ``pr_merge`` actually writes it, read back off an
+    isolated ledger — not a hand-copied literal that can drift from it."""
+    ledger = state_dir / "emitted.ndjson"
+    pr_merge._emit_refusal_receipt(
+        pr_number=1823,
+        dispatch_id=dispatch_id,
+        preflight_gates=pr_merge._preflight_ledger([], refused_by="review"),
+        refused_by="review",
+        head_sha="d" * 40,
+        receipts_file=str(ledger),
+    )
+    lines = [l for l in ledger.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 1, "helper must produce exactly one refusal line"
+    record = json.loads(lines[-1])
+    assert record["status"] == "blocked", (
+        "this test only means something while the refusal carries a "
+        "failure-shaped status"
+    )
+    return record
+
+
+def _merged(dispatch_id: str) -> Dict[str, Any]:
+    return {
+        "event_type": "pr_merged",
+        "receipt_kind": "state_mutation",
+        "status": "success",
+        "terminal": "T0",
+        "source": "pr_merge",
+        "dispatch_id": dispatch_id,
+        "pr_number": 1823,
+        "conclusion": "merged",
+    }
+
+
+def _real_failure(dispatch_id: str) -> Dict[str, Any]:
+    return {
+        "event_type": "dispatch_completed",
+        "receipt_kind": "dispatch",
+        "status": "failed",
+        "terminal": "T1",
+        "source": "envelope_govern",
+        "dispatch_id": dispatch_id,
+    }
+
+
+class TestRefusedMergeIsNotAFailedDispatch:
+    def test_refusal_then_merge_is_not_a_failure(self, state_dir):
+        """The dispatch's own failure scenario: refused at 10:00, merged at
+        11:30, both inside the 24h window."""
+        evidence = digest._build_evidence_map([
+            _real_refusal(state_dir, "20260908-x"),
+            _merged("20260908-x"),
+        ])
+
+        assert evidence["failed_dispatch_ids"] == []
+        assert "20260908-x" in evidence["dispatch_ids"]
+
+    def test_a_standing_refusal_is_still_not_a_failed_dispatch(self, state_dir):
+        """Even with no merge behind it: the door refusing is a gate doing its
+        job, not the dispatch failing. The refusal has its own event type and
+        its own readers."""
+        evidence = digest._build_evidence_map([_real_refusal(state_dir, "20260908-y")])
+
+        assert evidence["failed_dispatch_ids"] == []
+        assert evidence["dispatch_ids"] == ["20260908-y"]
+
+    def test_a_real_failure_is_still_counted(self, state_dir):
+        """The narrowing must not blunt the signal it was aimed around."""
+        evidence = digest._build_evidence_map([
+            _real_refusal(state_dir, "20260908-x"),
+            _real_failure("20260908-z"),
+        ])
+
+        assert evidence["failed_dispatch_ids"] == ["20260908-z"]
+
+    def test_a_dispatch_that_was_refused_and_also_really_failed_still_counts(
+        self, state_dir,
+    ):
+        """The exclusion is scoped to the refusal RECEIPT, not to the dispatch:
+        a dispatch carrying both a refusal and a genuine failure keeps its
+        failure. This is why the fix is an event_type filter and not "a later
+        success outranks an earlier failure" — the latter would silently drop
+        real failures across every event type in the ledger, a far larger
+        change to the metric than the defect being repaired."""
+        evidence = digest._build_evidence_map([
+            _real_refusal(state_dir, "20260908-w"),
+            _real_failure("20260908-w"),
+        ])
+
+        assert evidence["failed_dispatch_ids"] == ["20260908-w"]
+
+    def test_a_failure_status_without_a_readable_event_type_still_counts(self):
+        """Negative path. The filter must not become a hole: a receipt whose
+        event_type is missing or None is NOT exempt, it is unclassified, and an
+        unclassified failure stays a failure. Also pins that the added
+        ``event_type`` read cannot raise on ``None``."""
+        evidence = digest._build_evidence_map([
+            {"dispatch_id": "d1", "status": "blocked", "event_type": None},
+            {"dispatch_id": "d2", "status": "error"},
+        ])
+
+        assert evidence["failed_dispatch_ids"] == ["d1", "d2"]
+
+    def test_the_legacy_event_alias_is_honoured(self, state_dir):
+        """Older ledger lines carry ``event`` rather than ``event_type``
+        (``outcome_identity._resolve_event_name`` resolves both). A refusal
+        written under the legacy key must be exempt too."""
+        legacy = _real_refusal(state_dir, "20260908-legacy")
+        legacy["event"] = legacy.pop("event_type")
+
+        assert digest._build_evidence_map([legacy])["failed_dispatch_ids"] == []
+
+    def test_the_excluded_event_type_is_named_not_inferred(self):
+        """A reader of the digest must be able to see WHICH event types are
+        exempt without re-deriving the rule from a status list."""
+        assert "pr_merge_refused" in digest.NON_FAILURE_EVENT_TYPES
+
+
+class TestEvidenceMapReachesTheClassifier:
+    """One end-to-end pass through ``_load_recent_receipts`` so the wiring is
+    covered too, using a sub-second timestamp — the only shape that loader
+    accepts (see the module docstring's measurement)."""
+
+    def _write(self, state_dir: Path, records: List[Dict[str, Any]]) -> None:
+        stamp = (datetime.now(timezone.utc) - timedelta(minutes=30)).strftime(
+            "%Y-%m-%dT%H:%M:%S.%f"
+        )[:-3] + "+00:00"
+        with (state_dir / "t0_receipts.ndjson").open("w", encoding="utf-8") as fh:
+            for r in records:
+                fh.write(json.dumps(dict(r, timestamp=stamp)) + "\n")
+
+    def test_a_refusal_loaded_from_disk_is_not_a_failure(self, state_dir):
+        self._write(state_dir, [
+            _real_refusal(state_dir, "20260908-e2e"),
+            _real_failure("20260908-e2e-other"),
+        ])
+
+        loaded = digest._load_recent_receipts(state_dir)
+        assert len(loaded) == 2, "loader precondition: both lines must arrive"
+
+        evidence = digest._build_evidence_map(loaded)
+        assert evidence["failed_dispatch_ids"] == ["20260908-e2e-other"]
+        assert "20260908-e2e" in evidence["dispatch_ids"]


### PR DESCRIPTION
**Dispatch-ID**: 20260908-bx-d3-preflights-op-de-receipt
**Track**: golf-bx-poortlaag-schoonvegen, deliverable D3. **OI-1665.**

## Wat er mis was

`scripts/pr_merge.py` printte vijf preflight-oordelen naar de terminal en de `pr_merged`-receipt kende er geen. Een geweigerde merge liet niets achter: de vijf `return EXIT_ERROR`-takken in `main()` schreven niets, dus "deze deur weigerde PR #N en deze poort is waarom" bestond alleen zolang de pane openstond.

## Wat er nu gebeurt

Beide takken dragen hetzelfde veld `preflight_gates`: een record per poort met `gate`, `verdict`, `message`, `head_sha` en `overridden`.

**De short-circuit is ongewijzigd.** De deur stopt op de eerste NO-GO, dus een weigering kan nooit vijf echte oordelen dragen. De poorten na de beslissende krijgen `verdict: "not_evaluated"` mét de naam van de poort die de deur stopte. Dat onderscheid is het deliverable: zonder die waarde is een poort die niet gedraaid heeft simpelweg afwezig, en afwezigheid leest als stilzwijgende goedkeuring.

## Ontwerpkeuze: een eigen event_type

De weigering wordt `pr_merge_refused`, niet een `pr_merged` met `conclusion: "refused"`. Nagekeken lezers, allemaal een exacte string-vergelijking op `pr_merged` en geen enkele leest `conclusion`:

| Lezer | Regel | Wat hergebruik zou doen |
|---|---|---|
| `scripts/lib/track_reconciler.py` | 320 | een track vooruit zetten op een geweigerde merge |
| `scripts/build_feature_plan.py` | 212 | de PR als `merged` in het feature-plan |
| `scripts/build_t0_state.py` | 999 | dispatch-status `completed` |
| `scripts/lib/pr_queue_state.py` | 128 | de dispatch als terminaal uit de queue |
| `scripts/traceability_audit.py` | 610 | de traceability-gap dichtgerekend |
| `scripts/lib/digest/collectors/progress.py` | 63 | meegeteld als "PRs merged" |

Met een eigen event_type ziet geen van de zes het record, en dat is precies goed: een weigering is geen merge. `status="blocked"` komt uit de canonieke vocabulaire in `event_outcome_semantics` (een nieuw literal zou een vloot-brede wijziging zijn, geen deur-wijziging), `receipt_kind="state_mutation"` gelijk aan de `pr_merged`-zuster. `--dry-run` schrijft geen weiger-receipt: die vlag is gedocumenteerd als "no merge, no write".

## Tests

`tests/test_pr_merge_preflight_ledger.py`, 16 tests in drie groepen: de weigertak (drie verschillende falende posities, 1/2/4), de mergetak, en drie regressiewachters die aantonen dat de short-circuit ongewijzigd is. Eerst rood gedraaid tegen de ongewijzigde deur: 11 rood, 5 groen (de wachters zijn per definitie vooraf groen).

Alle `tests/test_pr_merge*.py` plus de directe buren: 205 passed.

Dispatch-ID: 20260908-bx-d3-preflights-op-de-receipt