### PR TITLE
feat(gate): surface spawn-layer diagnosis in report body and glm gate failure_reason

### DIFF
--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -421,6 +421,27 @@ def _lift_lane_log_reason(dispatch_id: str, data_dir: "Path | None") -> "str | N
     return reason if state == "lane_exhausted" else None
 
 
+def _lift_report_failure_reason(report_text: str) -> "str | None":
+    """OI-1710: read the canonical ``failure_reason`` the lane's own governance
+    emit already stamped onto the report frontmatter (the spawn-layer error, for
+    a run that died before the model could reply).
+
+    The lane-log lift above only reads the raw lane log — a spawn-layer failure
+    (proxy unreachable, harness refused to start) writes no lane log at all, so
+    the report is the only place the real reason survives. Returns the bounded
+    reason only when the frontmatter carries a real, non-empty value; returns
+    None — never invents a reason — on a missing/empty field or unreadable
+    frontmatter."""
+    if not report_text:
+        return None
+    try:
+        frontmatter = parse_frontmatter(report_text)
+    except SchemaViolation:
+        return None
+    reason = frontmatter.get("failure_reason")
+    return (reason or "").strip() or None
+
+
 def _status_summary(status: str, blocking: list, reason: str = "") -> str:
     """Summary line for the result record — outage vs recovery vs verdict must be unmistakable."""
     if status == "unavailable":
@@ -651,7 +672,9 @@ def main(argv: "list[str] | None" = None) -> int:
     # OI-1452 fix-forward: tracked across both branches below so the record
     # build can stamp the canonical failure_reason field (see there) — only
     # ever set by the lane-log lift in the run_failed branch, never guessed.
-    lane_log_reason: "str | None" = None
+    # OI-1710: also lifted from the report frontmatter when the lane log does
+    # not exist at all (a spawn-layer failure writes no lane log).
+    lifted_reason: "str | None" = None
     if dispatch_error:
         verdict: dict = {}
         status, blocking = "unavailable", []
@@ -695,9 +718,16 @@ def main(argv: "list[str] | None" = None) -> int:
                     # generic exit_code/token_usage summary. The glm lane does
                     # not always write this log — a missing file degrades to the
                     # frontmatter-only detail above, never a crash or a guess.
-                    lane_log_reason = _lift_lane_log_reason(dispatch_id, base_data_dir)
-                    if lane_log_reason:
-                        provider_failed_detail += f" — lane log: {lane_log_reason}"
+                    lifted_reason = _lift_lane_log_reason(dispatch_id, base_data_dir)
+                    if lifted_reason is None:
+                        # OI-1710: a spawn-layer failure (proxy unreachable,
+                        # harness refused to start) writes no lane log at all —
+                        # the lane died before the tee started. The report's own
+                        # frontmatter carries the canonical failure_reason the
+                        # governance emit stamped from the spawn error.
+                        lifted_reason = _lift_report_failure_reason(report_text or "")
+                    if lifted_reason:
+                        provider_failed_detail += f" — failure reason: {lifted_reason}"
                     status, blocking, residual = _verdict_to_status(
                         {}, report_text or "", provider_failed_detail=provider_failed_detail
                     )
@@ -871,18 +901,20 @@ def main(argv: "list[str] | None" = None) -> int:
         # OI-1452 fix-forward (OI-1453 tracks the other four gates): also
         # stamp the canonical failure_reason field (established OI-1415,
         # scripts/lib/phantom_guard.py) with the SAME text placed above in
-        # residual_risk, but ONLY the lifted lane-log reason — never a
-        # placeholder or a summary of the frontmatter fields when the lift
-        # found nothing. Three ways to be wrong here, in ascending order of
-        # danger: an EMPTY field fails visibly (a reader can tell the cause
-        # is unknown); a PLACEHOLDER ("unknown", "n/a") passes every
-        # presence check and fails silently; a SUMMARY that merely looks
-        # like a cause is worst of all, because it cannot be told apart from
-        # a real one. Filling this field with anything but the real lifted
-        # reason would make every existing record look complete while
+        # residual_risk, but ONLY the lifted reason — never a placeholder or a
+        # summary of the frontmatter fields when the lift found nothing.
+        # OI-1710: the lifted reason now has a second real source — the report
+        # frontmatter's own failure_reason (the spawn-layer error, for a run
+        # that died before writing any lane log). Three ways to be wrong here,
+        # in ascending order of danger: an EMPTY field fails visibly (a reader
+        # can tell the cause is unknown); a PLACEHOLDER ("unknown", "n/a")
+        # passes every presence check and fails silently; a SUMMARY that
+        # merely looks like a cause is worst of all, because it cannot be told
+        # apart from a real one. Filling this field with anything but the real
+        # lifted reason would make every existing record look complete while
         # explaining nothing — a regression hidden BEHIND the fix meant to
         # surface it.
-        "failure_reason": lane_log_reason or "",
+        "failure_reason": lifted_reason or "",
         "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         # dispatch-20260823-beta2-j: audit marker distinguishing a record
         # produced by a live model call from one formalized by --reprocess

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -631,6 +631,7 @@ def emit_unified_report(
     overwrite: bool = False,
     preserve_partial: bool = False,
     model: Optional[str] = None,
+    spawn_error: Optional[str] = None,
 ) -> Path:
     """Atomic write to unified_reports/<dispatch_id>.md. Returns path.
 
@@ -677,6 +678,14 @@ def emit_unified_report(
     ``None``; a non-empty list renders each finding. No validation rule is
     added and no report is refused — the wrapper simply stops writing an
     unfilled field as the authoritative "there are none".
+
+    When *spawn_error* is provided and *response_text* is empty, the spawn
+    layer already knows why no response exists (proxy unreachable, harness
+    refused to start) — that error is the authoritative diagnosis and is
+    surfaced in the body under an ``empty_response_state`` of ``spawn_error``,
+    labeled as NOT a model reply, ahead of the lane-log lift (OI-1710). The
+    lane-log lift stays the fallback for empty responses whose cause only the
+    raw lane log can explain.
 
     When *frontmatter* is provided, prepends a YAML frontmatter block and
     validates against unified_report_v1 schema.  Default is shadow-mode (log
@@ -772,19 +781,34 @@ def emit_unified_report(
         # placeholder — see _lift_lane_log_for_report above.
         response_block = response_text
         if not (response_text or "").strip():
-            lift = _lift_lane_log_for_report(dispatch_id, data_dir)
-            if lift is not None:
-                empty_response_state, response_block, lane_reason = lift
+            # OI-1710: the spawn layer already knowing why there is no response
+            # (proxy unreachable, harness refused to start) is the authoritative
+            # diagnosis — surface it ahead of the lane-log lift, labeled so it
+            # can never be misread as a model reply.
+            spawn_error_text = (spawn_error or "").strip()
+            if spawn_error_text:
+                empty_response_state = "spawn_error"
+                lift_reason = spawn_error_text
+                response_block = (
+                    "_No response text was captured from the model. The spawn "
+                    "layer failed before the model could run — the text below "
+                    "is the spawn error, NOT a model reply._\n\n"
+                    f"```\n{spawn_error_text}\n```"
+                )
             else:
-                empty_response_state, response_block, lane_reason = "no_response", None, None
+                lift = _lift_lane_log_for_report(dispatch_id, data_dir)
+                if lift is not None:
+                    empty_response_state, response_block, lift_reason = lift
+                else:
+                    empty_response_state, response_block, lift_reason = "no_response", None, None
             if frontmatter is not None:
                 frontmatter.setdefault("empty_response_state", empty_response_state)
                 # Canonical field (OI-1415/#1666): stamp the SAME failure_reason
                 # key generic failure readers already look for — never a
                 # lane-log-only field name — and never clobber a reason the
                 # caller already computed upstream.
-                if lane_reason and not frontmatter.get("failure_reason"):
-                    frontmatter["failure_reason"] = lane_reason
+                if lift_reason and not frontmatter.get("failure_reason"):
+                    frontmatter["failure_reason"] = lift_reason
 
         body = (
             f"# Dispatch {dispatch_id}\n\n"

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1302,6 +1302,11 @@ def _emit_governance(
                 duration_seconds=duration,
                 data_dir=data_dir,
                 frontmatter=frontmatter,
+                # OI-1710: thread the spawn-layer diagnosis into the report so an
+                # empty response never falls back to "(no response captured)" when
+                # the spawn layer already knows why it produced nothing (proxy
+                # unreachable, harness refused to start). Shared across every lane.
+                spawn_error=getattr(result, "error", None),
                 # OI-903: on failure/timeout, preserve a killed worker's partial
                 # report under a .partial.md sidecar instead of leaving an invalid
                 # file blocking the canonical (structured) failure report.

--- a/tests/test_dlv1_glm_gate.py
+++ b/tests/test_dlv1_glm_gate.py
@@ -603,3 +603,68 @@ def test_pass_verdict_on_truncated_but_nonempty_diff_stays_pass(glm_gate, tmp_pa
     assert record["status"] == "pass"
     assert record["execution_depth"]["mode"] == "single_shot"
     assert record["execution_depth"]["diff_truncated"] is True
+
+
+# ---------------------------------------------------------------------------
+# 12. OI-1710: a spawn-layer failure (proxy unreachable) writes no lane log at
+#     all, so the gate's canonical failure_reason must fall back to the
+#     report's own frontmatter — the real diagnosis the governance emit already
+#     stamped there — instead of staying empty while the report body explains
+#     the cause.
+# ---------------------------------------------------------------------------
+
+_SPAWN_ERROR_REPORT = (
+    "---\n"
+    "schema_version: 1\n"
+    "dispatch_id: glm-gate-pr4242-1\n"
+    "provider: glm-harness\n"
+    "sub_provider: zai\n"
+    "model: glm-5.2\n"
+    "terminal_id: plan-gate\n"
+    "pool_id: headless\n"
+    "role: review-gate\n"
+    "task_class: research_structured\n"
+    "pr_id: '4242'\n"
+    "duration_seconds: 0.5\n"
+    "exit_code: 1\n"
+    "token_usage:\n"
+    "  input: 0\n"
+    "  output: 0\n"
+    "  cache_read: 0\n"
+    "cost_usd: 0.0\n"
+    "route_decision:\n"
+    "  strategy: default\n"
+    "  selected_provider: glm-harness\n"
+    "  selected_model: glm-5.2\n"
+    "empty_response_state: spawn_error\n"
+    "failure_reason: glm-harness proxy unreachable at http://localhost:4141 (start the litellm proxy first)\n"
+    "---\n"
+    "\n"
+    "# Dispatch glm-gate-pr4242-1\n"
+    "\n"
+    "**Dispatch-ID**: glm-gate-pr4242-1\n"
+    "**Provider**: glm-harness\n"
+    "\n"
+    "## Response\n"
+    "\n"
+    "_No response text was captured from the model. The spawn layer failed "
+    "before the model could run — the text below is the spawn error, NOT a "
+    "model reply._\n"
+    "\n"
+    "```\nglm-harness proxy unreachable at http://localhost:4141 (start the litellm proxy first)\n```\n"
+)
+
+
+def test_proxy_unreachable_report_surfaces_spawn_error_in_gate_failure_reason(
+    glm_gate, tmp_path, monkeypatch,
+):
+    rc, record, _data_dir = _run_glm_gate_for_real_pr(
+        glm_gate, tmp_path, monkeypatch, _SPAWN_ERROR_REPORT, pr="4242",
+    )
+
+    assert rc == 1
+    assert record["status"] == "unavailable"
+    assert "http://localhost:4141" in record["failure_reason"], (
+        "the gate's canonical failure_reason must carry the spawn-layer diagnosis "
+        f"from the report frontmatter when no lane log exists: {record['failure_reason']!r}"
+    )

--- a/tests/test_provider_dispatch_governance_integration.py
+++ b/tests/test_provider_dispatch_governance_integration.py
@@ -511,3 +511,50 @@ def test_resolve_data_dir_no_project_context_fails_closed(tmp_path, monkeypatch)
 
     with pytest.raises(RuntimeError, match="Cannot resolve project_id"):
         provider_dispatch._resolve_data_dir()
+
+
+# ---------------------------------------------------------------------------
+# OI-1710: the spawn-layer diagnosis (result.error) must reach the report body,
+# not only the receipt's failure_reason. The fix lives in _emit_governance, so
+# every provider lane inherits it — glm proves the bug, codex proves the fix is
+# shared (not a glm-only special case).
+# ---------------------------------------------------------------------------
+
+def _read_report(tmp_path, dispatch_id):
+    data_dir = tmp_path / "data"
+    return (data_dir / "unified_reports" / f"{dispatch_id}.md").read_text()
+
+
+def test_glm_harness_proxy_unreachable_error_reaches_report_body(tmp_path, monkeypatch):
+    """The glm-harness spawn layer fail-closes on an unreachable litellm proxy;
+    the report body must carry that diagnosis instead of "(no response captured)"."""
+    url = "http://127.0.0.1:1"
+    monkeypatch.setenv("VNX_GLM_PROXY_URL", url)
+    args = _make_args("glm-harness", dispatch_id="glm-proxy-unreachable-001")
+    with patch("event_store.EventStore", MagicMock()):
+        rc = provider_dispatch._dispatch_glm_harness(args)
+    assert rc == 1
+    report = _read_report(tmp_path, "glm-proxy-unreachable-001")
+    assert url in report, (
+        f"report body must carry the spawn-layer diagnosis ({url}), "
+        f"not fall back to '(no response captured)': {report!r}"
+    )
+    assert "(no response captured)" not in report
+
+
+def test_codex_spawn_error_reaches_report_body(tmp_path):
+    """A second lane (codex) must surface its spawn error in the report body the
+    same way — the fix lives in the shared _emit_governance, not in the glm lane."""
+    args = _make_args("codex", dispatch_id="codex-spawn-error-001")
+    result = _SpawnResult(
+        returncode=1,
+        completion_text="",
+        error="codex proxy unreachable at http://localhost:9999 (start the codex proxy first)",
+    )
+    with patch("provider_spawns.codex_spawn.spawn_codex", return_value=result), \
+         patch("event_store.EventStore", MagicMock()):
+        rc = provider_dispatch._dispatch_codex(args)
+    assert rc == 1
+    report = _read_report(tmp_path, "codex-spawn-error-001")
+    assert "http://localhost:9999" in report
+    assert "(no response captured)" not in report


### PR DESCRIPTION
## Problem

The spawn-layer diagnosis (`result.error`) reached the receipt's `failure_reason` via `classify_failure_safe`, but was dropped from the unified report. An empty completion fell back to "(no response captured)" even when the spawn layer knew exactly why it produced nothing (e.g. `glm-harness proxy unreachable at <url>`).

Two real gaps behind the OI-1710 report:

1. **Report body** (`emit_unified_report`) had no path for the spawn error, so the "(no response captured)" fallback swallowed it.
2. **glm_gate's record** `failure_reason` read only the lane log. A spawn-layer failure (proxy unreachable) writes no lane log, so the record stayed empty.

## Fix

- `scripts/lib/provider_dispatch.py` — `_emit_governance` threads `result.error` into `emit_unified_report` as `spawn_error`. This is the single shared emit hook, so all provider lanes inherit it (claude, codex, litellm, kimi, glm-harness, and the rest).
- `scripts/lib/governance_emit.py` — `emit_unified_report` gains a `spawn_error` param. When the completion is empty and `spawn_error` is set, the report body renders the diagnosis under `empty_response_state: spawn_error`, explicitly labeled as NOT a model reply.
- `scripts/glm_gate.py` — the gate's `failure_reason` now falls back to the report frontmatter (`failure_reason`) when no lane log exists, so a spawn-layer failure surfaces in the gate result.

## Tests

- `tests/test_provider_dispatch_governance_integration.py`
  - Red→green test: real `_dispatch_glm_harness` against an unreachable proxy asserts the URL lands in the report body and "(no response captured)" is absent.
  - Second lane proof: patched `spawn_codex` spawn error reaches the report body, proving the fix is shared, not glm-specific.
- `tests/test_dlv1_glm_gate.py`
  - Gate-level test: a spawn-error report surfaces `failure_reason` (with the proxy address) in the gate result record.

All touched-file + neighbor tests are green before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)