### PR TITLE
fix(doctor): install:mode waarschuwt wanneer de pin niet gelijk is aan de actieve versie (OI-1678, OI-1679)

### DIFF
--- a/tests/test_vnx_doctor_strict.py
+++ b/tests/test_vnx_doctor_strict.py
@@ -177,10 +177,11 @@ class TestCentralMode:
         assert exit_code == 1
 
     def test_central_mode_pin_and_active_agree_with_pin_file(self, tmp_path, monkeypatch):
-        """OI-914: doctor's pin line and `cat .vnx-version` must agree. A
-        project pinning v1.4.0 while v1.4.1 is active is reported as BOTH —
-        the drift is visible, not silently reported as a single value that
-        matches neither."""
+        """OI-914 split ``pin`` and ``active`` into two separately-reported
+        values so a drift is visible instead of collapsed into one label —
+        but stopped short of comparing them, so this scenario (pin v1.4.0,
+        active v1.4.1) still PASSed. OI-1678 closes that gap: the two values
+        being visible only matters if a mismatch actually WARNs."""
         project = _make_project(tmp_path)
         (project / ".vnx-version").write_text("v1.4.0\n")
         active_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.4.1"
@@ -193,9 +194,112 @@ class TestCentralMode:
 
         result = _check_install_mode(project)
 
-        assert result.status == PASS
+        assert result.status == WARN
         assert "pin: v1.4.0" in result.detail
         assert "active: v1.4.1" in result.detail
+        assert "not honored" in result.detail
+
+    def test_central_mode_pin_diverges_from_active_warns(self, tmp_path, monkeypatch):
+        """OI-1678 live case (SEOcrawler_v2): pin v1.5.0, active v1.6.0. The
+        pin is readable and there is no marker problem, so pre-fix code fell
+        straight through to PASS — pin and active were reported side by side
+        but never compared. WARN, naming both versions and the pin file
+        path (OI-1679)."""
+        project = _make_project(tmp_path)
+        (project / ".vnx-version").write_text("v1.5.0\n")
+        active_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.6.0"
+        (active_dir / "scripts").mkdir(parents=True)
+        (active_dir / ".vnx-install-mode").write_text("central\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(active_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(project)
+
+        assert result.status == WARN
+        assert "mode: central" in result.detail
+        assert "pin: v1.5.0" in result.detail
+        assert "active: v1.6.0" in result.detail
+        assert "not honored" in result.detail
+        assert str(project / ".vnx-version") in result.detail
+
+    def test_central_mode_pin_unset_stays_pass_with_versioned_active(self, tmp_path, monkeypatch):
+        """An unpinned project must not get a false WARN just because active
+        resolves to a real version dir name (v1.6.0) instead of the literal
+        'current' fallback used by the no-VERSION-dir test above."""
+        project = _make_project(tmp_path)
+        active_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.6.0"
+        (active_dir / "scripts").mkdir(parents=True)
+        (active_dir / ".vnx-install-mode").write_text("central\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(active_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(project)
+
+        assert result.status == PASS
+        assert "pin: unset" in result.detail
+        assert "active: v1.6.0" in result.detail
+
+    def test_central_mode_pin_found_via_ancestor_walkup(self, tmp_path, monkeypatch):
+        """OI-1679: doctor run from a SUBDIRECTORY of a pinned project must
+        still see the pin — the same walk `_reexec._find_pin_dir` performs at
+        startup — and must name the ancestor path the pin came from, not
+        silently report 'unset' just because the immediate project_dir has no
+        pin file of its own."""
+        project = _make_project(tmp_path)
+        (project / ".vnx-version").write_text("v1.5.0\n")
+        submap = project / "sub" / "deeper"
+        submap.mkdir(parents=True)
+        active_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.6.0"
+        (active_dir / "scripts").mkdir(parents=True)
+        (active_dir / ".vnx-install-mode").write_text("central\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(active_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(submap)
+
+        assert result.status == WARN
+        assert "pin: v1.5.0" in result.detail
+        assert "active: v1.6.0" in result.detail
+        assert str(project / ".vnx-version") in result.detail
+
+    def test_central_mode_sibling_directory_does_not_inherit_pin(self, tmp_path, monkeypatch):
+        """OI-1679 documented blind spot: the pin walk only climbs ANCESTORS.
+        A build worktree checked out as a SIBLING of the pinned project root
+        (e.g. `<root>-wt-g1-<id>`) does not inherit the pin, so running this
+        check from inside the sibling reports 'unset'/PASS even though the
+        sibling may in fact be running a different engine version than the
+        pinned root expects. This locks in the accepted, documented scope of
+        the check (see the `_check_install_mode` docstring) — not a claim
+        that the split is undetected everywhere."""
+        root = tmp_path / "proj-root"
+        root.mkdir()
+        (root / ".vnx").mkdir()
+        (root / ".vnx-data" / "state").mkdir(parents=True)
+        (root / ".vnx-version").write_text("v1.5.0\n")
+
+        sibling = tmp_path / "proj-root-wt-g1-abc123"
+        sibling.mkdir()
+        (sibling / ".vnx").mkdir()
+        (sibling / ".vnx-data" / "state").mkdir(parents=True)
+
+        active_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.6.0"
+        (active_dir / "scripts").mkdir(parents=True)
+        (active_dir / ".vnx-install-mode").write_text("central\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(active_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(sibling)
+
+        assert result.status == PASS
+        assert "pin: unset" in result.detail
 
     def test_central_mode_missing_marker_warns(self, tmp_path, monkeypatch):
         """The active `current` resolves to a version dir with no

--- a/tests/test_vnx_doctor_strict.py
+++ b/tests/test_vnx_doctor_strict.py
@@ -224,6 +224,33 @@ class TestCentralMode:
         assert "not honored" in result.detail
         assert str(project / ".vnx-version") in result.detail
 
+    def test_central_mode_pin_without_v_prefix_matches_v_prefixed_active(self, tmp_path, monkeypatch):
+        """glm-gate finding on the OI-1678 PR: `_reexec` normalizes away a
+        decorative leading `v` (`_normalize_version`) before deciding whether
+        a pin is honored, but this check compared the raw pin string against
+        `active` directly. A pin written WITHOUT the `v` (e.g. `1.5.0`) that
+        names the SAME version as the `v`-prefixed active dir (`v1.5.0`) is
+        honored by re-exec, but pre-fix this check reported it as a mismatch
+        — the inverse of the bug OI-1678 closes: the check first stayed
+        silent where it should have warned, then warned where it should have
+        stayed silent."""
+        project = _make_project(tmp_path)
+        (project / ".vnx-version").write_text("1.5.0\n")
+        active_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.5.0"
+        (active_dir / "scripts").mkdir(parents=True)
+        (active_dir / ".vnx-install-mode").write_text("central\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(active_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(project)
+
+        assert result.status == PASS
+        assert "pin: 1.5.0" in result.detail
+        assert "active: v1.5.0" in result.detail
+        assert "not honored" not in result.detail
+
     def test_central_mode_pin_unset_stays_pass_with_versioned_active(self, tmp_path, monkeypatch):
         """An unpinned project must not get a false WARN just because active
         resolves to a real version dir name (v1.6.0) instead of the literal

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from vnx_cli import _engine
-from vnx_cli._reexec import PIN_FILE_NAME
+from vnx_cli._reexec import PIN_FILE_NAME, _find_pin_dir
 
 logger = logging.getLogger(__name__)
 
@@ -133,25 +133,40 @@ def _check_agents(project_dir: Path) -> Check:
     )
 
 
-def _read_project_pin(project_dir: Path) -> str:
-    """Read the project's ``.vnx-version`` pin file (the operator's pin intent).
+def _read_project_pin(project_dir: Path) -> "tuple[str, Path | None]":
+    """Locate and read the ``.vnx-version`` pin the startup re-exec would honor.
 
-    This is the SAME file ``vnx_cli._reexec`` honors at startup, so doctor's
-    ``pin`` field and ``cat .vnx-version`` agree (OI-914). Returns the raw
-    first line when present and non-empty, ``"unset"`` when there is no usable
-    pin, or ``"error"`` when a pin file exists but cannot be read.
+    Walks UP from ``project_dir`` the same way ``_reexec._find_pin_dir`` does
+    — nearest ancestor wins, bounded at the resolved home directory
+    (exclusive) — so doctor's ``pin`` field matches what ``vnx`` actually
+    honors when run from a SUBDIRECTORY of a pinned project, not just a pin
+    file sitting directly in ``project_dir`` (OI-1679). Delegates the walk to
+    ``_find_pin_dir`` instead of reimplementing it, so the two never drift.
+    When the pin sits directly in ``project_dir`` this still agrees with
+    ``cat .vnx-version`` (OI-914).
+
+    Returns ``(pin, pin_dir)``: the raw first line and the ancestor directory
+    it came from, ``("unset", None)`` when no ancestor within the boundary
+    carries a usable pin file (absent everywhere walked, or present but
+    empty), or ``("error", pin_dir)`` when a pin file is found but cannot be
+    read.
     """
-    pin_file = project_dir / PIN_FILE_NAME
-    if not pin_file.is_file():
-        return "unset"
     try:
-        first = pin_file.read_text(encoding="utf-8").strip().splitlines()[0]
+        start = project_dir.expanduser().resolve()
+    except OSError:
+        return "unset", None
+    pin_dir = _find_pin_dir(start)
+    if pin_dir is None:
+        return "unset", None
+    pin_file = pin_dir / PIN_FILE_NAME
+    try:
+        text = pin_file.read_text(encoding="utf-8").strip()
     except OSError as exc:
         logger.warning("doctor: cannot read pin file %s: %s", pin_file, exc)
-        return "error"
-    if not first:
-        return "unset"
-    return first
+        return "error", pin_dir
+    if not text:
+        return "unset", None
+    return text.splitlines()[0], pin_dir
 
 
 def _resolve_active_version(central_path: Path) -> str:
@@ -201,11 +216,24 @@ def _check_install_mode(project_dir: Path) -> Check:
 
     In central mode the check reports two values that OI-914 found conflated
     under one "pin" label:
-      * ``pin`` — the project's ``.vnx-version`` file (the pin the startup
-        re-exec honors; matches ``cat .vnx-version``);
+      * ``pin`` — the ``.vnx-version`` pin the startup re-exec would honor,
+        found the same way ``_reexec._find_pin_dir`` finds it: walking UP
+        from ``project_dir`` toward (not including) $HOME. Matches
+        ``cat .vnx-version`` when the pin sits directly in ``project_dir``,
+        and also catches a pin inherited from a parent when doctor runs from
+        a subdirectory of the project;
       * ``active`` — the version dir the ``current`` symlink resolves to
         (what actually runs absent a re-exec).
-    Reporting both makes a pin that is not honored visible.
+    A ``pin`` that is not ``"unset"`` and does not equal ``active`` is a split
+    install (OI-1678): the engine code a pinned project expects differs from
+    the engine code that is actually active. WARN, naming both versions and
+    the path the pin was read from (OI-1679).
+
+    Blind spot (OI-1679): the walk only climbs ANCESTORS of ``project_dir``.
+    A SIBLING directory — e.g. a build worktree checked out next to the
+    project root instead of nested under it — does not inherit the pin and
+    is invisible to this check; run doctor from inside that worktree to see
+    its own pin/active split.
     """
     embedded_path = project_dir / ".claude" / "vnx-system"
     central_path = Path.home() / ".vnx-system" / "current"
@@ -214,7 +242,7 @@ def _check_install_mode(project_dir: Path) -> Check:
     embedded_active = (embedded_path / "scripts").is_dir()
 
     if central_active:
-        pin = _read_project_pin(project_dir)
+        pin, pin_dir = _read_project_pin(project_dir)
         active = _resolve_active_version(central_path)
         marker_issue = _check_central_install_marker(central_path)
         if pin == "error":
@@ -226,11 +254,22 @@ def _check_install_mode(project_dir: Path) -> Check:
                     f"{project_dir / PIN_FILE_NAME} — check permissions), active: {active}"
                 ),
             )
+        warnings: "list[str]" = []
         if marker_issue is not None:
+            warnings.append(marker_issue)
+        if pin != "unset" and pin != active:
+            pin_path = pin_dir / PIN_FILE_NAME if pin_dir is not None else project_dir / PIN_FILE_NAME
+            warnings.append(
+                f"pin not honored: {pin_path} pins {pin} but active is {active} "
+                "(checked only from this directory up to $HOME — a sibling "
+                "directory such as a build worktree is not covered by this check "
+                "and must be doctored separately)"
+            )
+        if warnings:
             return Check(
                 name="install:mode",
                 status=WARN,
-                detail=f"mode: central, pin: {pin}, active: {active}, {marker_issue}",
+                detail=f"mode: central, pin: {pin}, active: {active}, {'; '.join(warnings)}",
             )
         return Check(
             name="install:mode",

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from vnx_cli import _engine
-from vnx_cli._reexec import PIN_FILE_NAME, _find_pin_dir
+from vnx_cli._reexec import PIN_FILE_NAME, _find_pin_dir, _normalize_version
 
 logger = logging.getLogger(__name__)
 
@@ -229,6 +229,26 @@ def _check_install_mode(project_dir: Path) -> Check:
     the engine code that is actually active. WARN, naming both versions and
     the path the pin was read from (OI-1679).
 
+    Comparison note (fix-forward on OI-1678, glm-gate finding): ``pin`` and
+    ``active`` are compared through ``_reexec._normalize_version`` — the
+    exact same normalization the startup re-exec applies (in
+    ``_resolve_pinned_dir`` / ``_warn_diverged_dev_checkout``) before it
+    decides whether a pin is honored, reused here rather than reimplemented
+    so the two can never drift apart. Without it a pin written without the
+    decorative ``v`` (e.g. ``1.5.0``) that names the SAME install as a
+    ``v``-prefixed ``active`` (e.g. ``v1.5.0``) — an install re-exec WOULD
+    honor — was reported here as a mismatch: the inverse of the OI-1678 bug,
+    a false WARN instead of a missed one. This is still only a normalized
+    VERSION-STRING comparison, not the full identity check
+    ``_maybe_reexec_pinned`` performs when it actually decides to re-exec:
+    that resolves the pin to a directory under ``versions/`` (trying several
+    candidate spellings) and compares the RESOLVED PATH against the running
+    engine root, which also catches a symlink escape, a custom store root, or
+    two differently-spelled dirs that happen to resolve to the same install
+    — none of which a string compare can see. ``pin`` and ``active``
+    normalizing equal is strong evidence of the same install, not proof of
+    it.
+
     Blind spot (OI-1679): the walk only climbs ANCESTORS of ``project_dir``.
     A SIBLING directory — e.g. a build worktree checked out next to the
     project root instead of nested under it — does not inherit the pin and
@@ -257,7 +277,7 @@ def _check_install_mode(project_dir: Path) -> Check:
         warnings: "list[str]" = []
         if marker_issue is not None:
             warnings.append(marker_issue)
-        if pin != "unset" and pin != active:
+        if pin != "unset" and _normalize_version(pin) != _normalize_version(active):
             pin_path = pin_dir / PIN_FILE_NAME if pin_dir is not None else project_dir / PIN_FILE_NAME
             warnings.append(
                 f"pin not honored: {pin_path} pins {pin} but active is {active} "


### PR DESCRIPTION
## Summary

`_check_install_mode` las `pin` en `active` allebei uit en zette ze in de detailregel, maar vergeleek ze nergens. OI-914 trok de twee labels uit elkaar zodat een drift zichtbaar zou zijn — maar liet de vergelijking zelf achterwege, dus een regel met `PASS` ervoor werd niet gelezen als drift.

Gemeten met een live geval (SEOcrawler_v2): `.vnx-version` = v1.5.0, actieve central-versie v1.6.0. `vnx doctor --project-dir .` gaf `[PASS] install:mode mode: central, pin: v1.5.0, active: v1.6.0`.

## Changes

- `vnx_cli/commands/doctor.py::_check_install_mode` — WARN zodra `pin != "unset"` en `pin != active`, met beide versies en het pinpad in de melding. De bestaande `pin == "error"`-tak (onleesbaar pinbestand) is ongewijzigd.
- `vnx_cli/commands/doctor.py::_read_project_pin` — loopt nu omhoog via `vnx_cli._reexec._find_pin_dir` (dezelfde walk als de startup re-exec: nearest ancestor wint, begrensd op $HOME exclusief) in plaats van alleen `project_dir` zelf te lezen. Retourneert `(pin, pin_dir)` zodat de melding het pad kan noemen waar de pin vandaan komt. `_reexec.py` zelf is niet gewijzigd (alleen geïmporteerd).
- Docstring van `_check_install_mode` beschrijft de blinde vlek uit OI-1679: de walk klimt alleen ANCESTORS. Een zustermap (bv. een build-worktree naast de project-root) erft de pin niet en wordt door deze check niet gezien — dat vraagt een aparte `vnx doctor` vanuit die map.
- `tests/test_vnx_doctor_strict.py` — bestaande test `test_central_mode_pin_and_active_agree_with_pin_file` aangepast naar het nieuwe (WARN-)gedrag, plus vier nieuwe tests: het live OI-1678-scenario, unset-pin-blijft-PASS met een versienaam als active, pin-gevonden-via-submap-walkup (OI-1679), en de zustermap-blinde-vlek expliciet vastgelegd als PASS/unset.

## Verification

Rood (oude `_check_install_mode`, nieuwe tests):
```
FAILED tests/test_vnx_doctor_strict.py::TestCentralMode::test_central_mode_pin_and_active_agree_with_pin_file
FAILED tests/test_vnx_doctor_strict.py::TestCentralMode::test_central_mode_pin_diverges_from_active_warns
FAILED tests/test_vnx_doctor_strict.py::TestCentralMode::test_central_mode_pin_found_via_ancestor_walkup
3 failed, 39 passed in 13.81s
```

Groen (fix toegepast):
```
python3 -m pytest tests/test_vnx_doctor_strict.py tests/test_vnx_cli_reexec.py
78 passed in 13.87s
```

`vnx doctor --strict` op een gesplitste installatie (direct `vnx_doctor()`-call met een gefaked HOME, pin v1.5.0 / active v1.6.0): `install:mode` geeft WARN en het proces sluit af met exit code 1 — bevestigd, de bestaande strict-regel (`if strict and (warned>0 or failed>0): exit 1`, ongewijzigd door deze PR) telt elke WARN mee, niet alleen FAIL.

`git diff HEAD` leeg voor de push.

## Open Items

None.

---
**Dispatch-ID**: 20260908-oi1678-doctor-weegt-de-pin
**Model**: sonnet
**Provider**: claude