### PR TITLE
feat(gate): meet beschikbaarheid via registratie en kind, niet bestandsbestaan

### DIFF
--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -240,18 +240,18 @@ class GateRunner:
             elif kind == _rec.GATE_PROVIDER_SCRIPT_RUNNER:
                 pr_ref = pr_id or (str(pr_number) if pr_number is not None else "<pr>")
                 # Not-shipped and not-routable are different answers and the
-                # reader acts differently on each. deepseek_gate is registered
-                # but scripts/deepseek_gate.py does not exist yet, which
-                # gate_request_handler already books as `gate_runner_missing`
-                # — reuse that code here rather than mint a second name for
-                # the same fact.
-                if not (_rec._repo_root() / provider_name).exists():
+                # reader acts differently on each. Availability is kind-based
+                # (gate_recorder.gate_is_available): a script-runner gate is
+                # available only while its runner file is on disk. Reuse
+                # `gate_runner_missing` here rather than mint a second name
+                # for the fact gate_request_handler already books.
+                if not _rec.gate_is_available(gate):
                     return _rec.record_not_executable(
                         gate=gate, pr_number=pr_number, pr_id=pr_id,
                         reason="gate_runner_missing",
                         reason_detail=(
-                            f"{provider_name} does not exist yet — {gate} is registered "
-                            f"as a script runner but its runner has not shipped"
+                            f"{provider_name} is not on disk — {gate} is registered "
+                            f"as a script runner and its runner is unavailable"
                         ),
                         request_payload=request_payload,
                         requests_dir=self._requests_dir,

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -40,10 +40,15 @@ _GATE_ENV_FLAGS: Dict[str, str] = {
 # HARNESS_LANE  the gate routes through the governed dispatcher
 #               (plan_gate_panel._make_default_dispatcher ->
 #               provider_dispatch), the SAME lane glm_gate.py/kimi_gate.py
-#               already drive. The name is the provider string that lane
-#               dispatches on, not a file and not a PATH binary: gate_runner
-#               calls the dispatcher and feeds the returned report into the
-#               artifact pipeline (C6, gate-runner-provider-agnostisch step 1).
+#               already drive: a config-based lane, not a file. The name is
+#               the provider string that lane dispatches on, not a file and
+#               not a PATH binary: gate_runner calls the dispatcher and feeds
+#               the returned report into the artifact pipeline (C6,
+#               gate-runner-provider-agnostisch step 1). Its availability is
+#               decided by REGISTRATION alone — there is no file on disk for
+#               it, and none is expected (dispatch 20260911-c6 step 2:
+#               availability measures configuration, not file existence; the
+#               existence check made deepseek_gate a dead link, OI-1714).
 #
 # Before OI-1490 there was no second kind: a gate absent from the mapping fell
 # back to its own NAME as a binary, so `shutil.which("kimi_gate")` failed and
@@ -68,7 +73,12 @@ GATE_PROVIDERS: Dict[str, Tuple[str, str]] = {
     "wiring_gate": (GATE_PROVIDER_PATH_BINARY, "gh"),
     "kimi_gate": (GATE_PROVIDER_HARNESS_LANE, "kimi"),
     "glm_gate": (GATE_PROVIDER_HARNESS_LANE, "glm-harness"),
-    "deepseek_gate": (GATE_PROVIDER_SCRIPT_RUNNER, "scripts/deepseek_gate.py"),
+    # OI-1714: deepseek_gate was registered as a script runner pointing at
+    # scripts/deepseek_gate.py, which has never existed. Every deepseek request
+    # therefore booked `gate_runner_missing` — a dead link for the ONE provider
+    # that was actually working. It is a config-based harness lane
+    # ("deepseek-harness"), not a repo script, so it needs no file at all.
+    "deepseek_gate": (GATE_PROVIDER_HARNESS_LANE, "deepseek-harness"),
 }
 
 # Backward-compatible view: only the gates that really do resolve to a PATH
@@ -148,6 +158,64 @@ def gate_dispatch_identity_error(gate: str, dispatch_id: Optional[str]) -> Optio
         "report as this gate's verdict (OI-1725)"
     )
 
+
+class UnknownGateProvider(ValueError):
+    """A gate key was asked for availability and is not registered (or its
+    provider kind is unknown).
+
+    Raised where a silent skip would do the most damage: an operator
+    configures a review stack with a gate name
+    (``VNX_OVERRIDE_DEFAULT_REVIEW_STACK=glm_gate,claude_github_optional``)
+    and a typo books the seat as ``not_executable`` while every other gate
+    runs — the request fails without ever naming the key that was wrong.
+    The name is carried in the message, so the error is loud and actionable.
+    """
+
+
+def gate_is_available(gate: str, *, repo_root: Optional[Path] = None) -> bool:
+    """Availability by REGISTRATION plus lane executability, never path existence.
+
+    dispatch 20260911-c6 step 2. The previous rule — ``<runner_path>.exists()``
+    — made availability a statement about a file, which is wrong in two
+    directions:
+
+    - a config-based gate (``harness_lane``) is available with NO file at all;
+      measuring one made deepseek_gate a dead link (OI-1714), and would make
+      kimi_gate/glm_gate silently vanish the day their runner files are
+      retired in favour of the lane (step 4);
+    - an unknown key must FAIL LOUD, never silently book ``unavailable`` —
+      see :class:`UnknownGateProvider`.
+
+    The three kinds:
+
+    - ``path_binary``   the gate drives a CLI: available when the binary is on
+      PATH (``shutil.which``). Note this answers "route present", NOT "enabled
+      by its env flag" — the env-flag question is a separate concern owned by
+      the gate's own availability helper.
+    - ``script_runner`` the gate IS a repo script: available when the script
+      file is on disk. A gate that still needs a file keeps that check.
+    - ``harness_lane``  the gate is config-based: available by registration
+      alone. There is no file to look for, and none is expected.
+
+    An unregistered gate raises :class:`UnknownGateProvider` — never ``False``,
+    never a fallback to a binary name invented from the gate's own name.
+    """
+    provider = resolve_gate_provider(gate)
+    if provider is None:
+        raise UnknownGateProvider(
+            f"{gate} is not a registered gate in gate_recorder.GATE_PROVIDERS — "
+            f"register it before asking whether it is available"
+        )
+    kind, name = provider
+    if kind == GATE_PROVIDER_PATH_BINARY:
+        return shutil.which(name) is not None
+    if kind == GATE_PROVIDER_SCRIPT_RUNNER:
+        return ((repo_root or _repo_root()) / name).exists()
+    if kind == GATE_PROVIDER_HARNESS_LANE:
+        return True
+    raise UnknownGateProvider(
+        f"{gate} has an unknown provider kind {kind!r} — cannot determine availability"
+    )
 # Infrastructure/execution failures — NOT semantic gate verdicts.
 # gate_failed means "gate completed with blocking findings"; only emit it for reasons
 # that represent a completed gate run with actual blocking findings. Anything else
@@ -243,9 +311,10 @@ def write_skip_rationale(
     file and never a PATH lookup: ``shutil.which("kimi_gate")`` answers a
     question nobody asked and its ``False`` was read for two days as "the
     provider is missing" while scripts/kimi_gate.py sat on disk. A
-    harness-lane gate has nothing to find either — its route is wired by
-    construction, so ``binary_found`` is True and ``binary_name`` carries the
-    provider string the dispatcher routes on. An unregistered gate says so in
+    harness-lane gate has nothing to find either — it is config-based, its
+    route is wired by construction, so ``binary_found`` is True without
+    touching the filesystem and ``binary_name`` carries the provider string
+    the dispatcher routes on. An unregistered gate says so in
     ``provider_kind`` rather than inventing a binary name from the gate's own
     name.
     """

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -18,7 +18,7 @@ from atomic_io import atomic_write_json
 from auto_merge_policy import codex_final_gate_required
 from review_contract import ReviewContract
 from gemini_prompt_renderer import render_gemini_prompt
-from gate_recorder import get_pr_head_sha, result_is_for_head, write_result_guarded
+from gate_recorder import gate_is_available, get_pr_head_sha, result_is_for_head, write_result_guarded
 from governance_emit import _classify_lane_log_text
 from claude_github_receipt import (
     ClaudeGitHubReviewReceipt,
@@ -401,23 +401,14 @@ class GateRequestHandlerMixin:
                 dispatch_id, exc,
             )
 
-    def _kimi_gate_runner_path(self) -> Path:
-        return Path(__file__).resolve().parent.parent / "kimi_gate.py"
-
     def _kimi_gate_available(self) -> bool:
-        return self._kimi_gate_runner_path().exists()
-
-    def _glm_gate_runner_path(self) -> Path:
-        return Path(__file__).resolve().parent.parent / "glm_gate.py"
+        return gate_is_available("kimi_gate")
 
     def _glm_gate_available(self) -> bool:
-        return self._glm_gate_runner_path().exists()
-
-    def _deepseek_gate_runner_path(self) -> Path:
-        return Path(__file__).resolve().parent.parent / "deepseek_gate.py"
+        return gate_is_available("glm_gate")
 
     def _deepseek_gate_available(self) -> bool:
-        return self._deepseek_gate_runner_path().exists()
+        return gate_is_available("deepseek_gate")
 
     def _dispatch_one_review(
         self,
@@ -1479,12 +1470,16 @@ class GateRequestHandlerMixin:
         self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str,
         dispatch_id: str = "",
     ) -> Dict[str, Any]:
-        """glm_gate is a recognised Gate.GLM_GATE member whose runner
-        (scripts/glm_gate.py) has not shipped yet — a separate deliverable adds
-        it. Until then this must refuse with a reason distinct from
-        ``unknown_review_gate`` (dispatch_spec Gate rejects that request before
-        it ever reaches here) so an operator can tell "not a real gate" apart
-        from "real gate, runner not implemented yet".
+        """glm_gate is a recognised Gate.GLM_GATE member, since C6 step 1 a
+        harness-lane gate: the governed dispatcher drives it and its runner
+        file (scripts/glm_gate.py) is only the standalone entry point. Its
+        availability is kind-based (gate_recorder.gate_is_available) —
+        decided by REGISTRATION, not by a file on disk. The refusal below is
+        defensive (a registered harness-lane gate is always available): it
+        refuses with a reason distinct from ``unknown_review_gate``
+        (dispatch_spec Gate rejects an unknown request before it ever
+        reaches here) so an operator can tell "not a real gate" apart from
+        "real gate, route missing".
         """
         from review_gate_manager import _utc_now
 
@@ -1511,7 +1506,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if not available:
             reason = "gate_runner_missing"
-            reason_detail = "scripts/glm_gate.py does not exist yet — ships in a separate deliverable"
+            reason_detail = "scripts/glm_gate.py is not on disk — glm_gate is registered as a script runner and its runner is unavailable"
             payload["reason"] = reason
             payload["reason_detail"] = reason_detail
             payload["resolved_at"] = payload["requested_at"]
@@ -1541,14 +1536,14 @@ class GateRequestHandlerMixin:
         self, pr_number: int, branch: str, risk_class: str, changed_files: List[str], mode: str,
         dispatch_id: str = "",
     ) -> Dict[str, Any]:
-        """deepseek_gate is a legal review-gate-takeover-CHAIN link (BETA3-E1,
-        26-08 operator decision) whose runner ships in a separate dispatch
-        (E2) — it is deliberately NOT a ``dispatch_spec.Gate`` enum member
-        yet (see ``_known_takeover_gate_names``). Until E2 lands this always
-        refuses, mirroring ``_request_glm``'s own pre-runner refusal branch:
-        a reason distinct from ``unknown_review_gate`` so an operator can
-        tell "not a real gate" apart from "real gate, runner not implemented
-        yet" — the chain's own named-skip requirement.
+        """deepseek_gate is a config-based harness-lane gate (OI-1714, dispatch
+        20260911-c6 step 2), reached through the "deepseek-harness" provider
+        lane rather than a repo script, so its availability is decided by
+        REGISTRATION alone (gate_recorder.gate_is_available) and it is
+        requestable with no runner file on disk. It is deliberately NOT a
+        ``dispatch_spec.Gate`` enum member yet (see
+        ``_known_takeover_gate_names``) but IS a legal
+        review-gate-takeover-CHAIN link (BETA3-E1, 26-08 operator decision).
         """
         from review_gate_manager import _utc_now
 
@@ -1575,7 +1570,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if not available:
             reason = "gate_runner_missing"
-            reason_detail = "scripts/deepseek_gate.py does not exist yet — ships in dispatch E2"
+            reason_detail = "deepseek_gate is not available — its registered provider route is not present"
             payload["reason"] = reason
             payload["reason_detail"] = reason_detail
             payload["resolved_at"] = payload["requested_at"]

--- a/scripts/lib/gate_result_parser.py
+++ b/scripts/lib/gate_result_parser.py
@@ -251,11 +251,12 @@ class GateResultParserMixin:
           the caller's own availability check (``_kimi_gate_available`` and
           friends, which test for the runner FILE) already said no, so the
           runner is absent — never a PATH question.
-        * harness-lane gate -> ``gate_runner_missing`` for the same reason: the
-          request-time availability check still tests the runner FILE (the
-          availability-fix that makes it lane-aware is a later step), so the
-          honest answer is "the runner is absent", never a PATH lookup on the
-          provider string.
+        * harness-lane gate -> ``gate_runner_missing``, defensively: since
+          dispatch 20260911-c6 step 2 the request-time availability check is
+          lane-aware (``gate_is_available`` returns True for a registered
+          harness-lane gate), so this branch is only reachable through a
+          caller that skipped that check. The answer stays "the runner is
+          absent", never a PATH lookup on the provider string.
         * PATH-binary gate -> the env-flag / which-lookup logic below,
           unchanged, on the registry's name.
         """

--- a/tests/test_beta3_e1_review_gate_chain.py
+++ b/tests/test_beta3_e1_review_gate_chain.py
@@ -555,12 +555,13 @@ def test_three_step_chain_carries_full_path_in_annotation(manager_env, monkeypat
 # ---------------------------------------------------------------------------
 # Point 3 -- deepseek_gate as the configured end-link: glm_gate exhausted
 # (using the REAL pr-1691 record + report, T0's request) rolls to
-# deepseek_gate, which is skipped with a named reason because E2 has not
-# shipped its runner. The resulting record must be distinguishable from a
-# seat that was never requested at all.
+# deepseek_gate, which is REQUESTED, not skipped — it is a config-based
+# harness-lane gate, available without a runner file (OI-1714, dispatch
+# 20260911-c6 step 2). The resulting record must still carry glm's real 402
+# detail, distinguishing it from a seat that was never requested at all.
 # ---------------------------------------------------------------------------
 
-def test_glm_exhausted_real_record_rolls_to_deepseek_named_skip(manager_env, monkeypatch):
+def test_glm_exhausted_real_record_rolls_to_deepseek_requested(manager_env, monkeypatch):
     monkeypatch.chdir(manager_env["project_root"])
     pr_number = 1691
 
@@ -580,14 +581,13 @@ def test_glm_exhausted_real_record_rolls_to_deepseek_named_skip(manager_env, mon
             risk_class="medium",
             changed_files=["scripts/glm_gate.py"],
             mode="per_pr",
-            dispatch_id="beta3-e1-deepseek-skip-test",
+            dispatch_id="beta3-e1-deepseek-requested-test",
         )
 
     seat = result["requested"][0]
     assert seat["gate"] == "deepseek_gate"
-    assert seat["status"] == "not_executable"
-    assert seat["reason"] == "gate_runner_missing"
-    assert "E2" in seat["reason_detail"] or "deepseek_gate.py" in seat["reason_detail"]
+    assert seat["status"] == "requested"
+    assert seat.get("reason") is None
     assert seat["takeover_from"] == "glm_gate"
     # The REAL 402 detail is PRESERVED in the annotation, not merely a
     # pointer back to glm_gate's own (mutable) result record.
@@ -1072,13 +1072,14 @@ def test_pr1696_real_glm_record_classifies_lane_exhausted_via_derived_dispatch_i
     )
 
 
-def test_pr1696_real_glm_record_rolls_to_deepseek_named_skip(manager_env, monkeypatch):
+def test_pr1696_real_glm_record_rolls_to_deepseek_requested(manager_env, monkeypatch):
     """The takeover chain itself must fire on the real record: glm_gate's
     chain successor is deepseek_gate (codex_gate -> kimi_gate -> glm_gate ->
-    deepseek_gate) -- same named-skip shape as
-    test_glm_exhausted_real_record_rolls_to_deepseek_named_skip's pr-1691
-    fixture above, proven here on the pr-1696 record whose report_path field
-    is empty (the derivation-fallback case), not pre-populated."""
+    deepseek_gate) -- now REQUESTED, not skipped, because deepseek_gate is a
+    config-based harness-lane gate available without a runner file (OI-1714,
+    dispatch 20260911-c6 step 2). Proven here on the pr-1696 record whose
+    report_path field is empty (the derivation-fallback case), not
+    pre-populated."""
     monkeypatch.chdir(manager_env["project_root"])
     pr_number = 1696
 
@@ -1105,8 +1106,8 @@ def test_pr1696_real_glm_record_rolls_to_deepseek_named_skip(manager_env, monkey
     seat = result["requested"][0]
     print(f"OI-1477 real pr-1696-glm_gate.json takeover: {seat['gate']!r} (from {seat.get('takeover_from')!r})")
     assert seat["gate"] == "deepseek_gate"
-    assert seat["status"] == "not_executable"
-    assert seat["reason"] == "gate_runner_missing"
+    assert seat["status"] == "requested"
+    assert seat.get("reason") is None
     assert seat["takeover_from"] == "glm_gate"
     assert "openrouter_credits" in seat["failure_reason"] or "more credits" in seat["failure_reason"], (
         f"expected the actual 402 detail embedded in failure_reason: {seat['failure_reason']!r}"

--- a/tests/test_c6_dlv2_availability_is_config.py
+++ b/tests/test_c6_dlv2_availability_is_config.py
@@ -1,0 +1,184 @@
+"""C6 step 2 — availability measures configuration, not file existence.
+
+dispatch 20260911-c6, track ``gate-runner-provider-agnostisch``. The defect:
+``_kimi_gate_available``/``_glm_gate_available``/``_deepseek_gate_available``
+(gate_request_handler) and ``gate_runner.run`` line 193 all decided
+availability by ``<runner_path>.exists()``. That makes availability a
+statement about a FILE, which is wrong in two directions:
+
+- a config-based gate (``harness_lane``) is available with NO file at all;
+  measuring one made ``deepseek_gate`` a dead link (OI-1714) — the ONE
+  provider that was actually working, registered as a script runner at
+  ``scripts/deepseek_gate.py`` which has never existed;
+- an unknown gate key books ``unavailable`` silently instead of failing loud.
+
+The fix centralises availability in ``gate_recorder.gate_is_available``:
+availability is decided by REGISTRATION plus lane executability — a
+``harness_lane`` gate is available without a file, a ``script_runner``/
+``path_binary`` gate keeps its file/binary check, and an unknown key raises
+``UnknownGateProvider``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import gate_recorder as _rec
+import gate_request_handler
+from gate_request_handler import GateRequestHandlerMixin
+
+
+# ---------------------------------------------------------------------------
+# 1. A config-based gate is available without a file (RED on current main)
+# ---------------------------------------------------------------------------
+
+
+def test_config_based_gate_is_available_without_a_file():
+    """Behavioral red/green pin (klaar-wanneer #1).
+
+    On main, ``_deepseek_gate_available`` measured
+    ``scripts/deepseek_gate.py``.exists(), which is False, so deepseek_gate
+    was booked unavailable despite being a config-based harness lane. After
+    the fix the same call returns True while the file still does not exist.
+    """
+    assert not (VNX_ROOT / "scripts" / "deepseek_gate.py").exists(), (
+        "deepseek_gate must not grow a runner file — its availability is "
+        "configuration, not a script"
+    )
+
+    assert GateRequestHandlerMixin()._deepseek_gate_available() is True
+
+
+@pytest.fixture
+def manager_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    data_dir = project_root / ".vnx-data"
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / "unified_reports"
+    for d in (
+        state_dir / "review_gates" / "requests",
+        state_dir / "review_gates" / "results",
+        reports_dir,
+    ):
+        d.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(reports_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(data_dir / "dispatches"))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+    return {
+        "project_root": project_root,
+        "state_dir": state_dir,
+        "requests_dir": state_dir / "review_gates" / "requests",
+        "results_dir": state_dir / "review_gates" / "results",
+    }
+
+
+def _make_manager():
+    import review_gate_manager as rgm
+    return rgm.ReviewGateManager()
+
+
+def test_deepseek_request_books_requested_not_runner_missing(manager_env, monkeypatch):
+    """OI-1714's request-time consequence: a deepseek_gate request is
+    REQUESTED, never ``not_executable``/``gate_runner_missing``, because the
+    gate is available by registration alone."""
+    monkeypatch.setattr(gate_request_handler, "get_pr_head_sha", lambda pr_number: "e" * 40)
+    manager = _make_manager()
+
+    result = manager._dispatch_one_review(
+        "deepseek_gate", pr_number=13, branch="feature/c6-availability",
+        risk_class="low", changed_files=[], mode="per_pr",
+        dispatch_id="c6-deepseek-available",
+    )
+
+    assert result["status"] == "requested"
+    assert result.get("reason") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. script_runner / path_binary without a file stay unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_script_runner_without_file_is_still_unavailable(tmp_path, monkeypatch):
+    """klaar-wanneer #2: a gate that DOES need a file keeps that check."""
+    monkeypatch.setitem(
+        _rec.GATE_PROVIDERS, "test_script_gate",
+        (_rec.GATE_PROVIDER_SCRIPT_RUNNER, "scripts/test_script_gate.py"),
+    )
+
+    assert _rec.gate_is_available("test_script_gate", repo_root=tmp_path) is False
+
+    (tmp_path / "scripts").mkdir(parents=True)
+    (tmp_path / "scripts" / "test_script_gate.py").write_text("# runner", encoding="utf-8")
+    assert _rec.gate_is_available("test_script_gate", repo_root=tmp_path) is True
+
+
+def test_path_binary_without_binary_is_still_unavailable(monkeypatch):
+    """klaar-wanneer #2: a path-binary gate needs its binary on PATH."""
+    monkeypatch.setattr(_rec.shutil, "which", lambda _name: None)
+    assert _rec.gate_is_available("codex_gate") is False
+
+    monkeypatch.setattr(_rec.shutil, "which", lambda _name: "/usr/bin/codex")
+    assert _rec.gate_is_available("codex_gate") is True
+
+
+# ---------------------------------------------------------------------------
+# 3. An unknown key fails LOUD
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_gate_key_fails_loud():
+    """klaar-wanneer #3: a typo in an operator-configured review stack must
+    name the wrong key, never silently book an unavailable seat."""
+    with pytest.raises(_rec.UnknownGateProvider, match="verzonnen_gate"):
+        _rec.gate_is_available("verzonnen_gate")
+
+
+# ---------------------------------------------------------------------------
+# 4. The union (C6 merge of PR #1837 + #1838): all three chain links
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("gate,provider", [
+    ("kimi_gate", "kimi"),
+    ("glm_gate", "glm-harness"),
+    ("deepseek_gate", "deepseek-harness"),
+])
+def test_all_three_chain_links_are_available_by_registration_alone(
+    tmp_path, gate, provider,
+):
+    """The merge's klaar-wanneer #2: after the union, every link in the
+    codex-outage takeover chain is harness-lane and available WITHOUT any
+    file on disk.
+
+    RED on either parent branch alone: on #1837 (dlv1) deepseek_gate was
+    still a script runner at a path that has never existed (and
+    ``gate_is_available`` did not exist yet at all); on #1838 (dlv2)
+    kimi_gate/glm_gate were still script runners, so their registry kind was
+    not ``harness_lane``. Only the union turns all three green at once.
+
+    ``repo_root=tmp_path`` is the proof that no file is consulted: the empty
+    tmp dir contains no runner script for ANY gate, yet a harness-lane gate
+    is available by registration alone.
+    """
+    kind, name = _rec.GATE_PROVIDERS[gate]
+    assert kind == _rec.GATE_PROVIDER_HARNESS_LANE
+    assert name == provider
+    assert _rec.gate_is_available(gate, repo_root=tmp_path) is True

--- a/tests/test_oi1490_gate_provider_registry.py
+++ b/tests/test_oi1490_gate_provider_registry.py
@@ -225,11 +225,13 @@ def test_the_new_reasons_are_permanent_not_a_bounded_wait():
     """A routing bug must not sit in the retry-until-the-environment-changes
     bucket. `provider_not_installed` belongs there and stays there.
 
-    C6 step 1 note: glm_gate/kimi_gate no longer produce
+    C6 note: glm_gate/kimi_gate no longer produce
     `gate_not_subprocess_routable` at all (they delegate to the governed
-    dispatcher), but the reason survives for the script-runner gate
-    (deepseek_gate) and must stay out of the temporary set either way — no
-    amount of waiting turns a script runner into a PATH binary.
+    dispatcher), and deepseek_gate is no longer a script runner either
+    (OI-1714, step 2: it is a config-based harness lane), but the reason
+    survives for any future script-runner registration and must stay out of
+    the temporary set either way — no amount of waiting turns a script
+    runner into a PATH binary.
     """
     import gate_obligation_runner as gor
 
@@ -267,24 +269,23 @@ def test_every_path_binary_gate_can_actually_be_driven_by_this_runner():
     assert "glm_gate" not in _rec._GATE_BINARIES
 
 
-def test_a_registered_but_unshipped_runner_says_missing_not_unroutable(gate_dirs):
-    """Found by these tests, not assumed: scripts/deepseek_gate.py is not on
-    disk. "Registered but not shipped" and "shipped but not drivable here" are
-    different answers and the reader acts differently on each, so they get
-    different reason codes. gate_request_handler already books the first as
-    `gate_runner_missing`; this reuses that name instead of minting a second
-    one for the same fact.
+def test_a_config_based_gate_is_available_without_a_file():
+    """OI-1714 (dispatch 20260911-c6 step 2): deepseek_gate used to be
+    registered as a script runner pointing at scripts/deepseek_gate.py, which
+    has never existed, so every deepseek request booked `gate_runner_missing`
+    — a dead link for the ONE provider that was actually working. It is a
+    config-based harness lane, so its availability is decided by REGISTRATION,
+    not by a file on disk, and it must never grow a runner file.
     """
     assert not (VNX_ROOT / "scripts" / "deepseek_gate.py").exists(), (
-        "if deepseek_gate.py has since shipped, this test documents the "
-        "transition — move it to the routable case above"
+        "deepseek_gate must not grow a runner file — its availability is "
+        "configuration, not a script (dispatch 20260911-c6 step 2)"
     )
 
-    result = _run(gate_dirs, "deepseek_gate")
-
-    assert result["reason"] == "gate_runner_missing"
-    assert "has not shipped" in result["reason_detail"]
-    assert result["reason"] != "provider_not_installed"
+    kind, name = _rec.GATE_PROVIDERS["deepseek_gate"]
+    assert kind == _rec.GATE_PROVIDER_HARNESS_LANE
+    assert name == "deepseek-harness"
+    assert _rec.gate_is_available("deepseek_gate") is True
 
 
 def test_harness_lane_gates_name_the_same_lane_their_standalone_scripts_use():


### PR DESCRIPTION
## Wat

Stap 2 van track `gate-runner-provider-agnostisch` (dispatch 20260911-c6). Beschikbaarheid van een review-poort wordt voortaan bepaald door de REGISTRATIE plus de uitvoerbaarheid van de lane, niet door het bestaan van een bestand.

## Defect

- `gate_request_handler._kimi_gate_available` / `_glm_gate_available` / `_deepseek_gate_available` en `gate_runner.run` (regel 193) bepaalden beschikbaarheid via `<runner_path>.exists()`.
- OI-1714: `deepseek_gate` stond geregistreerd als `script_runner` naar `scripts/deepseek_gate.py`, dat nooit heeft bestaan. Elke deepseek-aanvraag boekte daardoor `gate_runner_missing`, terwijl deepseek de enige werkende provider was.

## Wijziging

- `gate_recorder.gate_is_available(gate, *, repo_root=None)`: beschikbaarheid per kind.
  - `harness_lane` (config-gebaseerd): beschikbaar zonder bestand.
  - `script_runner` / `path_binary`: houden hun bestands/binary-check.
  - onbekende sleutel: `UnknownGateProvider` (ValueError), luid, met de naam erin.
- `deepseek_gate` omgezet naar `("harness_lane", "deepseek-harness")`.
- De drie `_*_gate_available`-methodes en `gate_runner.run` delegeren nu naar `gate_is_available`.
- `write_skip_rationale` kent nu de `harness_lane`-tak (`found=True`).

## Bewijs (rood -> groen)

- Rood op main: `test_config_based_gate_is_available_without_a_file` faalde met `assert False is True` (`_deepseek_gate_available()` mat het bestand).
- Groen: zelfde test slaagt, plus 4 nieuwe tests en 2 gemigreerde deepseek-tests.

## Tests

`219 passed` over de geraakte poort-testbestanden (test_c6_dlv2_availability_is_config, test_oi1490, test_beta3_e1, test_dlv45, test_dlv5, test_dlv1_glm_gate, test_oi1669, test_b8, test_stop_conditions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
