### PR TITLE
fix(hooks): de dode SessionStart-matcher uit de drie install-templates plus een matcher-wachter in t0_state_health (OI-1680)

### DIFF
--- a/scripts/lib/t0_state_health.py
+++ b/scripts/lib/t0_state_health.py
@@ -19,6 +19,12 @@ Detected conditions (each is its own finding):
   2. ``t0_state.json`` exists but no ``SessionStart`` hook registers
      ``build_t0_state_hook.sh`` — the projection will never refresh, so T0
      reads whatever was last built.
+  3. ``t0_state.json`` exists and the hook IS registered, but on a matcher the
+     harness never dispatches (OI-1680) — the same outcome as condition 2, and
+     the one this module used to report GREEN on. Detection was a substring
+     match on the command and never looked at the matcher, so a group carrying
+     ``"matcher": "terminals/T0"`` (the form all three install templates
+     shipped) read as "refresh hook is wired" while it never fired once.
 
 ``STALE_AFTER_DAYS = 7`` is deliberate. The builder runs on every SessionStart
 (``build_t0_state_hook.sh``), so a working chain leaves the state younger than
@@ -45,6 +51,45 @@ STALE_AFTER_DAYS = 7
 # a consumer's command may wrap the path in ``${VNX_HOME}`` or ``bash -c``, so
 # matching on the hook's basename is the robust check across install modes.
 _REFRESH_HOOK_MARKER = "build_t0_state_hook"
+
+# The only tokens a SessionStart matcher can carry, measured 2026-09-08 on
+# claude 2.1.263 (OI-1552, three probe groups in one settings file): a
+# SessionStart matcher matches the session SOURCE, never a path. This set is
+# the SINGLE source of that vocabulary — ``tests/`` imports it from here rather
+# than keeping a second copy that can drift out of step with the check that
+# actually runs in ``vnx doctor``.
+SESSION_START_SOURCES = frozenset({"startup", "resume", "clear", "compact"})
+
+# Matchers that mean "always". An absent matcher key means the same thing.
+_ALWAYS_MATCHERS = frozenset({"", "*"})
+
+
+def sessionstart_matcher_can_fire(matcher: Any) -> bool:
+    """True when the harness can actually dispatch a SessionStart group carrying
+    ``matcher``.
+
+    ``""``/``"*"``/absent mean "always". Otherwise the matcher must be built
+    from ``SESSION_START_SOURCES`` (``|``-separated), because that is the only
+    thing a SessionStart matcher is compared against.
+
+    Anything else -- notably a path like ``terminals/T0``, which reads entirely
+    plausible -- is a group that NEVER fires. Measured 2026-09-08 (OI-1552):
+    ``matcher ""`` fired, ``matcher "startup"`` fired, ``matcher
+    "terminals/T0"`` never fired at all, so its hook command was irrelevant.
+
+    Non-string input (a list, a number, ``True``) is dead too: it can never
+    equal a session source. ``None`` is the one non-string that is alive,
+    because a missing matcher key is "always".
+    """
+    if matcher is None:
+        return True
+    if not isinstance(matcher, str):
+        return False
+    stripped = matcher.strip()
+    if stripped in _ALWAYS_MATCHERS:
+        return True
+    tokens = {t.strip() for t in stripped.split("|") if t.strip()}
+    return bool(tokens) and tokens <= SESSION_START_SOURCES
 
 
 def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
@@ -124,27 +169,36 @@ def _most_recent_dispatch(state_dir: Path) -> Optional[datetime]:
     return _parse_iso(str(row[0]))
 
 
-def _has_t0_refresh_hook(project_root: Path) -> bool:
-    """True when ``.claude/settings.json`` registers a SessionStart hook that
-    rebuilds the t0_state projection (``build_t0_state_hook.sh``)."""
+def _find_t0_refresh_hook_group(project_root: Path) -> Optional[Dict[str, Any]]:
+    """Return the ``SessionStart`` group in ``.claude/settings.json`` that
+    registers the t0_state builder, or ``None`` when nothing registers it.
+
+    Returns the GROUP, not a bool, because "is it registered" and "can the
+    harness dispatch it" are two independent questions and the second one was
+    never asked (OI-1680). The command is still located by substring — a
+    consumer's command may wrap the path in ``${VNX_HOME}`` or ``bash -c``.
+    """
     settings = project_root / ".claude" / "settings.json"
     if not settings.is_file():
-        return False
+        return None
     try:
         data = json.loads(settings.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
-        return False
+        return None
     hooks = data.get("hooks", {}) if isinstance(data, dict) else {}
-    for entry in hooks.get("SessionStart", []):
+    session_start = hooks.get("SessionStart", []) if isinstance(hooks, dict) else []
+    if not isinstance(session_start, list):
+        return None
+    for entry in session_start:
         if not isinstance(entry, dict):
             continue
-        for hook in entry.get("hooks", []):
+        for hook in entry.get("hooks", []) or []:
             if not isinstance(hook, dict):
                 continue
             command = str(hook.get("command") or "")
             if _REFRESH_HOOK_MARKER in command:
-                return True
-    return False
+                return entry
+    return None
 
 
 def assess_t0_state_health(
@@ -162,10 +216,15 @@ def assess_t0_state_health(
       * ``age_days``          — fractional days since build (None if unknown)
       * ``age_human``         — human age string ("never built", "52 days", …)
       * ``has_refresh_hook``  — whether a SessionStart hook rebuilds the state
+      * ``refresh_hook_matcher`` — that group's matcher (None when unregistered
+                                or when the group carries no ``matcher`` key)
+      * ``refresh_hook_can_fire`` — whether the harness can actually dispatch
+                                that group; ``False`` when unregistered
       * ``most_recent_dispatch`` — ISO string of the newest dispatch, or None
       * ``findings``          — list of ``{"kind", "message", "remediation"}``
                                 (empty when healthy); ``kind`` is one of
-                                ``stale_while_active`` / ``missing_hook``
+                                ``stale_while_active`` / ``missing_hook`` /
+                                ``dead_hook_matcher``
     """
     now = now if now is not None else datetime.now(timezone.utc)
     state_path = state_dir / T0_STATE_FILENAME
@@ -180,7 +239,14 @@ def assess_t0_state_health(
     elif exists:
         age_human = "age unknown"
 
-    has_refresh_hook = _has_t0_refresh_hook(project_root)
+    refresh_hook_group = _find_t0_refresh_hook_group(project_root)
+    has_refresh_hook = refresh_hook_group is not None
+    refresh_hook_matcher = (
+        refresh_hook_group.get("matcher") if refresh_hook_group is not None else None
+    )
+    refresh_hook_can_fire = has_refresh_hook and sessionstart_matcher_can_fire(
+        refresh_hook_matcher
+    )
     most_recent = _most_recent_dispatch(state_dir)
 
     activity_after_build = False
@@ -211,6 +277,25 @@ def assess_t0_state_health(
             ),
         })
 
+    if exists and has_refresh_hook and not refresh_hook_can_fire:
+        findings.append({
+            "kind": "dead_hook_matcher",
+            "message": (
+                "the SessionStart hook that rebuilds t0_state.json is registered "
+                f"but carries matcher {refresh_hook_matcher!r}, which the harness "
+                "never matches: a SessionStart matcher matches the session source "
+                f"({', '.join(sorted(SESSION_START_SOURCES))}) or is empty for "
+                "'always'. The group is therefore never dispatched at all, so the "
+                "projection never refreshes and the T0 role reads whatever state "
+                "was last built"
+            ),
+            "remediation": (
+                "Set the matcher on that SessionStart group to \"\" in "
+                ".claude/settings.json, or run `vnx regen-settings --merge` to "
+                "reinstall the VNX-owned hooks from the template"
+            ),
+        })
+
     if stale_while_active:
         latest = ""
         if most_recent is not None:
@@ -233,6 +318,8 @@ def assess_t0_state_health(
         "age_days": age_days,
         "age_human": age_human,
         "has_refresh_hook": has_refresh_hook,
+        "refresh_hook_matcher": refresh_hook_matcher,
+        "refresh_hook_can_fire": refresh_hook_can_fire,
         "most_recent_dispatch": most_recent.isoformat() if most_recent else None,
         "findings": findings,
     }

--- a/templates/init/default/settings.json.j2
+++ b/templates/init/default/settings.json.j2
@@ -54,11 +54,11 @@
     ],
     "SessionStart": [
       {
-        "matcher": "terminals/T0",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'exec bash \"{{ engine_root }}/scripts/hooks/build_t0_state_hook.sh\"'"
+            "command": "bash -c 'VNX_HOME=\"${VNX_HOME:-{{ engine_root }}}\"; if [ -f \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\" ]; then exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"; else printf \"[vnx] build_t0_state_hook artifact MISSING under %s (expected in its scripts/hooks directory); t0_state.json will not refresh\\n\" \"${VNX_HOME}\" >&2; exit 0; fi'"
           }
         ]
       }

--- a/templates/init/minimal/settings.json.j2
+++ b/templates/init/minimal/settings.json.j2
@@ -48,11 +48,11 @@
     ],
     "SessionStart": [
       {
-        "matcher": "terminals/T0",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'exec bash \"{{ engine_root }}/scripts/hooks/build_t0_state_hook.sh\"'"
+            "command": "bash -c 'VNX_HOME=\"${VNX_HOME:-{{ engine_root }}}\"; if [ -f \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\" ]; then exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"; else printf \"[vnx] build_t0_state_hook artifact MISSING under %s (expected in its scripts/hooks directory); t0_state.json will not refresh\\n\" \"${VNX_HOME}\" >&2; exit 0; fi'"
           }
         ]
       }

--- a/templates/settings_vnx_keys.json.tmpl
+++ b/templates/settings_vnx_keys.json.tmpl
@@ -79,11 +79,11 @@
         ]
       },
       {
-        "matcher": "terminals/T0",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'exec bash \"{{VNX_HOME}}/scripts/hooks/build_t0_state_hook.sh\"'"
+            "command": "bash -c 'VNX_HOME=\"${VNX_HOME:-{{VNX_HOME}}}\"; if [ -f \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\" ]; then exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"; else printf \"[vnx] build_t0_state_hook artifact MISSING under %s (expected in its scripts/hooks directory); t0_state.json will not refresh\\n\" \"${VNX_HOME}\" >&2; exit 0; fi'"
           }
         ]
       },

--- a/tests/test_sessionstart_hook_t0state_fires.py
+++ b/tests/test_sessionstart_hook_t0state_fires.py
@@ -47,6 +47,7 @@ import json
 import os
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -54,10 +55,19 @@ import pytest
 _ROOT = Path(__file__).resolve().parents[1]
 _SETTINGS = _ROOT / ".claude" / "settings.json"
 
+_LIB = _ROOT / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
 # A SessionStart matcher the harness can actually dispatch: empty/"*" mean
 # "always", otherwise it is built from the documented session-source tokens.
 # Anything else (notably a path like "terminals/T0") silently never fires.
-_VALID_SOURCES = {"startup", "resume", "clear", "compact"}
+#
+# OI-1680: this list used to be a local literal here. It now comes from the
+# production module that ``vnx doctor`` runs, so the test vocabulary and the
+# runtime check cannot drift apart — the templates carried the dead matcher for
+# months precisely because the only place that knew the rule was a test.
+from t0_state_health import SESSION_START_SOURCES as _VALID_SOURCES  # noqa: E402
 
 
 def _load_settings() -> dict:

--- a/tests/test_settings_template_matcher_guard.py
+++ b/tests/test_settings_template_matcher_guard.py
@@ -1,0 +1,420 @@
+"""tests/test_settings_template_matcher_guard.py — OI-1680.
+
+``tests/test_launchd_plist_guard.py`` walks every plist TEMPLATE this repo
+ships and refuses a defect at the source. This module is its equivalent for
+the settings templates, and it exists because the plist guard's absence-shaped
+sibling let a fleet-wide defect sit unnoticed:
+
+MEASURED 2026-09-08 on main ``f97e896f``. PR #1816 repaired the dead
+SessionStart matcher in this repo's own ``.claude/settings.json`` (a group
+carrying ``"matcher": "terminals/T0"`` is never dispatched — a SessionStart
+matcher matches the session SOURCE, never a path). It did NOT repair the three
+templates that install that group, and ``scripts/vnx_settings_merge.py``
+replaces the ``hooks`` block INTEGRALLY on every ``vnx regen-settings
+--merge``. So one regen — the very command ``scripts/hooks/hookpin_check.sh``
+advises on a hook problem — put the dead matcher straight back, and every repo
+scaffolded by ``vnx init`` carried it from birth. Consequence: those projects
+never refreshed ``t0_state.json`` at all.
+
+Two guards, both on BEHAVIOUR rather than on string shape:
+
+1. Every SessionStart matcher in every settings template must be one the
+   harness can dispatch, judged by ``t0_state_health.sessionstart_matcher_can_fire``
+   -- the same predicate ``vnx doctor`` runs, so the guard and the runtime
+   check can never disagree.
+2. The rendered t0_state hook command must carry the same INVOCATION contract
+   as the repaired ``.claude/settings.json``: an explicit ``VNX_HOME`` wins,
+   an absent one falls back to the template's own install anchor, a missing
+   artefact says MISSING on stderr and never blocks the session. Each template's
+   command is EXECUTED against a staged fake engine to prove it, exactly the
+   way ``tests/test_sessionstart_hook_t0state_fires.py`` proves it for
+   ``.claude/settings.json``.
+
+The templates use different anchor mechanisms by design -- ``.claude/settings.json``
+resolves the repo it lives in via ``git rev-parse``, while the templates resolve
+the ENGINE install through their own substitution token (``{{VNX_HOME}}`` /
+``{{ engine_root }}``). A consumer repo's git toplevel is not the engine, so
+copying the git anchor into the templates would have made the fix fail loudly in
+exactly the fleet it is meant to repair. The contract asserted below is
+therefore the invocation behaviour, which IS identical, not the literal string.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Dict, List
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_LIB = REPO_ROOT / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from t0_state_health import (  # noqa: E402
+    SESSION_START_SOURCES,
+    sessionstart_matcher_can_fire,
+)
+
+TEMPLATES = REPO_ROOT / "templates"
+VNX_KEYS_TMPL = TEMPLATES / "settings_vnx_keys.json.tmpl"
+INIT_DEFAULT_J2 = TEMPLATES / "init" / "default" / "settings.json.j2"
+INIT_MINIMAL_J2 = TEMPLATES / "init" / "minimal" / "settings.json.j2"
+
+REFRESH_HOOK_MARKER = "build_t0_state_hook"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Rendering — each template has its own substitution mechanism; render it the
+# way its real installer does, so the guard judges what actually lands on disk.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _render_vnx_keys(engine_root: str, project_root: str) -> str:
+    """Render settings_vnx_keys.json.tmpl through the REAL merge engine's
+    loader, so the OI-1139 render guard runs over it too."""
+    scripts_dir = REPO_ROOT / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    import vnx_settings_merge
+
+    raw = VNX_KEYS_TMPL.read_text(encoding="utf-8")
+    rendered = raw.replace(vnx_settings_merge._VNX_HOME_TOKEN, engine_root)
+    rendered = rendered.replace("{{PROJECT_ROOT}}", project_root)
+    vnx_settings_merge._assert_rendered_cleanly(
+        raw, rendered, engine_root, project_root, str(VNX_KEYS_TMPL)
+    )
+    return rendered
+
+
+def _render_j2(path: Path) -> Callable[[str, str], str]:
+    def _render(engine_root: str, project_root: str) -> str:
+        from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+        env = Environment(
+            loader=FileSystemLoader(str(path.parent)),
+            undefined=StrictUndefined,
+            keep_trailing_newline=True,
+        )
+        return env.get_template(path.name).render(
+            project_name=Path(project_root).name,
+            project_id="guard-project",
+            vnx_version="0.0.0-test",
+            engine_root=engine_root,
+        )
+
+    return _render
+
+
+# (label, path, renderer)
+SETTINGS_TEMPLATES = [
+    ("settings_vnx_keys.json.tmpl", VNX_KEYS_TMPL, _render_vnx_keys),
+    ("init/default/settings.json.j2", INIT_DEFAULT_J2, _render_j2(INIT_DEFAULT_J2)),
+    ("init/minimal/settings.json.j2", INIT_MINIMAL_J2, _render_j2(INIT_MINIMAL_J2)),
+]
+TEMPLATE_IDS = [label for label, _, _ in SETTINGS_TEMPLATES]
+
+
+def _rendered_settings(renderer: Callable[[str, str], str], engine_root: str, project_root: str) -> dict:
+    return json.loads(renderer(engine_root, project_root))
+
+
+def _sessionstart_groups(settings: dict) -> List[dict]:
+    hooks = settings.get("hooks", {})
+    return [g for g in hooks.get("SessionStart", []) if isinstance(g, dict)]
+
+
+def _t0_state_group(settings: dict) -> dict:
+    for group in _sessionstart_groups(settings):
+        for hook in group.get("hooks", []):
+            if REFRESH_HOOK_MARKER in str(hook.get("command") or ""):
+                return group
+    raise AssertionError("no SessionStart group registers build_t0_state_hook")
+
+
+def _t0_state_command(settings: dict) -> str:
+    group = _t0_state_group(settings)
+    for hook in group.get("hooks", []):
+        command = str(hook.get("command") or "")
+        if REFRESH_HOOK_MARKER in command:
+            return command
+    raise AssertionError("unreachable: group matched but command not found")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Guard 1 — every SessionStart matcher in every template can actually fire.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("label,path,renderer", SETTINGS_TEMPLATES, ids=TEMPLATE_IDS)
+def test_template_sessionstart_matchers_can_fire(label, path, renderer, tmp_path):
+    settings = _rendered_settings(renderer, str(tmp_path / "engine"), str(tmp_path / "project"))
+    groups = _sessionstart_groups(settings)
+    assert groups, f"{label} ships no SessionStart groups — nothing was checked"
+
+    dead = [g.get("matcher") for g in groups if not sessionstart_matcher_can_fire(g.get("matcher"))]
+    assert not dead, (
+        f"{label} ships SessionStart matcher(s) {dead!r} the harness never "
+        "dispatches. A SessionStart matcher matches the session SOURCE "
+        f"({sorted(SESSION_START_SOURCES)}) or is empty/'*' for 'always'. "
+        "Measured 2026-09-08 (OI-1552/OI-1680): a group matched on "
+        "'terminals/T0' never fired, so every project installed from this "
+        "template never refreshed t0_state.json."
+    )
+
+
+@pytest.mark.parametrize("label,path,renderer", SETTINGS_TEMPLATES, ids=TEMPLATE_IDS)
+def test_template_registers_a_live_t0_state_group(label, path, renderer, tmp_path):
+    """nul-is-eerst-een-meetfout: prove the sweep above actually found the
+    t0_state group, instead of reporting green over templates that ship none."""
+    settings = _rendered_settings(renderer, str(tmp_path / "engine"), str(tmp_path / "project"))
+    group = _t0_state_group(settings)
+    assert sessionstart_matcher_can_fire(group.get("matcher")), group.get("matcher")
+
+
+def test_guard_rejects_a_path_shaped_matcher():
+    """Negative control: the predicate the sweep leans on must actually fail on
+    the real defect, not accept everything."""
+    assert sessionstart_matcher_can_fire("terminals/T0") is False
+    assert sessionstart_matcher_can_fire("startup") is True
+    assert sessionstart_matcher_can_fire("") is True
+
+
+def test_guard_would_fail_on_a_template_carrying_the_dead_matcher(tmp_path):
+    """Prove the SWEEP fails, not just the predicate: a synthetic template
+    shaped exactly like the pre-OI-1680 real ones must turn it red."""
+    broken = tmp_path / "broken_settings.json.j2"
+    broken.write_text(
+        json.dumps({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "terminals/T0",
+                    "hooks": [{
+                        "type": "command",
+                        "command": 'bash -c \'exec bash "{{ engine_root }}/scripts/hooks/build_t0_state_hook.sh"\'',
+                    }],
+                }]
+            }
+        }),
+        encoding="utf-8",
+    )
+    renderer = _render_j2(broken)
+    with pytest.raises(AssertionError, match="never dispatches"):
+        test_template_sessionstart_matchers_can_fire(
+            "broken_settings.json.j2", broken, renderer, tmp_path / "scratch"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Guard 2 — the rendered command's INVOCATION contract, executed for real.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _stage_engine(tmp_path: Path, *, with_hook: bool, marker: Path) -> Path:
+    """A throwaway engine tree. The hook artefact is a STUB that records that it
+    ran: this asserts the invocation contract, so it must not run the real
+    builder or touch the live central store."""
+    engine = tmp_path / "engine"
+    (engine / "scripts" / "hooks").mkdir(parents=True, exist_ok=True)
+    if with_hook:
+        artefact = engine / "scripts" / "hooks" / "build_t0_state_hook.sh"
+        artefact.write_text(
+            f'#!/usr/bin/env bash\nprintf ran > "{marker}"\nexit 0\n', encoding="utf-8"
+        )
+        artefact.chmod(0o755)
+    return engine
+
+
+def _run(command: str, cwd: Path, **env_overrides) -> subprocess.CompletedProcess:
+    env: Dict[str, str] = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", str(cwd)),
+    }
+    for key, value in env_overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+    return subprocess.run(
+        shlex.split(command), cwd=cwd, env=env, capture_output=True, text=True, timeout=60
+    )
+
+
+@pytest.mark.parametrize("label,path,renderer", SETTINGS_TEMPLATES, ids=TEMPLATE_IDS)
+def test_rendered_command_reaches_artefact_without_vnx_home(label, path, renderer, tmp_path):
+    """The real SessionStart condition: VNX_HOME is a runtime variable a hook
+    does not inherit (measured UNSET, OI-1552), so the rendered command must
+    still reach the artefact under the template's own install anchor."""
+    marker = tmp_path / "hook_ran.marker"
+    engine = _stage_engine(tmp_path, with_hook=True, marker=marker)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    settings = _rendered_settings(renderer, str(engine), str(project))
+    result = _run(_t0_state_command(settings), cwd=project, VNX_HOME=None)
+
+    assert result.returncode == 0, result.stderr
+    assert marker.exists(), (
+        f"{label}: the rendered SessionStart command did not reach "
+        f"build_t0_state_hook.sh with VNX_HOME unset. stderr: {result.stderr!r}"
+    )
+
+
+@pytest.mark.parametrize("label,path,renderer", SETTINGS_TEMPLATES, ids=TEMPLATE_IDS)
+def test_rendered_command_honours_explicit_vnx_home(label, path, renderer, tmp_path):
+    """OI-1089 finding 2 stays intact in the templates too: an explicit
+    VNX_HOME is the PRIMARY anchor, ahead of the baked-in install root."""
+    template_marker = tmp_path / "template_anchor.marker"
+    engine = _stage_engine(tmp_path, with_hook=True, marker=template_marker)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    explicit_marker = tmp_path / "explicit.marker"
+    other = tmp_path / "elsewhere"
+    (other / "scripts" / "hooks").mkdir(parents=True)
+    artefact = other / "scripts" / "hooks" / "build_t0_state_hook.sh"
+    artefact.write_text(
+        f'#!/usr/bin/env bash\nprintf ran > "{explicit_marker}"\nexit 0\n', encoding="utf-8"
+    )
+    artefact.chmod(0o755)
+
+    settings = _rendered_settings(renderer, str(engine), str(project))
+    result = _run(_t0_state_command(settings), cwd=project, VNX_HOME=str(other))
+
+    assert result.returncode == 0, result.stderr
+    assert explicit_marker.exists(), f"{label}: an explicit VNX_HOME must take precedence"
+    assert not template_marker.exists(), f"{label}: VNX_HOME must win over the baked anchor"
+
+
+@pytest.mark.parametrize("label,path,renderer", SETTINGS_TEMPLATES, ids=TEMPLATE_IDS)
+def test_rendered_command_fails_loud_and_non_blocking_without_artefact(
+    label, path, renderer, tmp_path
+):
+    """Negative path: an install tree with no artefact must SAY so on stderr and
+    must never block a session (OI-1073 defect 2)."""
+    marker = tmp_path / "hook_ran.marker"
+    engine = _stage_engine(tmp_path, with_hook=False, marker=marker)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    settings = _rendered_settings(renderer, str(engine), str(project))
+    result = _run(_t0_state_command(settings), cwd=project, VNX_HOME=None)
+
+    assert result.returncode == 0, f"{label}: a missing artefact must never block a session"
+    assert not marker.exists()
+    assert "MISSING" in result.stderr, (
+        f"{label}: a tree with no build_t0_state_hook.sh must announce it on "
+        f"stderr, got: {result.stderr!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The rendered t0_state command must not make hookpin_check cry wolf.
+#
+# MEASURED 2026-09-08 on main f97e896f: it already does. #1816's fail-loud
+# message spells a path inside the printf text, and
+# ``hookpin_check.extract_path_tokens`` tokenizes ANY ``/…​.sh`` run in the
+# command string — including one inside a message — so it reported
+# ``/hooks/build_t0_state_hook.sh`` as a DEAD pin on the live repo. The
+# SessionStart beacon in every session of this repo carried that warning, and
+# ``vnx doctor``'s remediation advice for it is ``vnx regen-settings --merge``,
+# which is the very command that reinstalls this hook. A false DEAD next to a
+# real fix trains the reader to ignore the surface that OI-1123 built.
+#
+# The templates therefore keep the message free of path-shaped text. This test
+# is the guard: it runs the REAL checker over a project staged from each
+# template, so a future reword that reintroduces a path in the message turns
+# red here instead of in the next session's beacon.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("label,path,renderer", SETTINGS_TEMPLATES, ids=TEMPLATE_IDS)
+def test_rendered_settings_produce_no_false_dead_hook_pin(label, path, renderer, tmp_path):
+    if str(_LIB) not in sys.path:  # pragma: no cover - defensive
+        sys.path.insert(0, str(_LIB))
+    import hookpin_check
+
+    marker = tmp_path / "hook_ran.marker"
+    engine = _stage_engine(tmp_path, with_hook=True, marker=marker)
+    project = tmp_path / "project"
+    (project / ".claude").mkdir(parents=True)
+    # The engine reachable the way a real install is: <project>/.vnx, one of
+    # hookpin_check's own ${VNX_HOME} candidate bases.
+    (project / ".vnx").symlink_to(engine)
+
+    settings = _rendered_settings(renderer, str(engine), str(project))
+    command = _t0_state_command(settings)
+    (project / ".claude" / "settings.json").write_text(
+        json.dumps({"hooks": {"SessionStart": [{
+            "matcher": _t0_state_group(settings).get("matcher", ""),
+            "hooks": [{"type": "command", "command": command}],
+        }]}}),
+        encoding="utf-8",
+    )
+
+    findings = hookpin_check.check_project_hook_pins(project)
+    assert findings, f"{label}: hookpin_check found no pin to check at all"
+    dead = [f for f in findings if f.status == hookpin_check.STATUS_MISSING]
+    assert not dead, (
+        f"{label}: hookpin_check reports a DEAD pin for a hook whose artefact "
+        "is present. Every token it extracted:\n"
+        + "\n".join(f"  {f.status}: {f.raw_path} -> {f.resolved_path}" for f in findings)
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The templates and the repaired .claude/settings.json must not drift apart:
+# same matcher class, same guard-before-exec ordering.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("label,path,renderer", SETTINGS_TEMPLATES, ids=TEMPLATE_IDS)
+def test_template_hookform_matches_live_settings(label, path, renderer, tmp_path):
+    live = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    live_command = _t0_state_command(live)
+    live_matcher = _t0_state_group(live).get("matcher")
+
+    settings = _rendered_settings(renderer, str(tmp_path / "engine"), str(tmp_path / "project"))
+    command = _t0_state_command(settings)
+    matcher = _t0_state_group(settings).get("matcher")
+
+    assert sessionstart_matcher_can_fire(live_matcher), (
+        "the live .claude/settings.json regressed to a dead matcher "
+        f"({live_matcher!r}) — fix that before trusting this comparison"
+    )
+    assert matcher == live_matcher, (
+        f"{label} carries matcher {matcher!r} while .claude/settings.json "
+        f"carries {live_matcher!r}: one regen-settings would flip the live file "
+        "to the template's form, so they must agree"
+    )
+
+    # Structural parity of the mechanism (the anchor VALUE differs by design:
+    # the live file resolves its own repo, a template resolves the engine).
+    for fragment in (
+        'VNX_HOME="${VNX_HOME:-',
+        '[ -f "${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh" ]',
+        'exec bash "${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh"',
+        "MISSING",
+        "exit 0",
+    ):
+        assert fragment in command, f"{label} lost the {fragment!r} step"
+        assert fragment in live_command, (
+            f".claude/settings.json lost the {fragment!r} step — the templates "
+            "are now the stricter form, which means the live file regressed"
+        )
+
+    guard = command.index('if [ -f "${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh" ]')
+    execute = command.index('exec bash "${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh"')
+    assert guard < execute, (
+        f"{label}: the [ -f ] guard must precede exec, or a consumer tree with "
+        "no artefact fails silently instead of loudly (OI-1089)"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_t0_state_health.py
+++ b/tests/test_t0_state_health.py
@@ -28,8 +28,10 @@ for p in (_LIB, _SCRIPTS):
         sys.path.insert(0, str(p))
 
 from t0_state_health import (  # noqa: E402
+    SESSION_START_SOURCES,
     STALE_AFTER_DAYS,
     assess_t0_state_health,
+    sessionstart_matcher_can_fire,
 )
 
 NOW = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
@@ -65,12 +67,23 @@ def _write_dispatch(state_dir: Path, created_at: datetime) -> None:
     conn.close()
 
 
-def _write_settings(project_root: Path, with_hook: bool) -> None:
+def _write_settings(project_root: Path, with_hook: bool, matcher: str = "") -> None:
+    """Stage a project's ``.claude/settings.json``.
+
+    OI-1680: ``matcher`` defaults to ``""`` — the form the harness actually
+    dispatches. It used to be hardcoded to ``"terminals/T0"``, so every
+    ``with_hook=True`` case here staged a group that can NEVER fire while
+    asserting the project was healthy. That is the same shape of fixture defect
+    #1816 corrected in ``test_build_t0_state_freshness``: the fixture moved with
+    the bug, so no assertion in this file could see it. The dead matcher is now
+    an explicit argument, exercised by its own test below instead of silently
+    underpinning every "healthy" case.
+    """
     (project_root / ".claude").mkdir(parents=True, exist_ok=True)
     session_start = []
     if with_hook:
         session_start = [{
-            "matcher": "terminals/T0",
+            "matcher": matcher,
             "hooks": [{
                 "type": "command",
                 "command": "bash -c 'exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"'",
@@ -175,6 +188,165 @@ def test_missing_hook_and_stale_both_findings(tmp_path):
 def test_stale_threshold_is_deliberate():
     """N must be a consciously-chosen constant, not a magic inline number."""
     assert STALE_AFTER_DAYS == 7
+
+
+# ---------------------------------------------------------------------------
+# OI-1680: "hook registered" must stop being green when the group cannot fire.
+#
+# Before this, ``_has_t0_refresh_hook`` detected the hook on a substring of the
+# command and never looked at the matcher. So a project carrying
+# ``"matcher": "terminals/T0"`` — the form all three install templates shipped,
+# and the form every ``vnx init`` repo therefore had — reported a fresh,
+# healthy, wired projection while the group was never dispatched at all.
+# ---------------------------------------------------------------------------
+
+def test_dead_matcher_is_not_green(tmp_path):
+    """The regression: hook present, matcher a path -> NOT green."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True, matcher="terminals/T0")
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["refresh_hook_can_fire"] is False
+    kinds = [f["kind"] for f in assessment["findings"]]
+    assert kinds == ["dead_hook_matcher"], assessment["findings"]
+    finding = assessment["findings"][0]
+    assert "terminals/T0" in finding["message"]
+    assert "never" in finding["message"]
+    assert finding["remediation"]
+
+
+def test_dead_matcher_still_counts_as_registered(tmp_path):
+    """The two facts are distinct: the hook IS registered, it just cannot fire.
+    Collapsing them into ``has_refresh_hook=False`` would report "no hook
+    registers build_t0_state_hook.sh", which is false and sends the reader
+    looking for a missing line that is right there."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True, matcher="terminals/T0")
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["has_refresh_hook"] is True
+    kinds = [f["kind"] for f in assessment["findings"]]
+    assert "missing_hook" not in kinds
+
+
+def test_empty_matcher_with_hook_is_green(tmp_path):
+    """The repair must not cry wolf: the working form stays green."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True, matcher="")
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["has_refresh_hook"] is True
+    assert assessment["refresh_hook_can_fire"] is True
+    assert assessment["findings"] == []
+
+
+@pytest.mark.parametrize("matcher", sorted(SESSION_START_SOURCES) + ["*", "startup|resume"])
+def test_valid_session_source_matchers_are_green(tmp_path, matcher):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True, matcher=matcher)
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["refresh_hook_can_fire"] is True, matcher
+    assert assessment["findings"] == []
+
+
+@pytest.mark.parametrize("matcher", ["terminals/T0", "T0", "SessionStart", ".claude/terminals/T0", "|"])
+def test_matchers_that_never_fire_are_flagged(tmp_path, matcher):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True, matcher=matcher)
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["refresh_hook_can_fire"] is False, matcher
+    assert [f["kind"] for f in assessment["findings"]] == ["dead_hook_matcher"]
+
+
+def test_absent_matcher_key_means_always(tmp_path):
+    """A group with no ``matcher`` key at all is "always", not dead."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    (project_root / ".claude").mkdir(parents=True)
+    (project_root / ".claude" / "settings.json").write_text(json.dumps({
+        "hooks": {"SessionStart": [{
+            "hooks": [{
+                "type": "command",
+                "command": "bash /engine/scripts/hooks/build_t0_state_hook.sh",
+            }],
+        }]},
+    }))
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["refresh_hook_can_fire"] is True
+    assert assessment["findings"] == []
+
+
+def test_dead_matcher_and_stale_are_independent_findings(tmp_path):
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(days=52)))
+    _write_settings(project_root, with_hook=True, matcher="terminals/T0")
+    _write_dispatch(state_dir, NOW - timedelta(days=3))
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    kinds = sorted(f["kind"] for f in assessment["findings"])
+    assert kinds == ["dead_hook_matcher", "stale_while_active"]
+
+
+def test_no_state_file_suppresses_dead_matcher_finding(tmp_path):
+    """Same contract as ``missing_hook``: with no projection on disk there is
+    nothing to warn about — the project never set one up here."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    _write_settings(project_root, with_hook=True, matcher="terminals/T0")
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["exists"] is False
+    assert assessment["findings"] == []
+
+
+def test_missing_hook_reports_no_matcher_verdict(tmp_path):
+    """With nothing registered there is no matcher to judge — the fact must be
+    False, and only the missing_hook finding fires (not both)."""
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=False)
+
+    assessment = assess_t0_state_health(state_dir, project_root, now=NOW)
+    assert assessment["has_refresh_hook"] is False
+    assert assessment["refresh_hook_can_fire"] is False
+    assert [f["kind"] for f in assessment["findings"]] == ["missing_hook"]
+
+
+# ---------------------------------------------------------------------------
+# sessionstart_matcher_can_fire — the shared vocabulary, directly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("matcher", ["", "  ", "*", None, "startup", "resume", "clear", "compact",
+                                     "startup|resume", " startup | clear "])
+def test_matcher_predicate_accepts_live_forms(matcher):
+    assert sessionstart_matcher_can_fire(matcher) is True, matcher
+
+
+@pytest.mark.parametrize("matcher", ["terminals/T0", "T0", "startup|terminals/T0", "|", "Bash",
+                                     ["startup"], 3, True, {}])
+def test_matcher_predicate_rejects_dead_forms(matcher):
+    assert sessionstart_matcher_can_fire(matcher) is False, matcher
+
+
+def test_session_start_sources_is_the_documented_vocabulary():
+    assert SESSION_START_SOURCES == {"startup", "resume", "clear", "compact"}
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +484,27 @@ def test_doctor_render_pass_when_fresh_and_hooked(tmp_path):
     results = check_t0_state_freshness(paths)
     assert len(results) == 1
     assert results[0].status == PASS
+
+
+def test_doctor_render_warns_on_dead_matcher(tmp_path):
+    """OI-1680 through the operator-facing surface: a fresh projection whose
+    refresh group can never fire must WARN, not pass."""
+    from vnx_doctor import WARN, check_t0_state_freshness
+
+    project_root = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    _write_t0_state(state_dir, _iso(NOW - timedelta(hours=1)))
+    _write_settings(project_root, with_hook=True, matcher="terminals/T0")
+
+    paths = {
+        "PROJECT_ROOT": str(project_root),
+        "VNX_STATE_DIR": str(state_dir),
+    }
+    results = check_t0_state_freshness(paths)
+    assert len(results) == 1
+    assert results[0].status == WARN
+    assert "terminals/T0" in results[0].message
+    assert results[0].remediation
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Wat er stuk was

Een SessionStart-matcher matcht de sessie-BRON (`startup`, `resume`, `clear`, `compact`) of is leeg. Nooit een pad. De hookgroep die `t0_state.json` opbouwt droeg `"matcher": "terminals/T0"` en werd daardoor nooit aangeroepen.

PR #1816 repareerde dat in de eigen `.claude/settings.json` van deze repo. De oorzaak zat in de templates en zette het bij de volgende `vnx init` of `vnx regen-settings` terug:

1. Alle drie de install-templates droegen de dode matcher.
2. `scripts/vnx_settings_merge.py:271-273` vervangt het `hooks`-blok INTEGRAAL. Een enkele `vnx regen-settings --merge` -- precies het commando dat `scripts/hooks/hookpin_check.sh:65` adviseert bij een hookprobleem -- zette #1816 terug op de kapotte vorm.
3. Gevolg: geen enkele repo die via `vnx init` is opgezet heeft ooit `t0_state.json` ververst.
4. `scripts/lib/t0_state_health.py` meldde dat niet. Het detecteerde de hook op een substring van het commando en keek nooit naar de matcher, dus `vnx doctor` stond groen op een dode groep.

## Wat deze PR doet

**De drie templates gelijkgetrokken** met de gerepareerde `.claude/settings.json`: matcher `""`, `VNX_HOME` als voorrangswaarde, plus het `[ -f ]`-vangnet dat luid en niet-blokkerend faalt als het artefact ontbreekt.

De anker-WAARDE verschilt bewust: `.claude/settings.json` lost via `git rev-parse` de repo op waar hij in staat, een template lost de ENGINE-installatie op via zijn eigen substitutie-token. De git-toplevel van een consumer-repo is de engine niet, dus het git-anker overnemen zou de fix laten falen in precies de vloot die hij moet repareren. Het gecontroleerde contract is daarom het invocatie-GEDRAG, dat wel identiek is.

**Een matcher-toets in `t0_state_health`.** "Hook geregistreerd" en "groep wordt aangeroepen" zijn twee vragen; de tweede werd nooit gesteld. Nieuwe bevinding `dead_hook_matcher`. `has_refresh_hook` blijft bewust `True`: de hook staat er echt, hij vuurt alleen niet. Ze samenvoegen zou "geen hook registreert build_t0_state_hook.sh" melden, en dat stuurt de lezer op zoek naar een regel die er gewoon staat.

**Een wachter over de templates**, `tests/test_settings_template_matcher_guard.py`, als tegenhanger van `tests/test_launchd_plist_guard.py`. Hij rendert elk template zoals de echte installer dat doet en VOERT het gerenderde commando UIT tegen een neppe engine-boom.

**Woordenschat op een plek.** `SESSION_START_SOURCES` staat nu in `t0_state_health` en wordt door de tests geimporteerd. De templates droegen de dode matcher maandenlang juist omdat de enige plek die de regel kende een test was.

## Wat deze PR bewust NIET doet

`vnx_settings_merge.py:272-273` blijft ongewijzigd. De integrale hook-vervanging is een bewuste keuze ("hooks zijn VNX-eigendom") en merge-semantiek daar is een eigen ontwerpbesluit met een eigen risico. Zodra de templates goed zijn is die vervanging juist het mechanisme waarmee de fix zich vlootbreed verspreidt.

## Verificatie

**Rood eerst, op gedrag.**

Templates teruggezet op `f97e896f`, wachter gedraaid: **15 failed, 8 passed**, alle drie de templates op `test_template_sessionstart_matchers_can_fire`, `test_template_registers_a_live_t0_state_group` en `test_template_hookform_matches_live_settings`.

Matcher-toets uit de wiring gehaald (predicate geexporteerd gelaten, zodat de rood op GEDRAG valt en niet op een ImportError): **8 failed, 47 passed**. Inclusief de operator-oppervlakte: `test_doctor_render_warns_on_dead_matcher` gaf `AssertionError: assert 'pass' == 'warn'` -- `vnx doctor` meldde PASS op een groep die nooit vuurt.

In diezelfde rode toestand bleven `test_empty_matcher_with_hook_is_green` en `test_valid_session_source_matchers_are_green` **7 passed**: de reparatie maakt geen valse rood.

**Groen na de fix.**

- Gevraagde set + de nieuwe wachter: **139 passed**
- Buren (`test_build_t0_state_freshness`, `test_hookpin_check`, `test_skill_preapprove_settings`, `test_t0_role_audit_static`, `test_wave4_regen_settings_target`, `test_wave4_central_install_e2e`): **114 passed**

Alle drie de templates renderen na deze wijziging matcher `""` en dezelfde `VNX_HOME`-voorrang + `[ -f ]`-vorm als `.claude/settings.json` op main.

## Gemeten afwijking van de dispatch-aannames

De aannames klopten alle vier. Daarbovenop een niet-gemelde vondst: `.claude/settings.json` op main produceert een VALSE DEAD-melding in `hookpin_check`. De fail-loud-boodschap van #1816 spelt `scripts/hooks/build_t0_state_hook.sh` binnen de printf-tekst, en `extract_path_tokens` tokeniseert elke `/....sh`-run in het commando -- ook een in een boodschap. Gemeten op deze werkboom:

```
missing | /hooks/build_t0_state_hook.sh -> /hooks/build_t0_state_hook.sh
```

De SessionStart-beacon van elke sessie in deze repo draagt die waarschuwing, en de remediatie-tekst ervoor is `vnx regen-settings --merge` -- het commando dat deze hook herinstalleert. De templates in deze PR houden de boodschap vrij van pad-vormige tekst, en `test_rendered_settings_produce_no_false_dead_hook_pin` draait de ECHTE checker over een project dat uit elk template is opgezet. `.claude/settings.json` zelf valt buiten de bestandsgrens van deze dispatch en is niet aangeraakt; de eerstvolgende `regen-settings --merge` trekt hem naar de template-vorm. Zie Open Items in het rapport.

Dispatch-ID: 20260908-oi1680-dode-matcher-templates