### PR TITLE
fix(pr-merge): de contract_invalid-override werkt alleen op zijn eigen redencode (golf Bx, D4, OI-1666)

### DIFF
--- a/scripts/lib/contract_invalid_ledger.py
+++ b/scripts/lib/contract_invalid_ledger.py
@@ -20,10 +20,14 @@ at session start. This module is the missing read side:
   - ``collect_contract_invalid_open`` / ``write_contract_invalid_open_ledger``:
     the single-file open-items ledger — one row per still-open dispatch, not
     one open item per receipt (gevolg 2, "een lijst, geen vloed").
-  - ``is_deliverable_acceptable``: the gate a closer must call before
-    treating a dispatch's deliverable as done (gevolg 3, "niet stil
-    sluitbaar"). Its call site is the merge door (``pr_merge.py``'s
-    ``_run_contract_invalid_gate``).
+  - ``is_deliverable_acceptable`` / ``evaluate_deliverable_acceptance``: the
+    gate a closer must call before treating a dispatch's deliverable as done
+    (gevolg 3, "niet stil sluitbaar"). Its call site is the merge door
+    (``pr_merge.py``'s ``_run_contract_invalid_gate``). The first returns
+    ``(bool, prose)``; the second returns that same judgment plus the
+    machine-readable ``code`` a caller may DECIDE on (golf Bx, D4 / OI-1666 —
+    the door's override covers one of the three refusals, and prose is not a
+    contract).
 
 Which receipts that gate may judge is itself the thing that decides whether
 it fires at all, and it takes TWO filters to get there:
@@ -59,7 +63,7 @@ import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 _LIB_DIR = Path(__file__).resolve().parent
 if str(_LIB_DIR) not in sys.path:
@@ -151,6 +155,90 @@ DECIDED_OUTCOME_STATUSES = frozenset({
 })
 
 _MIN_AWARE_DATETIME = datetime.min.replace(tzinfo=timezone.utc)
+
+# ── Acceptance reason codes (golf Bx, D4 / OI-1666) ───────────────────────
+#
+# ``is_deliverable_acceptable`` answered with a bool plus a Dutch prose
+# reason, and that prose was the ONLY thing distinguishing its three refusals
+# from one another. The merge door's ``--override-contract-invalid`` therefore
+# covered all three: an operator who meant "I know about that
+# contract_invalid" silently also waved through "I cannot read the ledger",
+# where repairing is the right move and proceeding is not.
+#
+# These codes are what a caller DECIDES on; the reason string stays a message
+# for a human and may be reworded freely without moving a gate. Matching on
+# that prose instead is the exact failure class golf Bx exists to remove — it
+# breaks on the first rewrite, silently and in the permissive direction.
+#
+# Deliberately plain string constants rather than an ``enum.Enum``: this
+# module already carries its vocabularies this way
+# (``CONTRACT_INVALID_STATUS``, ``DECIDED_OUTCOME_STATUSES``), the values are
+# written straight into JSON gate results, and a ``(str, Enum)`` member
+# formats as ``AcceptanceCode.X`` in an f-string on Python 3.11+ but as its
+# value on 3.10 — a version-dependent difference that has no place in an
+# audit message.
+
+#: Refusal: the latest decided deliverable-outcome receipt IS contract_invalid.
+#: The ONE case ``--override-contract-invalid`` may bypass. Its VALUE equals
+#: ``CONTRACT_INVALID_STATUS`` because it names the same fact from the other
+#: side (a receipt status vs. why this gate refused); they are separate
+#: constants and a caller compares a code against codes, never against a
+#: receipt's ``status`` field.
+CODE_CONTRACT_INVALID = "contract_invalid"
+
+#: Refusal: the ledger exists but could not be read (``strict=True``). A gate
+#: outage to be repaired, never a judgment about the deliverable.
+CODE_LEDGER_UNREADABLE = "ledger_unreadable"
+
+#: Refusal: no dispatch_id was given, so there is no chain to judge at all.
+CODE_EMPTY_DISPATCH_ID = "empty_dispatch_id"
+
+#: Accepted: a decided outcome receipt exists and is not contract_invalid.
+CODE_NOT_CONTRACT_INVALID = "not_contract_invalid"
+
+#: Accepted (fail-open absence): no deliverable-outcome receipt on record.
+CODE_NO_OUTCOME_RECEIPT = "no_outcome_receipt"
+
+#: Accepted (fail-open absence): outcome receipts exist but none of them
+#: decides the deliverable.
+CODE_NO_DECIDED_OUTCOME = "no_decided_outcome"
+
+#: The closed set of codes this module returns. A reader may switch on a code
+#: from this set; anything outside it is a bug in this module, not a case to
+#: handle permissively — a consumer meeting an unknown code must fail closed.
+ACCEPTANCE_CODES = frozenset({
+    CODE_CONTRACT_INVALID,
+    CODE_LEDGER_UNREADABLE,
+    CODE_EMPTY_DISPATCH_ID,
+    CODE_NOT_CONTRACT_INVALID,
+    CODE_NO_OUTCOME_RECEIPT,
+    CODE_NO_DECIDED_OUTCOME,
+})
+
+#: The refusing subset, for a caller that wants to assert it handled them all.
+REFUSING_ACCEPTANCE_CODES = frozenset({
+    CODE_CONTRACT_INVALID,
+    CODE_LEDGER_UNREADABLE,
+    CODE_EMPTY_DISPATCH_ID,
+})
+
+
+class DeliverableAcceptance(NamedTuple):
+    """The verdict of ``evaluate_deliverable_acceptance``: the boolean, the
+    machine-readable ``code`` a caller decides on, and the human ``reason``.
+
+    A NamedTuple rather than a widened return tuple on
+    ``is_deliverable_acceptable``: that function is a gate function with
+    call sites outside this module (``pr_merge.py``) and ~20 in the suite,
+    all unpacking two values. Widening it to three would have broken every
+    one of them at once, so the widening is ADDITIVE — the two-tuple contract
+    stays exactly as it was and is still tested, and the coded form is a
+    second entry point that returns the same judgment with its cause attached.
+    """
+
+    acceptable: bool
+    code: str
+    reason: str
 
 
 class ReceiptsUnreadableError(OSError):
@@ -403,6 +491,75 @@ def write_contract_invalid_open_ledger(
     return payload
 
 
+def evaluate_deliverable_acceptance(
+    dispatch_id: str,
+    receipts_path: Path,
+    *,
+    project_id: Optional[str] = None,
+    strict: bool = True,
+) -> DeliverableAcceptance:
+    """The full judgment behind ``is_deliverable_acceptable``: the same
+    boolean and the same prose, plus the machine-readable ``code`` that says
+    WHICH of the six outcomes produced it (see the ``CODE_*`` constants).
+
+    Callers that only display the answer keep using
+    ``is_deliverable_acceptable``. A caller that DECIDES on the answer —
+    today the merge door, whose ``--override-contract-invalid`` may bypass
+    ``CODE_CONTRACT_INVALID`` and nothing else (OI-1666) — must use this one:
+    the three refusals are indistinguishable in the boolean and separable in
+    the prose only by matching Dutch text, which is not a contract.
+    """
+    did = (dispatch_id or "").strip()
+    if not did:
+        return DeliverableAcceptance(False, CODE_EMPTY_DISPATCH_ID, "empty dispatch_id")
+
+    try:
+        records = _read_receipts_strict(receipts_path) if strict else _read_receipts(receipts_path)
+    except ReceiptsUnreadableError as exc:
+        return DeliverableAcceptance(
+            False, CODE_LEDGER_UNREADABLE, f"grootboek onleesbaar: {exc}",
+        )
+
+    records = _filter_project(records, project_id)
+    outcomes = [
+        r for r in records
+        if str(r.get("dispatch_id") or "").strip() == did and _is_outcome_receipt(r)
+    ]
+    if not outcomes:
+        return DeliverableAcceptance(
+            True,
+            CODE_NO_OUTCOME_RECEIPT,
+            f"geen uitkomst-receipt op record voor {did} "
+            f"(afwezigheid is geen weigering)",
+        )
+
+    decided = [r for r in outcomes if _is_decided_outcome(r)]
+    if not decided:
+        seen = sorted({
+            str(r.get("status") or "").strip().lower() or "<leeg>" for r in outcomes
+        })
+        return DeliverableAcceptance(
+            True,
+            CODE_NO_DECIDED_OUTCOME,
+            f"geen besliste uitkomst voor {did}: {len(outcomes)} uitkomst-receipt(s), "
+            f"alle onbeslist (status: {', '.join(seen)}) "
+            f"(afwezigheid is geen weigering)",
+        )
+
+    latest = sorted(decided, key=_sort_key)[-1]
+    if _is_contract_invalid(latest):
+        event_type = str(latest.get("event_type") or latest.get("event") or "")
+        return DeliverableAcceptance(
+            False,
+            CODE_CONTRACT_INVALID,
+            f"latest decided outcome receipt for {did} is contract_invalid "
+            f"(event_type={event_type!r}, report_path={latest.get('report_path')!r})",
+        )
+    return DeliverableAcceptance(
+        True, CODE_NOT_CONTRACT_INVALID, "latest decided outcome receipt is not contract_invalid",
+    )
+
+
 def is_deliverable_acceptable(
     dispatch_id: str,
     receipts_path: Path,
@@ -447,57 +604,40 @@ def is_deliverable_acceptable(
     than degrading to an empty read that would look like that same
     fail-open absence. ``strict=False`` restores the advisory soft read for a
     caller that only wants a hint.
+
+    The three refusals above are three DIFFERENT things and this signature
+    cannot tell them apart — a caller that acts on the difference (the merge
+    door's ``--override-contract-invalid``, which may bypass the
+    contract_invalid one and neither of the other two) must call
+    ``evaluate_deliverable_acceptance`` and read its ``code``. This function
+    is the unchanged display form: same boolean, same prose, one judgment,
+    computed in exactly one place.
     """
-    did = (dispatch_id or "").strip()
-    if not did:
-        return False, "empty dispatch_id"
-
-    try:
-        records = _read_receipts_strict(receipts_path) if strict else _read_receipts(receipts_path)
-    except ReceiptsUnreadableError as exc:
-        return False, f"grootboek onleesbaar: {exc}"
-
-    records = _filter_project(records, project_id)
-    outcomes = [
-        r for r in records
-        if str(r.get("dispatch_id") or "").strip() == did and _is_outcome_receipt(r)
-    ]
-    if not outcomes:
-        return True, (
-            f"geen uitkomst-receipt op record voor {did} "
-            f"(afwezigheid is geen weigering)"
-        )
-
-    decided = [r for r in outcomes if _is_decided_outcome(r)]
-    if not decided:
-        seen = sorted({
-            str(r.get("status") or "").strip().lower() or "<leeg>" for r in outcomes
-        })
-        return True, (
-            f"geen besliste uitkomst voor {did}: {len(outcomes)} uitkomst-receipt(s), "
-            f"alle onbeslist (status: {', '.join(seen)}) "
-            f"(afwezigheid is geen weigering)"
-        )
-
-    latest = sorted(decided, key=_sort_key)[-1]
-    if _is_contract_invalid(latest):
-        event_type = str(latest.get("event_type") or latest.get("event") or "")
-        return False, (
-            f"latest decided outcome receipt for {did} is contract_invalid "
-            f"(event_type={event_type!r}, report_path={latest.get('report_path')!r})"
-        )
-    return True, "latest decided outcome receipt is not contract_invalid"
+    result = evaluate_deliverable_acceptance(
+        dispatch_id, receipts_path, project_id=project_id, strict=strict,
+    )
+    return result.acceptable, result.reason
 
 
 __all__ = [
+    "ACCEPTANCE_CODES",
+    "CODE_CONTRACT_INVALID",
+    "CODE_EMPTY_DISPATCH_ID",
+    "CODE_LEDGER_UNREADABLE",
+    "CODE_NOT_CONTRACT_INVALID",
+    "CODE_NO_DECIDED_OUTCOME",
+    "CODE_NO_OUTCOME_RECEIPT",
     "CONTRACT_INVALID_STATUS",
     "CONTRACT_INVALID_EVENT_TYPE",
     "DECIDED_OUTCOME_STATUSES",
     "DELIVERABLE_OUTCOME_EVENT_TYPES",
     "OPEN_LEDGER_FILENAME",
+    "REFUSING_ACCEPTANCE_CODES",
+    "DeliverableAcceptance",
     "ReceiptsUnreadableError",
     "build_contract_invalid_summary",
     "collect_contract_invalid_open",
+    "evaluate_deliverable_acceptance",
     "write_contract_invalid_open_ledger",
     "is_deliverable_acceptable",
 ]

--- a/scripts/lib/contract_invalid_ledger.py
+++ b/scripts/lib/contract_invalid_ledger.py
@@ -190,6 +190,27 @@ CODE_CONTRACT_INVALID = "contract_invalid"
 #: outage to be repaired, never a judgment about the deliverable.
 CODE_LEDGER_UNREADABLE = "ledger_unreadable"
 
+#: Not a refusal: the same read failure met in ADVISORY mode (``strict=False``),
+#: where this function does not gate anything and may not block a caller.
+#:
+#: It exists because the advisory branch previously reported that failure as
+#: ``CODE_NO_OUTCOME_RECEIPT`` — the soft read swallowed the error, handed back
+#: an empty list, and the absence branch below took it from there. Two
+#: different states then shared one code, which is the conflation D4 removed
+#: one level up. They are not the same state and the difference is directional:
+#: an absence is genuinely fail-open (a dispatch that wrote no outcome receipt
+#: makes no claim about its deliverable), while a read failure may be hiding a
+#: contract_invalid record this reader could not see. A caller that treats them
+#: alike is choosing the permissive reading of an unknown.
+#:
+#: The boolean stays ``True`` here on purpose. ``strict=False`` is the contract
+#: an advisory reader asks for — a SessionStart counter must not crash and must
+#: not block over a permission bit — and hardening it would turn every such
+#: reader into a second gate. What changes is only that the answer now says
+#: which kind of not-judging it was, so a caller that DOES care can see it.
+#: The gate itself keeps ``strict=True`` and its own refusing code.
+CODE_LEDGER_UNREADABLE_ADVISORY = "ledger_unreadable_advisory"
+
 #: Refusal: no dispatch_id was given, so there is no chain to judge at all.
 CODE_EMPTY_DISPATCH_ID = "empty_dispatch_id"
 
@@ -209,6 +230,7 @@ CODE_NO_DECIDED_OUTCOME = "no_decided_outcome"
 ACCEPTANCE_CODES = frozenset({
     CODE_CONTRACT_INVALID,
     CODE_LEDGER_UNREADABLE,
+    CODE_LEDGER_UNREADABLE_ADVISORY,
     CODE_EMPTY_DISPATCH_ID,
     CODE_NOT_CONTRACT_INVALID,
     CODE_NO_OUTCOME_RECEIPT,
@@ -216,6 +238,13 @@ ACCEPTANCE_CODES = frozenset({
 })
 
 #: The refusing subset, for a caller that wants to assert it handled them all.
+#:
+#: Membership tracks the BOOLEAN exactly: a code is in this set if and only if
+#: the judgment carrying it has ``acceptable=False``. That is why the advisory
+#: read failure gets its own code instead of reusing ``CODE_LEDGER_UNREADABLE``
+#: with a ``True`` boolean — a reader switching on the code alone would then
+#: reach a different verdict than a reader reading the boolean, and having one
+#: answer mean two things is the defect this vocabulary exists to prevent.
 REFUSING_ACCEPTANCE_CODES = frozenset({
     CODE_CONTRACT_INVALID,
     CODE_LEDGER_UNREADABLE,
@@ -500,7 +529,7 @@ def evaluate_deliverable_acceptance(
 ) -> DeliverableAcceptance:
     """The full judgment behind ``is_deliverable_acceptable``: the same
     boolean and the same prose, plus the machine-readable ``code`` that says
-    WHICH of the six outcomes produced it (see the ``CODE_*`` constants).
+    WHICH of the seven outcomes produced it (see the ``CODE_*`` constants).
 
     Callers that only display the answer keep using
     ``is_deliverable_acceptable``. A caller that DECIDES on the answer —
@@ -513,11 +542,25 @@ def evaluate_deliverable_acceptance(
     if not did:
         return DeliverableAcceptance(False, CODE_EMPTY_DISPATCH_ID, "empty dispatch_id")
 
+    # The read failure is caught HERE in both modes, rather than delegating the
+    # advisory mode to ``_read_receipts``. That helper turns the error into an
+    # empty list, and an empty list walks straight into the absence branch
+    # below — so an I/O failure came back as "geen uitkomst-receipt", which is
+    # a statement about the dispatch and not about the reader. The two modes
+    # differ in what they DO with the failure (refuse vs. decline to judge),
+    # never in whether they can still tell it apart from an absence.
     try:
-        records = _read_receipts_strict(receipts_path) if strict else _read_receipts(receipts_path)
+        records = _read_receipts_strict(receipts_path)
     except ReceiptsUnreadableError as exc:
+        if strict:
+            return DeliverableAcceptance(
+                False, CODE_LEDGER_UNREADABLE, f"grootboek onleesbaar: {exc}",
+            )
         return DeliverableAcceptance(
-            False, CODE_LEDGER_UNREADABLE, f"grootboek onleesbaar: {exc}",
+            True,
+            CODE_LEDGER_UNREADABLE_ADVISORY,
+            f"grootboek onleesbaar: {exc} — advisory-modus (strict=False) "
+            f"velt hierover geen oordeel; dit is geen afwezigheid",
         )
 
     records = _filter_project(records, project_id)
@@ -603,7 +646,10 @@ def is_deliverable_acceptable(
     unreadable ledger returns ``(False, "grootboek onleesbaar: ...")`` rather
     than degrading to an empty read that would look like that same
     fail-open absence. ``strict=False`` restores the advisory soft read for a
-    caller that only wants a hint.
+    caller that only wants a hint — it does not refuse, but it still does not
+    call that read failure an absence: it answers with
+    ``CODE_LEDGER_UNREADABLE_ADVISORY`` and prose that names the failure. See
+    that constant for why the two must stay apart even where neither blocks.
 
     The three refusals above are three DIFFERENT things and this signature
     cannot tell them apart — a caller that acts on the difference (the merge
@@ -624,6 +670,7 @@ __all__ = [
     "CODE_CONTRACT_INVALID",
     "CODE_EMPTY_DISPATCH_ID",
     "CODE_LEDGER_UNREADABLE",
+    "CODE_LEDGER_UNREADABLE_ADVISORY",
     "CODE_NOT_CONTRACT_INVALID",
     "CODE_NO_DECIDED_OUTCOME",
     "CODE_NO_OUTCOME_RECEIPT",

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -71,6 +71,13 @@ the flag is reported as unnecessary and nothing is stamped, so
 refused chain a non-empty reason overrides visibly and is stamped onto the
 ``pr_merged`` receipt; an empty reason is refused (no silent bypass).
 
+The hatch covers ONE refusal, the contract_invalid one (golf Bx, D4 /
+OI-1666). The gate's other two refusals — an unreadable ledger and an empty
+dispatch_id — are not judgments about the deliverable and stand regardless of
+the flag; an unreadable ledger is repaired, not merged past. The door decides
+on ``contract_invalid_ledger``'s machine-readable acceptance CODE, never on
+the Dutch reason text.
+
 Receipt written to t0_receipts.ndjson:
     event_type  : "pr_merged"
     pr_number   : <int>
@@ -165,7 +172,10 @@ from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt
 from merge_preflight_ci_check import check_ci_run_for_head, _resolve_override_reason
 from merge_preflight_adr_check import check_adr_numbers_for_pr
-from contract_invalid_ledger import is_deliverable_acceptable
+from contract_invalid_ledger import (
+    CODE_CONTRACT_INVALID,
+    evaluate_deliverable_acceptance,
+)
 from forge_protection_drift import (
     PROTECTION_YAML_RELATIVE_PATH,
     ProtectionConfigError,
@@ -601,6 +611,25 @@ def _run_contract_invalid_gate(
     NO-GO. On a clean chain the flag is reported as unnecessary and nothing
     is stamped; on a dirty chain a non-empty reason overrides visibly and an
     empty one is refused (no silent bypass).
+
+    And it only covers its OWN refusal (golf Bx, D4 / OI-1666). The gate
+    refuses in three distinguishable cases — the real contract_invalid, an
+    unreadable ledger, and an empty dispatch_id — and this branch used to set
+    GO on all three, because ``is_deliverable_acceptable`` returned a bool
+    plus Dutch prose and nothing that could be decided on. An operator who
+    means "I know about that contract_invalid" was thereby silently also
+    waving through "I cannot read the ledger", where the right move is to
+    repair it. The decision is now on
+    ``evaluate_deliverable_acceptance``'s ``code``: only
+    ``CODE_CONTRACT_INVALID`` may be overridden, any other refusal stands
+    with ``override_not_applicable: True`` and ``overridden: False`` (no
+    bypass happened, so nothing may be stamped as one). Deliberately not a
+    match on the message text — that prose is a message for a human and
+    breaks on the first rewording, in the permissive direction.
+
+    Applicability is judged BEFORE the reason's emptiness: a flag that does
+    not cover this refusal is no override at all, so there is nothing to
+    demand a reason for. Both orders refuse; this one names the real cause.
     """
     did = (dispatch_id or "").strip()
     resolved_from_pr = False
@@ -622,7 +651,8 @@ def _run_contract_invalid_gate(
 
     paths = ensure_env()
     receipts_path = Path(paths["VNX_STATE_DIR"]) / "t0_receipts.ndjson"
-    acceptable, reason = is_deliverable_acceptable(did, receipts_path)
+    acceptance = evaluate_deliverable_acceptance(did, receipts_path)
+    acceptable, reason = acceptance.acceptable, acceptance.reason
 
     origin = f" (dispatch-id afgeleid uit PR #{pr_number})" if resolved_from_pr else ""
     result: Dict[str, Any] = {
@@ -632,6 +662,8 @@ def _run_contract_invalid_gate(
         "overridden": False,
         "override_reason": None,
         "override_unnecessary": False,
+        "override_not_applicable": False,
+        "reason_code": acceptance.code,
         "resolved_from_pr": resolved_from_pr,
     }
 
@@ -645,6 +677,17 @@ def _run_contract_invalid_gate(
             f"(de keten is schoon); geen override op de receipt"
         )
         result["override_unnecessary"] = True
+        return result
+
+    # The refusal must be the one this flag is FOR. Judged on the acceptance
+    # code, never on the message: those strings are Dutch prose for a human.
+    if acceptance.code != CODE_CONTRACT_INVALID:
+        result["message"] = (
+            f"{result['message']} — --override-contract-invalid geldt alleen voor "
+            f"een contract_invalid-uitkomst, niet voor '{acceptance.code}'; "
+            f"deze weigering blijft staan"
+        )
+        result["override_not_applicable"] = True
         return result
 
     reason_text = override_reason.strip()
@@ -1406,7 +1449,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--override-contract-invalid", default=None,
         help="Escape hatch (golf B, B7): accept a dispatch whose latest receipt is "
              "contract_invalid, with this required reason (empty is refused). Separate "
-             "from --override-reason.",
+             "from --override-reason. Covers ONLY that refusal: an unreadable ledger "
+             "or an unresolvable dispatch_id stands regardless of this flag.",
     )
     parser.add_argument(
         "--allow-weaken", default=None,

--- a/scripts/pr_merge.py
+++ b/scripts/pr_merge.py
@@ -99,7 +99,19 @@ printed a verdict to the terminal and none of them reached the ledger, so
 REFUSED merge left no record at all — the five ``return EXIT_ERROR`` branches
 in ``main()`` wrote nothing. Both branches now carry the same field,
 ``preflight_gates``: one record per gate in ``PREFLIGHT_ORDER``, each
-``{"gate", "verdict", "message", "head_sha", "overridden"}``.
+``{"gate", "verdict", "message", "head_sha", "overridden",
+"override_unnecessary", "override_not_applicable", "reason_code"}``.
+
+``reason_code`` is the machine-readable cause the gate decided on, next to the
+Dutch ``message`` (golf Bx, D4 / OI-1666). D3 landed this ledger an hour before
+D4 landed those codes and the two never met: the door decided on a code and
+recorded only prose, so telling three distinguishable refusals apart afterwards
+was back to matching Dutch text — the exact failure class D4 removed inside the
+door, reintroduced in the record it writes. Today only the contract_invalid
+preflight publishes a code vocabulary
+(``contract_invalid_ledger.ACCEPTANCE_CODES`` plus ``REASON_CODE_GATE_SKIPPED``
+for its own skip); the other four carry ``""``, and the key is written on every
+record either way.
 
 The door SHORT-CIRCUITS on the first NO-GO (each preflight returns
 EXIT_ERROR on its own, before the next one runs) and that stays exactly as
@@ -231,6 +243,19 @@ VERDICT_NOT_EVALUATED = "not_evaluated"
 #: ran, ever" from the short-circuit padding a refusal produces.
 GATES_NOT_RUN_MESSAGE = "niet uitgevoerd: deze aanroep draaide de preflights van de deur niet"
 
+#: ``reason_code`` for the contract_invalid preflight's own skip: no dispatch_id
+#: was given and none could be derived from the PR, so the ledger was never
+#: read and no acceptance code exists.
+#:
+#: Deliberately a DOOR literal and deliberately NOT a member of
+#: ``contract_invalid_ledger.ACCEPTANCE_CODES``: that set is the closed
+#: vocabulary of judgments the ledger produced, and a reader validating a code
+#: against it must not be handed a value the ledger never returned. What it may
+#: not be is the empty string — that is what a gate with no code vocabulary at
+#: all carries, and reusing it here would make "this gate published no code"
+#: and "this gate skipped without reading anything" the same record.
+REASON_CODE_GATE_SKIPPED = "gate_skipped_no_dispatch_id"
+
 
 def _preflight_record(name: str, gate: Dict[str, Any], head_sha: str = "") -> Dict[str, Any]:
     """One preflight's outcome, in the shape the ledger stores it.
@@ -240,6 +265,31 @@ def _preflight_record(name: str, gate: Dict[str, Any], head_sha: str = "") -> Di
     the commit that gate judged; it is the same head for all five (established
     once by ``_run_ci_gate``) and is carried per record so a single record is
     self-contained evidence rather than a pointer to a sibling field.
+
+    ``reason_code`` is the machine-readable cause the gate DECIDED on (golf Bx,
+    D4 / OI-1666). Without it this record held the verdict and the Dutch
+    message and nothing else, so establishing afterwards WHICH refusal fired —
+    a real contract_invalid, an unreadable ledger, an empty dispatch_id — meant
+    matching that prose. Deciding on prose is the failure class D4 removed
+    inside the door; a record that keeps only the prose puts it back one level
+    up, where the reader is a digest or a human weeks later. The door and its
+    record now name the same fact the same way.
+
+    The two override fields travel for the same reason. ``overridden`` alone
+    covers only one of the three things that can happen to an override flag:
+    it was applied, it was passed but does not cover this refusal
+    (``override_not_applicable``), or it was passed while the chain was clean
+    and nothing needed bypassing (``override_unnecessary``). An operator who
+    TRIED to override and was held is an audit fact of its own, and with only
+    the first field that attempt and "no flag was passed at all" produce an
+    identical record.
+
+    Every key is written on every record, including for the four gates that
+    publish no code at all — they decide on their own logic and their record
+    carries ``reason_code: ""``. That is the same rule ``VERDICT_NOT_EVALUATED``
+    exists for: a key that is present on some records and absent on others
+    forces its first reader to guess, and the natural repair for the resulting
+    KeyError is a permissive default.
     """
     return {
         "gate": name,
@@ -247,6 +297,9 @@ def _preflight_record(name: str, gate: Dict[str, Any], head_sha: str = "") -> Di
         "message": str(gate.get("message") or ""),
         "head_sha": head_sha or "",
         "overridden": bool(gate.get("overridden")),
+        "override_unnecessary": bool(gate.get("override_unnecessary")),
+        "override_not_applicable": bool(gate.get("override_not_applicable")),
+        "reason_code": str(gate.get("reason_code") or ""),
     }
 
 
@@ -270,7 +323,12 @@ def _preflight_ledger(
     verdict, so the message is what tells the two apart.
 
     A gate that did not run judged no commit, so its ``head_sha`` is empty —
-    deliberately not the PR head, which would suggest it looked at it.
+    deliberately not the PR head, which would suggest it looked at it. Its
+    ``reason_code`` is empty for the same reason: a gate that never ran reached
+    no cause. The padding is built from ``_preflight_record`` itself rather than
+    from a second literal, so the two shapes cannot drift apart — when D4's
+    ``reason_code`` landed on the one and not the other, a reader met the key on
+    three of five records and a KeyError on the rest.
     """
     default_message = (
         f"niet uitgevoerd: de deur stopte op de {refused_by}-preflight"
@@ -284,13 +342,10 @@ def _preflight_ledger(
         if record is not None:
             ledger.append(record)
             continue
-        ledger.append({
-            "gate": name,
+        ledger.append(_preflight_record(name, {
             "verdict": VERDICT_NOT_EVALUATED,
             "message": unevaluated_message or default_message,
-            "head_sha": "",
-            "overridden": False,
-        })
+        }))
     return ledger
 
 
@@ -630,6 +685,18 @@ def _run_contract_invalid_gate(
     Applicability is judged BEFORE the reason's emptiness: a flag that does
     not cover this refusal is no override at all, so there is nothing to
     demand a reason for. Both orders refuse; this one names the real cause.
+
+    ``overridden`` is True on exactly one branch: the one that returns GO
+    because a real reason bypassed a real contract_invalid. Every other use of
+    the flag — inapplicable, unnecessary, or refused for lacking a reason —
+    leaves it False, because no bypass happened on any of them and the field is
+    copied verbatim into the ``pr_merged``/``pr_merge_refused`` record.
+
+    ``reason_code`` travels out of this function on every branch, so the record
+    it lands in can name the cause the door decided on instead of only the
+    Dutch message. Its values are ``contract_invalid_ledger.ACCEPTANCE_CODES``
+    plus this module's ``REASON_CODE_GATE_SKIPPED`` for the skip above, which
+    never reaches the ledger.
     """
     did = (dispatch_id or "").strip()
     resolved_from_pr = False
@@ -646,6 +713,8 @@ def _run_contract_invalid_gate(
             "overridden": False,
             "override_reason": None,
             "override_unnecessary": False,
+            "override_not_applicable": False,
+            "reason_code": REASON_CODE_GATE_SKIPPED,
             "resolved_from_pr": False,
         }
 
@@ -697,7 +766,19 @@ def _run_contract_invalid_gate(
             "override zonder reden geweigerd: --override-contract-invalid "
             "vereist een niet-lege reden (geen stille bypass)"
         )
-        result["overridden"] = True
+        # NOT ``overridden: True``. The verdict stays NO-GO, so nothing was
+        # bypassed — the same rule the branch two above already applies to an
+        # inapplicable flag, and the same one this function's docstring states
+        # for a clean chain. It is not a cosmetic field either: ``main`` builds
+        # the ``contract_invalid_override`` audit stamp from it, and
+        # ``_preflight_record`` copies it straight into the preflight ledger, so
+        # a True here put "this merge door was overridden" into the very record
+        # written to prove it refused.
+        #
+        # ``override_reason`` keeps the empty string rather than ``None``: the
+        # flag WAS passed here, and the distinction from the branches that leave
+        # it None is the only in-band trace of an attempt that carried no reason.
+        result["overridden"] = False
         result["override_reason"] = reason_text
         return result
 

--- a/tests/test_contract_invalid_ledger.py
+++ b/tests/test_contract_invalid_ledger.py
@@ -607,6 +607,112 @@ def test_advisory_readers_keep_soft_behaviour_on_unreadable_ledger(tmp_path: Pat
 
 
 # ---------------------------------------------------------------------------
+# evaluate_deliverable_acceptance: the MACHINE-READABLE reason (golf Bx, D4)
+#
+# is_deliverable_acceptable returns (False, <Dutch prose>) for three
+# distinguishable cases — the real contract_invalid, an unreadable ledger, and
+# an empty dispatch_id — and the merge door's --override-contract-invalid
+# covered all three because prose is all it had to go on (OI-1666). The code
+# is what the door decides on; the prose stays a message for a human.
+# ---------------------------------------------------------------------------
+
+def test_code_for_a_real_contract_invalid_chain(tmp_path: Path) -> None:
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [_ci_receipt("d-open", "kimi", "2026-09-06T10:00:00Z")])
+
+    acceptance = cil.evaluate_deliverable_acceptance("d-open", receipts)
+
+    assert acceptance.acceptable is False
+    assert acceptance.code == cil.CODE_CONTRACT_INVALID
+    assert "contract_invalid" in acceptance.reason
+
+
+def test_code_for_an_unreadable_ledger_is_not_contract_invalid(tmp_path: Path) -> None:
+    """The fail-closed I/O refusal is its OWN code — the whole point of D4:
+    an operator who says "I know about that contract_invalid" must not thereby
+    also wave through "I cannot read the ledger"."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    receipts.mkdir(parents=True)
+
+    acceptance = cil.evaluate_deliverable_acceptance("d-any", receipts)
+
+    assert acceptance.acceptable is False
+    assert acceptance.code == cil.CODE_LEDGER_UNREADABLE
+    assert acceptance.code != cil.CODE_CONTRACT_INVALID
+    assert "grootboek onleesbaar" in acceptance.reason
+
+
+def test_code_for_an_empty_dispatch_id(tmp_path: Path) -> None:
+    receipts = tmp_path / "t0_receipts.ndjson"
+
+    acceptance = cil.evaluate_deliverable_acceptance("", receipts)
+
+    assert acceptance.acceptable is False
+    assert acceptance.code == cil.CODE_EMPTY_DISPATCH_ID
+    assert acceptance.code != cil.CODE_CONTRACT_INVALID
+
+
+def test_codes_for_the_three_acceptable_outcomes(tmp_path: Path) -> None:
+    """The accepting side is coded too: a caller that logs or branches on the
+    code never has to re-derive "which kind of yes" from the prose."""
+    healed = tmp_path / "healed.ndjson"
+    _write_receipts(healed, [
+        _ci_receipt("d-healed", "kimi", "2026-09-06T10:00:00Z"),
+        _success_receipt("d-healed", "kimi", "2026-09-06T11:00:00Z"),
+    ])
+    absent = tmp_path / "absent.ndjson"
+    _write_receipts(absent, [_ci_receipt("d-other", "kimi", "2026-09-06T10:00:00Z")])
+    undecided = tmp_path / "undecided.ndjson"
+    _write_receipts(undecided, [
+        _ci_receipt("d-u", "kimi", "2026-09-06T10:00:00Z", status="unknown", report_path=None),
+    ])
+
+    assert cil.evaluate_deliverable_acceptance("d-healed", healed).code == (
+        cil.CODE_NOT_CONTRACT_INVALID
+    )
+    assert cil.evaluate_deliverable_acceptance("never-ran", absent).code == (
+        cil.CODE_NO_OUTCOME_RECEIPT
+    )
+    assert cil.evaluate_deliverable_acceptance("d-u", undecided).code == (
+        cil.CODE_NO_DECIDED_OUTCOME
+    )
+
+
+def test_every_code_is_registered(tmp_path: Path) -> None:
+    """ACCEPTANCE_CODES is the closed set a reader may switch on; a code
+    returned but not registered would break that promise silently."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [_ci_receipt("d-open", "kimi", "2026-09-06T10:00:00Z")])
+
+    for did, path in (("d-open", receipts), ("", receipts), ("nobody", receipts)):
+        assert cil.evaluate_deliverable_acceptance(did, path).code in cil.ACCEPTANCE_CODES
+
+
+def test_is_deliverable_acceptable_keeps_its_two_tuple_contract(tmp_path: Path) -> None:
+    """The widening is additive: the existing (bool, str) callers are
+    untouched and still get the same prose."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    _write_receipts(receipts, [_ci_receipt("d-open", "kimi", "2026-09-06T10:00:00Z")])
+
+    ok, reason = cil.is_deliverable_acceptable("d-open", receipts)
+    acceptance = cil.evaluate_deliverable_acceptance("d-open", receipts)
+
+    assert (ok, reason) == (acceptance.acceptable, acceptance.reason)
+
+
+def test_strict_false_is_carried_through_to_the_coded_form(tmp_path: Path) -> None:
+    """strict=False still degrades an unreadable ledger to the soft read —
+    the new entry point must not quietly harden the advisory contract."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    receipts.mkdir(parents=True)
+
+    acceptance = cil.evaluate_deliverable_acceptance("d-any", receipts, strict=False)
+
+    assert acceptance.acceptable is True
+    assert acceptance.code == cil.CODE_NO_OUTCOME_RECEIPT
+
+
+# ---------------------------------------------------------------------------
 # build_t0_state.py wiring: full-state key + t0_index compact form
 # ---------------------------------------------------------------------------
 

--- a/tests/test_contract_invalid_ledger.py
+++ b/tests/test_contract_invalid_ledger.py
@@ -582,15 +582,42 @@ def test_unreadable_ledger_permission_bit_is_a_refusal(tmp_path: Path) -> None:
 
 
 def test_strict_false_keeps_the_soft_read(tmp_path: Path) -> None:
-    """The advisory contract is still available explicitly — strict=False
-    degrades an unreadable ledger to an empty read, as before."""
+    """The advisory contract is still available explicitly — strict=False does
+    not REFUSE on an unreadable ledger.
+
+    What it may not do is call that read failure an absence: see
+    ``test_strict_false_names_the_read_failure_instead_of_absence`` for the
+    other half of this pair. The boolean is the advisory contract; the code and
+    the prose are what must stay honest.
+    """
     receipts = tmp_path / "t0_receipts.ndjson"
     receipts.mkdir(parents=True)
 
     ok, reason = cil.is_deliverable_acceptable("d-any", receipts, strict=False)
 
     assert ok is True
-    assert "geen uitkomst-receipt" in reason
+    assert "onleesbaar" in reason
+
+
+def test_strict_false_names_the_read_failure_instead_of_absence(tmp_path: Path) -> None:
+    """An I/O failure in advisory mode must not read as "no receipt on record".
+
+    The two states are not the same thing. Absence is genuinely fail-open — a
+    dispatch that never wrote an outcome receipt makes no claim about its
+    deliverable. A read failure is a gate outage: the ledger may hold a
+    contract_invalid record this reader simply could not see. Reporting the
+    second under the first's code is the same conflation D4 removed one level
+    up, where three distinguishable refusals shared one prose channel.
+    """
+    receipts = tmp_path / "t0_receipts.ndjson"
+    receipts.mkdir(parents=True)
+
+    ok, reason = cil.is_deliverable_acceptable("d-any", receipts, strict=False)
+
+    assert ok is True, "advisory mode still does not refuse"
+    assert "geen uitkomst-receipt" not in reason, (
+        "a read failure reported as an absence: the two are different states"
+    )
 
 
 def test_advisory_readers_keep_soft_behaviour_on_unreadable_ledger(tmp_path: Path) -> None:
@@ -701,15 +728,69 @@ def test_is_deliverable_acceptable_keeps_its_two_tuple_contract(tmp_path: Path) 
 
 
 def test_strict_false_is_carried_through_to_the_coded_form(tmp_path: Path) -> None:
-    """strict=False still degrades an unreadable ledger to the soft read —
-    the new entry point must not quietly harden the advisory contract."""
+    """strict=False still does not refuse — the new entry point must not
+    quietly harden the advisory contract — and it names WHY it did not judge."""
     receipts = tmp_path / "t0_receipts.ndjson"
     receipts.mkdir(parents=True)
 
     acceptance = cil.evaluate_deliverable_acceptance("d-any", receipts, strict=False)
 
     assert acceptance.acceptable is True
-    assert acceptance.code == cil.CODE_NO_OUTCOME_RECEIPT
+    assert acceptance.code == cil.CODE_LEDGER_UNREADABLE_ADVISORY
+    assert acceptance.code != cil.CODE_NO_OUTCOME_RECEIPT, (
+        "an unreadable ledger is not an absent one"
+    )
+
+
+def test_advisory_read_failure_has_its_own_registered_code(tmp_path: Path) -> None:
+    """The advisory read failure is in the closed set a reader may switch on,
+    and it is NOT a refusal — the boolean and the code stay in step."""
+    receipts = tmp_path / "t0_receipts.ndjson"
+    receipts.mkdir(parents=True)
+
+    acceptance = cil.evaluate_deliverable_acceptance("d-any", receipts, strict=False)
+
+    assert acceptance.code in cil.ACCEPTANCE_CODES
+    assert acceptance.code not in cil.REFUSING_ACCEPTANCE_CODES
+    assert cil.CODE_LEDGER_UNREADABLE_ADVISORY != cil.CODE_LEDGER_UNREADABLE, (
+        "the strict refusal and the advisory non-judgment are different outcomes"
+    )
+
+
+def test_refusing_codes_and_the_boolean_never_disagree(tmp_path: Path) -> None:
+    """The partition invariant, over every outcome this module can produce:
+    a code in REFUSING_ACCEPTANCE_CODES appears if and only if
+    ``acceptable`` is False. A reader that switches on the code alone (which
+    is the whole point of having codes) must never reach a different verdict
+    than a reader that reads the boolean.
+    """
+    unreadable = tmp_path / "unreadable.ndjson"
+    unreadable.mkdir(parents=True)
+    open_chain = tmp_path / "open.ndjson"
+    _write_receipts(open_chain, [_ci_receipt("d-open", "kimi", "2026-09-06T10:00:00Z")])
+    healed = tmp_path / "healed.ndjson"
+    _write_receipts(healed, [
+        _ci_receipt("d-healed", "kimi", "2026-09-06T10:00:00Z"),
+        _success_receipt("d-healed", "kimi", "2026-09-06T11:00:00Z"),
+    ])
+    undecided = tmp_path / "undecided.ndjson"
+    _write_receipts(undecided, [
+        _ci_receipt("d-u", "kimi", "2026-09-06T10:00:00Z", status="unknown", report_path=None),
+    ])
+
+    cases = [
+        ("d-open", open_chain, True),
+        ("d-healed", healed, True),
+        ("d-u", undecided, True),
+        ("never-ran", healed, True),
+        ("", open_chain, True),
+        ("d-any", unreadable, True),
+        ("d-any", unreadable, False),
+    ]
+    for did, path, strict in cases:
+        result = cil.evaluate_deliverable_acceptance(did, path, strict=strict)
+        assert result.code in cil.ACCEPTANCE_CODES, result
+        assert (result.code in cil.REFUSING_ACCEPTANCE_CODES) is (not result.acceptable), result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_merge_contract_invalid.py
+++ b/tests/test_pr_merge_contract_invalid.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
 import pr_merge
+import contract_invalid_ledger as cil
 
 
 SHA = "b" * 40
@@ -653,3 +654,138 @@ class TestOverrideOnlyStampsARealBypass:
             "flag": "--override-contract-invalid",
             "reason": "handmatig geverifieerd",
         }
+
+
+class TestOverrideAppliesOnlyToItsOwnReasonCode:
+    """Golf Bx, D4 / OI-1666: the flag used to force GO on EVERY non-acceptable
+    verdict, because the gate only ever saw ``(False, <Dutch prose>)`` and
+    never why. ``is_deliverable_acceptable`` refuses in three distinguishable
+    cases — the real contract_invalid, an unreadable ledger (the fail-closed
+    I/O refusal), and an empty dispatch_id — and an operator who means "I know
+    about that contract_invalid" was silently also waving through "I cannot
+    read the ledger", where repairing is the right move, not proceeding.
+
+    The door now decides on the machine-readable code
+    (``contract_invalid_ledger.CODE_*``), never on the message text: those
+    strings are Dutch prose for a human and break on the first rewording.
+    """
+
+    def test_unreadable_ledger_with_the_flag_is_still_no_go(self, vnx_env):
+        """The core case. On the pre-D4 door this said GO."""
+        vnx_env["receipts_path"].mkdir(parents=True)
+
+        gate = pr_merge._run_contract_invalid_gate(
+            "d-any", override_reason="ik weet van die contract_invalid",
+        )
+
+        assert gate["verdict"] == "NO-GO"
+        assert gate["overridden"] is False, (
+            "no bypass happened, so nothing may be stamped as one"
+        )
+        assert gate["override_not_applicable"] is True
+        assert gate["reason_code"] == cil.CODE_LEDGER_UNREADABLE
+        assert "grootboek onleesbaar" in gate["message"]
+        assert "geldt alleen" in gate["message"]
+
+    def test_main_refuses_unreadable_ledger_even_with_the_flag(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        vnx_env["receipts_path"].mkdir(parents=True)
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", "d-any",
+            "--override-contract-invalid", "ik weet van die contract_invalid",
+        ])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls, (
+            "an unreadable ledger must be repaired, not overridden past"
+        )
+        assert "grootboek onleesbaar" in capsys.readouterr().err
+
+    def test_unreadable_ledger_with_an_empty_reason_is_also_no_go(self, vnx_env):
+        """Applicability is judged before the reason is: a flag that does not
+        cover this refusal is no override at all, so there is nothing to
+        demand a reason for. Both orders refuse; this one says why."""
+        vnx_env["receipts_path"].mkdir(parents=True)
+
+        gate = pr_merge._run_contract_invalid_gate("d-any", override_reason="   ")
+
+        assert gate["verdict"] == "NO-GO"
+        assert gate["overridden"] is False
+        assert gate["override_not_applicable"] is True
+        assert gate["reason_code"] == cil.CODE_LEDGER_UNREADABLE
+
+    def test_real_contract_invalid_with_a_reason_still_grants_go(self, vnx_env):
+        """The repair must not take away the escape hatch it was built for."""
+        did = "20260908-d4-real-contract-invalid"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T11:36:00Z"),
+            _gate_request(did, "2026-09-06T11:50:54Z"),
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(
+            did, override_reason="rapport handmatig nagelezen",
+        )
+
+        assert gate["verdict"] == "GO"
+        assert gate["overridden"] is True
+        assert gate["override_not_applicable"] is False
+        assert gate["override_reason"] == "rapport handmatig nagelezen"
+        assert gate["reason_code"] == cil.CODE_CONTRACT_INVALID
+
+    def test_empty_reason_on_a_real_contract_invalid_stays_refused(self, vnx_env):
+        """Unchanged behaviour: on the reason the flag DOES cover, an empty
+        one is still a refused silent bypass."""
+        did = "20260908-d4-empty-reason"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_ci(did, "2026-09-06T11:36:00Z"),
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(did, override_reason="   ")
+
+        assert gate["verdict"] == "NO-GO"
+        assert gate["overridden"] is True
+        assert gate["override_not_applicable"] is False
+        assert "niet-lege reden" in gate["message"]
+
+    def test_clean_chain_with_the_flag_is_unchanged(self, vnx_env):
+        """Unchanged behaviour: nothing to override, nothing stamped — and the
+        'unnecessary' branch is not the 'not applicable' one."""
+        did = "20260908-d4-clean-chain"
+        _write_receipts(vnx_env["receipts_path"], [
+            _outcome_success(did, "2026-09-06T11:36:00Z"),
+        ])
+
+        gate = pr_merge._run_contract_invalid_gate(did, override_reason="voor de zekerheid")
+
+        assert gate["verdict"] == "GO"
+        assert gate["overridden"] is False
+        assert gate["override_unnecessary"] is True
+        assert gate["override_not_applicable"] is False
+        assert gate["reason_code"] == cil.CODE_NOT_CONTRACT_INVALID
+
+    @pytest.mark.parametrize("code", [
+        cil.CODE_LEDGER_UNREADABLE,
+        cil.CODE_EMPTY_DISPATCH_ID,
+        "een_code_die_later_wordt_toegevoegd",
+    ])
+    def test_no_other_refusal_code_can_be_overridden(self, vnx_env, monkeypatch, code):
+        """The rule is on the code, not on the cases this door can reach
+        today: ``empty_dispatch_id`` is unreachable here (the door skips a
+        missing id loudly before the ledger read) and a code added later is
+        unknown to this test — both must refuse by construction, not by
+        having been enumerated. Only the evaluator is stubbed; the door's own
+        decision runs for real."""
+        monkeypatch.setattr(
+            pr_merge, "evaluate_deliverable_acceptance",
+            lambda did, path, **kw: cil.DeliverableAcceptance(False, code, f"reden: {code}"),
+        )
+
+        gate = pr_merge._run_contract_invalid_gate("d-any", override_reason="toch maar wel")
+
+        assert gate["verdict"] == "NO-GO"
+        assert gate["overridden"] is False
+        assert gate["reason_code"] == code

--- a/tests/test_pr_merge_contract_invalid.py
+++ b/tests/test_pr_merge_contract_invalid.py
@@ -140,6 +140,21 @@ def _track_do_merge(monkeypatch):
     return calls
 
 
+def _refusal_record(path: Path, gate_name: str) -> Dict[str, Any]:
+    """The named gate's entry inside the one ``pr_merge_refused`` receipt.
+
+    Golf Bx, D3 writes that receipt with all five preflights in
+    ``preflight_gates``; this is the record a human or a reader meets when
+    asking why the door refused.
+    """
+    refusals = [
+        r for r in _load_receipts(path) if r.get("event_type") == "pr_merge_refused"
+    ]
+    assert len(refusals) == 1, f"expected exactly one refusal record, got {len(refusals)}"
+    gates = {g["gate"]: g for g in refusals[0]["preflight_gates"]}
+    return gates[gate_name]
+
+
 # ---------------------------------------------------------------------------
 # Unit tests: _run_contract_invalid_gate
 # ---------------------------------------------------------------------------
@@ -190,7 +205,9 @@ class TestRunContractInvalidGate:
         ])
         gate = pr_merge._run_contract_invalid_gate(did, override_reason="   ")
         assert gate["verdict"] == "NO-GO"
-        assert gate["overridden"] is True
+        assert gate["overridden"] is False, (
+            "the gate stayed NO-GO, so no override was applied"
+        )
         assert "niet-lege reden" in gate["message"]
 
     def test_override_nonempty_reason_grants_go(self, vnx_env):
@@ -747,7 +764,9 @@ class TestOverrideAppliesOnlyToItsOwnReasonCode:
         gate = pr_merge._run_contract_invalid_gate(did, override_reason="   ")
 
         assert gate["verdict"] == "NO-GO"
-        assert gate["overridden"] is True
+        assert gate["overridden"] is False, (
+            "an override that was refused is not an override that was applied"
+        )
         assert gate["override_not_applicable"] is False
         assert "niet-lege reden" in gate["message"]
 
@@ -789,3 +808,246 @@ class TestOverrideAppliesOnlyToItsOwnReasonCode:
         assert gate["verdict"] == "NO-GO"
         assert gate["overridden"] is False
         assert gate["reason_code"] == code
+
+
+class TestRefusedOverrideIsNotAnAppliedOne:
+    """Golf Bx, D4 fix-forward: the empty-reason branch stamped
+    ``overridden: True`` on a gate that stayed NO-GO.
+
+    Two lines above it, the same function refuses to mark an inapplicable
+    override as applied, for the stated reason that nothing was bypassed. An
+    override that was REFUSED for lacking a reason bypassed exactly as little.
+    The field travels: ``_preflight_record`` copies ``overridden`` straight
+    into the preflight ledger, so the refusal record claimed a merge door had
+    been overridden while it was in the act of refusing.
+    """
+
+    def test_the_empty_reason_branch_records_no_override(self, vnx_env):
+        did = "20260908-d4ff-empty-reason-field"
+        _write_receipts(vnx_env["receipts_path"], [_outcome_ci(did, "2026-09-06T11:36:00Z")])
+
+        gate = pr_merge._run_contract_invalid_gate(did, override_reason="   ")
+
+        assert gate["verdict"] == "NO-GO"
+        assert gate["overridden"] is False
+
+    def test_the_refusal_record_does_not_claim_an_override(
+        self, vnx_env, monkeypatch,
+    ):
+        """The field as a reader meets it: inside ``preflight_gates`` on the
+        ``pr_merge_refused`` receipt, not just on the gate dict in memory."""
+        did = "20260908-d4ff-empty-reason-record"
+        _write_receipts(vnx_env["receipts_path"], [_outcome_ci(did, "2026-09-06T11:36:00Z")])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", did, "--override-contract-invalid", "  ",
+        ])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls
+
+        record = _refusal_record(vnx_env["receipts_path"], "contract_invalid")
+        assert record["verdict"] == "NO-GO"
+        assert record["overridden"] is False, (
+            "a refused merge may not carry an override in its own record"
+        )
+
+    def test_an_applied_override_is_still_recorded_as_one(self, vnx_env, monkeypatch):
+        """The other direction, so the fix cannot be "always False": a real
+        override with a real reason still reads as overridden on the merged
+        receipt."""
+        did = "20260908-d4ff-real-override-record"
+        _write_receipts(vnx_env["receipts_path"], [_outcome_ci(did, "2026-09-06T11:36:00Z")])
+        _bypass_upstream_gates(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main([
+            "--pr", "1", "--dispatch-id", did,
+            "--override-contract-invalid", "rapport handmatig nagelezen",
+        ])
+
+        assert rc == pr_merge.EXIT_OK
+        merged = [
+            r for r in _load_receipts(vnx_env["receipts_path"])
+            if r.get("event_type") == "pr_merged"
+        ]
+        assert len(merged) == 1
+        gates = {g["gate"]: g for g in merged[0]["preflight_gates"]}
+        assert gates["contract_invalid"]["overridden"] is True
+
+
+class TestRefusalRecordCarriesTheCodeNotOnlyTheProse:
+    """Golf Bx, D4 fix-forward: the redencode never reached the record.
+
+    D3 (OI-1665) landed ``_preflight_record`` an hour before D4 (OI-1666)
+    landed the codes, and the two never met. ``_preflight_record`` copies five
+    fields off the gate result — gate, verdict, message, head_sha, overridden —
+    and ``reason_code`` was not one of them.
+
+    So the door DECIDED on the machine-readable code and then recorded only
+    the Dutch prose. Establishing afterwards which of the three refusals fired
+    was back to matching that prose, which is the exact failure class D4 exists
+    to remove, put back one level up: it breaks on the first rewording, and it
+    breaks permissively.
+    """
+
+    def test_a_real_contract_invalid_refusal_names_its_code(
+        self, vnx_env, monkeypatch,
+    ):
+        """Nothing stubbed but the upstream gates and the merge itself: the
+        ledger, the gate decision and the emit path are the real ones."""
+        did = "20260908-d4ff-code-in-record"
+        _write_receipts(vnx_env["receipts_path"], [_outcome_ci(did, "2026-09-06T11:36:00Z")])
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls
+
+        record = _refusal_record(vnx_env["receipts_path"], "contract_invalid")
+        assert record["verdict"] == "NO-GO"
+        assert record["reason_code"] == cil.CODE_CONTRACT_INVALID
+        assert record["reason_code"] in cil.ACCEPTANCE_CODES
+
+    @pytest.mark.parametrize("code", [
+        cil.CODE_LEDGER_UNREADABLE,
+        cil.CODE_EMPTY_DISPATCH_ID,
+    ])
+    def test_the_other_two_refusals_name_their_own_code(
+        self, vnx_env, monkeypatch, code,
+    ):
+        """The two refusals that cannot be produced through the door with a
+        WRITABLE ledger, so only the evaluator is stubbed and everything after
+        it is real.
+
+        Neither is reachable otherwise. ``empty_dispatch_id`` is caught by the
+        door's own loud skip before the ledger is ever read, and a genuinely
+        unreadable ledger is also an unwritable one — the refusal record would
+        have nowhere to land, which is a separate, pre-existing property
+        ``_refuse_merge`` already warns about. Stubbing the evaluator is what
+        lets the record itself be tested for all three codes.
+        """
+        did = "20260908-d4ff-code-" + code
+        monkeypatch.setattr(
+            pr_merge, "evaluate_deliverable_acceptance",
+            lambda d, path, **kw: cil.DeliverableAcceptance(False, code, f"reden: {code}"),
+        )
+        _bypass_upstream_gates(monkeypatch)
+        do_merge_calls = _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_ERROR
+        assert not do_merge_calls
+
+        record = _refusal_record(vnx_env["receipts_path"], "contract_invalid")
+        assert record["reason_code"] == code
+        assert record["reason_code"] != cil.CODE_CONTRACT_INVALID
+
+    def test_the_three_refusals_are_separable_without_reading_the_prose(
+        self, vnx_env, monkeypatch,
+    ):
+        """The blocker itself, stated as one assertion: three refusals, three
+        distinct codes in the record, no Dutch text consulted."""
+        seen = set()
+        for code in (
+            cil.CODE_CONTRACT_INVALID,
+            cil.CODE_LEDGER_UNREADABLE,
+            cil.CODE_EMPTY_DISPATCH_ID,
+        ):
+            monkeypatch.setattr(
+                pr_merge, "evaluate_deliverable_acceptance",
+                lambda d, path, _c=code, **kw: cil.DeliverableAcceptance(
+                    False, _c, "een en dezelfde nederlandse tekst voor alle drie",
+                ),
+            )
+            _bypass_upstream_gates(monkeypatch)
+            _track_do_merge(monkeypatch)
+
+            pr_merge.main(["--pr", "1", "--dispatch-id", f"20260908-d4ff-sep-{code}"])
+
+            records = [
+                {g["gate"]: g for g in r["preflight_gates"]}["contract_invalid"]
+                for r in _load_receipts(vnx_env["receipts_path"])
+                if r.get("event_type") == "pr_merge_refused"
+            ]
+            seen.add(records[-1]["reason_code"])
+
+        assert seen == {
+            cil.CODE_CONTRACT_INVALID,
+            cil.CODE_LEDGER_UNREADABLE,
+            cil.CODE_EMPTY_DISPATCH_ID,
+        }
+
+    def test_an_inapplicable_override_attempt_is_visible_in_the_record(
+        self, vnx_env, monkeypatch,
+    ):
+        """An operator who TRIED to override a refusal this flag does not cover
+        is an audit fact of its own. Without the field, that attempt and "no
+        flag was passed at all" are the same record, separable only in the
+        message."""
+        monkeypatch.setattr(
+            pr_merge, "evaluate_deliverable_acceptance",
+            lambda d, path, **kw: cil.DeliverableAcceptance(
+                False, cil.CODE_LEDGER_UNREADABLE, "grootboek onleesbaar: stub",
+            ),
+        )
+        _bypass_upstream_gates(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main([
+            "--pr", "1", "--dispatch-id", "20260908-d4ff-attempt",
+            "--override-contract-invalid", "ik weet van die contract_invalid",
+        ])
+
+        record = _refusal_record(vnx_env["receipts_path"], "contract_invalid")
+        assert record["override_not_applicable"] is True
+        assert record["overridden"] is False
+
+    def test_the_merged_receipt_carries_the_accepting_code_too(
+        self, vnx_env, monkeypatch,
+    ):
+        """Not only refusals: a merge records WHICH kind of yes the gate gave,
+        so "the chain was clean" and "there was nothing on record" are
+        separable on a merged receipt as well."""
+        did = "20260908-d4ff-merged-code"
+        _write_receipts(vnx_env["receipts_path"], [_outcome_success(did, "2026-09-06T11:36:00Z")])
+        _bypass_upstream_gates(monkeypatch)
+        _track_do_merge(monkeypatch)
+
+        rc = pr_merge.main(["--pr", "1", "--dispatch-id", did])
+
+        assert rc == pr_merge.EXIT_OK
+        merged = [
+            r for r in _load_receipts(vnx_env["receipts_path"])
+            if r.get("event_type") == "pr_merged"
+        ]
+        gates = {g["gate"]: g for g in merged[0]["preflight_gates"]}
+        assert gates["contract_invalid"]["reason_code"] == cil.CODE_NOT_CONTRACT_INVALID
+
+    def test_a_skipped_gate_says_so_instead_of_leaving_the_field_empty(
+        self, vnx_env, monkeypatch, capsys,
+    ):
+        """The gate's own skip (no dispatch_id, none derivable from the PR)
+        never reaches the ledger, so it has no acceptance code — and an empty
+        string there would be indistinguishable from a record written before
+        this field existed. It gets a door-level literal instead, deliberately
+        outside the ledger's closed set."""
+        _bypass_upstream_gates(monkeypatch)
+        _track_do_merge(monkeypatch)
+        monkeypatch.setattr(pr_merge, "_lookup_dispatch_id_by_pr_number", lambda n: "")
+
+        rc = pr_merge.main(["--pr", "1"])
+
+        assert rc == pr_merge.EXIT_OK
+        merged = [
+            r for r in _load_receipts(vnx_env["receipts_path"])
+            if r.get("event_type") == "pr_merged"
+        ]
+        gates = {g["gate"]: g for g in merged[0]["preflight_gates"]}
+        assert gates["contract_invalid"]["reason_code"] == pr_merge.REASON_CODE_GATE_SKIPPED
+        assert pr_merge.REASON_CODE_GATE_SKIPPED not in cil.ACCEPTANCE_CODES

--- a/tests/test_pr_merge_preflight_ledger.py
+++ b/tests/test_pr_merge_preflight_ledger.py
@@ -645,3 +645,57 @@ class TestMergedReceiptAlwaysCarriesTheKey:
 
         assert gateless[0]["message"] != short_circuited[0]["message"]
         assert "ci" in short_circuited[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# 6. One record shape, whether the gate ran or not (golf Bx, D4 fix-forward)
+# ---------------------------------------------------------------------------
+
+class TestOneRecordShape:
+    """Every preflight record carries the same keys, on both paths.
+
+    ``_preflight_record`` builds the records of gates that RAN and
+    ``_preflight_ledger`` pads the ones that did not, and the two shapes are
+    written by two different literals. When D4's ``reason_code`` reached the
+    first and not the second, a reader would have met the key on three of five
+    records and a KeyError on the other two — and the natural repair for that
+    (``.get(...)``, defaulting to something falsy) is how a missing code turns
+    back into a code that says nothing.
+    """
+
+    def test_a_padded_record_has_the_same_keys_as_a_real_one(self):
+        real = pr_merge._preflight_record(
+            "contract_invalid",
+            {"verdict": "NO-GO", "message": "m", "reason_code": "contract_invalid"},
+            "a" * 40,
+        )
+        padded = pr_merge._preflight_ledger([], refused_by="ci")[0]
+
+        assert set(real) == set(padded)
+
+    def test_every_record_of_a_refusal_carries_the_full_shape(
+        self, vnx_env, monkeypatch,
+    ):
+        _stub_gh_gates(monkeypatch, ci=_no_go("CI-run niet groen op deze head"))
+        _track_do_merge(monkeypatch)
+
+        pr_merge.main(["--pr", "7", "--dispatch-id", "20260908-d4ff-shape"])
+
+        gates = _refusal(vnx_env["receipts_path"])["preflight_gates"]
+        assert len(gates) == len(pr_merge.PREFLIGHT_ORDER)
+        for g in gates:
+            assert set(g) == {
+                "gate", "verdict", "message", "head_sha",
+                "overridden", "override_unnecessary", "override_not_applicable",
+                "reason_code",
+            }, g
+
+    def test_a_gate_without_a_code_vocabulary_says_so_explicitly(self):
+        """Four of the five preflights decide on their own logic and publish no
+        code. Their record carries the key with an empty value — the key is
+        never simply left out, for the reason ``VERDICT_NOT_EVALUATED`` exists.
+        """
+        record = pr_merge._preflight_record("ci", {"verdict": "GO", "message": "groen"}, "b" * 40)
+
+        assert record["reason_code"] == ""
+        assert record["override_not_applicable"] is False


### PR DESCRIPTION
## Wat er stuk was

`--override-contract-invalid` zette GO op **elke** niet-acceptabele uitkomst. `contract_invalid_ledger.is_deliverable_acceptable` weigert in drie te onderscheiden gevallen:

1. de echte contract_invalid (de laatste besliste uitkomst-receipt is contract_invalid);
2. `grootboek onleesbaar: ...` — de fail-closed leesfout bij `strict=True`;
3. `empty dispatch_id`.

De deur zag alleen `(False, <Nederlands proza>)` en kon ze niet uit elkaar houden. Een operator die "ik weet van die contract_invalid" bedoelt, passeerde stilzwijgend ook "ik kan het grootboek niet lezen". Bij een leesfout is repareren de juiste handeling, niet doorlopen.

De rode test bewees dat gedrag: met een onleesbaar grootboek plus de vlag MERGEDE de deur gewoon (`assert not [(1, 'squash', 'bbbb...')]`).

## De reparatie

Een machineleesbare redencode naast de tekst, en de deur beslist daarop. **Niet op de prozatekst matchen**: die strings zijn Nederlandse boodschappen voor een mens en breken bij de eerste herformulering, in de toegeeflijke richting.

`scripts/lib/contract_invalid_ledger.py`
- Zes `CODE_*`-constanten (drie weigerend, drie accepterend), de gesloten verzameling `ACCEPTANCE_CODES` en `REFUSING_ACCEPTANCE_CODES`.
- `DeliverableAcceptance(acceptable, code, reason)` — een NamedTuple.
- `evaluate_deliverable_acceptance(...)`: dezelfde beoordeling, met de code erbij.
- `is_deliverable_acceptable` behoudt zijn `(bool, str)`-contract exact en is nu een gevel over die ene beoordeling.

De verbreding is **additief**, geen signatuurwijziging: een derde returnwaarde had elke aanroeper tegelijk gebroken. Buiten de module is er precies één productie-aanroeper, `pr_merge.py::_run_contract_invalid_gate`; in de suite ~20 aanroepen die twee waarden uitpakken. Die blijven allemaal ongemoeid en getest.

`scripts/pr_merge.py`
- De poort leest `evaluate_deliverable_acceptance` en draagt `reason_code` + `override_not_applicable` in zijn resultaat.
- Alleen `CODE_CONTRACT_INVALID` mag overruled worden. Elke andere weigering blijft staan met `override_not_applicable: True` en `overridden: False` — er is niets omzeild, dus er mag ook niets als omzeiling op de receipt gestempeld worden.
- Toepasselijkheid gaat VOOR de lege-reden-controle: een vlag die deze weigering niet dekt is geen override, dus valt er ook geen reden voor te eisen.

## Wat onveranderd blijft

- Echte contract_invalid + vlag met reden: GO, zichtbaar, gestempeld op de `pr_merged`-receipt.
- Lege reden op die weigering: geweigerd (geen stille bypass).
- Schone keten + vlag: "niet nodig", niets gestempeld.

## Verificatie

Rood eerst, op gedrag (deur ongewijzigd, alleen de code-rapportage bedraad):

```
python3 -m pytest tests/test_pr_merge_contract_invalid.py::TestOverrideAppliesOnlyToItsOwnReasonCode -q
6 failed, 3 passed in 0.91s
```

Groen na de reparatie:

```
python3 -m pytest tests/test_pr_merge*.py tests/test_contract_invalid_ledger.py -q
226 passed in 23.15s
```

Buren:

```
python3 -m pytest tests/test_pr_merge_contract_invalid.py tests/test_pr_merge_branch_protection.py \
  tests/test_pr_merge_ci_gate.py tests/test_pr_merge_review_gate.py tests/test_pr_merge_receipt.py \
  tests/test_pr_merge_preflight_ledger.py tests/test_pr_merge_match_head.py tests/test_pr_merge_dual_scheme.py \
  tests/test_pr_merge_outcome_exitcode.py tests/test_contract_invalid_ledger.py \
  tests/test_contract_invalid_window.py tests/test_build_t0_state.py -q
302 passed in 27.04s
```

`tests/test_per_pr_closure.py` staat op 9 rood — gemeten identiek op `b9cbac1a` in een schone worktree, dus bestaand en niet van deze wijziging (raakt `closure_verifier`, dat deze module niet importeert).

## Deur-integriteit

Beide gewijzigde bestanden staan in `_DOOR_INTEGRITY_PATHS`. Na de merge weigert de deur elke volgende merge tot main lokaal getrokken is.

Dispatch-ID: 20260908-bx-d4-override-redencode