### PR TITLE
feat(gate-runner): harness-lane strategie delegeert glm/kimi naar de governed dispatcher

### DIFF
--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -68,6 +68,36 @@ GATE_CLI_ARGS: Dict[str, List[str]] = {
 # actual failure reason, e.g. a quota-reset time, behind a bare exit code).
 _REASON_DETAIL_TAIL_CHARS = 4000
 
+# Harness-lane gates (glm_gate/kimi_gate) delegate to the governed dispatcher
+# (C6 step 1). These constants mirror what scripts/glm_gate.py and
+# scripts/kimi_gate.py already hold, so a run through gate_runner's third
+# strategy has the same model, timeout, diff cap and verdict contract as the
+# same gate run standalone — verbatim effect, different entry point.
+_HARNESS_LANE_MODEL: Dict[str, tuple] = {
+    "glm_gate": ("VNX_GLM_GATE_MODEL", "glm-5.2"),
+    "kimi_gate": ("VNX_KIMI_GATE_MODEL", "kimi-k3"),
+}
+# glm_gate.py/kimi_gate.py drive the governed lane with DEFAULT_TIMEOUT=900.
+# headless_adapter.gate_timeout() has no entry for these gates and would fall
+# back to 600, cutting a run short that the standalone gate would have let
+# finish. The dispatcher's timeout_seconds is the lane's own deadline, so it
+# must match the standalone gate, not the runner's PATH-binary default.
+_HARNESS_LANE_TIMEOUT_SECONDS = 900
+_HARNESS_LANE_MAX_DIFF_CHARS = 50000
+# Verbatim-identical to glm_gate._VERDICT_CONTRACT and kimi_gate._VERDICT_CONTRACT.
+_HARNESS_LANE_VERDICT_CONTRACT = (
+    "When done, end your report with a structured JSON verdict ONLY, in a fenced block:\n"
+    "```json\n"
+    "{\n"
+    '  "verdict": "pass|fail|blocked",\n'
+    '  "findings": [{"severity": "error|warning|info", "message": "..."}],\n'
+    '  "residual_risk": "remaining risk or null"\n'
+    "}\n"
+    "```\n"
+    "verdict=fail/blocked ONLY for a real, blocking correctness/security/governance issue "
+    "introduced by THIS diff. Style nits are severity=info, never blocking.\n"
+)
+
 
 def _tail(text: str, limit: int) -> str:
     """Return the last `limit` characters of `text`, stripped."""
@@ -156,6 +186,11 @@ class GateRunner:
         """
         provider = _rec.resolve_gate_provider(gate)
         using_vertex = gate == "gemini_review" and os.environ.get("VNX_GEMINI_ROUTING", "oauth") == "vertex"
+        # Harness-lane gates (C6 step 1) delegate to the governed dispatcher
+        # instead of a PATH binary or a spawned script. Resolved here so the
+        # dispatch below routes to _run_harness_lane_path, never to a PATH
+        # lookup on the provider string.
+        harness_provider = ""
 
         if not using_vertex:
             # OI-1490: three outcomes, not one. Before this, an unregistered
@@ -173,8 +208,8 @@ class GateRunner:
                     reason="unsupported_gate_type",
                     reason_detail=(
                         f"{gate} is not in gate_recorder.GATE_PROVIDERS — register it as a "
-                        f"PATH binary or a script runner; this runner will not guess a "
-                        f"binary name from the gate name"
+                        f"PATH binary, a script runner, or a harness lane; this runner "
+                        f"will not guess a binary name from the gate name"
                     ),
                     request_payload=request_payload,
                     requests_dir=self._requests_dir,
@@ -182,7 +217,13 @@ class GateRunner:
                     state_dir=self._state_dir,
                 )
             kind, provider_name = provider
-            if kind == _rec.GATE_PROVIDER_SCRIPT_RUNNER:
+            if kind == _rec.GATE_PROVIDER_HARNESS_LANE:
+                # C6 step 1: glm_gate/kimi_gate route through the governed
+                # dispatcher, not a PATH binary. The provider string is the
+                # lane's own identifier ("glm-harness"/"kimi") — never a
+                # shutil.which target.
+                harness_provider = provider_name
+            elif kind == _rec.GATE_PROVIDER_SCRIPT_RUNNER:
                 pr_ref = pr_id or (str(pr_number) if pr_number is not None else "<pr>")
                 # Not-shipped and not-routable are different answers and the
                 # reader acts differently on each. deepseek_gate is registered
@@ -217,17 +258,18 @@ class GateRunner:
                     results_dir=self._results_dir,
                     state_dir=self._state_dir,
                 )
-            binary = provider_name
-            if shutil.which(binary) is None:
-                return _rec.record_not_executable(
-                    gate=gate, pr_number=pr_number, pr_id=pr_id,
-                    reason="provider_not_installed",
-                    reason_detail=f"{binary} binary not found in PATH",
-                    request_payload=request_payload,
-                    requests_dir=self._requests_dir,
-                    results_dir=self._results_dir,
-                    state_dir=self._state_dir,
-                )
+            else:
+                binary = provider_name
+                if shutil.which(binary) is None:
+                    return _rec.record_not_executable(
+                        gate=gate, pr_number=pr_number, pr_id=pr_id,
+                        reason="provider_not_installed",
+                        reason_detail=f"{binary} binary not found in PATH",
+                        request_payload=request_payload,
+                        requests_dir=self._requests_dir,
+                        results_dir=self._results_dir,
+                        state_dir=self._state_dir,
+                    )
         else:
             binary = GATE_BINARIES.get(gate, "")
 
@@ -241,6 +283,12 @@ class GateRunner:
             return self._run_vertex_path(
                 gate=gate, pr_number=pr_number, pr_id=pr_id,
                 prompt=prompt, request_payload=request_payload, pid=os.getpid(),
+            )
+
+        if harness_provider:
+            return self._run_harness_lane_path(
+                gate=gate, provider=harness_provider, prompt=prompt,
+                pr_number=pr_number, pr_id=pr_id, request_payload=request_payload,
             )
 
         return self._run_subprocess_path(
@@ -266,6 +314,8 @@ class GateRunner:
             prompt = self._build_gemini_prompt(request_payload)
         elif not prompt and gate == "codex_gate":
             prompt = self._build_codex_prompt(request_payload)
+        elif not prompt and gate in ("glm_gate", "kimi_gate"):
+            prompt = self._build_harness_lane_prompt(gate, request_payload)
         if (
             using_vertex
             and gate == "gemini_review"
@@ -382,6 +432,70 @@ class GateRunner:
         return _art.materialize_artifacts(
             gate=gate, pr_number=pr_number, pr_id=pr_id,
             stdout=raw_text, request_payload=request_payload,
+            duration_seconds=time.monotonic() - _start,
+            requests_dir=self._requests_dir, results_dir=self._results_dir,
+            reports_dir=self._reports_dir,
+        )
+
+    def _run_harness_lane_path(
+        self,
+        *,
+        gate: str,
+        provider: str,
+        prompt: str,
+        pr_number: Optional[int],
+        pr_id: str,
+        request_payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Execute a harness-lane gate (glm_gate/kimi_gate) through the governed dispatcher (C6 step 1).
+
+        This strategy starts NO process of its own. It calls the SAME dispatcher
+        ``glm_gate.py``/``kimi_gate.py`` call
+        (``plan_gate_panel._make_default_dispatcher``), which runs the provider
+        through its governed lane, writes the unified report, and returns its
+        text. That text is then materialized into the runner's receipt + report
+        exactly like codex/gemini stdout. A provider-outage/dispatch failure is
+        an execution failure (``unavailable``), never ``failed`` — the same
+        OI-1142 separation the standalone gates enforce.
+        """
+        # Lazy import: plan_gate_panel pulls in the whole governed dispatch
+        # graph, and only the harness-lane path needs it.
+        from plan_gate_panel import _make_default_dispatcher
+
+        # reports_dir is <data_dir>/unified_reports, so its parent is the data
+        # dir the dispatcher resolves and the lane writes its report into.
+        data_dir = self._reports_dir.parent
+        dispatch_id = request_payload.get("dispatch_id") or (
+            f"{gate}-pr{pr_number if pr_number is not None else pr_id}-{int(time.time())}"
+        )
+        model_env, default_model = _HARNESS_LANE_MODEL.get(gate, ("", ""))
+        model = os.environ.get(model_env, default_model) if model_env else default_model
+
+        _start = time.monotonic()
+        try:
+            dispatcher = _make_default_dispatcher(
+                str(data_dir), _HARNESS_LANE_TIMEOUT_SECONDS, role="review-gate",
+            )
+            report_text = dispatcher(provider, model, prompt, dispatch_id)
+        except Exception as exc:  # noqa: BLE001 — governed dispatch/report-read failure
+            return _rec.record_failure(
+                gate=gate, pr_number=pr_number, pr_id=pr_id,
+                result={
+                    "reason": "harness_lane_dispatch_error",
+                    "reason_detail": str(exc),
+                    "duration_seconds": time.monotonic() - _start,
+                    "partial_output_lines": 0,
+                    "runner_pid": os.getpid(),
+                },
+                request_payload=request_payload,
+                requests_dir=self._requests_dir,
+                results_dir=self._results_dir,
+            )
+
+        request_payload["dispatch_id"] = dispatch_id
+        return _art.materialize_artifacts(
+            gate=gate, pr_number=pr_number, pr_id=pr_id,
+            stdout=report_text, request_payload=request_payload,
             duration_seconds=time.monotonic() - _start,
             requests_dir=self._requests_dir, results_dir=self._results_dir,
             reports_dir=self._reports_dir,
@@ -504,6 +618,28 @@ class GateRunner:
         )
         formatted = format_for_provider(assembled, "gemini")
         return f"{formatted['system_instruction']}\n\n---\n\n{formatted['prompt']}"
+
+    @staticmethod
+    def _build_harness_lane_prompt(gate: str, request_payload: Dict[str, Any]) -> str:
+        """Build the diff-review prompt for a harness-lane gate (glm_gate/kimi_gate).
+
+        Mirrors ``glm_gate._build_prompt`` / ``kimi_gate._build_prompt``: the PR
+        diff is delimited untrusted data (OI-1442), the verdict contract is the
+        pass|fail|blocked shape both standalone gates share verbatim, and the
+        diff is capped at the same MAX_DIFF_CHARS those scripts apply. The
+        prompt is what the governed dispatcher hands to the lane, so a
+        harness-lane run must not silently diverge from the same gate run
+        directly through its own script.
+        """
+        pr_number = request_payload.get("pr_number")
+        diff_content = GateRunner._fetch_gh_pr_diff(pr_number)
+        return build_review_prompt(
+            gate_name=gate,
+            pr=str(pr_number),
+            diff_text=diff_content,
+            verdict_contract=_HARNESS_LANE_VERDICT_CONTRACT,
+            max_chars=_HARNESS_LANE_MAX_DIFF_CHARS,
+        )
 
     # Subprocess execution — stays here so tests can patch gate_runner.subprocess.Popen,
     # gate_runner.os.read, gate_runner.select.select, gate_runner.os.getpgid

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -28,7 +28,7 @@ _GATE_ENV_FLAGS: Dict[str, str] = {
     "wiring_gate": "VNX_WIRING_GATE_REQUIRED",
 }
 
-# How each gate's provider is actually reached. Two KINDS, kept apart because
+# How each gate's provider is actually reached. Three KINDS, kept apart because
 # their failure modes are different and collapsing them is OI-1490.
 #
 # PATH_BINARY   the gate drives a CLI that must be on PATH, with a prompt on
@@ -37,6 +37,13 @@ _GATE_ENV_FLAGS: Dict[str, str] = {
 #               its own contract, dispatches, parses the verdict and writes
 #               its own result record. There is no PATH binary to look for,
 #               and there never will be.
+# HARNESS_LANE  the gate routes through the governed dispatcher
+#               (plan_gate_panel._make_default_dispatcher ->
+#               provider_dispatch), the SAME lane glm_gate.py/kimi_gate.py
+#               already drive. The name is the provider string that lane
+#               dispatches on, not a file and not a PATH binary: gate_runner
+#               calls the dispatcher and feeds the returned report into the
+#               artifact pipeline (C6, gate-runner-provider-agnostisch step 1).
 #
 # Before OI-1490 there was no second kind: a gate absent from the mapping fell
 # back to its own NAME as a binary, so `shutil.which("kimi_gate")` failed and
@@ -51,6 +58,7 @@ _GATE_ENV_FLAGS: Dict[str, str] = {
 # cannot happen.
 GATE_PROVIDER_PATH_BINARY = "path_binary"
 GATE_PROVIDER_SCRIPT_RUNNER = "script_runner"
+GATE_PROVIDER_HARNESS_LANE = "harness_lane"
 
 GATE_PROVIDERS: Dict[str, Tuple[str, str]] = {
     "gemini_review": (GATE_PROVIDER_PATH_BINARY, "gemini"),
@@ -58,8 +66,8 @@ GATE_PROVIDERS: Dict[str, Tuple[str, str]] = {
     "claude_github_optional": (GATE_PROVIDER_PATH_BINARY, "gh"),
     "ci_gate": (GATE_PROVIDER_PATH_BINARY, "gh"),
     "wiring_gate": (GATE_PROVIDER_PATH_BINARY, "gh"),
-    "kimi_gate": (GATE_PROVIDER_SCRIPT_RUNNER, "scripts/kimi_gate.py"),
-    "glm_gate": (GATE_PROVIDER_SCRIPT_RUNNER, "scripts/glm_gate.py"),
+    "kimi_gate": (GATE_PROVIDER_HARNESS_LANE, "kimi"),
+    "glm_gate": (GATE_PROVIDER_HARNESS_LANE, "glm-harness"),
     "deepseek_gate": (GATE_PROVIDER_SCRIPT_RUNNER, "scripts/deepseek_gate.py"),
 }
 
@@ -106,6 +114,11 @@ EXECUTION_FAILURE_REASONS: frozenset = frozenset({
     # would read as a rejected PR) and never `completed` (which would read as
     # a clean review).
     "gate_execution_degenerate",
+    # The harness-lane dispatcher (C6 step 1) raised before producing a report
+    # (provider_dispatch timeout, missing report, lane outage). An execution
+    # failure like any other: the PR was never reviewed, so it books
+    # `unavailable`, never `failed`.
+    "harness_lane_dispatch_error",
 })
 
 
@@ -166,9 +179,12 @@ def write_skip_rationale(
     (OI-1490). A script-runner gate gets an existence check on its runner
     file and never a PATH lookup: ``shutil.which("kimi_gate")`` answers a
     question nobody asked and its ``False`` was read for two days as "the
-    provider is missing" while scripts/kimi_gate.py sat on disk. An
-    unregistered gate says so in ``provider_kind`` rather than inventing a
-    binary name from the gate's own name.
+    provider is missing" while scripts/kimi_gate.py sat on disk. A
+    harness-lane gate has nothing to find either — its route is wired by
+    construction, so ``binary_found`` is True and ``binary_name`` carries the
+    provider string the dispatcher routes on. An unregistered gate says so in
+    ``provider_kind`` rather than inventing a binary name from the gate's own
+    name.
     """
     provider = resolve_gate_provider(gate)
     if provider is None:
@@ -176,6 +192,9 @@ def write_skip_rationale(
     elif provider[0] == GATE_PROVIDER_SCRIPT_RUNNER:
         kind, name = provider
         found = (_repo_root() / name).exists()
+    elif provider[0] == GATE_PROVIDER_HARNESS_LANE:
+        kind, name = provider
+        found = True
     else:
         kind, name = provider
         found = shutil.which(name) is not None

--- a/scripts/lib/gate_result_parser.py
+++ b/scripts/lib/gate_result_parser.py
@@ -243,7 +243,7 @@ class GateResultParserMixin:
         ``gate_runner``'s, on the other of the two paths; fixing one and
         leaving the other is a promise the code does not keep.
 
-        Three answers, matching gate_runner's:
+        Four answers, matching gate_runner's:
 
         * unregistered gate -> ``unsupported_gate_type``; a routing bug, not an
           environment complaint.
@@ -251,11 +251,18 @@ class GateResultParserMixin:
           the caller's own availability check (``_kimi_gate_available`` and
           friends, which test for the runner FILE) already said no, so the
           runner is absent — never a PATH question.
+        * harness-lane gate -> ``gate_runner_missing`` for the same reason: the
+          request-time availability check still tests the runner FILE (the
+          availability-fix that makes it lane-aware is a later step), so the
+          honest answer is "the runner is absent", never a PATH lookup on the
+          provider string.
         * PATH-binary gate -> the env-flag / which-lookup logic below,
           unchanged, on the registry's name.
         """
         from gate_recorder import (  # noqa: PLC0415
-            GATE_PROVIDER_SCRIPT_RUNNER, resolve_gate_provider,
+            GATE_PROVIDER_HARNESS_LANE,
+            GATE_PROVIDER_SCRIPT_RUNNER,
+            resolve_gate_provider,
         )
 
         provider = resolve_gate_provider(gate)
@@ -263,7 +270,8 @@ class GateResultParserMixin:
             return (
                 "unsupported_gate_type",
                 f"{gate} is not in gate_recorder.GATE_PROVIDERS — register it as a PATH "
-                f"binary or a script runner; no binary name is guessed from the gate name",
+                f"binary, a script runner, or a harness lane; no binary name is guessed "
+                f"from the gate name",
             )
         provider_kind, binary_name = provider
         if provider_kind == GATE_PROVIDER_SCRIPT_RUNNER:
@@ -271,6 +279,13 @@ class GateResultParserMixin:
                 "gate_runner_missing",
                 f"{binary_name} does not exist — {gate} is a script runner and its "
                 f"runner is not on disk; this is not a PATH lookup",
+            )
+        if provider_kind == GATE_PROVIDER_HARNESS_LANE:
+            return (
+                "gate_runner_missing",
+                f"{gate} is a harness-lane gate (provider {binary_name}); its "
+                f"request-time availability check said no and its runner file is "
+                f"not on disk — this is not a PATH lookup",
             )
 
         # NOTE: this per-gate (env_var, default) map is NOT the same data as

--- a/tests/test_audit_correctness_fixes.py
+++ b/tests/test_audit_correctness_fixes.py
@@ -328,8 +328,8 @@ class TestC7InWindowKeyNotEvicted:
 # Note on the PR-1762 anecdote in the dispatch prompt (glm_gate UNAVAILABLE
 # then kimi_gate PASS): that specific pair does NOT collide under the
 # CURRENT key, because "gate" already differs (glm_gate vs kimi_gate) and
-# because glm_gate.py/kimi_gate.py are GATE_PROVIDER_SCRIPT_RUNNER gates
-# that record their own verdict via gate_recorder.record_terminal_result —
+# because glm_gate.py/kimi_gate.py record their own verdict via
+# gate_recorder.record_terminal_result —
 # a direct JSON-file write with its own overwrite guard, never through
 # append_receipt_payload/idempotency.py at all. The real, reachable
 # collision is the SAME gate re-verdicted on the SAME PR (the

--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -1179,3 +1179,130 @@ class TestGateWorktreeCheckout:
             project_root=custom_root,
         )
         mock_remove.assert_called_once_with(fake_worktree, project_root=custom_root)
+
+
+class TestHarnessLaneDelegation:
+    """C6 step 1: glm_gate/kimi_gate run through the governed dispatcher.
+
+    The third strategy starts NO process of its own — it calls the SAME
+    dispatcher the standalone glm_gate.py/kimi_gate.py scripts call
+    (``plan_gate_panel._make_default_dispatcher``) and materializes the
+    returned report into the runner's receipt + unified report, exactly like
+    codex/gemini stdout. The ``Popen`` patch below is the RED guard: an
+    implementation that directly started a subprocess (the old path_binary
+    behaviour) would blow up here, while the delegating strategy never touches
+    ``Popen``.
+    """
+
+    @staticmethod
+    def _fake_dispatcher(report_text):
+        calls = []
+
+        def factory(data_dir, timeout_seconds, *, role="plan-reviewer"):
+            def dispatch(provider, model, instruction, dispatch_id):
+                calls.append({
+                    "data_dir": data_dir,
+                    "timeout_seconds": timeout_seconds,
+                    "role": role,
+                    "provider": provider,
+                    "model": model,
+                    "instruction": instruction,
+                    "dispatch_id": dispatch_id,
+                })
+                return report_text
+            return dispatch
+
+        return factory, calls
+
+    def test_harness_lane_produces_a_receipt_and_unified_report(
+        self, gate_env, monkeypatch,
+    ):
+        report_text = "Reviewed the diff.\nRan the tests.\nNo blocking findings.\n"
+        factory, calls = self._fake_dispatcher(report_text)
+
+        monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", factory)
+        monkeypatch.delenv("VNX_KIMI_GATE_MODEL", raising=False)
+        monkeypatch.setattr(
+            gate_runner.subprocess, "Popen",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                AssertionError("harness-lane must delegate, not start a process")
+            ),
+        )
+
+        report_path = str(gate_env["reports_dir"] / "kimi-gate-pr1.md")
+        dispatch_id = "kimi-gate-pr1-1788815204"
+        payload = _make_request_payload(
+            gate="kimi_gate",
+            prompt="Review this diff for correctness and security",
+            report_path=report_path,
+            dispatch_id=dispatch_id,
+        )
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"],
+            reports_dir=gate_env["reports_dir"],
+        )
+        result = runner.run(gate="kimi_gate", request_payload=payload, pr_number=1)
+
+        # Receipt: a completed result record on disk with contract evidence.
+        assert result["status"] == "completed", result.get("reason_detail")
+        assert result["contract_hash"] != ""
+        assert result["dispatch_id"] == dispatch_id
+
+        result_file = gate_env["results_dir"] / "pr-1-kimi_gate.json"
+        assert result_file.exists()
+        saved = json.loads(result_file.read_text(encoding="utf-8"))
+        assert saved["status"] == "completed"
+        assert saved["dispatch_id"] == dispatch_id
+
+        # Unified report: the dispatcher's text materialized to report_path.
+        report = Path(report_path)
+        assert report.exists()
+        assert "No blocking findings." in report.read_text(encoding="utf-8")
+
+        # Delegation, once, through the governed seam with the lane's args.
+        assert len(calls) == 1
+        assert calls[0]["provider"] == "kimi"
+        assert calls[0]["role"] == "review-gate"
+        assert calls[0]["model"] == "kimi-k3"
+        assert calls[0]["dispatch_id"] == dispatch_id
+        assert calls[0]["instruction"] == "Review this diff for correctness and security"
+
+    def test_harness_lane_builds_the_diff_prompt_when_none_is_supplied(
+        self, gate_env, monkeypatch,
+    ):
+        """The production shape: review_gate_manager builds no prompt for these
+        gates, so the runner must assemble it from the PR diff exactly like the
+        standalone scripts do — diff wrapped as delimited untrusted data and the
+        verbatim pass|fail|blocked verdict contract attached."""
+        report_text = "Reviewed the diff.\nRan the tests.\nNo blocking findings.\n"
+        factory, calls = self._fake_dispatcher(report_text)
+
+        monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", factory)
+        monkeypatch.delenv("VNX_KIMI_GATE_MODEL", raising=False)
+        monkeypatch.setattr(
+            GateRunner, "_fetch_gh_pr_diff",
+            staticmethod(lambda pr: "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new"),
+        )
+
+        report_path = str(gate_env["reports_dir"] / "kimi-gate-pr2.md")
+        dispatch_id = "kimi-gate-pr2-1788815205"
+        payload = _make_request_payload(
+            gate="kimi_gate", report_path=report_path, dispatch_id=dispatch_id,
+        )
+        payload.pop("prompt")  # production request payloads carry no prompt key
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"],
+            reports_dir=gate_env["reports_dir"],
+        )
+        result = runner.run(gate="kimi_gate", request_payload=payload, pr_number=2)
+
+        assert result["status"] == "completed", result.get("reason_detail")
+        assert result["contract_hash"] != ""
+
+        assert len(calls) == 1
+        instruction = calls[0]["instruction"]
+        assert "BEGIN PR DIFF: UNTRUSTED DATA" in instruction
+        assert "-old" in instruction and "+new" in instruction
+        assert '"verdict": "pass|fail|blocked"' in instruction

--- a/tests/test_oi1490_gate_provider_registry.py
+++ b/tests/test_oi1490_gate_provider_registry.py
@@ -77,49 +77,104 @@ def _run(gate_dirs, gate: str, pr_number: int = 1) -> dict:
     return runner.run(gate=gate, request_payload=_payload(gate, pr_number), pr_number=pr_number)
 
 
+def _run_harness(gate_dirs, monkeypatch, gate: str, report_text: str, pr_number: int = 1):
+    """Drive a harness-lane gate through the REAL GateRunner.run with the
+    governed dispatcher faked at the plan_gate_panel seam (C6 step 1).
+
+    The fake records exactly what the runner handed to the dispatcher and
+    returns ``report_text``, which materialize_artifacts then treats like
+    subprocess stdout — the same seam the standalone glm_gate.py/kimi_gate.py
+    reach. Returns ``(result, dispatcher_calls, report_path)``.
+    """
+    calls = []
+
+    def fake_factory(data_dir, timeout_seconds, *, role="plan-reviewer"):
+        def _dispatch(provider, model, instruction, dispatch_id):
+            calls.append({
+                "data_dir": data_dir,
+                "timeout_seconds": timeout_seconds,
+                "role": role,
+                "provider": provider,
+                "model": model,
+                "instruction": instruction,
+                "dispatch_id": dispatch_id,
+            })
+            return report_text
+        return _dispatch
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_factory)
+    report_path = str(gate_dirs["reports"] / f"{gate}-pr{pr_number}.md")
+    payload = _payload(gate, pr_number)
+    payload["report_path"] = report_path
+    runner = GateRunner(state_dir=gate_dirs["state"], reports_dir=gate_dirs["reports"])
+    result = runner.run(gate=gate, request_payload=payload, pr_number=pr_number)
+    return result, calls, report_path
+
+
 # ---------------------------------------------------------------------------
 # 1. The measured defect, per gate
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("gate,runner_file", [
-    ("kimi_gate", "scripts/kimi_gate.py"),
-    ("glm_gate", "scripts/glm_gate.py"),
+@pytest.mark.parametrize("gate,provider", [
+    ("kimi_gate", "kimi"),
+    ("glm_gate", "glm-harness"),
 ])
-def test_a_script_runner_gate_is_not_a_missing_binary(gate_dirs, gate, runner_file):
-    """RED on main: every one of these booked provider_not_installed."""
-    result = _run(gate_dirs, gate)
+def test_a_harness_lane_gate_delegates_to_the_governed_dispatcher(
+    gate_dirs, monkeypatch, gate, provider,
+):
+    """Migrated from the script-runner refusal test for C6 step 1.
 
-    assert result["reason"] != "provider_not_installed", (
-        f"{gate} has no PATH binary and never had one; reporting a missing "
-        f"binary sends the reader after an install that cannot help"
+    The old assertion (reason == gate_not_subprocess_routable, detail naming
+    the runner FILE) described the refusal this runner used to book because it
+    could not drive glm_gate/kimi_gate. Those gates now DELEGATE to the same
+    governed dispatcher their standalone scripts call, so the correct
+    behaviour is a call through that seam — a completed result with a receipt
+    and report — never a refusal and never a PATH lookup on the provider
+    string.
+    """
+    result, calls, report_path = _run_harness(
+        gate_dirs, monkeypatch, gate,
+        report_text="Review complete.\nNo blocking findings.\nApproved.\n",
     )
-    assert result["reason"] == "gate_not_subprocess_routable"
-    assert runner_file in result["reason_detail"], (
-        "the detail must name the runner that DOES exist, so the reader can act"
-    )
-    assert "--pr 1" in result["reason_detail"], (
-        "and the invocation that actually works, with the PR filled in"
+
+    assert result["status"] == "completed", result.get("reason_detail")
+    assert result["contract_hash"] != "", "a completed run must carry receipt evidence"
+    assert Path(report_path).exists(), "the harness-lane run must materialize a report"
+
+    assert len(calls) == 1, "the runner must delegate exactly once"
+    assert calls[0]["provider"] == provider
+    assert calls[0]["role"] == "review-gate"
+    assert calls[0]["model"] in ("glm-5.2", "kimi-k3")
+    assert calls[0]["timeout_seconds"] == 900, (
+        "the dispatcher's timeout must match the standalone gate's own "
+        "DEFAULT_TIMEOUT, not the runner's PATH-binary default"
     )
 
 
-def test_the_invented_binary_name_is_gone_from_the_audit_trail(gate_dirs):
-    """The exact shape measured in gate_execution_audit.ndjson."""
-    _run(gate_dirs, "kimi_gate")
+def test_a_harness_lane_run_never_consults_path(gate_dirs, monkeypatch):
+    """Migrated from the invented-binary audit-trail test for C6 step 1.
 
-    audit = (gate_dirs["state"] / "gate_execution_audit.ndjson").read_text()
-    record = json.loads(audit.strip().splitlines()[-1])
-    check = record["provider_check"]
+    The old assertion pinned what the refusal writer logged when this runner
+    could not drive kimi_gate. Now kimi_gate/glm_gate are harness-lane: their
+    provider string ("kimi"/"glm-harness") is a lane identifier the governed
+    dispatcher routes on, not a PATH binary. A PATH lookup on it is exactly
+    the OI-1490 mistake again (shutil.which("kimi_gate")), so the runner must
+    never call shutil.which for these gates.
+    """
+    monkeypatch.setattr(
+        gate_runner.shutil, "which",
+        lambda b: (_ for _ in ()).throw(
+            AssertionError(f"harness-lane gate must not PATH-lookup {b!r}")
+        ),
+    )
 
-    assert check["binary_name"] != "kimi_gate", (
-        "this is the invented name: shutil.which('kimi_gate') answers a "
-        "question nobody asked, and its False was read as a missing provider"
+    result, _calls, _report_path = _run_harness(
+        gate_dirs, monkeypatch, "kimi_gate",
+        report_text="Review complete.\nNo blocking findings.\nApproved.\n",
     )
-    assert check["provider_kind"] == "script_runner"
-    assert check["binary_name"] == "scripts/kimi_gate.py"
-    assert check["binary_found"] is True, (
-        "the runner is on disk — that is the whole point: nothing was missing"
-    )
+
+    assert result["status"] == "completed", result.get("reason_detail")
 
 
 def test_an_unregistered_gate_says_so_instead_of_inventing_a_binary(gate_dirs):
@@ -168,7 +223,14 @@ def test_a_present_path_binary_gate_is_not_refused_here(gate_dirs, monkeypatch):
 
 def test_the_new_reasons_are_permanent_not_a_bounded_wait():
     """A routing bug must not sit in the retry-until-the-environment-changes
-    bucket. `provider_not_installed` belongs there and stays there."""
+    bucket. `provider_not_installed` belongs there and stays there.
+
+    C6 step 1 note: glm_gate/kimi_gate no longer produce
+    `gate_not_subprocess_routable` at all (they delegate to the governed
+    dispatcher), but the reason survives for the script-runner gate
+    (deepseek_gate) and must stay out of the temporary set either way — no
+    amount of waiting turns a script runner into a PATH binary.
+    """
     import gate_obligation_runner as gor
 
     temporary = gor._TEMPORARY_NOT_EXECUTABLE_REASONS
@@ -194,8 +256,9 @@ def test_every_path_binary_gate_can_actually_be_driven_by_this_runner():
     """A gate registered as a PATH binary is one this runner builds an argv
     for. Registering kimi_gate as `kimi` would satisfy the PATH check and then
     run a bare `kimi` with a review prompt — passing the gate and producing no
-    contract_hash, no report_path, no verdict. Worse than the loud refusal it
-    replaced, which is why kimi_gate is a script runner here and not a binary.
+    contract_hash, no report_path, no verdict. That is why kimi_gate/glm_gate
+    are NOT path binaries: historically script runners, and since C6 step 1
+    harness-lane gates that delegate to the governed dispatcher.
     """
     for gate in _rec._GATE_BINARIES:
         kind, _name = _rec.GATE_PROVIDERS[gate]
@@ -224,13 +287,28 @@ def test_a_registered_but_unshipped_runner_says_missing_not_unroutable(gate_dirs
     assert result["reason"] != "provider_not_installed"
 
 
-def test_shipped_script_runners_are_on_disk():
-    """The two gates that DO have runners must keep having them — a rename
-    that leaves the registry pointing at nothing would otherwise turn every
-    one of their runs into a silent `gate_runner_missing`."""
+def test_harness_lane_gates_name_the_same_lane_their_standalone_scripts_use():
+    """Adapted for C6 step 1. This used to assert glm_gate/kimi_gate's registry
+    name pointed at a runner FILE on disk — a rename leaving nothing on disk
+    would have turned every run into a silent gate_runner_missing. Those gates
+    are now harness-lane: their name is the provider string the governed
+    dispatcher routes on, matching the literal each standalone script
+    dispatches (glm_gate.py -> "glm-harness", kimi_gate.py -> "kimi"). Asking
+    (VNX_ROOT / name).exists() here would be the OI-1490 invented-name mistake
+    read as a file instead of a binary. The routing-correctness guard for a
+    lane is this cross-module consistency pin, not a file existence check.
+    """
+    lane_identifiers = {"kimi_gate": "kimi", "glm_gate": "glm-harness"}
     for gate in ("kimi_gate", "glm_gate"):
-        _kind, name = _rec.GATE_PROVIDERS[gate]
-        assert (VNX_ROOT / name).exists(), f"{gate} names a runner that is not on disk: {name}"
+        kind, name = _rec.GATE_PROVIDERS[gate]
+        assert kind == _rec.GATE_PROVIDER_HARNESS_LANE
+        assert name == lane_identifiers[gate], (
+            f"{gate} must name the lane its standalone script dispatches on, "
+            f"not {name!r}"
+        )
+        assert "/" not in name and not name.endswith(".py"), (
+            f"{gate} names a provider lane ({name!r}), not a runner path"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -309,11 +387,14 @@ def test_the_delegating_writer_produces_the_registry_shape(tmp_path, monkeypatch
     )
     check = record["provider_check"]
 
-    assert check["provider_kind"] == "script_runner", (
-        "the delegating writer must produce the SAME shape as the direct one, "
-        "or one file carries two shapes of one event_type"
+    assert check["provider_kind"] == "harness_lane", (
+        "C6 step 1: glm_gate is now a harness-lane gate, and the delegating "
+        "writer must produce the SAME shape as the direct one, or one file "
+        "carries two shapes of one event_type"
     )
-    assert check["binary_name"] == "scripts/glm_gate.py"
+    assert check["binary_name"] == "glm-harness", (
+        "the lane identifier the dispatcher routes on, not a runner file path"
+    )
     assert check["binary_found"] is True
 
 
@@ -353,12 +434,18 @@ def _classify(gate: str):
 def test_request_time_kimi_is_not_a_missing_binary():
     """The caller passed binary_name="kimi_gate.py" — not a binary, never was,
     so the lookup could only fail and the gate could only be booked
-    provider_not_installed."""
+    provider_not_installed.
+
+    C6 step 1 note: kimi_gate is now harness-lane, so the detail names the
+    lane ("harness-lane") instead of the runner file. The invariant that
+    matters is unchanged: this is still never a PATH lookup on an invented
+    binary name.
+    """
     reason, detail = _classify("kimi_gate")
 
     assert reason != "provider_not_installed"
     assert reason == "gate_runner_missing"
-    assert "scripts/kimi_gate.py" in detail
+    assert "harness-lane" in detail
     assert "not a PATH lookup" in detail
 
 


### PR DESCRIPTION
## Summary

C6 stap 1 (track `gate-runner-provider-agnostisch`): `scripts/gate_runner.py` krijgt een derde executie-strategie, **`harness_lane`**, naast `path_binary` en `vertex`. `glm_gate` en `kimi_gate` routeren niet langer als script-runner (een weigering), maar delegeren naar de governed dispatcher (`plan_gate_panel._make_default_dispatcher`) — exact dezelfde dispatcher die `glm_gate.py`/`kimi_gate.py` al aanroepen. De nieuwe strategie start géén eigen proces; de teruggekeerde report gaat door `materialize_artifacts` als codex/gemini stdout, dus de run levert een receipt én een unified report op.

## Changes

- `scripts/gate_runner.py`: `_run_harness_lane_path` (delegatie, model/timeout/diff-cap/verdict-contract gelijk aan de standalone gates), routing in `run()`, en `_build_harness_lane_prompt` voor de productie-route zonder meegegeven prompt.
- `scripts/lib/gate_recorder.py`: derde provider-kind `harness_lane`; `kimi_gate` → `("harness_lane", "kimi")`, `glm_gate` → `("harness_lane", "glm-harness")`; `harness_lane_dispatch_error` in `EXECUTION_FAILURE_REASONS` zodat een dispatch-fout `unavailable` boekt, nooit `failed` (OI-1142).
- `scripts/lib/gate_result_parser.py`: request-time `_classify_unavailable` kent de `harness_lane`-branch (nooit een PATH-lookup op de provider-string).
- `tests/test_oi1490_gate_provider_registry.py`: de drie tests die `gate_not_subprocess_routable` vastpinden zijn gemigreerd/geadapteerd, elk met per-test motivatie in de docstring.
- `tests/test_gate_runner.py`: nieuwe delegatie-test die receipt + unified report bewijst en rood is op een implementatie die direct een proces start (`gate_runner.subprocess.Popen` gepatched om te raisen), plus een test voor de prompt-opbouw-route zonder meegegeven prompt.

**Keuze: flip nu, niet in de removal-stap.** Scope zegt "met glm en kimi erop"; de refusal-tests migreren heeft alleen zin ná de flip; de delegatie-test is het schoonst tegen een echt aangesloten gate; en de removal-stap houdt dan alleen bestandsverwijdering over.

**Buiten scope (latere stappen):** `scripts/glm_gate.py`/`scripts/kimi_gate.py` blijven bestaan; de provider-keys `glm_gate`/`kimi_gate` blijven bestaan (mission-control hangt aan de key, niet aan het pad); deepseek volgt later.

## Verification

- `python3 -m pytest tests/test_gate_runner.py` — 35 passed.
- `python3 -m pytest tests/test_oi1490_gate_provider_registry.py tests/test_gate_unavailable_rollup.py tests/test_oi1669_routing_announcement_is_not_a_verdict.py tests/test_bxd7_takeover_record_without_verdict.py tests/test_audit_correctness_fixes.py` — 165 passed (gecombineerd).

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
