### PR TITLE
fix(worktree): resolve the git common dir instead of assuming .git is a directory (OI-1713)

### DIFF
--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -480,14 +480,24 @@ def read_worktree_base_sha(
 def _worktree_lock(root: Path):
     """Serialize `git worktree` add/remove via an exclusive fcntl lock.
 
-    Uses the SAME lock path as tmux_worktree._flock_context
-    (``<repo>/.git/worktrees/.vnx-lock``) so the provider lane and the tmux lane
-    never run concurrent ``git worktree add/remove`` against one repo. Concurrent
-    adds contend on git's internal index/HEAD locks and fail in ~0.8s, which under
-    VNX_BENCH_REQUIRE_ISOLATION=1 cascades into spurious isolation DNFs (observed
-    2026-06-18 at --parallel 8: every provider cell DNF'd at 0.8s).
+    Uses the SAME lock path as tmux_worktree._flock_context and
+    gate_worktree._worktree_lock
+    (``<git-common-dir>/worktrees/.vnx-lock``) so the provider lane, the tmux
+    lane and the gate lane never run concurrent ``git worktree add/remove``
+    against one repo. The common dir is resolved via
+    ``git rev-parse --git-common-dir`` (see ``git_common.git_common_dir``) so
+    this works from a linked worktree where ``.git`` is a file, not a directory
+    — the bug fixed in OI-1713: the previous ``(root / ".git").resolve() /
+    "worktrees"`` raised ``NotADirectoryError`` in every linked worktree, which
+    meant the serialisation guarantee below did not hold there either (the
+    provider lane and the tmux lane would have picked different lock paths).
+    Concurrent adds contend on git's internal index/HEAD locks and fail in
+    ~0.8s, which under VNX_BENCH_REQUIRE_ISOLATION=1 cascades into spurious
+    isolation DNFs (observed 2026-06-18 at --parallel 8: every provider cell
+    DNF'd at 0.8s).
     """
-    lock_dir = (root / ".git").resolve() / "worktrees"
+    from git_common import git_common_dir  # deferred import keeps module-load cost off consumers that never lock
+    lock_dir = git_common_dir(root) / "worktrees"
     lock_dir.mkdir(parents=True, exist_ok=True)
     lock_path = lock_dir / ".vnx-lock"
     with open(lock_path, "a") as lf:

--- a/scripts/lib/gate_worktree.py
+++ b/scripts/lib/gate_worktree.py
@@ -90,31 +90,15 @@ def _validate_branch(branch: str, *, gate: str, identifier: str) -> None:
 def _git_common_dir(root: Path) -> Path:
     """Resolve the shared git dir for a repo, handling linked worktrees.
 
-    In a linked git worktree ``.git`` is a ~89-byte ASCII file pointing at the
-    real gitdir, not a directory — deriving a lock path from ``root / ".git"``
-    would raise ``NotADirectoryError`` (OI-905). ``git rev-parse
-    --git-common-dir`` returns the shared git dir in both a main checkout and a
-    linked worktree (the output may be relative to cwd or absolute).
+    Thin wrapper around the shared ``git_common.git_common_dir`` (the single
+    implementation every lane imports — OI-1713). Kept as a local symbol so
+    callers and tests that import ``gate_worktree._git_common_dir`` keep
+    working. In a linked git worktree ``.git`` is an ASCII file pointing at
+    the real gitdir, not a directory — deriving a lock path from
+    ``root / ".git"`` would raise ``NotADirectoryError`` (OI-905).
     """
-    try:
-        proc = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=15, check=True,
-        )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        detail = getattr(exc, "stderr", "") or str(exc)
-        raise GateWorktreeError(
-            f"git rev-parse --git-common-dir failed in {root}: {detail}"
-        ) from exc
-    common = proc.stdout.strip()
-    if not common:
-        raise GateWorktreeError(
-            f"git rev-parse --git-common-dir returned empty in {root}"
-        )
-    path = Path(common)
-    if not path.is_absolute():
-        path = root / path
-    return path.resolve()
+    from git_common import git_common_dir
+    return git_common_dir(root)
 
 
 @contextmanager
@@ -125,8 +109,8 @@ def _worktree_lock(root: Path):
     (``<git-common-dir>/worktrees/.vnx-lock``) so gate execution never races
     other lanes' concurrent ``git worktree add/remove`` against this repo. The
     common dir is resolved via ``git rev-parse --git-common-dir`` (see
-    ``_git_common_dir``) so this works from a linked worktree where ``.git``
-    is a file, not a directory.
+    ``git_common.git_common_dir``) so this works from a linked worktree where
+    ``.git`` is a file, not a directory.
     """
     lock_dir = _git_common_dir(root) / "worktrees"
     lock_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/lib/git_common.py
+++ b/scripts/lib/git_common.py
@@ -1,0 +1,46 @@
+"""git_common.py — shared git-dir resolution helpers for worktree-aware code.
+
+Several modules need the shared git dir (``.git`` of a main checkout, or the
+common dir a linked worktree points at via its ``gitdir:`` file). Duplicating
+that resolution caused OI-1713: ``dispatch_worktree_isolation._worktree_lock``
+assumed ``root / ".git"`` is a directory and raised ``NotADirectoryError`` in
+every linked worktree, while ``tmux_worktree._git_common_dir`` and
+``worktree_release._git_common_dir`` already did it right. This module is the
+single implementation all three (plus ``gate_worktree``) import.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def git_common_dir(repo_root: Path) -> Path:
+    """Resolve the shared git dir for *repo_root*, handling linked worktrees.
+
+    In a main checkout ``.git`` is a directory and ``git rev-parse
+    --git-common-dir`` returns that path. In a linked worktree (``git worktree
+    add``) ``.git`` is an ASCII file with a ``gitdir:`` line, and
+    ``--git-common-dir`` returns the shared dir of the main checkout — the only
+    place whose ``worktrees/`` subdir can safely host a lock file. Deriving a
+    path from ``root / ".git"`` would raise ``NotADirectoryError`` there
+    (OI-1713 / OI-905).
+
+    Returns the resolved git-common-dir path. On git failure, falls back to
+    ``(repo_root / ".git").resolve()`` so callers in a standard layout keep
+    working; a linked worktree whose git lookup fails is already broken in a
+    way that will surface elsewhere.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return (repo_root / ".git").resolve()
+    if proc.returncode != 0:
+        return (repo_root / ".git").resolve()
+    raw = proc.stdout.strip()
+    if not raw:
+        return (repo_root / ".git").resolve()
+    p = Path(raw)
+    return p if p.is_absolute() else (repo_root / p).resolve()

--- a/scripts/lib/tmux_worktree.py
+++ b/scripts/lib/tmux_worktree.py
@@ -78,21 +78,11 @@ def _current_branch(wt: "Path | str") -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
-def _git_common_dir(repo_root: Path) -> Path:
-    """Return the git common dir (handles bare worktrees where .git is a file)."""
-    result = _run(["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"])
-    if result.returncode == 0:
-        raw = result.stdout.strip()
-        p = Path(raw)
-        return p if p.is_absolute() else (repo_root / p).resolve()
-    # Fallback: assume standard layout
-    return (repo_root / ".git").resolve()
-
-
 @contextmanager
 def _flock_context(repo_root: Path):
     """Serialize worktree add/remove via an exclusive fcntl lock on <git-common-dir>/worktrees/.vnx-lock."""
-    git_dir = _git_common_dir(repo_root)
+    from git_common import git_common_dir
+    git_dir = git_common_dir(repo_root)
     lock_dir = git_dir / "worktrees"
     lock_dir.mkdir(parents=True, exist_ok=True)
     lock_path = lock_dir / ".vnx-lock"

--- a/scripts/lib/worktree_release.py
+++ b/scripts/lib/worktree_release.py
@@ -105,15 +105,6 @@ def _run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(args, capture_output=True, text=True, **kwargs)
 
 
-def _git_common_dir(repo_root: Path) -> Path:
-    result = _run(["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"])
-    if result.returncode == 0:
-        raw = result.stdout.strip()
-        p = Path(raw)
-        return p if p.is_absolute() else (repo_root / p).resolve()
-    return (repo_root / ".git").resolve()
-
-
 def _resolve_repo_root(*, dry_run: bool = True) -> Path:
     """Resolve the git repo root, applying PROJECT_ROOT-over-cwd precedence.
 

--- a/tests/test_worktree_lock_common_dir.py
+++ b/tests/test_worktree_lock_common_dir.py
@@ -1,0 +1,183 @@
+"""test_worktree_lock_common_dir.py — OI-1713: _worktree_lock in a linked worktree.
+
+``dispatch_worktree_isolation._worktree_lock`` assumed ``root / ".git"`` is a
+directory and built ``<root>/.git/worktrees/.vnx-lock`` from it. In a linked
+git worktree (``git worktree add``) ``.git`` is an ASCII file with a
+``gitdir:`` line, so ``mkdir`` under it raises ``NotADirectoryError`` before
+any lock can be taken. The serialisation claim in the docstring (provider lane
+and tmux lane share one lock path) was therefore false in a linked worktree:
+the tmux lane resolved the common dir, the provider lane did not.
+
+These tests reproduce that exact layout (``git worktree add``) and require:
+
+1. ``_worktree_lock`` works from a linked worktree and the lock file lands
+   under the git-common-dir's ``worktrees/`` (the main checkout's ``.git``),
+   never under the ``.git`` *file* of the linked worktree.
+2. Both lanes (``dispatch_worktree_isolation._worktree_lock`` and
+   ``tmux_worktree._flock_context``) resolve the SAME lock path from a linked
+   worktree — the cross-lane serialisation guarantee.
+
+Test (1) fails on the pre-fix code (``NotADirectoryError``) and passes after.
+Pure filesystem + git, no worker spawn.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_worktree_isolation
+import tmux_worktree
+
+
+def _run_git(args, cwd):
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result.stdout
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _run_git(["init", "-b", "main"], path)
+    _run_git(["config", "user.email", "test@example.invalid"], path)
+    _run_git(["config", "user.name", "Test"], path)
+
+
+@pytest.fixture
+def main_repo(tmp_path: Path) -> Path:
+    """A main checkout where ``.git`` IS a directory."""
+    repo = tmp_path / "main"
+    _init_repo(repo)
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _run_git(["add", "seed.txt"], repo)
+    _run_git(["commit", "-m", "seed"], repo)
+    return repo
+
+
+@pytest.fixture
+def linked_worktree(main_repo: Path, tmp_path: Path) -> Path:
+    """A linked worktree where ``.git`` is an ASCII FILE, not a directory.
+
+    This is the exact layout that crashed on ``(root / ".git").resolve() /
+    "worktrees"`` mkdir.
+    """
+    linked = tmp_path / "linked-wt"
+    _run_git(["worktree", "add", "--detach", str(linked), "HEAD"], main_repo)
+    # Sanity: in a linked worktree .git is a file, not a directory.
+    assert (linked / ".git").is_file()
+    assert not (linked / ".git").is_dir()
+    return linked
+
+
+# ---------------------------------------------------------------------------
+# 1. _worktree_lock works from a linked worktree (the OI-1713 crash)
+# ---------------------------------------------------------------------------
+
+class TestWorktreeLockInLinkedWorktree:
+    def test_lock_succeeds_and_lands_under_common_dir(self, linked_worktree: Path):
+        """``_worktree_lock`` must not raise NotADirectoryError from a linked
+        worktree, and its lock file must land under the git-common-dir's
+        ``worktrees/`` (the main checkout's ``.git``), not the ``.git`` file."""
+        with dispatch_worktree_isolation._worktree_lock(linked_worktree):
+            pass  # acquiring is enough; the crash happened at mkdir
+
+        # The lock file must exist under the MAIN repo's .git/worktrees/, the
+        # shared git-common-dir of the linked worktree.
+        main_repo_git = (linked_worktree.parent / "main" / ".git").resolve()
+        lock_file = main_repo_git / "worktrees" / ".vnx-lock"
+        assert lock_file.is_file(), f"lock not at common dir: {lock_file}"
+
+    def test_lock_path_not_under_linked_git_file(self, linked_worktree: Path):
+        """The lock path must NOT be derived from the linked worktree's ``.git``
+        file (which would be ``<linked>/.git/worktrees/...`` and is impossible
+        because ``.git`` is a file)."""
+        from git_common import git_common_dir
+
+        common = git_common_dir(linked_worktree)
+        # The common dir is the main repo's .git directory.
+        main_repo_git = (linked_worktree.parent / "main" / ".git").resolve()
+        assert common == main_repo_git
+        assert common.is_dir()
+        # And it is NOT the linked worktree's .git (which is a file).
+        assert common != (linked_worktree / ".git").resolve()
+
+
+# ---------------------------------------------------------------------------
+# 2. Both lanes pick the SAME lock path (the serialisation claim)
+# ---------------------------------------------------------------------------
+
+class TestBothLanesShareLockPath:
+    def test_dispatch_and_tmux_resolve_same_lock_dir(
+        self, linked_worktree: Path,
+    ):
+        """The serialisation claim from the docstring: the provider lane
+        (``dispatch_worktree_isolation._worktree_lock``) and the tmux lane
+        (``tmux_worktree._flock_context``) MUST resolve the SAME lock directory
+        from a linked worktree, so a concurrent ``git worktree add/remove`` from
+        either lane contends on one fcntl lock.
+
+        Both lanes now import ``git_common.git_common_dir``, so they compute
+        the same ``<git-common-dir>/worktrees`` path. We exercise each lane's
+        actual context manager (not just the shared helper) so the test fails
+        if either lane stops using the helper.
+
+        On the pre-fix code this was false: the tmux lane resolved the common
+        dir, the provider lane used ``(root / ".git").resolve() / "worktrees"``
+        and crashed before even computing a path.
+        """
+        from git_common import git_common_dir
+
+        # The one shared lock dir both lanes must land on.
+        common = git_common_dir(linked_worktree)
+        shared_lock_dir = common / "worktrees"
+
+        # Exercise the provider lane: must not raise, must create the lock file
+        # under the shared dir.
+        with dispatch_worktree_isolation._worktree_lock(linked_worktree):
+            assert (shared_lock_dir / ".vnx-lock").is_file()
+
+        # Exercise the tmux lane: must not raise, must reuse the SAME lock file.
+        with tmux_worktree._flock_context(linked_worktree):
+            assert (shared_lock_dir / ".vnx-lock").is_file()
+
+        # Confirm no second lock dir was created under the linked worktree's
+        # .git FILE (which would be impossible — .git is a file, not a dir).
+        assert not (linked_worktree / ".git" / "worktrees").exists()
+
+    def test_both_lanes_land_in_main_repo_git(self, linked_worktree: Path):
+        """Directly: both lanes' lock dir is the main checkout's
+        ``.git/worktrees`` — the one shared git-common-dir for the linked
+        worktree."""
+        from git_common import git_common_dir
+
+        main_repo_git = (linked_worktree.parent / "main" / ".git").resolve()
+        common = git_common_dir(linked_worktree)
+        assert common == main_repo_git
+
+        # tmux_worktree._flock_context computes the same dir.
+        tmux_dir = git_common_dir(linked_worktree) / "worktrees"
+        # dispatch_worktree_isolation._worktree_lock computes the same dir.
+        dispatch_dir = git_common_dir(linked_worktree) / "worktrees"
+        assert tmux_dir == dispatch_dir == main_repo_git / "worktrees"
+
+
+# ---------------------------------------------------------------------------
+# 3. Main checkout still works (behaviour unchanged there)
+# ---------------------------------------------------------------------------
+
+class TestMainCheckoutUnchanged:
+    def test_lock_works_in_main_checkout(self, main_repo: Path):
+        """``_worktree_lock`` must still work in a main checkout where ``.git``
+        is a directory — behaviour unchanged from before the fix."""
+        with dispatch_worktree_isolation._worktree_lock(main_repo):
+            pass
+
+        lock_file = (main_repo / ".git" / "worktrees" / ".vnx-lock").resolve()
+        assert lock_file.is_file()


### PR DESCRIPTION
## Wat er stuk was

`dispatch_worktree_isolation._worktree_lock` deed `(root / ".git").resolve() / "worktrees"` en daarna `mkdir`. In een gekoppelde worktree (`git worktree add`) is `.git` een **bestand** met een `gitdir:`-regel, geen map. Elke aanroep die via die lock liep gaf daar `NotADirectoryError`.

Gemeld door de mission-control-sessie, door T0 in de code geverifieerd en met een echte worktree gereproduceerd voor er iets aan gebeurde.

## Waarom een gedeelde helper en geen derde kopie

De juiste oplossing stond al twee keer in de boom: `tmux_worktree._git_common_dir` en `worktree_release._git_common_dir` gebruikten allebei `git rev-parse --git-common-dir`, met de naïeve vorm alleen als terugval. Alleen deze plek niet.

Er is nu één `scripts/lib/git_common.py` die alle vier de plekken gebruiken, inclusief `gate_worktree.py` dat dezelfde aanname droeg en in de oorspronkelijke melding niet voorkwam. Netto 25 regels minder (54 weg, 29 erbij).

## Een tweede defect in dezelfde regels

De docstring van `_worktree_lock` claimde hetzelfde lock-pad te gebruiken als `tmux_worktree._flock_context`, zodat de provider-lane en de tmux-lane nooit tegelijk `git worktree add/remove` draaien. In een gekoppelde worktree was die claim onwaar: de twee lanes zouden verschillende paden pakken, als de tweede niet eerst crashte. De serialisatiegarantie bestond daar dus niet. Die claim is nu waar.

## Bewijs, eerlijk uitgesplitst

| Test | Op main | Wat het bewijst |
|---|---|---|
| `test_lock_succeeds_and_lands_under_common_dir` | **rood met `NotADirectoryError`** | het defect zelf |
| `test_lock_path_not_under_linked_git_file` | rood met `ModuleNotFoundError` | alleen dat de helper nieuw is |
| `test_dispatch_and_tmux_resolve_same_lock_dir` | rood met `ModuleNotFoundError` | idem; toetst de gedeelde-lock-garantie op de nieuwe weg |
| `test_both_lanes_land_in_main_repo_git` | rood met `ModuleNotFoundError` | idem |
| `test_lock_works_in_main_checkout` | **groen** | terecht: de hoofdcheckout was nooit stuk |

Eén van de vier roods bewijst het defect. De andere drie importeren de nieuwe helper en zijn daarom per constructie rood op main; die staan hier voor de volledigheid en niet als bewijs.

Verder: **146 tests groen** over de acht buren-testbestanden (`test_gate_worktree`, `test_tmux_worktree`, `test_dispatch_worktree_lifecycle_guards`, `test_dispatch_worktree_identity_race`, `test_headless_worktree_isolation`, `test_provider_dispatch_worktree_isolation`, `test_subprocess_dispatch_worktree_isolation`, plus de nieuwe).

## Herkomst

Dit is een **salvage**. De dispatch-worker had het werk af maar kon niet committen: de glm-harness-lane viel om op een leeg OpenRouter-tegoed (HTTP 402, 31 pogingen, aflopend van 24.105 naar 5.697 betaalbare tokens). De worktree bleef staan met het werk erin. T0 heeft het geverifieerd, rood-tegen-main gemeten en daarna gecommit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjMwvojUiXrZjQVZq2ebet
