### PR TITLE
fix(stop-conditions): scope the door's blocking verdict to this dispatch's own provider/gate (OI-1694)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from typing import Optional
+from typing import Optional, Set
 
 _LIB_DIR = Path(__file__).resolve().parent
 if str(_LIB_DIR) not in sys.path:
@@ -1900,18 +1900,75 @@ def _log_checkout_lag(spec: DispatchSpec, lag: Optional[int]) -> None:
 # See point 3 above for the full reasoning and the CI evidence this is based on.
 _STOP_CONDITIONS_BLOCKING_CHECK_IDS = frozenset({"provider_exhausted", "repeated_gate_failure_cause"})
 
+# 6. OI-1694: a blocking-eligible TRIGGERED check still measures BROADLY (see
+#    point 1 — run_all_checks never filters), but no longer refuses on the
+#    bare fact that SOMETHING somewhere is exhausted/repeating: it refuses
+#    only when the entity that fired (a provider, a gate) is RELEVANT to
+#    THIS dispatch's own provider/gate. Relevance is computed by
+#    _resolve_stop_conditions_scope + stop_conditions.ledger_label_is_relevant
+#    and is deliberately inverted to fail closed: a TRIGGERED sub-result
+#    blocks UNLESS it can be POSITIVELY proven unrelated (a known label
+#    outside this dispatch's alias set, or a gate name that is not this
+#    dispatch's own gate). An undeterminable scope (spec.provider == AUTO,
+#    or a gate absent from stop_conditions.GATE_LEDGER_PROVIDERS) is NOT a
+#    proven-unrelated scope — _resolve_stop_conditions_scope returns
+#    (None, None) for those and the door falls back to the pre-OI-1694 wide
+#    blocking behavior. A scoped-out TRIGGERED sub-result is never silently
+#    dropped: it is folded into the same WARN-only reporting path as
+#    main_ci_red/gh_auth_dead below, annotated with why it did not block.
+
+
+def _resolve_stop_conditions_scope(spec: DispatchSpec) -> "tuple[Optional[Set[str]], Optional[Set[str]]]":
+    """Compute this dispatch's (relevant_spec_providers, relevant_gates)
+    stop-conditions scope, or (None, None) when the scope cannot be
+    determined at all — which must fall back to unscoped/broad blocking
+    (see point 6 above): ``spec.provider == Provider.AUTO`` (not yet
+    resolved to a real provider), an empty ``spec.gate``, or a gate outside
+    stop_conditions.GATE_LEDGER_PROVIDERS (e.g. a legacy phase sentinel).
+    """
+    from stop_conditions import GATE_LEDGER_PROVIDERS  # noqa: PLC0415
+
+    if spec.provider == Provider.AUTO:
+        return None, None
+    gate_name = (spec.gate or "").strip()
+    if not gate_name or gate_name not in GATE_LEDGER_PROVIDERS:
+        return None, None
+    relevant_spec_providers = {spec.provider.value} | set(GATE_LEDGER_PROVIDERS[gate_name])
+    relevant_gates = {gate_name}
+    return relevant_spec_providers, relevant_gates
+
 
 def _check_stop_conditions_verdict(
-    *, state_dir: Path, override_reason: Optional[str] = None, dry_run: bool = False,
+    *,
+    state_dir: Path,
+    override_reason: Optional[str] = None,
+    dry_run: bool = False,
+    relevant_spec_providers: Optional[Set[str]] = None,
+    relevant_gates: Optional[Set[str]] = None,
 ) -> Optional[ConstraintVerdict]:
     """Measure stop_conditions.run_all_checks() live and return a BLOCKING
     ConstraintVerdict iff a check in _STOP_CONDITIONS_BLOCKING_CHECK_IDS is
-    TRIGGERED, unless override_reason is a non-empty explicit operator reason
-    (audited, warn-severity verdict instead). Returns None when nothing
-    blocking-eligible is TRIGGERED — see the module-level comment above for
-    the full tri-state / blocking-vs-warn-only / halt.json-write contract.
+    TRIGGERED AND relevant to this dispatch's scope, unless override_reason
+    is a non-empty explicit operator reason (audited, warn-severity verdict
+    instead). Returns None when nothing blocking-eligible-and-relevant is
+    TRIGGERED — see the module-level comment above for the full tri-state /
+    blocking-vs-warn-only / scoping / halt.json-write contract.
+
+    ``relevant_spec_providers``/``relevant_gates`` of None means "scope not
+    determinable" — stay unscoped, block on the bare TRIGGERED fact exactly
+    like before OI-1694. Passing concrete sets (see
+    _resolve_stop_conditions_scope) narrows a blocking-eligible TRIGGERED
+    check to the sub-entities that are actually relevant to THIS dispatch;
+    everything scoped out is folded into the WARN-only report, never
+    dropped.
     """
-    from stop_conditions import CheckStatus, run_all_checks, write_halt_file  # noqa: PLC0415
+    from stop_conditions import (  # noqa: PLC0415
+        CheckStatus,
+        ledger_label_is_relevant,
+        run_all_checks,
+        triggered_entity_labels,
+        write_halt_file,
+    )
 
     try:
         # write_halt=False: a measurement pass never writes on its own — see
@@ -1935,8 +1992,42 @@ def _check_stop_conditions_verdict(
             file=sys.stderr,
         )
 
-    blocking_triggered = [r for r in triggered if r.check_id in _STOP_CONDITIONS_BLOCKING_CHECK_IDS]
+    blocking_eligible = [r for r in triggered if r.check_id in _STOP_CONDITIONS_BLOCKING_CHECK_IDS]
     warn_only_triggered = [r for r in triggered if r.check_id not in _STOP_CONDITIONS_BLOCKING_CHECK_IDS]
+
+    # Scope each blocking-eligible TRIGGERED check down to whether it is
+    # relevant to THIS dispatch. Scoping is only active when the caller
+    # supplied a determinable scope for the relevant axis (see
+    # _resolve_stop_conditions_scope) — otherwise a check stays unscoped and
+    # blocks on the bare TRIGGERED fact, unchanged from before OI-1694. Same
+    # fail-closed inversion when NO entity labels can be extracted at all
+    # (evidence missing the per_provider/per_gate sub-structure _combine()
+    # normally produces): that is an undeterminable scope, not a
+    # positively-proven-unrelated one, so it stays relevant too.
+    blocking_triggered = []
+    scoped_out = []
+    for r in blocking_eligible:
+        if r.check_id == "provider_exhausted" and relevant_spec_providers is not None:
+            fired = triggered_entity_labels(r, sub_key="per_provider", entity_field="provider")
+            relevant = not fired or any(ledger_label_is_relevant(label, relevant_spec_providers) for label in fired)
+        elif r.check_id == "repeated_gate_failure_cause" and relevant_gates is not None:
+            fired = triggered_entity_labels(r, sub_key="per_gate", entity_field="gate")
+            relevant = not fired or any(gate in relevant_gates for gate in fired)
+        else:
+            relevant = True
+        (blocking_triggered if relevant else scoped_out).append(r)
+
+    if scoped_out:
+        print(
+            f"[dispatch_cli] [WARN] stop-condition(s) TRIGGERED but scoped "
+            f"OUT of this dispatch's path (measured — provably unrelated to "
+            f"provider(s)={sorted(relevant_spec_providers or ())} "
+            f"gate(s)={sorted(relevant_gates or ())} — never blocks, never "
+            f"persisted to halt.json on its own for THIS dispatch): "
+            + "; ".join(f"{r.check_id}: {r.message}" for r in scoped_out),
+            file=sys.stderr,
+        )
+
     if warn_only_triggered:
         print(
             f"[dispatch_cli] [WARN] stop-condition(s) TRIGGERED but WARN-only "
@@ -2223,10 +2314,15 @@ def build_runtime_snapshot(
         constraint_verdicts = constraint_verdicts + (track_verdict,)
 
     # golf 2A: T0 autonomous-chain stop-conditions, measured live on every fire.
+    # OI-1694: scoped to THIS dispatch's own provider/gate — see
+    # _resolve_stop_conditions_scope for the fallback-to-broad rules.
+    _relevant_spec_providers, _relevant_gates = _resolve_stop_conditions_scope(spec)
     stop_verdict = _check_stop_conditions_verdict(
         state_dir=data_dir / "state",
         override_reason=stop_conditions_override_reason,
         dry_run=dry_run,
+        relevant_spec_providers=_relevant_spec_providers,
+        relevant_gates=_relevant_gates,
     )
     if stop_verdict is not None:
         constraint_verdicts = constraint_verdicts + (stop_verdict,)

--- a/scripts/lib/stop_conditions.py
+++ b/scripts/lib/stop_conditions.py
@@ -59,7 +59,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
 
 _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
@@ -689,6 +689,93 @@ def check_repeated_gate_failure_cause(
         )
 
     return _combine(check_id, sub_results, sub_key="per_gate")
+
+
+# ── Ledger label <-> spec-provider/gate scoping (OI-1694) ───────────────────
+#
+# check_provider_exhausted/check_repeated_gate_failure_cause measure BROADLY
+# — run_all_checks below never threads providers=/gates= through them, on
+# purpose: filtering AT MEASUREMENT TIME would throw away the wide reading a
+# WARN needs (a dead kimi lane must stay visible in a claude-dispatch's
+# output, not vanish). Whether a TRIGGERED sub-result actually matters to
+# ONE dispatch is a decision the CALLER (the dispatch door) makes AFTER
+# measuring, using the maps below. They live here — not in dispatch_cli.py —
+# because the vocabulary they encode (which raw ledger labels a
+# spec-provider/gate corresponds to) is a fact about how THIS module reads
+# the ledger, not about the door.
+#
+# Measured on the last 5000 t0_receipts.ndjson lines of this project
+# (2026-09-08): claude_code 1269 | claude 1237 | deepseek-harness 449 |
+# glm-harness 417 | kimi 283 | codex 244 | unknown 60 | codex_cli 43 |
+# deepseek 41 | gemini_cli 7 | anthropic 3 — plus free text ("Moonshot AI
+# (Kimi Code CLI)", a line containing only "`."). Anything not accounted for
+# below is exactly that free-text/unknown tail; see
+# ledger_label_is_relevant's fail-closed handling of it.
+
+PROVIDER_LEDGER_ALIASES: Dict[str, FrozenSet[str]] = {
+    "auto": frozenset(),  # not yet resolved to a real provider — never a positive match on its own
+    "claude": frozenset({"claude", "claude_code", "anthropic"}),
+    "codex": frozenset({"codex", "codex_cli"}),
+    "kimi": frozenset({"kimi"}),
+    "gemini": frozenset({"gemini", "gemini_cli"}),
+    "litellm:deepseek": frozenset({"deepseek"}),
+    "litellm:zai": frozenset({"glm-harness"}),  # benchmark-baseline only; prod GLM ledger label is glm-harness too
+    "litellm:moonshot": frozenset({"kimi"}),  # benchmark-baseline only; prod kimi ledger label is kimi too
+    "deepseek-harness": frozenset({"deepseek-harness"}),
+    "glm-harness": frozenset({"glm-harness"}),
+    "local-gemma": frozenset({"local-gemma"}),
+}
+
+_ALL_KNOWN_LEDGER_PROVIDER_LABELS: FrozenSet[str] = frozenset().union(*PROVIDER_LEDGER_ALIASES.values())
+
+GATE_LEDGER_PROVIDERS: Dict[str, FrozenSet[str]] = {
+    "gemini_review": frozenset({"gemini", "gemini_cli"}),
+    "codex_gate": frozenset({"codex", "codex_cli"}),
+    "claude_github_optional": frozenset(),  # runs on gh, no model provider — explicit, not absent
+    "ci_gate": frozenset(),  # runs on gh, no model provider — explicit, not absent
+    "wiring_gate": frozenset(),  # runs on gh, no model provider — explicit, not absent
+    "kimi_gate": frozenset({"kimi"}),
+    "glm_gate": frozenset({"glm-harness"}),
+}
+
+
+def ledger_label_is_relevant(label: str, spec_providers: Set[str]) -> bool:
+    """Is a raw ledger provider ``label`` (e.g. "kimi", "claude_code")
+    relevant to a dispatch whose scope is ``spec_providers``?
+
+    True when ``label`` falls, via PROVIDER_LEDGER_ALIASES, inside the union
+    of what ``spec_providers`` covers. ALSO true when ``label`` does not
+    appear in ANY alias set at all: unrecognized ledger vocabulary (free
+    text, a future provider, a typo) can never be positively proven
+    unrelated to this dispatch, so it stays relevant. Fail-closed — a missed
+    match here means the brake does not fire when it should, the opposite
+    and worse failure than firing one time too many.
+    """
+    relevant_labels: Set[str] = set()
+    for provider in spec_providers:
+        relevant_labels |= PROVIDER_LEDGER_ALIASES.get(provider, frozenset())
+    if label in relevant_labels:
+        return True
+    return label not in _ALL_KNOWN_LEDGER_PROVIDER_LABELS
+
+
+def triggered_entity_labels(result: StopConditionResult, *, sub_key: str, entity_field: str) -> Set[str]:
+    """Entity labels (provider or gate names) of the TRIGGERED sub-results
+    folded into a combined check's ``evidence[sub_key]`` (see ``_combine``).
+
+    Lets a caller scope a blocking-eligible TRIGGERED verdict down to the
+    entities that actually fired, instead of the bare fact that some
+    sub-result did.
+    """
+    sub = result.evidence.get(sub_key) or {}
+    labels: Set[str] = set()
+    for sub_result in sub.values():
+        if sub_result.get("status") != CheckStatus.TRIGGERED.value:
+            continue
+        entity = sub_result.get("evidence", {}).get(entity_field)
+        if entity:
+            labels.add(entity)
+    return labels
 
 
 # ── Orchestration + halt.json ───────────────────────────────────────────────

--- a/tests/test_dispatch_stop_conditions_gate.py
+++ b/tests/test_dispatch_stop_conditions_gate.py
@@ -50,7 +50,9 @@ from stop_conditions import CheckStatus, StopConditionResult  # noqa: E402
 # Shared helpers (mirrors tests/test_dispatch_refire_guard.py's _make_bundle)
 # ---------------------------------------------------------------------------
 
-def _make_bundle(tmp_path: Path, *, staging_id: str, dispatch_id: str) -> "tuple[Path, Path]":
+def _make_bundle(
+    tmp_path: Path, *, staging_id: str, dispatch_id: str, provider: str = "claude", gate: str = "codex_gate",
+) -> "tuple[Path, Path]":
     data_dir = tmp_path / "vnx-data"
     bundle_dir = data_dir / "dispatches" / "pending" / staging_id
     bundle_dir.mkdir(parents=True, exist_ok=True)
@@ -64,14 +66,19 @@ def _make_bundle(tmp_path: Path, *, staging_id: str, dispatch_id: str) -> "tuple
         "instruction_file": str(instruction),
         "role": "backend-developer",
         "target_slot": "T0",
-        "gate": "codex_gate",
+        "gate": gate,
         "dispatch_paths": [],
-        "provider": "claude",
+        "provider": provider,
         "deadline_seconds": 3600,
         "isolation": "worktree",
-        "force_tmux": True,
-        "force_tmux_reason": "stop-conditions gate test asserts door decisions, not lane behavior",
     }
+    # force_tmux is only a legal opt-out for provider=claude/auto (dispatch_spec
+    # validate() Rule 12b) — omit it entirely for any other provider so
+    # OI-1694's non-claude scoping scenarios (e.g. provider=kimi) don't trip an
+    # unrelated force-tmux-claude-only rejection.
+    if provider in ("claude", "auto"):
+        spec["force_tmux"] = True
+        spec["force_tmux_reason"] = "stop-conditions gate test asserts door decisions, not lane behavior"
     spec_file = bundle_dir / "dispatch-spec.json"
     spec_file.write_text(json.dumps(spec), encoding="utf-8")
     return data_dir, spec_file
@@ -303,17 +310,17 @@ def test_measurement_crash_degrades_to_unmeasurable_not_a_door_crash(tmp_path, m
 # neutralized via shutil.which so the test has no real network/gh-auth
 # dependency; provider_exhausted and repeated_gate_failure_cause run for real,
 # resolved against the state_dir this call passes in.
+#
+# OI-1694: the door now SCOPES a blocking-eligible TRIGGERED sub-result down
+# to whether it is actually relevant to THIS dispatch's provider/gate, instead
+# of refusing on the bare fact that SOMETHING, somewhere, is exhausted. Every
+# test below uses a REAL receipts ledger / review_gates results dir in
+# tmp_path — never a patched stop_conditions.run_all_checks — so the
+# relevance logic itself is exercised, not a mock standing in for it.
 # ---------------------------------------------------------------------------
 
-def test_real_provider_exhaustion_blocks_any_provider_end_to_end(tmp_path, monkeypatch, capsys):
-    data_dir, spec_file = _make_bundle(
-        tmp_path, staging_id="20260904-staging-stopcond-e2e", dispatch_id="20260904-stopcond-e2e",
-    )
-    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
-    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
-    state_dir = data_dir / "state"
+def _write_kimi_exhausted_ledger(state_dir: Path) -> None:
     state_dir.mkdir(parents=True, exist_ok=True)
-
     with (state_dir / "t0_receipts.ndjson").open("a", encoding="utf-8") as fh:
         for i in range(3):
             rec = {
@@ -326,26 +333,239 @@ def test_real_provider_exhaustion_blocks_any_provider_end_to_end(tmp_path, monke
             }
             fh.write(json.dumps(rec) + "\n")
 
+
+def _write_exhausted_ledger(state_dir: Path, provider: str) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with (state_dir / "t0_receipts.ndjson").open("a", encoding="utf-8") as fh:
+        for i in range(3):
+            rec = {
+                "event_type": "task_complete",
+                "provider": provider,
+                "status": "failed",
+                "failure_class": "auth_rejected",
+                "dispatch_id": f"20260903-{provider}-fail-{i}",
+                "timestamp": f"2026-09-03T0{i}:00:00Z",
+            }
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _neutralize_gh(monkeypatch) -> None:
     import stop_conditions
     monkeypatch.setattr(stop_conditions.shutil, "which", lambda _bin: None)
+
+
+def _write_repeated_gate_results(results_dir: Path, gate: str, reason: str = "provider_not_installed") -> None:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    for i, pr in enumerate([9001, 9002, 9003]):
+        d = {
+            "pr_number": pr,
+            "gate": gate,
+            "status": "unavailable",
+            "reason": reason,
+            "recorded_at": f"2026-09-0{i+1}T00:00:00Z",
+        }
+        (results_dir / f"pr-{pr}-{gate}.json").write_text(json.dumps(d), encoding="utf-8")
+
+
+def test_1_unrelated_provider_exhaustion_does_not_block(tmp_path, monkeypatch, capsys):
+    """Scenario 1 (rood, het defect zelf): only kimi is exhausted; a dispatch
+    with provider=claude, gate=glm_gate touches neither kimi nor glm-harness
+    — the door must NOT block."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path, staging_id="20260908-staging-oi1694-1", dispatch_id="20260908-oi1694-1",
+        provider="claude", gate="glm_gate",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    state_dir = data_dir / "state"
+    _write_kimi_exhausted_ledger(state_dir)
+    _neutralize_gh(monkeypatch)
 
     with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
         rc = run_dispatch(spec_file)
 
-    assert rc == 1, (
-        "3 consecutive kimi auth_rejected receipts must trip "
-        "check_provider_exhausted for real (resolved against THIS call's own "
-        "state_dir, never the real central store) and refuse the fire — even "
-        "though THIS dispatch targets claude/T0, not kimi: it is a "
-        "chain-level halt"
+    assert rc == 0, "kimi-exhaustion must not block a claude/glm_gate dispatch that never touches kimi"
+    mock_execute.assert_called_once()
+
+    # Scenario 6: the measurement is NOT gone — it is a WARN, not a deletion.
+    err = capsys.readouterr().err
+    assert "kimi" in err, "the exhausted-but-out-of-scope provider must still be named in the door's output"
+
+    import stop_conditions
+    raw_results = stop_conditions.run_all_checks(state_dir=state_dir, write_halt=False)
+    by_id = {r.check_id: r for r in raw_results}
+    assert by_id["provider_exhausted"].status == CheckStatus.TRIGGERED
+    assert "kimi" in json.dumps(by_id["provider_exhausted"].evidence)
+
+
+def test_2_provider_match_still_blocks(tmp_path, monkeypatch, capsys):
+    """Scenario 2: same kimi-only ledger, but the dispatch itself IS kimi —
+    the brake must still bite via the provider match."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path, staging_id="20260908-staging-oi1694-2", dispatch_id="20260908-oi1694-2",
+        provider="kimi", gate="glm_gate",
     )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    state_dir = data_dir / "state"
+    _write_kimi_exhausted_ledger(state_dir)
+    _neutralize_gh(monkeypatch)
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1, "a kimi dispatch must still be refused by kimi's own exhaustion"
     mock_execute.assert_not_called()
     err = capsys.readouterr().err
     assert "stop-conditions-triggered" in err
-    assert "provider_exhausted" in err
-    assert (state_dir / "halt.json").exists(), (
-        "a real fire hitting a blocking-eligible trigger must persist "
-        "halt.json via the explicit write_halt_file() call"
+
+
+def test_3_gate_match_pulls_provider_into_scope_and_still_blocks(tmp_path, monkeypatch, capsys):
+    """Scenario 3: glm-harness is exhausted; dispatch is provider=claude,
+    gate=glm_gate — glm_gate's own provider (glm-harness) pulls this
+    dispatch's scope in, so the brake must still bite."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path, staging_id="20260908-staging-oi1694-3", dispatch_id="20260908-oi1694-3",
+        provider="claude", gate="glm_gate",
     )
-    halt = json.loads((state_dir / "halt.json").read_text(encoding="utf-8"))
-    assert any(t["check_id"] == "provider_exhausted" for t in halt["triggered"])
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    state_dir = data_dir / "state"
+    _write_exhausted_ledger(state_dir, "glm-harness")
+    _neutralize_gh(monkeypatch)
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1, "glm_gate must pull glm-harness exhaustion into scope even for a claude-provider dispatch"
+    mock_execute.assert_not_called()
+
+
+def test_4_unknown_ledger_vocabulary_blocks_regardless_of_provider(tmp_path, monkeypatch, capsys):
+    """Scenario 4: an exhausted label absent from every alias set can never
+    be positively proven unrelated — it must block no matter the spec
+    provider/gate."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path, staging_id="20260908-staging-oi1694-4", dispatch_id="20260908-oi1694-4",
+        provider="claude", gate="glm_gate",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    state_dir = data_dir / "state"
+    _write_exhausted_ledger(state_dir, "future-provider-xyz")
+    _neutralize_gh(monkeypatch)
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1, "unrecognized ledger vocabulary must fail closed and block"
+    mock_execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5: undeterminable scope falls back to (None, None) — i.e. broad
+# blocking. Unit-tested directly against _resolve_stop_conditions_scope
+# rather than through run_dispatch: by the time build_runtime_snapshot runs,
+# spec.provider == Provider.AUTO can no longer occur on the real path (OI-962's
+# smart router resolves AUTO to a concrete provider, falling back to CLAUDE,
+# BEFORE validate()/build_runtime_snapshot — see run_dispatch's own comment
+# at the router-pre-validate call), and an empty spec.gate is filled in by
+# _resolve_gate_via_router before build_runtime_snapshot too. Both router
+# steps are fail-open (a broken router leaves AUTO/empty-gate untouched), so
+# _resolve_stop_conditions_scope's own fallback is still live defense-in-depth
+# for that fail-open path — exercised here directly, at the level it actually
+# guards.
+# ---------------------------------------------------------------------------
+
+from dispatch_cli import _resolve_stop_conditions_scope  # noqa: E402
+from dispatch_spec import DispatchSpec, Isolation, Provider  # noqa: E402
+
+
+def _spec(*, provider: Provider, gate: str) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="20260908-oi1694-scope-unit",
+        staging_id="20260908-oi1694-scope-unit",
+        instruction_file=Path("/tmp/instruction.md"),
+        role="backend-developer",
+        target_slot="T0",
+        gate=gate,
+        dispatch_paths=(),
+        provider=provider,
+        isolation=Isolation.WORKTREE,
+    )
+
+
+def test_5a_auto_provider_cannot_be_scoped():
+    """Scenario 5 (auto half): provider=auto has not resolved to a real
+    provider yet — the scope is undeterminable, so the door must fall back
+    to broad blocking (None, None) exactly like before OI-1694."""
+    scope = _resolve_stop_conditions_scope(_spec(provider=Provider.AUTO, gate="glm_gate"))
+    assert scope == (None, None)
+
+
+def test_5b_empty_gate_cannot_be_scoped():
+    """Scenario 5 (empty-gate half): a non-auto provider with no gate
+    assigned also cannot be scoped via GATE_LEDGER_PROVIDERS — same broad
+    fallback."""
+    scope = _resolve_stop_conditions_scope(_spec(provider=Provider.CLAUDE, gate=""))
+    assert scope == (None, None)
+
+
+def test_5c_gate_outside_gate_ledger_providers_cannot_be_scoped():
+    """A legacy phase sentinel ("planning"/"implementation") is a legal
+    spec.gate value (dispatch_spec's LEGACY_GATE_SENTINELS) but is not a key
+    in GATE_LEDGER_PROVIDERS — undeterminable, same broad fallback."""
+    scope = _resolve_stop_conditions_scope(_spec(provider=Provider.CLAUDE, gate="planning"))
+    assert scope == (None, None)
+
+
+def test_determinable_scope_unions_provider_and_gate_ledger_labels():
+    """Sanity check on the happy path this whole dispatch is about: a
+    concrete provider + a known gate resolves to a real, unioned scope."""
+    providers, gates = _resolve_stop_conditions_scope(_spec(provider=Provider.CLAUDE, gate="glm_gate"))
+    assert providers == {"claude", "glm-harness"}
+    assert gates == {"glm_gate"}
+
+
+def test_8a_repeated_gate_failure_on_a_different_gate_does_not_block(tmp_path, monkeypatch, capsys):
+    """Scenario 8 (different-gate half): codex_gate has a real 3x repeat, but
+    THIS dispatch is scoped to glm_gate — must not block."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path, staging_id="20260908-staging-oi1694-8a", dispatch_id="20260908-oi1694-8a",
+        provider="claude", gate="glm_gate",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    state_dir = data_dir / "state"
+    _write_repeated_gate_results(state_dir / "review_gates" / "results", "codex_gate")
+    _neutralize_gh(monkeypatch)
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0, "a repeated failure on codex_gate must not block a glm_gate dispatch"
+    mock_execute.assert_called_once()
+    err = capsys.readouterr().err
+    assert "codex_gate" in err, "the out-of-scope repeat must still be named, not silently dropped"
+
+
+def test_8b_repeated_gate_failure_on_the_dispatchs_own_gate_still_blocks(tmp_path, monkeypatch, capsys):
+    """Scenario 8 (own-gate half): the same 3x repeat, but the dispatch
+    itself targets codex_gate — must block."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path, staging_id="20260908-staging-oi1694-8b", dispatch_id="20260908-oi1694-8b",
+        provider="claude", gate="codex_gate",
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    state_dir = data_dir / "state"
+    _write_repeated_gate_results(state_dir / "review_gates" / "results", "codex_gate")
+    _neutralize_gh(monkeypatch)
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1, "a repeated failure on the dispatch's own gate must still block"
+    mock_execute.assert_not_called()

--- a/tests/test_stop_conditions.py
+++ b/tests/test_stop_conditions.py
@@ -664,3 +664,97 @@ class TestCompletionOutcomeVocabulary:
         _write_receipt_lines(receipts, records)
         result = check_provider_exhausted(receipts, threshold=3)
         assert result.status == CheckStatus.CLEAR
+
+
+# ── ledger label <-> spec-provider/gate scoping (OI-1694) ──────────────────
+#
+# stop_conditions.run_all_checks() itself stays UNSCOPED (measures every
+# provider/gate on the ledger, always) — see run_all_checks's own call site,
+# which never threads providers=/gates= through. The scoping objects below
+# only decide whether a TRIGGERED sub-result is *relevant* to one particular
+# dispatch; that decision is made by the door (dispatch_cli.py), not here.
+# These tests pin the vocabulary/relevance contract in isolation from the door.
+
+
+class TestLedgerScoping:
+    def test_known_relevant_label_matches_its_own_provider(self):
+        assert sc.ledger_label_is_relevant("kimi", {"kimi"}) is True
+
+    def test_known_irrelevant_label_does_not_match_an_unrelated_provider(self):
+        # "kimi" is a KNOWN ledger label (it has its own alias entry) — a
+        # dispatch scoped to "claude" only must NOT treat it as relevant.
+        assert sc.ledger_label_is_relevant("kimi", {"claude"}) is False
+
+    def test_claude_family_aliases_are_recognized(self):
+        for label in ("claude", "claude_code", "anthropic"):
+            assert sc.ledger_label_is_relevant(label, {"claude"}) is True
+
+    def test_codex_family_aliases_are_recognized(self):
+        for label in ("codex", "codex_cli"):
+            assert sc.ledger_label_is_relevant(label, {"codex"}) is True
+
+    def test_litellm_zai_and_glm_harness_share_the_same_ledger_label(self):
+        assert sc.ledger_label_is_relevant("glm-harness", {"litellm:zai"}) is True
+        assert sc.ledger_label_is_relevant("glm-harness", {"glm-harness"}) is True
+
+    def test_unknown_ledger_vocabulary_is_relevant_fail_closed(self):
+        # Free text / a future provider / a typo — never in ANY alias set —
+        # can never be positively proven unrelated, so it stays relevant
+        # regardless of scope.
+        assert sc.ledger_label_is_relevant("Moonshot AI (Kimi Code CLI)", {"claude"}) is True
+        assert sc.ledger_label_is_relevant("`.", {"claude"}) is True
+
+    def test_empty_spec_providers_still_recognizes_unknown_as_relevant(self):
+        assert sc.ledger_label_is_relevant("some-new-provider", set()) is True
+
+    def test_empty_spec_providers_excludes_known_labels(self):
+        assert sc.ledger_label_is_relevant("kimi", set()) is False
+
+    def test_triggered_entity_labels_extracts_only_triggered_providers(self):
+        # Build a combined result directly via _combine to avoid depending on
+        # ledger I/O for this pure extraction test.
+        triggered = StopConditionResult(
+            "provider_exhausted:kimi", CheckStatus.TRIGGERED, "kimi exhausted", evidence={"provider": "kimi"},
+        )
+        clear = StopConditionResult(
+            "provider_exhausted:claude", CheckStatus.CLEAR, "claude fine", evidence={"provider": "claude"},
+        )
+        combined = sc._combine("provider_exhausted", [triggered, clear], sub_key="per_provider")
+        labels = sc.triggered_entity_labels(combined, sub_key="per_provider", entity_field="provider")
+        assert labels == {"kimi"}
+
+    def test_triggered_entity_labels_extracts_gate_names(self):
+        triggered = StopConditionResult(
+            "repeated_gate_failure_cause:glm_gate", CheckStatus.TRIGGERED, "glm_gate repeat", evidence={"gate": "glm_gate"},
+        )
+        combined = sc._combine("repeated_gate_failure_cause", [triggered], sub_key="per_gate")
+        labels = sc.triggered_entity_labels(combined, sub_key="per_gate", entity_field="gate")
+        assert labels == {"glm_gate"}
+
+
+class TestLedgerScopingEnumDrift:
+    """Every Provider/Gate enum member must have an explicit entry in the
+    corresponding alias map — a missing entry is not an empty scope, it is a
+    silent hole in the scoping contract. Mirrors
+    test_closure_verifier_gate_enum_drift.py's style."""
+
+    def test_every_provider_enum_member_has_a_ledger_alias_entry(self):
+        from dispatch_spec import Provider
+
+        missing = [p.value for p in Provider if p.value not in sc.PROVIDER_LEDGER_ALIASES]
+        assert not missing, f"Provider enum member(s) missing from PROVIDER_LEDGER_ALIASES: {missing}"
+
+    def test_every_gate_enum_member_has_a_ledger_provider_entry(self):
+        from dispatch_spec import Gate
+
+        missing = [g.value for g in Gate if g.value not in sc.GATE_LEDGER_PROVIDERS]
+        assert not missing, f"Gate enum member(s) missing from GATE_LEDGER_PROVIDERS: {missing}"
+
+    def test_non_model_gates_carry_an_explicit_empty_set_not_a_missing_key(self):
+        # ci_gate/wiring_gate/claude_github_optional run on gh, not a model
+        # provider — they must still be a real (empty) dict entry, never
+        # simply absent, so a lookup miss can never be confused with "runs
+        # on no provider by design".
+        for gate_name in ("ci_gate", "wiring_gate", "claude_github_optional"):
+            assert gate_name in sc.GATE_LEDGER_PROVIDERS
+            assert sc.GATE_LEDGER_PROVIDERS[gate_name] == frozenset()


### PR DESCRIPTION
## Summary

`stop_conditions.run_all_checks()` calls `check_provider_exhausted()` and `check_repeated_gate_failure_cause()` without their existing `providers=`/`gates=` filters, so the door (`dispatch_cli._check_stop_conditions_verdict`) blocked **every** dispatch whenever *any* provider or gate was exhausted anywhere — even a claude dispatch that never touches the exhausted provider. Kimi's weekly-quota 403 (since 2026-09-03) cost 27 `--override-stop-conditions` overrules in one day.

The fix does **not** filter at measurement time (that would hide the WARN-worthy signal for unrelated dispatches). Instead:

- `scripts/lib/stop_conditions.py` gains `PROVIDER_LEDGER_ALIASES` (spec-provider → raw ledger labels), `GATE_LEDGER_PROVIDERS` (gate → the ledger labels of the provider it runs), `ledger_label_is_relevant()` (fail-closed: unknown ledger vocabulary is always relevant), and `triggered_entity_labels()` (pulls the fired provider/gate names out of a combined result).
- `scripts/lib/dispatch_cli.py` gains `_resolve_stop_conditions_scope()` (computes this dispatch's provider/gate scope, or `(None, None)` when undeterminable — `provider=auto`, empty gate, or a gate outside `GATE_LEDGER_PROVIDERS`) and threads it through `_check_stop_conditions_verdict`, which now only blocks on a TRIGGERED sub-result that is relevant to this dispatch. A scoped-out trigger is still printed as a WARN — never silently dropped — and the underlying `StopConditionResult.status` is never mutated.

## Changes

- `scripts/lib/stop_conditions.py`: added the ledger-scoping section (`PROVIDER_LEDGER_ALIASES`, `GATE_LEDGER_PROVIDERS`, `ledger_label_is_relevant`, `triggered_entity_labels`).
- `scripts/lib/dispatch_cli.py`: added `_resolve_stop_conditions_scope`; `_check_stop_conditions_verdict` gained `relevant_spec_providers`/`relevant_gates` kwargs and now scopes blocking-eligible TRIGGERED checks (fail-closed when no entity labels can be extracted at all); `build_runtime_snapshot`'s stop-conditions call site now resolves and passes the scope.
- `tests/test_stop_conditions.py`: `TestLedgerScoping` + `TestLedgerScopingEnumDrift` (every `Provider`/`Gate` enum member must have an alias-map entry).
- `tests/test_dispatch_stop_conditions_gate.py`: `_make_bundle` now takes `provider=`/`gate=`; rewrote the old `test_real_provider_exhaustion_blocks_any_provider_end_to_end` (which literally asserted the bug being fixed) plus 8 new end-to-end scenarios covering the required matrix (unrelated provider doesn't block, own provider still blocks, gate pulls its provider into scope, unknown vocabulary fail-closed blocks, undeterminable scope falls back to broad blocking, repeated-gate-failure scoped by gate).

## Verification

Targeted suite, red before the fix:
```
5 failed, 78 passed in 2.17s
FAILED tests/test_dispatch_stop_conditions_gate.py::test_triggered_stop_condition_blocks_fire
FAILED tests/test_dispatch_stop_conditions_gate.py::test_stop_conditions_checked_on_dry_run_too
FAILED tests/test_dispatch_stop_conditions_gate.py::test_2_provider_match_still_blocks
FAILED tests/test_dispatch_stop_conditions_gate.py::test_5a_auto_provider_cannot_be_scoped_and_blocks
FAILED tests/test_dispatch_stop_conditions_gate.py::test_5b_empty_gate_cannot_be_scoped_and_blocks
```

Green after the fix:
```
python3 -m pytest tests/test_stop_conditions.py tests/test_dispatch_stop_conditions_gate.py -q
85 passed in 1.75s
```

Direct neighbors, unaffected:
```
python3 -m pytest tests/test_dispatch_cli.py tests/test_dispatch_refire_guard.py -q
163 passed in 89.55s

python3 -m pytest tests/test_closure_verifier_gate_enum_drift.py tests/test_dlv45_gate_recognition.py -q
29 passed in 2.01s
```

Central-mode path gate (`check_no_file_derived_data_paths.py`) against the modified `stop_conditions.py`: `violations: []`.

## Open Items

None.

**PR_Ref**: (filled on creation)

Dispatch-ID: 20260908-oi1694-stopconditie-scopen