### PR TITLE
feat(beacon): reader-register + park + dedupe (golf C, C2a)

### DIFF
--- a/hooks/sessionstart.sh
+++ b/hooks/sessionstart.sh
@@ -90,9 +90,25 @@ from vnx_paths import resolve_paths
 p = resolve_paths()
 print(p['VNX_STATE_DIR'])
 print(p['VNX_DATA_DIR'])
+try:
+    from beacon_register import expected_component_names, parked_component_names
+    print(','.join(expected_component_names()))
+    print(','.join(parked_component_names()))
+except Exception:
+    print('')
+    print('')
 " 2>/dev/null || true)"
       _VNX_STATE_DIR="$(printf '%s\n' "$_VNX_PATHS_OUT" | sed -n 1p)"
       _VNX_DATA_DIR="$(printf '%s\n' "$_VNX_PATHS_OUT" | sed -n 2p)"
+      # C2a: expected/parked component names (beacon_register.py), resolved
+      # once in the same subprocess as the paths above rather than a second
+      # python call — --expected makes a component that never wrote a
+      # beacon at all (fleet_role_drift, receipt_conversion_rejections)
+      # surface as absent instead of being silently omitted from this
+      # digest; --parked keeps learning_loop/intelligence_daemon (parked by
+      # operator decision, PARKED_COMPONENTS) out of the "NOT ok" list below.
+      _VNX_EXPECTED_BEACONS="$(printf '%s\n' "$_VNX_PATHS_OUT" | sed -n 3p)"
+      _VNX_PARKED_BEACONS="$(printf '%s\n' "$_VNX_PATHS_OUT" | sed -n 4p)"
     fi
 
     if [ -n "$_VNX_STATE_DIR" ] && [ -d "$_VNX_STATE_DIR" ]; then
@@ -173,13 +189,19 @@ ${T0_CONTRACT_INVALID}"
     BEACON_SECTION=""
     _HEALTH_CHECK_PY="$_HOOK_DIR/../scripts/health_check.py"
     if [ -n "$_VNX_DATA_DIR" ] && [ -n "$_VNX_PY" ] && [ -f "$_HEALTH_CHECK_PY" ]; then
-      _BEACON_JSON="$("$_VNX_PY" "$_HEALTH_CHECK_PY" --state-dir "$_VNX_DATA_DIR" --json 2>/dev/null || true)"
+      _HEALTH_CHECK_ARGS=(--state-dir "$_VNX_DATA_DIR" --json)
+      [ -n "${_VNX_EXPECTED_BEACONS:-}" ] && _HEALTH_CHECK_ARGS+=(--expected "$_VNX_EXPECTED_BEACONS")
+      [ -n "${_VNX_PARKED_BEACONS:-}" ] && _HEALTH_CHECK_ARGS+=(--parked "$_VNX_PARKED_BEACONS")
+      _BEACON_JSON="$("$_VNX_PY" "$_HEALTH_CHECK_PY" "${_HEALTH_CHECK_ARGS[@]}" 2>/dev/null || true)"
       if [ -n "$_BEACON_JSON" ] && command -v jq &>/dev/null; then
         _BEACON_PARSE_OK=$(echo "$_BEACON_JSON" | jq -e '.beacons | type == "object"' >/dev/null 2>&1 && echo yes || echo no)
         if [ "$_BEACON_PARSE_OK" = "yes" ]; then
           _BEACON_TOTAL=$(echo "$_BEACON_JSON" | jq '.beacons | length' 2>/dev/null || echo "0")
+          # "parked" (C2a) is an operator decision to stop expecting
+          # freshness, not a defect — excluded from the NOT-ok list the same
+          # way "ok" itself is.
           _BEACON_BAD=$(echo "$_BEACON_JSON" | jq -r '
-            [.beacons | to_entries[] | select(.value.health != "ok")]
+            [.beacons | to_entries[] | select(.value.health != "ok" and .value.health != "parked")]
             | sort_by(if .value.health == "fail" then 0 elif .value.health == "corrupt" then 1 else 2 end)
             | .[] | "  - [\(.value.health)] \(.key): last_run \(.value.last_run_iso // "unknown"), age \(.value.age_seconds // "unknown")s"
           ' 2>/dev/null || true)

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -122,13 +122,16 @@ def _print_table(beacons: dict, requested: list[str]) -> None:
         )
 
 
+_NON_BAD_HEALTH = frozenset({"ok", "parked"})
+
+
 def _exit_code(beacons: dict, requested: list[str]) -> int:
     requested_set = {c for c in requested if c}
     if requested_set:
         for name in requested_set:
             if name not in beacons:
                 return 1
-            if beacons[name].get("health") != "ok":
+            if beacons[name].get("health") not in _NON_BAD_HEALTH:
                 return 1
         return 0
 
@@ -136,7 +139,7 @@ def _exit_code(beacons: dict, requested: list[str]) -> int:
         # No requested filter and no beacons present -> degraded.
         return 1
     for b in beacons.values():
-        if b.get("health") != "ok":
+        if b.get("health") not in _NON_BAD_HEALTH:
             return 1
     return 0
 
@@ -160,11 +163,32 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Comma-separated component names to filter on.",
     )
+    parser.add_argument(
+        "--expected",
+        default=None,
+        help=(
+            "Comma-separated component names that MUST have a beacon (C2a) — "
+            "any name here with no beacon on disk reports health=absent "
+            "instead of being silently omitted. Opt-in: omitting this leaves "
+            "output byte-for-byte unchanged (backward compatible)."
+        ),
+    )
+    parser.add_argument(
+        "--parked",
+        default=None,
+        help=(
+            "Comma-separated component names (C2a) whose silence/absence is "
+            "a deliberate decision, not a defect — reported health=parked "
+            "instead of stale/unknown/absent."
+        ),
+    )
     args = parser.parse_args(argv)
 
     requested = [
         c.strip() for c in (args.components or "").split(",") if c.strip()
     ]
+    expected = [c.strip() for c in (args.expected or "").split(",") if c.strip()]
+    parked = [c.strip() for c in (args.parked or "").split(",") if c.strip()]
 
     try:
         state_dir = _resolve_state_dir(args.state_dir)
@@ -180,7 +204,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     try:
-        beacons = all_beacons(state_dir)
+        beacons = all_beacons(state_dir, expected=expected or None, parked=parked or None)
     except Exception as exc:
         msg = {"error": "beacon_read_failed", "message": str(exc)}
         if args.json:

--- a/scripts/lib/beacon_reader_register.py
+++ b/scripts/lib/beacon_reader_register.py
@@ -1,0 +1,327 @@
+"""beacon_reader_register — the other half of the beacon absence-is-loud
+contract (golf C, track ``absence-is-loud``, C2a).
+
+``beacon_register.py`` already answers "which components are EXPECTED to
+write a beacon" by parsing every resolvable ``HealthBeacon(...)`` call site.
+Nothing paired that with "and does anything actually READ that signal" —
+a grep for reader/lezer/consumer in ``producer_freshness.py`` and
+``beacon_register.py`` turns up only comments, no mechanism. This module is
+that mechanism, derived from the code the same way the writer register is:
+
+  - a GENERIC reader is a call site of ``health_beacon.all_beacons`` /
+    ``beacon_summary`` that passes an ``expected=`` argument. Passing
+    ``expected=`` is what makes a component that NEVER wrote a beacon at all
+    surface as ``health="absent"`` (see ``health_beacon.py``'s D3a gap 2) —
+    a generic reader-with-expected therefore covers every CURRENT and
+    FUTURE registered component automatically, the same self-updating
+    property ``beacon_register.py`` already has on the writer side. Measured
+    live in this repo (2026-09-09): ``dashboard/api_health.py`` and
+    ``scripts/build_t0_state.py`` both already pass ``expected=
+    expected_component_names()`` — this register makes that fact
+    inspectable and testable instead of living only in two docstrings.
+  - a SPECIFIC reader is a source location, outside the component's own
+    writer file and outside this module's own infra siblings, that
+    references the component's exact name as a non-docstring string literal
+    (Python) or a quoted substring (the two bash hooks). E.g.
+    ``hooks/monitor_tripwire.sh`` hardcodes
+    ``health/producer_freshness_monitor.json``.
+
+Scope, mirroring ``beacon_register.py``'s own documented boundary: this
+module answers the reader side for the SAME namespace ``beacon_register.py``
+covers (the AST-resolvable ``HealthBeacon(...)`` call sites). Cockpit
+subsystems (``subsystem_health.known_subsystems()``, e.g.
+``governance-enforcement-stack`` / ``plan-gate-panel``) are a different
+namespace with their own already-documented readers
+(``dashboard/api_health.py``'s ``_subsystem_effectiveness_summary``,
+``dashboard/api_subsystems.py``, ``vnx_cli/commands/subsystems.py``) and are
+out of scope here for the same reason ``beacon_register.py`` excludes their
+writer call site (a loop variable, not a fixed name).
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import project_root  # noqa: E402
+from beacon_register import read_beacon_register  # noqa: E402
+
+# Calls that, when given an `expected=` keyword, cover every registered
+# component's absence -- not just the ones that happen to have a file today.
+_GENERIC_CALL_NAMES = frozenset({"all_beacons", "beacon_summary"})
+
+# This module's own infra siblings -- never a reader in their own right, so
+# their docstring examples (health_beacon.py's top docstring literally uses
+# "learning_loop" as a sample component name) can never self-count.
+_INFRA_RELATIVE_PATHS = frozenset({
+    "scripts/lib/health_beacon.py",
+    "scripts/lib/beacon_register.py",
+    "scripts/lib/beacon_reader_register.py",
+})
+
+# Where a reader can plausibly live. Broader than a curated per-component
+# list (which would be hand-maintained, the exact thing this module exists
+# to avoid) -- every .py file under these roots is scanned; only the
+# component-name MATCH is code-derived, not the surface.
+_READER_PY_DIRS: Tuple[str, ...] = ("scripts", "dashboard", "vnx_cli")
+_READER_SH_DIRS: Tuple[str, ...] = ("hooks",)
+
+_QUOTED_RE = re.compile(r'"([^"]*)"|\'([^\']*)\'')
+
+
+@dataclass(frozen=True)
+class ReaderSpec:
+    """One code location that reads/acts on a beacon's signal.
+
+    ``component`` is ``None`` for a GENERIC reader: a call to
+    ``all_beacons``/``beacon_summary`` with an ``expected=`` argument covers
+    every component, present or not, so it is not tied to one name.
+    """
+
+    component: Optional[str]
+    source_file: str
+    line: int
+    kind: str  # "generic" | "specific"
+
+
+def _default_project_root() -> Path:
+    return project_root.resolve_project_root()
+
+
+def _iter_files(root: Path, subdirs: Sequence[str], suffix: str) -> List[Path]:
+    files: List[Path] = []
+    for sub in subdirs:
+        base = root / sub
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob(f"*{suffix}")):
+            if "tests" in path.relative_to(root).parts[:-1]:
+                continue
+            files.append(path)
+    return files
+
+
+def _docstring_positions(tree: ast.AST) -> Dict[Tuple[int, int], None]:
+    """Positions of every module/class/function DOCSTRING string constant.
+
+    A docstring is the first statement of a Module/ClassDef/FunctionDef body
+    when that statement is a bare string expression -- the same shape
+    ``ast.get_docstring`` recognizes. Narrative prose there (this repo's own
+    heavily-commented style routinely name-drops other components) must
+    never count as a reader reference; only non-docstring string literals
+    (paths, CLI args, log messages) do.
+    """
+    positions: Dict[Tuple[int, int], None] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            positions[(first.value.lineno, first.value.col_offset)] = None
+    return positions
+
+
+def _find_generic_readers_in_py(path: Path, rel: str) -> List[ReaderSpec]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not any(name in text for name in _GENERIC_CALL_NAMES):
+        return []
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return []
+    found: List[ReaderSpec] = []
+    for node in ast.walk(tree):
+        func = node.func if isinstance(node, ast.Call) else None
+        name = None
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        if name not in _GENERIC_CALL_NAMES:
+            continue
+        for kw in node.keywords:
+            if kw.arg != "expected":
+                continue
+            if isinstance(kw.value, ast.Constant) and kw.value.value is None:
+                continue  # expected=None is explicitly "no expectation declared"
+            found.append(ReaderSpec(component=None, source_file=rel, line=node.lineno, kind="generic"))
+            break
+    return found
+
+
+def _find_specific_readers_in_py(path: Path, rel: str, names: Sequence[str]) -> List[ReaderSpec]:
+    if not names:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not any(name in text for name in names):
+        return []
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return []
+    doc_positions = _docstring_positions(tree)
+    found: List[ReaderSpec] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+            continue
+        if (node.lineno, node.col_offset) in doc_positions:
+            continue
+        for name in names:
+            if name in node.value:
+                found.append(ReaderSpec(component=name, source_file=rel, line=node.lineno, kind="specific"))
+    return found
+
+
+def _find_specific_readers_in_sh(path: Path, rel: str, names: Sequence[str]) -> List[ReaderSpec]:
+    if not names:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    found: List[ReaderSpec] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if line.strip().startswith("#"):
+            continue
+        for match in _QUOTED_RE.finditer(line):
+            fragment = match.group(1) if match.group(1) is not None else match.group(2)
+            if not fragment:
+                continue
+            for name in names:
+                if name in fragment:
+                    found.append(ReaderSpec(component=name, source_file=rel, line=lineno, kind="specific"))
+    return found
+
+
+def read_reader_register(
+    beacon_names: Optional[Sequence[str]] = None,
+    *,
+    project_root_dir: Optional[Path] = None,
+    writer_source_by_component: Optional[Dict[str, str]] = None,
+) -> Tuple[ReaderSpec, ...]:
+    """Derive every reader (generic + specific) for ``beacon_names``.
+
+    ``beacon_names``/``writer_source_by_component`` default to the live
+    ``beacon_register.read_beacon_register()`` output; tests inject a
+    synthetic register (via these params, or by monkeypatching
+    ``read_beacon_register`` itself) instead of depending on this repo's
+    real writer set — mirrors how ``build_t0_state.py`` already injects
+    ``expected_beacon_components`` for its own tests.
+    """
+    root = Path(project_root_dir) if project_root_dir is not None else _default_project_root()
+    if beacon_names is None:
+        # Only derive BOTH from the live writer register together when
+        # neither was given -- an explicit beacon_names (a test's synthetic
+        # or partial input) must never fall back to scanning the REAL
+        # project root for the writer-source exclusion map underneath it.
+        register = read_beacon_register()
+        beacon_names = tuple(spec.name for spec in register)
+        if writer_source_by_component is None:
+            writer_source_by_component = {spec.name: spec.source_file for spec in register}
+    if writer_source_by_component is None:
+        writer_source_by_component = {}
+
+    specs: List[ReaderSpec] = []
+    for path in _iter_files(root, _READER_PY_DIRS, ".py"):
+        rel = str(path.relative_to(root))
+        if rel in _INFRA_RELATIVE_PATHS:
+            continue
+        specs.extend(_find_generic_readers_in_py(path, rel))
+        applicable = [n for n in beacon_names if writer_source_by_component.get(n) != rel]
+        specs.extend(_find_specific_readers_in_py(path, rel, applicable))
+    for path in _iter_files(root, _READER_SH_DIRS, ".sh"):
+        rel = str(path.relative_to(root))
+        applicable = [n for n in beacon_names if writer_source_by_component.get(n) != rel]
+        specs.extend(_find_specific_readers_in_sh(path, rel, applicable))
+    return tuple(specs)
+
+
+def has_generic_reader(register: Sequence[ReaderSpec]) -> bool:
+    return any(r.kind == "generic" for r in register)
+
+
+def readers_for_component(component: str, register: Sequence[ReaderSpec]) -> Tuple[ReaderSpec, ...]:
+    """Every reader that covers ``component`` -- every generic reader
+    (they cover all names) plus any specific reader naming it exactly."""
+    return tuple(r for r in register if r.kind == "generic" or r.component == component)
+
+
+def components_without_reader(
+    beacon_names: Sequence[str], register: Sequence[ReaderSpec]
+) -> Tuple[str, ...]:
+    """Names in ``beacon_names`` with ZERO readers in ``register``.
+
+    A single generic reader (``expected=`` present anywhere) covers every
+    name, so the result is only non-empty when the register has no generic
+    reader at all AND a specific name has no dedicated reader either --
+    exactly the "silent producer, nobody reads it" case this track closes.
+    """
+    if has_generic_reader(register):
+        return ()
+    covered = {r.component for r in register if r.kind == "specific"}
+    return tuple(name for name in beacon_names if name not in covered)
+
+
+def check_coverage(
+    beacon_names: Optional[Sequence[str]] = None,
+    *,
+    project_root_dir: Optional[Path] = None,
+) -> Dict[str, object]:
+    """Structural check: every beacon ``beacon_register`` expects a writer
+    for must have at least one reader here. Returns a
+    ``producer_freshness``-shaped section (``findings`` of kind
+    ``"no_reader"``) so ``producer_freshness_monitor.py`` can fold it
+    straight into its own report/heartbeat without inventing a second
+    finding shape.
+    """
+    if beacon_names is None:
+        beacon_names = tuple(spec.name for spec in read_beacon_register())
+    register = read_reader_register(beacon_names, project_root_dir=project_root_dir)
+    orphans = components_without_reader(beacon_names, register)
+    findings = [
+        {
+            "producer": "beacon_reader_coverage",
+            "key": name,
+            "kind": "no_reader",
+            "cadence_seconds": None,
+        }
+        for name in orphans
+    ]
+    return {
+        "producer": "beacon_reader_coverage",
+        "type": "beacon_reader_register",
+        "kind": "structural",
+        "keys": [{"key": name} for name in beacon_names],
+        "findings": findings,
+        "status": "stale" if findings else "ok",
+    }
+
+
+__all__ = [
+    "ReaderSpec",
+    "read_reader_register",
+    "has_generic_reader",
+    "readers_for_component",
+    "components_without_reader",
+    "check_coverage",
+]

--- a/scripts/lib/beacon_register.py
+++ b/scripts/lib/beacon_register.py
@@ -67,6 +67,16 @@ if str(_LIB_DIR) not in sys.path:
 
 import project_root  # noqa: E402
 
+# golf C / C2a operator decision (2026-09-09): the intelligence layer stays
+# PARKED until the governance ledger is falsifiable (per the PRD, not a
+# regression) -- learning_loop (last write 2026-06-26) and intelligence_daemon
+# (last write 2026-06-27) are therefore expected to sit silent, on purpose.
+# A parked component still HAS a reader (both already pass through the same
+# generic all_beacons(expected=...) readers every other component does) --
+# this list only tells health_beacon.all_beacons() to stop classifying their
+# age as "stale", not to stop expecting/reading them.
+PARKED_COMPONENTS: frozenset = frozenset({"learning_loop", "intelligence_daemon"})
+
 
 @dataclass(frozen=True)
 class BeaconSpec:
@@ -171,4 +181,51 @@ def expected_component_names(register: Optional[Sequence[BeaconSpec]] = None) ->
     return tuple(spec.name for spec in register)
 
 
-__all__ = ["BeaconSpec", "read_beacon_register", "expected_component_names"]
+def parked_component_names() -> Tuple[str, ...]:
+    """Convenience: :data:`PARKED_COMPONENTS` as a sorted tuple, for passing
+    straight to ``all_beacons(parked=...)``."""
+    return tuple(sorted(PARKED_COMPONENTS))
+
+
+# Historical duplicate-write locations for the same beacon component (C2a).
+# report_to_receipt_converter's own writer passed VNX_STATE_DIR straight
+# through to HealthBeacon instead of its parent (data dir) until #1736
+# (2026-08-30) fixed it -- every OTHER writer in the fleet already resolved
+# `state_dir.parent` correctly. The leftover file this produced
+# (`<data_dir>/state/health/report_to_receipt_converter.json`) is stale, not
+# actively rewritten (confirmed via `git log -S` against the fixed call
+# site), but it was never cleaned up and a monitor that glob-scanned BOTH
+# roots would silently read the wrong, frozen half.
+_PRIMARY_HEALTH_SUBDIR = "health"
+_SECONDARY_HEALTH_SUBDIR = "state/health"
+
+
+def find_duplicate_beacon_writers(data_dir: Path) -> Dict[str, Tuple[Path, Path]]:
+    """Return ``{component: (primary_path, secondary_path)}`` for every
+    component with a beacon file under BOTH ``<data_dir>/health/`` (the one
+    every reader resolves to) and ``<data_dir>/state/health/`` (the historical
+    wrong path). An empty dict when either root is absent or no name
+    collides -- this is advisory, not a crash on a fresh/partial store.
+    """
+    data_dir = Path(data_dir)
+    primary = data_dir / _PRIMARY_HEALTH_SUBDIR
+    secondary = data_dir / _SECONDARY_HEALTH_SUBDIR
+    if not primary.is_dir() or not secondary.is_dir():
+        return {}
+    primary_names = {p.stem for p in primary.glob("*.json")}
+    secondary_names = {p.stem for p in secondary.glob("*.json")}
+    dupes = sorted(primary_names & secondary_names)
+    return {
+        name: (primary / f"{name}.json", secondary / f"{name}.json")
+        for name in dupes
+    }
+
+
+__all__ = [
+    "BeaconSpec",
+    "read_beacon_register",
+    "expected_component_names",
+    "PARKED_COMPONENTS",
+    "parked_component_names",
+    "find_duplicate_beacon_writers",
+]

--- a/scripts/lib/health_beacon.py
+++ b/scripts/lib/health_beacon.py
@@ -157,6 +157,7 @@ class HealthBeacon:
 def all_beacons(
     state_dir: Path,
     expected: Optional[Sequence[str]] = None,
+    parked: Optional[Sequence[str]] = None,
 ) -> Dict[str, Dict[str, Any]]:
     """Read all beacons under ``state_dir/health`` and classify each.
 
@@ -183,9 +184,16 @@ def all_beacons(
     is a real, deliberate "expected nothing" and also adds nothing; a
     populated sequence adds one ``"absent"`` entry per name not found.
 
-    Returns a mapping ``component_name -> beacon_dict`` (the raw payload
-    plus the derived ``health`` and ``age_seconds`` keys; synthetic
-    ``"absent"`` entries carry only ``component`` and ``health``).
+    ``parked`` (golf C / C2a, optional): component names that are a
+    deliberate operator decision to stop expecting fresh writes from — see
+    ``beacon_register.PARKED_COMPONENTS``. A parked component still gets a
+    reader like any other (this only changes its HEALTH classification):
+    a beacon that would otherwise read ``"stale"``/``"unknown"`` (silence-
+    driven) or ``"absent"`` (never wrote) is reported ``"parked"`` instead.
+    A parked component that reports a genuine ``"fail"``/``"corrupt"`` while
+    fresh is NOT overridden — parking suppresses silence, not a real defect.
+    ``None`` (the default) changes nothing, same backward-compatibility
+    contract ``expected=None`` already has.
     """
     state_dir = Path(state_dir)
     health_dir = state_dir / "health"
@@ -253,12 +261,18 @@ def all_beacons(
                 else:
                     data["health"] = _status_to_health(status)
 
+            if parked and component in parked and data["health"] in ("stale", "unknown"):
+                data["health"] = "parked"
+
             out[component] = data
 
     if expected:
         for name in expected:
             if name not in out:
-                out[name] = {"component": name, "health": "absent"}
+                if parked and name in parked:
+                    out[name] = {"component": name, "health": "parked"}
+                else:
+                    out[name] = {"component": name, "health": "absent"}
 
     return out
 
@@ -266,11 +280,12 @@ def all_beacons(
 def beacon_summary(
     state_dir: Path,
     expected: Optional[Sequence[str]] = None,
+    parked: Optional[Sequence[str]] = None,
 ) -> Dict[str, Any]:
     """Return a compact summary suitable for dashboard / CI consumption.
 
-    ``expected`` is forwarded to ``all_beacons`` verbatim — see its
-    docstring for the None/empty/populated distinction.
+    ``expected``/``parked`` are forwarded to ``all_beacons`` verbatim — see
+    its docstring for the None/empty/populated distinction.
 
     Both new D3a health values feed ``overall`` (the exact trap this
     dispatch closes elsewhere: adding a health value to ``counts`` without
@@ -279,11 +294,13 @@ def beacon_summary(
     as bad as a confirmed ``fail``, so it joins the ``fail`` tier. ``unknown``
     — an event-driven beacon whose freshness can no longer be verified — is
     "can't verify", not "confirmed bad", so it joins the milder ``stale``
-    tier instead.
+    tier instead. ``parked`` (golf C / C2a) deliberately joins NEITHER tier —
+    it is an operator decision to stop expecting freshness, not evidence of
+    a problem, so it never floors ``overall`` away from ``"ok"``.
     """
-    beacons = all_beacons(state_dir, expected=expected)
+    beacons = all_beacons(state_dir, expected=expected, parked=parked)
     counts: Dict[str, int] = {
-        "ok": 0, "stale": 0, "fail": 0, "corrupt": 0, "absent": 0, "unknown": 0,
+        "ok": 0, "stale": 0, "fail": 0, "corrupt": 0, "absent": 0, "unknown": 0, "parked": 0,
     }
     for b in beacons.values():
         h = b.get("health", "corrupt")

--- a/scripts/producer_freshness_monitor.py
+++ b/scripts/producer_freshness_monitor.py
@@ -179,10 +179,8 @@ def main(argv: Optional[List[str]] = None) -> int:
                 report["findings"].extend(new_findings)
                 report["findings_count"] = len(report["findings"])
                 report["status"] = "stale"
-        except (ImportError, OSError) as exc:
-            # A bonus structural signal in the same run; its failure must not
-            # suppress the per-key freshness findings the sweep already has.
-            beacon_checks = {"skipped": False, "error": str(exc)}
+        except Exception as exc:  # vnx-silent-except: a bonus structural signal; an unexpected failure (ValueError/AttributeError/SyntaxError from the AST-driven reader register, not just ImportError/OSError) must not take the already-built sweep findings down with it
+            beacon_checks = {"skipped": True, "error": str(exc)}
     report["beacon_reader_coverage"] = beacon_checks
 
     job_exits: Dict[str, object] = {"skipped": True}
@@ -191,10 +189,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             import job_exit_capture  # noqa: PLC0415
 
             job_exits = job_exit_capture.harvest_launchd(state_dir)
-        except (ImportError, OSError) as exc:
-            # The harvest is a bonus signal in the same run; its failure must
-            # not suppress the freshness findings.
-            job_exits = {"skipped": False, "error": str(exc)}
+        except Exception as exc:  # vnx-silent-except: the launchd harvest is a bonus signal; an unexpected failure (e.g. a ValueError from a corrupt harvest cache, not just ImportError/OSError) must not take the already-built sweep findings down with it
+            job_exits = {"skipped": True, "error": str(exc)}
     report["job_exits"] = job_exits
 
     if not args.no_write:

--- a/scripts/producer_freshness_monitor.py
+++ b/scripts/producer_freshness_monitor.py
@@ -90,6 +90,15 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--state-dir", default=None, help="VNX state dir (default: resolved via vnx_paths)")
     parser.add_argument("--no-write", action="store_true", help="read-only sweep; report to stdout only")
     parser.add_argument("--skip-job-exits", action="store_true", help="do not harvest launchd exit codes")
+    parser.add_argument(
+        "--skip-beacon-checks",
+        action="store_true",
+        help=(
+            "do not run the beacon reader-coverage / duplicate-writer checks "
+            "(C2a: scripts/lib/beacon_reader_register.py, "
+            "beacon_register.find_duplicate_beacon_writers)"
+        ),
+    )
     parser.add_argument("--human", action="store_true", help="human-readable output")
     parser.add_argument(
         "--latest-findings",
@@ -134,6 +143,47 @@ def main(argv: Optional[List[str]] = None) -> int:
         return EXIT_IO
 
     report = pf.run_sweep(state_dir, registry)
+
+    # C2a (absence-is-loud, the reader half): a producer/beacon with zero
+    # readers is exactly as invisible as one with zero writers. Kept OUTSIDE
+    # pf.run_sweep() itself (never touches its signature/behavior) so every
+    # existing run_sweep()-level test asserting exact findings_count against
+    # a hand-built YAML registry stays unaffected — this only runs at the
+    # CLI layer, folded into the SAME NDJSON report + heartbeat as the rest.
+    beacon_checks: Dict[str, object] = {"skipped": True}
+    if not args.skip_beacon_checks:
+        try:
+            import beacon_reader_register  # noqa: PLC0415
+            import beacon_register  # noqa: PLC0415
+
+            coverage = beacon_reader_register.check_coverage()
+            data_dir = state_dir.parent if state_dir.name == "state" else state_dir
+            duplicates = beacon_register.find_duplicate_beacon_writers(data_dir)
+            duplicate_findings = [
+                {
+                    "producer": "beacon_reader_coverage",
+                    "key": name,
+                    "kind": "duplicate_writer",
+                    "cadence_seconds": None,
+                    "paths": [str(p) for p in paths],
+                }
+                for name, paths in duplicates.items()
+            ]
+            new_findings = list(coverage["findings"]) + duplicate_findings
+            beacon_checks = {
+                "skipped": False,
+                "no_reader_count": len(coverage["findings"]),
+                "duplicate_writer_count": len(duplicate_findings),
+            }
+            if new_findings:
+                report["findings"].extend(new_findings)
+                report["findings_count"] = len(report["findings"])
+                report["status"] = "stale"
+        except (ImportError, OSError) as exc:
+            # A bonus structural signal in the same run; its failure must not
+            # suppress the per-key freshness findings the sweep already has.
+            beacon_checks = {"skipped": False, "error": str(exc)}
+    report["beacon_reader_coverage"] = beacon_checks
 
     job_exits: Dict[str, object] = {"skipped": True}
     if not args.skip_job_exits and not args.no_write:

--- a/tests/test_beacon_reader_register.py
+++ b/tests/test_beacon_reader_register.py
@@ -1,0 +1,217 @@
+"""Tests for scripts/lib/beacon_reader_register.py (golf C, C2a).
+
+Mirrors tests/test_beacon_register.py's own pattern: fixture trees exercise
+the parser's edge cases in isolation, plus a sanity check against the real
+repo tree. Per the C2a dispatch's own instruction, the RED case for
+"a beacon with zero readers" is forced with a synthetic/injected register,
+never asserted against the real tree -- a real-tree assertion would go
+green the moment anyone adds a reader and then test nothing further.
+"""
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import beacon_reader_register as brr  # noqa: E402
+
+
+def _write(root: Path, relative: str, content: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Generic reader detection
+# ---------------------------------------------------------------------------
+
+
+def test_generic_reader_with_expected_kwarg_is_detected(tmp_path: Path) -> None:
+    _write(tmp_path, "scripts/consumer.py", """
+        from health_beacon import beacon_summary
+        beacon_summary(data_dir, expected=expected_component_names())
+    """)
+    readers = brr.read_reader_register(("any_name",), project_root_dir=tmp_path)
+    assert brr.has_generic_reader(readers)
+    generic = [r for r in readers if r.kind == "generic"]
+    assert generic and generic[0].source_file == "scripts/consumer.py"
+
+
+def test_all_beacons_call_without_expected_is_not_generic(tmp_path: Path) -> None:
+    """The pre-D3a call shape (no `expected=` at all) never surfaces an
+    absent component -- it must not count as a reader that covers silence."""
+    _write(tmp_path, "scripts/consumer.py", """
+        from health_beacon import all_beacons
+        all_beacons(data_dir)
+    """)
+    readers = brr.read_reader_register(("any_name",), project_root_dir=tmp_path)
+    assert not brr.has_generic_reader(readers)
+
+
+def test_expected_none_literal_is_not_generic(tmp_path: Path) -> None:
+    """`expected=None` is the explicit "no expectation declared" value
+    (health_beacon.py's own docstring) -- a call site passing it literally
+    must not be mistaken for a generic reader."""
+    _write(tmp_path, "scripts/consumer.py", """
+        from health_beacon import all_beacons
+        all_beacons(data_dir, expected=None)
+    """)
+    readers = brr.read_reader_register(("any_name",), project_root_dir=tmp_path)
+    assert not brr.has_generic_reader(readers)
+
+
+# ---------------------------------------------------------------------------
+# Specific reader detection
+# ---------------------------------------------------------------------------
+
+
+def test_specific_reader_quoted_literal_is_detected(tmp_path: Path) -> None:
+    _write(tmp_path, "hooks/watcher.sh", """
+        #!/bin/bash
+        CANDIDATES="$VNX_DATA_DIR/health/producer_freshness_monitor.json"
+    """)
+    readers = brr.read_reader_register(("producer_freshness_monitor",), project_root_dir=tmp_path)
+    specific = [r for r in readers if r.kind == "specific"]
+    assert any(r.component == "producer_freshness_monitor" and r.source_file == "hooks/watcher.sh" for r in specific)
+
+
+def test_docstring_mention_is_not_a_specific_reader(tmp_path: Path) -> None:
+    """A component name that only appears in a module/function DOCSTRING
+    (this repo's own heavily cross-referenced commentary style) must not
+    count as a reader -- narrative prose is not code that acts on the
+    signal."""
+    _write(tmp_path, "scripts/unrelated.py", '''
+        """This module has nothing to do with cleanup_worker_exit, but its
+        docstring name-drops it for context."""
+        x = 1
+    ''')
+    readers = brr.read_reader_register(("cleanup_worker_exit",), project_root_dir=tmp_path)
+    assert not any(r.component == "cleanup_worker_exit" for r in readers)
+
+
+def test_comment_mention_in_bash_is_not_a_specific_reader(tmp_path: Path) -> None:
+    _write(tmp_path, "hooks/unrelated.sh", """
+        #!/bin/bash
+        # this hook has nothing to do with "ledger_health"
+        echo hi
+    """)
+    readers = brr.read_reader_register(("ledger_health",), project_root_dir=tmp_path)
+    assert not any(r.component == "ledger_health" for r in readers)
+
+
+def test_writer_own_file_is_excluded_from_its_own_specific_readers(tmp_path: Path) -> None:
+    """A component's own writer file inevitably mentions its own name (log
+    messages, the HealthBeacon(...) call itself) -- that must never count as
+    the component's OWN reader."""
+    _write(tmp_path, "scripts/lib/some_writer.py", '''
+        from health_beacon import HealthBeacon
+        HealthBeacon(state_dir, "self_writer").heartbeat(status="ok")
+        print("self_writer wrote a beacon")
+    ''')
+    readers = brr.read_reader_register(
+        ("self_writer",),
+        project_root_dir=tmp_path,
+        writer_source_by_component={"self_writer": "scripts/lib/some_writer.py"},
+    )
+    assert not any(r.component == "self_writer" for r in readers)
+
+
+def test_tests_directory_is_never_scanned(tmp_path: Path) -> None:
+    _write(tmp_path, "scripts/tests/test_something.py", '''
+        x = "cleanup_worker_exit"
+    ''')
+    readers = brr.read_reader_register(("cleanup_worker_exit",), project_root_dir=tmp_path)
+    assert not any(r.component == "cleanup_worker_exit" for r in readers)
+
+
+# ---------------------------------------------------------------------------
+# components_without_reader -- forced RED/GREEN via an injected register,
+# per the dispatch's own instruction (never asserted against the real tree).
+# ---------------------------------------------------------------------------
+
+
+def test_components_without_reader_flags_a_synthetic_orphan() -> None:
+    fake_register = (
+        brr.ReaderSpec(component="has_specific", source_file="hooks/fake.sh", line=1, kind="specific"),
+    )
+    orphans = brr.components_without_reader(("has_specific", "orphan"), fake_register)
+    assert orphans == ("orphan",)
+
+
+def test_a_single_generic_reader_covers_every_name_including_future_ones() -> None:
+    fake_register = (
+        brr.ReaderSpec(component=None, source_file="dashboard/api_health.py", line=96, kind="generic"),
+    )
+    orphans = brr.components_without_reader(("a", "b", "never_registered_yet"), fake_register)
+    assert orphans == ()
+
+
+def test_no_readers_at_all_flags_every_name() -> None:
+    orphans = brr.components_without_reader(("a", "b"), ())
+    assert set(orphans) == {"a", "b"}
+
+
+def test_readers_for_component_includes_generic_and_matching_specific() -> None:
+    register = (
+        brr.ReaderSpec(component=None, source_file="dashboard/api_health.py", line=1, kind="generic"),
+        brr.ReaderSpec(component="x", source_file="hooks/fake.sh", line=2, kind="specific"),
+        brr.ReaderSpec(component="y", source_file="hooks/other.sh", line=3, kind="specific"),
+    )
+    readers = brr.readers_for_component("x", register)
+    assert {r.source_file for r in readers} == {"dashboard/api_health.py", "hooks/fake.sh"}
+
+
+# ---------------------------------------------------------------------------
+# check_coverage -- the producer_freshness_monitor.py integration point
+# ---------------------------------------------------------------------------
+
+
+def test_check_coverage_reports_no_reader_finding_when_forced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(brr, "read_reader_register", lambda *a, **k: ())
+    result = brr.check_coverage(beacon_names=("orphan_one",))
+    assert result["status"] == "stale"
+    assert result["findings"] == [
+        {"producer": "beacon_reader_coverage", "key": "orphan_one", "kind": "no_reader", "cadence_seconds": None}
+    ]
+
+
+def test_check_coverage_is_clean_when_a_generic_reader_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        brr,
+        "read_reader_register",
+        lambda *a, **k: (brr.ReaderSpec(component=None, source_file="x.py", line=1, kind="generic"),),
+    )
+    result = brr.check_coverage(beacon_names=("anything",))
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# Sanity check against the real repo tree
+# ---------------------------------------------------------------------------
+
+
+def test_real_tree_has_a_generic_reader_covering_every_ast_registered_beacon() -> None:
+    """Measured 2026-09-09: dashboard/api_health.py and
+    scripts/build_t0_state.py both already call
+    beacon_summary(data_dir, expected=expected_component_names()) -- a
+    generic reader that covers every beacon_register.py-derived name,
+    present or not. This is what makes ALL of them mechanically covered
+    already; the C2a per-beacon decisions (park learning_loop/
+    intelligence_daemon, dedupe report_to_receipt_converter's stale leftover
+    file) are about health classification and writer hygiene, not about a
+    missing reader."""
+    import beacon_register as br
+
+    names = tuple(spec.name for spec in br.read_beacon_register())
+    register = brr.read_reader_register(names)
+    assert brr.has_generic_reader(register)
+    assert brr.components_without_reader(names, register) == ()

--- a/tests/test_beacon_register.py
+++ b/tests/test_beacon_register.py
@@ -155,6 +155,62 @@ def test_expected_component_names_is_just_the_names(fixture_scripts: Path) -> No
     assert br.expected_component_names(reg) == ("one",)
 
 
+# ---------------------------------------------------------------------------
+# PARKED_COMPONENTS / parked_component_names (golf C, C2a)
+# ---------------------------------------------------------------------------
+
+
+def test_parked_component_names_is_learning_loop_and_intelligence_daemon() -> None:
+    """Operator decision 2026-09-09: the intelligence layer stays parked
+    until the governance ledger is falsifiable (per the PRD) -- both
+    already-silent components get a deliberate status, not a removal."""
+    assert br.parked_component_names() == ("intelligence_daemon", "learning_loop")
+
+
+def test_parked_components_is_a_subset_of_the_real_register() -> None:
+    names = {s.name for s in br.read_beacon_register()}
+    assert set(br.parked_component_names()) <= names
+
+
+# ---------------------------------------------------------------------------
+# find_duplicate_beacon_writers (golf C, C2a) -- forced red/green via
+# tmp_path fixtures, per the dispatch's own "een test die twee schrijfpaden
+# voor dezelfde component rood maakt" instruction.
+# ---------------------------------------------------------------------------
+
+
+def test_find_duplicate_beacon_writers_flags_a_forced_collision(tmp_path: Path) -> None:
+    primary = tmp_path / "health"
+    secondary = tmp_path / "state" / "health"
+    primary.mkdir(parents=True)
+    secondary.mkdir(parents=True)
+    (primary / "report_to_receipt_converter.json").write_text("{}", encoding="utf-8")
+    (secondary / "report_to_receipt_converter.json").write_text("{}", encoding="utf-8")
+
+    dupes = br.find_duplicate_beacon_writers(tmp_path)
+    assert set(dupes.keys()) == {"report_to_receipt_converter"}
+    primary_path, secondary_path = dupes["report_to_receipt_converter"]
+    assert primary_path == primary / "report_to_receipt_converter.json"
+    assert secondary_path == secondary / "report_to_receipt_converter.json"
+
+
+def test_find_duplicate_beacon_writers_clean_when_only_one_root_has_the_file(tmp_path: Path) -> None:
+    primary = tmp_path / "health"
+    secondary = tmp_path / "state" / "health"
+    primary.mkdir(parents=True)
+    secondary.mkdir(parents=True)
+    (primary / "only_here.json").write_text("{}", encoding="utf-8")
+
+    assert br.find_duplicate_beacon_writers(tmp_path) == {}
+
+
+def test_find_duplicate_beacon_writers_missing_secondary_root_is_clean(tmp_path: Path) -> None:
+    (tmp_path / "health").mkdir(parents=True)
+    (tmp_path / "health" / "only_here.json").write_text("{}", encoding="utf-8")
+
+    assert br.find_duplicate_beacon_writers(tmp_path) == {}
+
+
 def test_real_scripts_tree_gives_the_nine_measured_writers() -> None:
     """Sanity check against the actual repo (measured 2026-09-05, was 9 on
     2026-08-30): 10 statically-resolvable HealthBeacon(...) call sites.

--- a/tests/test_health_beacon.py
+++ b/tests/test_health_beacon.py
@@ -544,5 +544,114 @@ def test_beacon_summary_counts_always_include_absent_and_unknown_keys(tmp_path: 
     HealthBeacon(tmp_path, "good").heartbeat()
     summary = beacon_summary(tmp_path)
     assert summary["counts"] == {
-        "ok": 1, "stale": 0, "fail": 0, "corrupt": 0, "absent": 0, "unknown": 0,
+        "ok": 1, "stale": 0, "fail": 0, "corrupt": 0, "absent": 0, "unknown": 0, "parked": 0,
     }
+
+
+# ---------------------------------------------------------------------------
+# golf C / C2a — `parked`: an operator decision to stop expecting freshness
+# from a component must never be classified the same as a real defect.
+# ---------------------------------------------------------------------------
+
+
+def test_parked_overrides_stale_classification(tmp_path: Path) -> None:
+    """learning_loop's exact real shape: wrote 'ok' 64+ days ago against an
+    86400s interval -- would classify 'stale' without the override."""
+    health_dir = tmp_path / "health"
+    _write_raw_beacon(
+        health_dir, "learning_loop", status="ok",
+        last_run_ts=int(time.time() - 64 * 86400), expected_interval_seconds=86400,
+    )
+    result = all_beacons(tmp_path, parked=["learning_loop"])
+    assert result["learning_loop"]["health"] == "parked"
+
+
+def test_parked_overrides_unknown_classification_on_event_driven_beacon(tmp_path: Path) -> None:
+    health_dir = tmp_path / "health"
+    _write_raw_beacon(
+        health_dir, "evented_parked", status="ok",
+        last_run_ts=int(time.time() - 1_000_000), expected_interval_seconds=None,
+    )
+    result = all_beacons(tmp_path, parked=["evented_parked"])
+    assert result["evented_parked"]["health"] == "parked"
+
+
+def test_parked_component_that_never_wrote_is_parked_not_absent(tmp_path: Path) -> None:
+    result = all_beacons(tmp_path, expected=["never_wrote"], parked=["never_wrote"])
+    assert result["never_wrote"] == {"component": "never_wrote", "health": "parked"}
+
+
+def test_parked_does_not_override_a_fresh_genuine_fail(tmp_path: Path) -> None:
+    """Parking suppresses SILENCE, not a real self-reported problem: a
+    parked component that is fresh and reports status=fail must still
+    surface as fail — parking is not a blanket amnesty."""
+    HealthBeacon(tmp_path, "parked_but_broken", expected_interval_seconds=3600).heartbeat(
+        status="fail", details={"err": "current problem"}
+    )
+    result = all_beacons(tmp_path, parked=["parked_but_broken"])
+    assert result["parked_but_broken"]["health"] == "fail"
+
+
+def test_parked_none_is_backward_compatible(tmp_path: Path) -> None:
+    """Omitting `parked` entirely must produce byte-for-byte the same
+    output as before it existed."""
+    health_dir = tmp_path / "health"
+    _write_raw_beacon(
+        health_dir, "learning_loop", status="ok",
+        last_run_ts=int(time.time() - 64 * 86400), expected_interval_seconds=86400,
+    )
+    result = all_beacons(tmp_path)
+    assert result["learning_loop"]["health"] == "stale"
+
+
+def test_cli_expected_flag_surfaces_absent_component(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "present").heartbeat()
+    rc, stdout, _ = _run_cli(tmp_path, "--json", "--expected", "present,never_wrote")
+    assert rc == 1
+    payload = json.loads(stdout)
+    assert payload["beacons"]["never_wrote"]["health"] == "absent"
+
+
+def test_cli_omitting_expected_is_backward_compatible(tmp_path: Path) -> None:
+    """The pre-C2a call shape (no --expected at all) must not change: a
+    component that never wrote a beacon is simply absent from the output,
+    not synthesized as "absent"."""
+    HealthBeacon(tmp_path, "present").heartbeat()
+    rc, stdout, _ = _run_cli(tmp_path, "--json")
+    assert rc == 0
+    payload = json.loads(stdout)
+    assert set(payload["beacons"].keys()) == {"present"}
+
+
+def test_cli_parked_flag_excludes_from_bad_exit_code(tmp_path: Path) -> None:
+    health_dir = tmp_path / "health"
+    _write_raw_beacon(
+        health_dir, "parked_stale", status="ok",
+        last_run_ts=int(time.time() - 64 * 86400), expected_interval_seconds=86400,
+    )
+    rc, stdout, _ = _run_cli(tmp_path, "--json", "--parked", "parked_stale")
+    assert rc == 0, stdout
+    payload = json.loads(stdout)
+    assert payload["beacons"]["parked_stale"]["health"] == "parked"
+
+
+def test_cli_without_parked_flag_the_same_beacon_is_bad(tmp_path: Path) -> None:
+    health_dir = tmp_path / "health"
+    _write_raw_beacon(
+        health_dir, "parked_stale", status="ok",
+        last_run_ts=int(time.time() - 64 * 86400), expected_interval_seconds=86400,
+    )
+    rc, _stdout, _ = _run_cli(tmp_path, "--json")
+    assert rc == 1
+
+
+def test_beacon_summary_parked_never_floors_overall_away_from_ok(tmp_path: Path) -> None:
+    HealthBeacon(tmp_path, "good").heartbeat()
+    health_dir = tmp_path / "health"
+    _write_raw_beacon(
+        health_dir, "parked_one", status="ok",
+        last_run_ts=int(time.time() - 64 * 86400), expected_interval_seconds=86400,
+    )
+    summary = beacon_summary(tmp_path, parked=["parked_one"])
+    assert summary["counts"]["parked"] == 1
+    assert summary["overall"] == "ok"

--- a/tests/test_producer_freshness.py
+++ b/tests/test_producer_freshness.py
@@ -971,3 +971,168 @@ def test_latest_findings_ignores_a_torn_final_line(tmp_path: Path) -> None:
     assert result["swept"] is True
     assert result["run_id"] == "torntest0001"
     assert len(result["findings"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# golf C / C2a — beacon reader-coverage + duplicate-writer checks, wired into
+# producer_freshness_monitor.py's CLI (never into pf.run_sweep() itself, so
+# every findings_count-exact test above stays unaffected — see the module
+# comment at the call site). Forced via monkeypatch on the imported modules,
+# per the dispatch's own "don't assert this against the real tree" rule.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_beacon_reader_coverage_finding_lands_in_the_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+    import beacon_reader_register as brr  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    config_path = tmp_path / "registry.yaml"
+    config_path.write_text(
+        "producers:\n"
+        "  - name: trivial\n"
+        "    type: directory\n"
+        f"    path: '{tmp_path / 'empty'}'\n"
+        "    cadence_seconds: 86400\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        brr,
+        "check_coverage",
+        lambda: {
+            "producer": "beacon_reader_coverage",
+            "type": "beacon_reader_register",
+            "kind": "structural",
+            "keys": [{"key": "orphan_beacon"}],
+            "findings": [
+                {"producer": "beacon_reader_coverage", "key": "orphan_beacon", "kind": "no_reader", "cadence_seconds": None}
+            ],
+            "status": "stale",
+        },
+    )
+
+    rc = cli.main(["--config", str(config_path), "--state-dir", str(state_dir), "--no-write"])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "stale"
+    assert out["beacon_reader_coverage"]["no_reader_count"] == 1
+    assert any(
+        f["producer"] == "beacon_reader_coverage" and f["key"] == "orphan_beacon" and f["kind"] == "no_reader"
+        for f in out["findings"]
+    )
+
+
+def test_cli_beacon_checks_clean_when_coverage_and_duplicates_are_both_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+    import beacon_reader_register as brr  # noqa: PLC0415
+    import beacon_register as br  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    config_path = tmp_path / "registry.yaml"
+    config_path.write_text(
+        "producers:\n"
+        "  - name: trivial\n"
+        "    type: directory\n"
+        f"    path: '{tmp_path / 'empty'}'\n"
+        "    cadence_seconds: 86400\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(brr, "check_coverage", lambda: {
+        "producer": "beacon_reader_coverage", "type": "beacon_reader_register", "kind": "structural",
+        "keys": [], "findings": [], "status": "ok",
+    })
+    monkeypatch.setattr(br, "find_duplicate_beacon_writers", lambda data_dir: {})
+
+    rc = cli.main(["--config", str(config_path), "--state-dir", str(state_dir), "--no-write"])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "ok"
+    assert out["beacon_reader_coverage"] == {"skipped": False, "no_reader_count": 0, "duplicate_writer_count": 0}
+
+
+def test_cli_flags_a_duplicate_beacon_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    """Forces the exact report_to_receipt_converter shape: the same
+    component's beacon present under both <data_dir>/health/ and
+    <data_dir>/state/health/."""
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+    import beacon_reader_register as brr  # noqa: PLC0415
+    import beacon_register as br  # noqa: PLC0415
+
+    data_dir = tmp_path
+    state_dir = data_dir / "state"
+    state_dir.mkdir()
+    primary = data_dir / "health"
+    secondary = data_dir / "state" / "health"
+    primary.mkdir()
+    secondary.mkdir()
+    (primary / "dup_component.json").write_text("{}", encoding="utf-8")
+    (secondary / "dup_component.json").write_text("{}", encoding="utf-8")
+
+    config_path = tmp_path / "registry.yaml"
+    config_path.write_text(
+        "producers:\n"
+        "  - name: trivial\n"
+        "    type: directory\n"
+        f"    path: '{tmp_path / 'empty'}'\n"
+        "    cadence_seconds: 86400\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(brr, "check_coverage", lambda: {
+        "producer": "beacon_reader_coverage", "type": "beacon_reader_register", "kind": "structural",
+        "keys": [], "findings": [], "status": "ok",
+    })
+
+    rc = cli.main(["--config", str(config_path), "--state-dir", str(state_dir), "--no-write"])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["beacon_reader_coverage"]["duplicate_writer_count"] == 1
+    dup = [f for f in out["findings"] if f["kind"] == "duplicate_writer"]
+    assert len(dup) == 1
+    assert dup[0]["key"] == "dup_component"
+
+
+def test_cli_skip_beacon_checks_flag_disables_the_section(tmp_path: Path, capsys) -> None:
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    config_path = tmp_path / "registry.yaml"
+    config_path.write_text(
+        "producers:\n"
+        "  - name: trivial\n"
+        "    type: directory\n"
+        f"    path: '{tmp_path / 'empty'}'\n"
+        "    cadence_seconds: 86400\n",
+        encoding="utf-8",
+    )
+
+    rc = cli.main([
+        "--config", str(config_path), "--state-dir", str(state_dir),
+        "--no-write", "--skip-beacon-checks",
+    ])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["beacon_reader_coverage"] == {"skipped": True}
+
+
+def test_real_cli_run_against_the_real_registry_carries_zero_no_reader_findings(fake_state: Path, capsys) -> None:
+    """Sanity check against the LIVE register (not a mock): measured
+    2026-09-09, dashboard/api_health.py + scripts/build_t0_state.py already
+    give every beacon_register.py-derived component a generic reader, so a
+    real (unmocked) run must report zero no_reader findings even though the
+    registry itself finds other, unrelated stale keys."""
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+
+    rc = cli.main([
+        "--config", str(REPO_ROOT / "configs" / "producer_freshness.yaml"),
+        "--state-dir", str(fake_state), "--no-write",
+    ])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["beacon_reader_coverage"]["no_reader_count"] == 0

--- a/tests/test_producer_freshness.py
+++ b/tests/test_producer_freshness.py
@@ -1121,6 +1121,96 @@ def test_cli_skip_beacon_checks_flag_disables_the_section(tmp_path: Path, capsys
     assert out["beacon_reader_coverage"] == {"skipped": True}
 
 
+def _sweep_finding_config(tmp_path: Path) -> Path:
+    """A minimal registry yielding exactly one sweep finding (a never-written
+    expected key), independent of the beacon / job-exits bonus sections. A
+    bonus-section crash can then be proven NOT to take that finding down."""
+    config_path = tmp_path / "registry.yaml"
+    config_path.write_text(
+        "producers:\n"
+        "  - name: never_seen\n"
+        "    type: directory\n"
+        f"    path: '{tmp_path / 'no_such_dir'}'\n"
+        "    expected_keys:\n"
+        "      - never_written\n"
+        "    cadence_seconds: 86400\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_cli_beacon_check_error_keeps_sweep_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """An unexpected ValueError from the AST-driven reader register must be
+    caught at the CLI layer: the report still exists, the sweep finding is
+    still in it, and the beacon section says it was skipped with the reason."""
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+    import beacon_reader_register as brr  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    def _explode(*args, **kwargs) -> dict:
+        raise ValueError("reader register exploded")
+
+    monkeypatch.setattr(brr, "check_coverage", _explode)
+
+    rc = cli.main([
+        "--config", str(_sweep_finding_config(tmp_path)),
+        "--state-dir", str(state_dir),
+        "--no-write",
+    ])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["findings_count"] == 1
+    assert out["findings"][0]["producer"] == "never_seen"
+    assert out["findings"][0]["key"] == "never_written"
+    assert out["findings"][0]["kind"] == "missing"
+    assert out["beacon_reader_coverage"]["skipped"] is True
+    assert "reader register exploded" in out["beacon_reader_coverage"]["error"]
+
+
+def test_cli_job_exits_error_keeps_sweep_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """The launchd harvest has the same shape as the beacon check: an
+    unexpected ValueError from it must not take the sweep findings down.
+    Runs WITHOUT --no-write (that flag gates the job_exits block off)."""
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+    import beacon_reader_register as brr  # noqa: PLC0415
+    import beacon_register as br  # noqa: PLC0415
+    import job_exit_capture as jec  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    # Keep the beacon section clean and fast (it runs before job_exits) so
+    # this test isolates the job_exits guard.
+    monkeypatch.setattr(brr, "check_coverage", lambda: {
+        "producer": "beacon_reader_coverage", "type": "beacon_reader_register",
+        "kind": "structural", "keys": [], "findings": [], "status": "ok",
+    })
+    monkeypatch.setattr(br, "find_duplicate_beacon_writers", lambda data_dir: {})
+
+    def _explode(state_dir, **kwargs) -> dict:
+        raise ValueError("launchd harvest exploded")
+
+    monkeypatch.setattr(jec, "harvest_launchd", _explode)
+
+    rc = cli.main([
+        "--config", str(_sweep_finding_config(tmp_path)),
+        "--state-dir", str(state_dir),
+    ])
+    assert rc == cli.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["findings_count"] == 1
+    assert out["findings"][0]["producer"] == "never_seen"
+    assert out["findings"][0]["kind"] == "missing"
+    assert out["job_exits"]["skipped"] is True
+    assert "launchd harvest exploded" in out["job_exits"]["error"]
+
+
 def test_real_cli_run_against_the_real_registry_carries_zero_no_reader_findings(fake_state: Path, capsys) -> None:
     """Sanity check against the LIVE register (not a mock): measured
     2026-09-09, dashboard/api_health.py + scripts/build_t0_state.py already

--- a/tests/test_sessionstart_hook_beacon_health.py
+++ b/tests/test_sessionstart_hook_beacon_health.py
@@ -216,6 +216,62 @@ class TestBeaconHealthDigest:
         assert result.returncode == 0, result.stderr
 
 
+class TestBeaconHealthDigestExpectedAndParked:
+    """C2a: hooks/sessionstart.sh now resolves beacon_register.py's
+    expected_component_names()/parked_component_names() (in the SAME
+    python subprocess that already resolves VNX_STATE_DIR/VNX_DATA_DIR
+    above) and forwards them to health_check.py as --expected/--parked.
+
+    That resolution is CWD-anchored (beacon_register.py's own
+    project_root.resolve_project_root() is CWD-first, no __file__ anchor —
+    see its docstring), so it only succeeds when the hook runs from inside
+    a real git checkout. The other tests in this file run the hook from a
+    synthetic tmp_path project with no .git at all (by design — they only
+    need DATA isolation, not a real scripts/lib) which makes the try/except
+    around that resolution swallow a RuntimeError and fall back to empty
+    --expected/--parked, i.e. old behavior. These tests instead run the
+    hook from THIS repo's own .claude/terminals/T0 (real git checkout, so
+    project-root/beacon_register resolution succeeds) while still fully
+    isolating DATA via VNX_DATA_HOME -- never touching this repo's own
+    .vnx-data or the developer's live ~/.vnx-data/<project>/ store.
+    """
+
+    def test_parked_component_is_excluded_from_the_not_ok_list(self, tmp_path, monkeypatch):
+        """The exact learning_loop/intelligence_daemon shape (golf C
+        operator decision): stale-by-age but parked, so it must not surface
+        as [stale] anymore."""
+        _clean_env(monkeypatch)
+        real_t0_dir = REPO / ".claude" / "terminals" / "T0"
+        monkeypatch.setenv("VNX_DATA_HOME", str(tmp_path / "vnx-data-home"))
+        env = dict(os.environ)
+
+        data_dir = Path(vnx_paths.resolve_paths()["VNX_DATA_DIR"])
+        _write_beacon(
+            data_dir, "learning_loop", status="ok",
+            age_seconds=64.6 * 86400, expected_interval_seconds=86400,
+        )
+
+        out = _run_hook(real_t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "[stale] learning_loop" not in ctx, ctx
+        assert "[parked] learning_loop" not in ctx, (
+            "parked is excluded from the bad-list entirely, not relisted under a new label: " + ctx
+        )
+
+    def test_expected_component_that_never_wrote_surfaces_as_absent(self, tmp_path, monkeypatch):
+        """fleet_role_drift's real shape: an ast-registered writer that has
+        never once produced a beacon file -- invisible before this PR's
+        --expected wiring, now surfaces by name."""
+        _clean_env(monkeypatch)
+        real_t0_dir = REPO / ".claude" / "terminals" / "T0"
+        monkeypatch.setenv("VNX_DATA_HOME", str(tmp_path / "vnx-data-home"))
+        env = dict(os.environ)
+
+        out = _run_hook(real_t0_dir, env)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "[absent] fleet_role_drift" in ctx, ctx
+
+
 _CALL_SITE_TARGETS = frozenset({"all_beacons", "beacon_summary"})
 _CALL_SITE_EXCLUDE_DIRS = frozenset({"tests"})
 


### PR DESCRIPTION
## Summary

C2a — "elke stille producent krijgt een lezer, of hij gaat eruit" — builds the missing reader-side half of `beacon_register.py`'s writer register, and resolves the 8 troubled beacons from the golf-C measurement table.

- **`scripts/lib/beacon_reader_register.py`** (new): derives beacon readers from code, mirroring `beacon_register.py`'s own approach — a GENERIC reader (`all_beacons()`/`beacon_summary()` call site with `expected=`) covers every current and future component; a SPECIFIC reader is a non-docstring string-literal reference to one component's name. `components_without_reader()` is the red-test surface, forced via injection per the dispatch's own instruction (never asserted against the real tree for the red case).
- **Measured**: all 10 `beacon_register.py`-derived components already have a generic reader (`dashboard/api_health.py`, `scripts/build_t0_state.py` both already pass `expected=`) — nothing needed removing.
- **`scripts/health_check.py`** gains opt-in `--expected`/`--parked` flags; **`hooks/sessionstart.sh`** now resolves and passes them, so the live SessionStart hot path (not just the dashboard/CLI few people open) surfaces `fleet_role_drift`/`receipt_conversion_rejections` (never-fired writers) as `absent` for the first time.
- **`learning_loop`/`intelligence_daemon` parked** by explicit operator decision (intelligence layer paused until the ledger is falsifiable, per the PRD) — `beacon_register.PARKED_COMPONENTS` + a new `"parked"` health value in `health_beacon.py` that never floors `overall` and is excluded from the sessionstart "NOT ok" list.
- **`report_to_receipt_converter`'s double beacon**: `beacon_register.find_duplicate_beacon_writers()` detects a component written under both `health/` and `state/health/`. Verified via `git log -S` that the writer bug was already fixed by #1736 (2026-08-30) — the second file is a stale leftover, not an active second writer. The detector makes recurrence of this class inspectable/testable.
- **`governance-enforcement-stack`/`plan-gate-panel`**: out of scope, same boundary `beacon_register.py` itself already documents (a different namespace, already read by `vnx_cli/commands/subsystems.py` + `dashboard/api_subsystems.py` — verified, not just trusted from the docstring).
- **Plan correction**: the golf-C plan claimed `producer_freshness_monitor` had 3 readers including `scripts/lib/session_state_freshness.py`. Verified that file never references producer_freshness at all (only a docstring cross-reference) — the real readers are `hooks/sessionstart.sh` (2 sections) and `hooks/monitor_tripwire.sh`.

Both new checks (reader-coverage, duplicate-writer) are wired into `producer_freshness_monitor.py`'s CLI layer only, never into `producer_freshness.run_sweep()` — several existing tests assert exact `findings_count` against a hand-built registry and must stay unaffected by a structural check unrelated to per-key freshness.

Out of scope per the dispatch: removing `dispatcher_minimal.sh`/`dispatcher_supervisor.sh` (86 references, own PR).

## Test plan
- [x] `tests/test_beacon_reader_register.py` (new, 15 tests) — generic/specific reader detection, docstring/comment exclusion, forced orphan red/green
- [x] `tests/test_beacon_register.py` — `PARKED_COMPONENTS`, `find_duplicate_beacon_writers()` forced red/green
- [x] `tests/test_health_beacon.py` — `parked=` classification (stale/unknown/absent → parked; genuine fresh fail NOT overridden; backward-compat)
- [x] `tests/test_producer_freshness.py` — CLI-level beacon-check integration, `--skip-beacon-checks`, real-registry zero-orphan sanity check
- [x] `tests/test_sessionstart_hook_beacon_health.py` — real end-to-end hook run (this repo's own `.claude/terminals/T0` for code resolution, isolated `VNX_DATA_HOME` for data) proving `learning_loop` no longer surfaces as `[stale]` and `fleet_role_drift` now surfaces as `[absent]`
- [x] Full neighbor sweep: 396 passed, 1 skipped, 0 failed (incl. pre-existing `test_build_t0_brief_output.py` DB-migration failures confirmed pre-existing via `git stash`)

Dispatch-ID: `20260909-golfc-c2a-beacon-lezers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)