### PR TITLE
fix(stop-conditions): gate_runner_missing niet meer als terugkerende E6-oorzaak (OI-1693)

### DIFF
--- a/scripts/lib/stop_conditions.py
+++ b/scripts/lib/stop_conditions.py
@@ -545,6 +545,16 @@ def check_provider_exhausted(
 # ── Check 4: E6 — repeated gate-failure cause ───────────────────────────────
 
 _INFRA_FAIL_STATUSES = frozenset({"failed", "fail", "unavailable", "not_executable"})
+
+# Reasons that mean "the gate was never built" — no runner file exists on
+# disk for it — as opposed to "the gate ran (or tried to) and failed"
+# (provider_not_installed, gate_execution_degenerate). Those two are real
+# operational failures the same runner can recover from on a later attempt;
+# a missing runner file cannot self-heal by retrying, so a streak of it is
+# not evidence of a recurring failure — it is a standing configuration gap
+# (OI-1693: a gate requested in the routing paths but never shipped).
+_UNBUILT_GATE_REASONS = frozenset({"gate_runner_missing"})
+
 DEFAULT_REPEAT_THRESHOLD = 3
 
 
@@ -583,6 +593,14 @@ def check_repeated_gate_failure_cause(
     unparseable timestamp is excluded — order-unknown, never guessed, mirrors
     OI-1613's rule) and checks whether the last ``n`` results for that gate
     all carry the same non-null cause.
+
+    A record whose cause is ``reason:<r>`` with ``r`` in
+    ``_UNBUILT_GATE_REASONS`` (i.e. ``gate_runner_missing``) never enters
+    that streak — see the constant's docstring for why. Such records are
+    tracked separately and surfaced as a non-triggering, ``_unmeasurable``-
+    shaped notice per gate instead (OI-1693): the absence of a runner is
+    reported loudly, exactly once per gate, but can never flip this check to
+    TRIGGERED.
     """
     check_id = "repeated_gate_failure_cause"
     if results_dir is not None:
@@ -602,6 +620,7 @@ def check_repeated_gate_failure_cause(
         return _unmeasurable(check_id, f"resultaten-map niet leesbaar: {exc}")
 
     by_gate: Dict[str, List[Tuple[datetime, Any, Optional[str]]]] = {}
+    unbuilt_gate_records: Dict[str, List[Tuple[datetime, Any]]] = {}
     for fp in files:
         try:
             d = json.loads(fp.read_text(encoding="utf-8"))
@@ -615,10 +634,19 @@ def check_repeated_gate_failure_cause(
         ts = _parse_iso(d.get("recorded_at"))
         if ts is None:
             continue
+        # _gate_result_cause reports what the record honestly says, for any
+        # infra-fail reason alike. The POLICY choice of which causes count
+        # toward a repeating-failure streak belongs here, not in that
+        # helper: a gate_runner_missing record means the gate was never
+        # built, not that it failed and might recover on retry. It is
+        # excluded from the streak and tracked separately below instead.
         cause = _gate_result_cause(d)
+        if cause is not None and cause.startswith("reason:") and cause[len("reason:") :] in _UNBUILT_GATE_REASONS:
+            unbuilt_gate_records.setdefault(gate, []).append((ts, d.get("pr_number")))
+            continue
         by_gate.setdefault(gate, []).append((ts, d.get("pr_number"), cause))
 
-    if not by_gate:
+    if not by_gate and not unbuilt_gate_records:
         return _unmeasurable(check_id, "geen bruikbare gate-resultaten met geldige recorded_at gevonden")
 
     sub_results: List[StopConditionResult] = []
@@ -641,6 +669,24 @@ def check_repeated_gate_failure_cause(
             )
         else:
             sub_results.append(_clear(sub_id, f"laatste {n} PR's op gate '{gate}' niet allemaal dezelfde blokkade-oorzaak", gate=gate, causes=causes, prs=prs))
+
+    # Absence must be loud: a gate requested with no runner on disk is a
+    # standing configuration gap, not a recurring failure. Report it every
+    # time it is seen, per gate, as an _unmeasurable-shaped notice — that
+    # status can never tip _combine's verdict to TRIGGERED below, so this
+    # can only ever be a loud non-event, never a silent one (OI-1693).
+    for gate, records in unbuilt_gate_records.items():
+        records.sort(key=lambda r: r[0])
+        newest_pr = records[-1][1]
+        sub_id = f"{check_id}:unbuilt:{gate}"
+        sub_results.append(
+            _unmeasurable(
+                sub_id,
+                f"gate '{gate}' wordt aangevraagd maar heeft geen runner "
+                f"(reason:gate_runner_missing, {len(records)}x gezien, meest recente PR #{newest_pr})",
+                gate=gate, reason="gate_runner_missing", count=len(records), newest_pr=newest_pr,
+            )
+        )
 
     return _combine(check_id, sub_results, sub_key="per_gate")
 

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -399,6 +399,67 @@ class TestRepeatedGateFailureCause:
         result = check_repeated_gate_failure_cause(results_dir, n=3)
         assert result.status == CheckStatus.TRIGGERED
 
+    def test_unbuilt_gate_runner_missing_does_not_trigger(self, tmp_path):
+        # OI-1693: gate_runner_missing means the gate was never built, not
+        # that it failed and might recover — a 3x streak of it must NOT
+        # trigger E6. This is the case that was ROOD before the fix (main
+        # b634b58b: deepseek_gate's #1729/#1782/#1803 forced
+        # --override-stop-conditions on every dispatch since 07-09).
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        for i, pr in enumerate([1729, 1782, 1803]):
+            d = _gate_result(pr, "deepseek_gate", status="not_executable", reason="gate_runner_missing", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-deepseek_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status != CheckStatus.TRIGGERED
+
+    def test_provider_not_installed_still_triggers_alongside_unbuilt_gate(self, tmp_path):
+        # Proves the fix is narrow: a REAL recurring cause (provider not
+        # installed, which can recover on retry) on one gate must still
+        # trigger E6, even while an unbuilt gate's records sit in the same
+        # results dir and are excluded from every streak.
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        for i, pr in enumerate([901, 902, 903]):
+            d = _gate_result(pr, "codex_gate", status="unavailable", reason="provider_not_installed", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-codex_gate.json").write_text(json.dumps(d))
+        for i, pr in enumerate([1729, 1782, 1803]):
+            d = _gate_result(pr, "deepseek_gate", status="not_executable", reason="gate_runner_missing", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-deepseek_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status == CheckStatus.TRIGGERED
+
+    def test_unbuilt_gate_notice_names_gate_and_newest_pr(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        for i, pr in enumerate([1729, 1782, 1803]):
+            d = _gate_result(pr, "deepseek_gate", status="not_executable", reason="gate_runner_missing", recorded_at=f"2026-09-0{i+1}T00:00:00Z")
+            (results_dir / f"pr-{pr}-deepseek_gate.json").write_text(json.dumps(d))
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        notice = result.evidence["per_gate"]["repeated_gate_failure_cause:unbuilt:deepseek_gate"]
+        assert notice["status"] == CheckStatus.UNMEASURABLE.value
+        assert "deepseek_gate" in notice["message"]
+        assert "1803" in notice["message"]
+        assert notice["evidence"]["gate"] == "deepseek_gate"
+        assert notice["evidence"]["count"] == 3
+        assert notice["evidence"]["newest_pr"] == 1803
+
+    def test_mixed_reasons_on_same_gate_only_excludes_unbuilt_records(self, tmp_path):
+        # A gate can flip from gate_runner_missing to a real cause mid-window
+        # (the runner shipped, then broke). Only the unbuilt-reason records
+        # are pulled out of the streak; the real ones still count normally.
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        d1 = _gate_result(1001, "deepseek_gate", status="not_executable", reason="gate_runner_missing", recorded_at="2026-09-01T00:00:00Z")
+        d2 = _gate_result(1002, "deepseek_gate", status="unavailable", reason="provider_not_installed", recorded_at="2026-09-02T00:00:00Z")
+        d3 = _gate_result(1003, "deepseek_gate", status="unavailable", reason="provider_not_installed", recorded_at="2026-09-03T00:00:00Z")
+        for pr, d in [(1001, d1), (1002, d2), (1003, d3)]:
+            (results_dir / f"pr-{pr}-deepseek_gate.json").write_text(json.dumps(d))
+        # Only 2 non-unbuilt dated records remain for this gate -> below n=3,
+        # so this must read as insufficient data, never triggered.
+        result = check_repeated_gate_failure_cause(results_dir, n=3)
+        assert result.status != CheckStatus.TRIGGERED
+
     def test_different_gates_scored_independently(self, tmp_path):
         # codex_gate stays clean; kimi_gate has the 3x repeat — overall must
         # still trigger (any-sub-triggered wins), and the untriggered gate


### PR DESCRIPTION
## Summary

`check_repeated_gate_failure_cause` (E6) telde `reason:gate_runner_missing` als
gewone infra-faal-oorzaak: drie PR's op een rij op een gate zonder runner-bestand
(`deepseek_gate`: #1729, #1782, #1803) triggerde de stop-conditie, en kon nooit
opklaren omdat een niet-bestaand bestand niet vanzelf gerepareerd raakt. Gevolg:
sinds 07-09 moest elke dispatch met `--override-stop-conditions` gevuurd worden
(27 overrides op één dag).

## Changes

- `scripts/lib/stop_conditions.py`: nieuwe constante `_UNBUILT_GATE_REASONS =
  frozenset({"gate_runner_missing"})` naast `_INFRA_FAIL_STATUSES`, met comment
  waarom deze reason categorisch anders is dan `provider_not_installed`/
  `gate_execution_degenerate`. `_gate_result_cause` blijft ongewijzigd — de
  beleidskeuze zit in `check_repeated_gate_failure_cause`. Records met deze
  reason gaan niet meer in `by_gate` (dus niet in de streak) en worden apart
  verzameld; is die verzameling niet leeg, dan komt er per gate een
  niet-triggerende `_unmeasurable`-vormgegeven mededeling in de output met
  gate-naam, aantal en nieuwste PR-nummer.
- `tests/test_stop_conditions.py`: vier nieuwe gevallen in
  `TestRepeatedGateFailureCause` (geen trigger op 3x `gate_runner_missing`,
  wél trigger op een echte oorzaak ernaast, de mededeling noemt gate+PR, en
  een gate die halverwege van `gate_runner_missing` naar een echte oorzaak
  wisselt telt alleen de echte records mee).

## Verification

```
python3 -m pytest tests/test_stop_conditions.py tests/test_dispatch_stop_conditions_gate.py -q
```
63 passed.

Rood-groen bewijs (vóór de fix reproduceerde de bug):
```
$ git apply -R <fix-patch> && python3 -m pytest tests/test_stop_conditions.py -k "unbuilt_gate or mixed_reasons" -v
...
tests/test_stop_conditions.py::TestRepeatedGateFailureCause::test_unbuilt_gate_runner_missing_does_not_trigger FAILED
tests/test_stop_conditions.py::TestRepeatedGateFailureCause::test_unbuilt_gate_notice_names_gate_and_newest_pr FAILED
E   assert <CheckStatus.TRIGGERED: 'triggered'> != <CheckStatus.TRIGGERED: 'triggered'>
2 failed, 2 passed in 0.32s

$ git apply <fix-patch> && python3 -m pytest tests/test_stop_conditions.py -v
...
54 passed in 0.25s
```

Doorgelopen andere stop-condities in de module (`check_main_ci_red`,
`check_gh_auth_dead`, `check_provider_exhausted`): geen enkele leest het
`reason`-veld uit `review_gates/results/*.json`. `check_provider_exhausted`
matcht op `failure_class` (auth_rejected/credit_exhausted) uit een andere
bron (`t0_receipts.ndjson`); `gate_runner_missing` zit niet in
`failure_classification.FAILURE_CLASSES`. `check_repeated_gate_failure_cause`
is dus het enige pad dat `gate_runner_missing` als storingsoorzaak telde.

## Open Items

None.

Dispatch-ID: 20260908-oi1693-ontbrekend-is-niet-falend
**Model**: sonnet
**Provider**: claude