### PR TITLE
feat(update): cutover names its behindness and refuses stale targets (OI-1718)

### DIFF
--- a/docs/core/SUBSYSTEMS.md
+++ b/docs/core/SUBSYSTEMS.md
@@ -30,6 +30,7 @@ This document is the single source of truth for which VNX subsystems are live, p
 | central-db-routing | Central-DB read mode for the runtime coordination store (per-project vs central vs shadow). | `VNX_USE_CENTRAL_DB` | ACTIVATE-and-measure | unknown — no probe yet |
 | smart-router-staging | Phased smart-router AUTO routing rollout (per-tier enable + deterministic canary fraction). | `VNX_SMART_ROUTER_CANARY_PCT` | ACTIVATE-and-measure | unknown — no probe yet |
 | claude-tmux-serialization | N-slot serial lock protecting the shared Claude subscription session cap for the claude-tmux dispatch lane. | `VNX_TMUX_MAX_CONCURRENT` | ACTIVATE-and-measure | unknown — no probe yet |
+| central-install-cutover | Cutover behind-guard: every central-install flip measures and names how far the target lags main; over the threshold the flip needs an explicit operator reason (OI-1718). | `VNX_CUTOVER_MAX_BEHIND_COMMITS` | ACTIVATE-and-measure | unknown — no probe yet |
 | plan-gate-panel | 5-model deliberation panel for plan-first enforcement. | `VNX_PLAN_GATE_ENFORCE` | SCOPE | works — panel runs, verdicts recorded |
 | plan-gate-task-class-scope | Restrict panel to complex features; run trivial tracks on a reduced 2-seat panel (scope read-site: plan_gate_enforcement.plan_gate_scope). | `VNX_PLAN_GATE_COMPLEX_ONLY` | SCOPE | works — scope read-site present (light plans run 2 seats) |
 | subsystem-cockpit | SUBSYSTEMS.md + config_registry + vnx subsystems + dashboard tile. | — | COCKPIT | degraded — SSOT exists, probes partial |

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -272,6 +272,23 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         # this subsystem's 5 flags. Not re-audited by this dispatch — out of scope.
         cockpit_canonical=True),
 
+    # OI-1718: the cutover behind-guard threshold. Every central-install
+    # cutover (release --set-current, update --to) measures and prints how far
+    # the target lags main BEFORE flipping `current`; above this count the
+    # flip is refused without an explicit non-empty --cutover-reason (recorded
+    # in the central-install audit log). Unmeasurable behindness is reported
+    # as UNKNOWN, never silently 0, and proceeds loudly (update/rollback are
+    # recovery tools); rollback is exempt from refusal by design.
+    "VNX_CUTOVER_MAX_BEHIND_COMMITS": _e(
+        "VNX_CUTOVER_MAX_BEHIND_COMMITS", "string", "20", "gate",
+        "Max commits a cutover target may lag main before the flip is refused "
+        "without an explicit --cutover-reason (OI-1718). Default 20 mirrors "
+        "update.py DEFAULT_CUTOVER_MAX_BEHIND_COMMITS (pinned by "
+        "test_registry_entry_registered_with_description); the incident was a "
+        "tag measured 36->42 commits behind main within one evening.",
+        approval=True,
+        subsystem="central-install-cutover", status="ACTIVATE"),
+
     # Operator directive 2026-08-21 (dispatch-20260821-t0-tmux-concurrency-10): the
     # claude-tmux N-slot lock's concurrency cap, raised from 5 to 10 and made
     # registry-backed so an operator can flip it from the dashboard, not just env.

--- a/tests/test_oi1711_publish_update_rerun.py
+++ b/tests/test_oi1711_publish_update_rerun.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""OI-1711 — the publication path must work more than once.
+
+Two independent defects in the same flow, kept apart in these tests:
+
+Defect 1 (publish side): ``vnx release publish`` materializes via
+install-central.sh from a temp checkout under /var/folders and leaves that
+temp path as the published dir's ``origin``. The temp dir is deleted right
+after, so the origin points at nothing.
+
+Defect 2 (update side): ``vnx update --to <tag>`` on an existing version dir
+takes ``git pull --ff-only``, which can never succeed on a tag clone: the
+clone (``--branch <tag> --depth 1``) has a detached HEAD with no upstream.
+
+Acceptance criterion, literally: publish followed by ``update --to`` on the
+SAME tag works twice in a row. The second run is the point; the first always
+worked (as long as the target dir did not exist yet).
+
+Every measurement carries two controls: something that MUST be found (e.g.
+origin == VNX_GIT_REMOTE after publish) and something that must NOT be found
+(e.g. a /var/folders temp path as origin, a pull failure on a detached HEAD).
+"""
+
+import io
+import subprocess
+import sys
+from argparse import Namespace
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import vnx_cli.commands.release as release_module
+import vnx_cli.commands.update as update_module
+from vnx_cli.commands.release import vnx_release_publish
+from vnx_cli.commands.update import (
+    INSTALL_MODE_MARKER,
+    INSTALL_MODE_VALUE,
+    _fetch_version,
+    vnx_update,
+)
+
+TAG = "v9.9.9"
+OLD_TAG = "v9.9.8"
+
+
+def _git(path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _git_repo_with_tag(path: Path, tag: "str | None" = TAG) -> Path:
+    """A local git repo standing in for the canonical remote (offline).
+
+    Carries a VERSION file agreeing with ``tag`` so the publish version-guard
+    passes, and a normalized ``main`` branch so ``edge`` clones work.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    (path / "README.md").write_text("test\n", encoding="utf-8")
+    version = tag.lstrip("vV") if tag else "0.0.0"
+    (path / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md", "VERSION"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+    subprocess.run(["git", "branch", "-M", "main"], cwd=path, check=True)
+    if tag:
+        subprocess.run(["git", "tag", tag], cwd=path, check=True)
+    return path
+
+
+def _commit_file(repo: Path, name: str, content: str) -> str:
+    (repo / name).write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", name], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", f"add {name}"], cwd=repo, check=True)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+@pytest.fixture
+def central_root(tmp_path, monkeypatch):
+    """Isolated central store, audit log, registry and pin-scan roots.
+
+    Without the registry/pin-scan isolation, ``vnx_update``'s prune sweep
+    would read the operator's REAL ~/.vnx/projects.json and scan the REAL
+    $HOME for .vnx-version pins.
+    """
+    root = tmp_path / "vnx-system"
+    monkeypatch.setenv("VNX_HOME_ROOT", str(root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "vnx-data"))
+    monkeypatch.setenv("VNX_PIN_SCAN_ROOTS", str(tmp_path / "empty-pin-scan-root"))
+    monkeypatch.setenv("VNX_PROJECT_REGISTRY", str(tmp_path / "no-projects.json"))
+    return root
+
+
+@pytest.fixture
+def real_install_central(monkeypatch):
+    """Use the repo's real install-central.sh (the temp-checkout clone is
+    exactly where defect 1 lives — a stub would hide it)."""
+    monkeypatch.delenv("VNX_INSTALL_CENTRAL_SCRIPT", raising=False)
+
+
+@pytest.fixture
+def no_fleet_migration(monkeypatch):
+    """Stub the post-update fleet store-migration sweep: it is best-effort
+    and orthogonal to the fetch path under test, and must never touch real
+    per-project stores from a test run."""
+    monkeypatch.setattr(
+        "vnx_cli.commands.migrate.migrate_all_central_stores", lambda: 0
+    )
+
+
+def _use_as_canonical_remote(monkeypatch, origin: Path) -> None:
+    """Patch VNX_GIT_REMOTE in BOTH command modules (release.py binds its own
+    imported copy; update.py reads its module global)."""
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+    monkeypatch.setattr(release_module, "VNX_GIT_REMOTE", str(origin))
+
+
+def _publish_args(*, tag=TAG, repo=None) -> Namespace:
+    return Namespace(tag=tag, repo=repo, dry_run=False, set_current=False)
+
+
+def _update_args(*, to_version=TAG) -> Namespace:
+    return Namespace(
+        to_version=to_version,
+        keep_last=3,
+        dry_run=False,
+        rollback=False,
+        protect_pins=None,
+    )
+
+
+def _run_publish(args) -> "tuple[str, str, int]":
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = vnx_release_publish(args)
+    return out.getvalue(), err.getvalue(), rc
+
+
+def _run_update(args) -> "tuple[str, str, int]":
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = vnx_update(args)
+    return out.getvalue(), err.getvalue(), rc
+
+
+def _origin_url(version_dir: Path) -> str:
+    return _git(version_dir, "remote", "get-url", "origin").stdout.strip()
+
+
+def _head_sha(version_dir: Path) -> str:
+    return _git(version_dir, "rev-parse", "HEAD").stdout.strip()
+
+
+def _head_branch(version_dir: Path) -> "str | None":
+    result = _git(version_dir, "symbolic-ref", "-q", "--short", "HEAD", check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — publish must not leave a vanished temp checkout as origin
+# ---------------------------------------------------------------------------
+
+def test_publish_sets_origin_to_canonical_remote(
+    tmp_path, central_root, real_install_central
+):
+    """MUST find: origin == VNX_GIT_REMOTE. Must NOT find: the deleted
+    /var/folders temp checkout path anywhere in the dir's remotes."""
+    origin = _git_repo_with_tag(tmp_path / "origin", TAG)
+
+    out, err, rc = _run_publish(_publish_args(tag=TAG, repo=str(origin)))
+    assert rc == 0, err
+
+    target_dir = central_root / "versions" / TAG
+    assert target_dir.is_dir()
+
+    remote_v = _git(target_dir, "remote", "-v").stdout
+    # Positive control: an origin exists, and it is the canonical remote
+    # (this test does NOT patch VNX_GIT_REMOTE, so it must be the real URL).
+    assert "origin" in remote_v
+    assert _origin_url(target_dir) == release_module.VNX_GIT_REMOTE
+    # Negative controls: no vanished publish-temp path left behind.
+    assert "vnx-release-" not in remote_v
+    assert "/var/folders" not in remote_v
+
+
+def test_publish_sets_origin_exactly_to_vnx_git_remote(
+    tmp_path, central_root, real_install_central, monkeypatch
+):
+    """The published dir's origin is re-pointed at the canonical remote so a
+    later ``vnx update`` fetches from the same place it clones from."""
+    origin = _git_repo_with_tag(tmp_path / "origin", TAG)
+    _use_as_canonical_remote(monkeypatch, origin)
+
+    out, err, rc = _run_publish(_publish_args(tag=TAG, repo=str(origin)))
+    assert rc == 0, err
+
+    target_dir = central_root / "versions" / TAG
+    # Positive control.
+    assert _origin_url(target_dir) == str(origin)
+    # Negative control.
+    assert "vnx-release-" not in _git(target_dir, "remote", "-v").stdout
+
+
+# ---------------------------------------------------------------------------
+# Acceptance — publish, then ``update --to`` the SAME tag, twice
+# ---------------------------------------------------------------------------
+
+def test_publish_then_update_to_same_tag_works_twice(
+    tmp_path, central_root, real_install_central, no_fleet_migration, monkeypatch
+):
+    """The literal acceptance criterion. On the broken code the FIRST update
+    already fails: publish left a deleted temp path as origin (defect 1) and
+    the pull branch cannot work on the tag's detached HEAD anyway (defect 2).
+    """
+    origin = _git_repo_with_tag(tmp_path / "origin", TAG)
+    _use_as_canonical_remote(monkeypatch, origin)
+
+    out, err, rc = _run_publish(_publish_args(tag=TAG, repo=str(origin)))
+    assert rc == 0, err
+    target_dir = central_root / "versions" / TAG
+    assert target_dir.is_dir()
+
+    # First update --to the same tag: the target dir already exists.
+    out1, err1, rc1 = _run_update(_update_args(to_version=TAG))
+    assert rc1 == 0, f"first update failed: {err1}"
+    assert "Error" not in err1
+
+    # Second update --to the same tag: the whole point of OI-1711. A
+    # tag-pinned dir already at the target tag is DONE, not broken.
+    out2, err2, rc2 = _run_update(_update_args(to_version=TAG))
+    assert rc2 == 0, f"second update failed: {err2}"
+    assert "already at" in out2
+    assert "Error" not in err2
+
+    # Controls: origin is the canonical remote, never the publish temp dir.
+    # (The fixture remote itself lives under pytest's tmp_path — which on
+    # macOS is also /var/folders — so the meaningful negative here is the
+    # publish temp-checkout prefix, not the folder root. The unprefixed
+    # /var/folders negative lives in the unpatched-remote publish test.)
+    assert _origin_url(target_dir) == str(origin)
+    remote_v = _git(target_dir, "remote", "-v").stdout
+    assert "vnx-release-" not in remote_v
+    # The marker self-heal still ran on the no-op path.
+    marker = target_dir / INSTALL_MODE_MARKER
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — the update pull branch on a tag-pinned (detached HEAD) dir
+# ---------------------------------------------------------------------------
+
+def test_update_existing_tag_dir_at_target_is_noop(tmp_path, central_root, capsys, monkeypatch):
+    """Second ``_fetch_version`` for the same tag: HEAD already sits on the
+    tag commit, so the right outcome is a no-op with a clear message — no
+    pull, no error. On the broken code ``git pull --ff-only`` on the detached
+    HEAD raises CalledProcessError here."""
+    origin = _git_repo_with_tag(tmp_path / "origin", TAG)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+    root = central_root
+
+    target_dir = _fetch_version(root, TAG, dry_run=False)
+    assert _head_branch(target_dir) is None  # tag clone => detached HEAD
+    sha_before = _head_sha(target_dir)
+
+    target_again = _fetch_version(root, TAG, dry_run=False)
+
+    assert target_again == target_dir
+    out = capsys.readouterr().out
+    assert "already at" in out
+    assert "nothing to pull" in out
+    # No-op means no-op: HEAD untouched, still detached at the same commit.
+    assert _head_sha(target_dir) == sha_before
+    assert _head_branch(target_dir) is None
+
+
+def test_update_detached_dir_below_target_fetches_and_checks_out_tag(
+    tmp_path, central_root, capsys, monkeypatch
+):
+    """A tag dir whose HEAD is NOT at the target ref is re-pinned by fetch +
+    explicit checkout of the tag — the move that works for a tag, instead of
+    a ``pull --ff-only`` that only ever worked for a branch."""
+    origin = _git_repo_with_tag(tmp_path / "origin", None)
+    old_sha = _git(origin, "rev-parse", "HEAD").stdout.strip()
+    subprocess.run(["git", "tag", OLD_TAG], cwd=origin, check=True)
+    new_sha = _commit_file(origin, "NEWER.md", "newer\n")
+    subprocess.run(["git", "tag", TAG], cwd=origin, check=True)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+
+    # Simulate a dir pinned BELOW the target: cloned at the older tag under
+    # the target's name.
+    target_dir = central_root / "versions" / TAG
+    subprocess.run(
+        ["git", "clone", "--quiet", "--branch", OLD_TAG, "--depth", "1",
+         str(origin), str(target_dir)],
+        check=True,
+    )
+    assert _head_sha(target_dir) == old_sha
+    assert _head_branch(target_dir) is None
+
+    result = _fetch_version(central_root, TAG, dry_run=False)
+
+    assert result == target_dir
+    out = capsys.readouterr().out
+    assert "checkout" in out.lower() or "Fetching" in out
+    # Re-pinned at the target tag, detached as a tag clone should be.
+    assert _head_sha(target_dir) == new_sha
+    assert _head_branch(target_dir) is None
+
+
+def test_update_repairs_origin_pointing_at_vanished_path(
+    tmp_path, central_root, capsys, monkeypatch
+):
+    """An origin that points at a deleted path (exactly what a pre-fix
+    publish left behind) is repaired to the canonical remote with a clear
+    message — not git's opaque ``fatal: ... does not appear to be a git
+    repository`` surfacing as an unexplained failure."""
+    origin = _git_repo_with_tag(tmp_path / "origin", TAG)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+
+    target_dir = _fetch_version(central_root, TAG, dry_run=False)
+
+    # Break the origin the way defect 1 did: point it at a path that does
+    # not exist. (Dir is read-only after the pin lock — unlock to tamper.)
+    vanished = tmp_path / "vanished-checkout"
+    subprocess.run(["chmod", "-R", "u+w", str(target_dir)], check=True)
+    _git(target_dir, "remote", "set-url", "origin", str(vanished))
+    assert _origin_url(target_dir) == str(vanished)
+    assert not vanished.exists()
+
+    result = _fetch_version(central_root, TAG, dry_run=False)
+
+    assert result == target_dir
+    out = capsys.readouterr().out
+    # Positive control: the repair is named, the canonical remote is set.
+    assert "Repaired" in out
+    assert _origin_url(target_dir) == str(origin)
+    # Negative control: no unexplained git fatal, and HEAD still on the tag.
+    assert "does not appear to be a git repository" not in out
+    assert _head_branch(target_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — the ``edge`` (branch) path must keep working as before
+# ---------------------------------------------------------------------------
+
+def test_update_edge_existing_dir_still_pulls_new_commits(
+    tmp_path, central_root, monkeypatch
+):
+    """``--to edge`` clones branch main with an attached HEAD; the existing
+    ``pull --ff-only`` behaviour for that case is correct and must survive
+    the tag fix. This guard passes on the old code too — it exists to prove
+    the fix does not break the branch path."""
+    origin = _git_repo_with_tag(tmp_path / "origin", None)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+
+    target_dir = _fetch_version(central_root, "edge", dry_run=False)
+    assert _head_branch(target_dir) == "main"
+
+    new_sha = _commit_file(origin, "SECOND.md", "second\n")
+
+    target_again = _fetch_version(central_root, "edge", dry_run=False)
+
+    assert target_again == target_dir
+    assert _head_sha(target_dir) == new_sha
+    assert (target_dir / "SECOND.md").is_file()
+    # edge stays attached to its branch — the pull path, not a detach.
+    assert _head_branch(target_dir) == "main"

--- a/tests/test_oi1718_cutover_behind_guard.py
+++ b/tests/test_oi1718_cutover_behind_guard.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""OI-1718 — a cutover names its behindness out loud.
+
+A cutover (``_atomic_symlink_flip``) can silently activate a target that is
+far behind ``main``: measured 2026-09-11, tag ``v1.6.1`` sat 42 commits behind
+``origin/main`` and nothing in ``vnx update --to`` / ``vnx release publish
+--set-current`` surfaced that. These tests pin the guard:
+
+1. The behind-count is ALWAYS named — under the threshold, over it, and on
+   every successful flip. A silent successful cutover is the bug.
+2. Over the (configurable) threshold the flip is REFUSED; the refusal names
+   the count, the target ref, and the way out.
+3. The escape hatch is an explicit REASON (``--cutover-reason``), never a bare
+   flag; an empty/whitespace reason is itself a refusal. A used reason is
+   recorded in the central-install audit log.
+4. Unmeasurable behindness (unreachable source, missing ref) is a THIRD
+   outcome: reported as UNKNOWN, never silently as 0. UNKNOWN proceeds loudly
+   rather than blocking — a cutover is non-destructive, and refusing every
+   flip whenever the remote is unreachable would make ``update``/``rollback``
+   unusable exactly when they are needed as recovery tools. Rollback is never
+   refused at all: rolling back goes backwards by design.
+
+Every measurement carries two controls: something that MUST be found (the
+count in the output of a succeeding cutover) and something that must NOT be
+found (a cutover path with no count, an empty reason waved through).
+"""
+
+import io
+import json
+import stat
+import subprocess
+import sys
+from argparse import Namespace
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(REPO_ROOT / "scripts" / "lib") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import config_registry as cr
+import vnx_cli.commands.update as update_module
+from vnx_cli.commands.update import (
+    CutoverRefusedError,
+    DEFAULT_CUTOVER_MAX_BEHIND_COMMITS,
+    _atomic_symlink_flip,
+    _cutover_max_behind_commits,
+    _do_rollback,
+    _measure_behind_main,
+    vnx_update,
+)
+from vnx_cli.commands.release import vnx_release_publish
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _git(path: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _source_repo(path: Path, tag: str = "v1.0.0", ahead: int = 5) -> Path:
+    """A local git repo standing in for the canonical source (offline).
+
+    ``tag`` sits ``ahead`` commits behind the tip of ``main`` — the exact
+    shape of the OI-1718 incident (a tag cut from an older main).
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    (path / "VERSION").write_text(f"{tag.lstrip('vV')}\n", encoding="utf-8")
+    subprocess.run(["git", "add", "VERSION"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+    subprocess.run(["git", "tag", tag], cwd=path, check=True)
+    subprocess.run(["git", "branch", "-M", "main"], cwd=path, check=True)
+    for i in range(ahead):
+        (path / f"file{i}.md").write_text(f"{i}\n", encoding="utf-8")
+        subprocess.run(["git", "add", f"file{i}.md"], cwd=path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", f"ahead {i}"], cwd=path, check=True)
+    return path
+
+
+@pytest.fixture
+def central_root(tmp_path, monkeypatch):
+    """Isolated central store + audit log location."""
+    root = tmp_path / "vnx-system"
+    monkeypatch.setenv("VNX_HOME_ROOT", str(root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "vnx-data"))
+    return root
+
+
+@pytest.fixture
+def audit_log(tmp_path):
+    return tmp_path / "events" / "central_install.ndjson"
+
+
+def _audit_events(audit_log: Path):
+    if not audit_log.exists():
+        return []
+    return [json.loads(line) for line in audit_log.read_text().strip().splitlines()]
+
+
+def _flip_target(root: Path, name: str) -> Path:
+    target = root / "versions" / name
+    target.mkdir(parents=True)
+    return target
+
+
+def _flip(root, target_dir, audit_log, **kwargs):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        _atomic_symlink_flip(
+            root, target_dir, dry_run=False, audit_log=audit_log, **kwargs
+        )
+    return out.getvalue(), err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _measure_behind_main — the measurement itself
+# ---------------------------------------------------------------------------
+
+def test_measure_behind_main_counts_commits(tmp_path):
+    src = _source_repo(tmp_path / "src", ahead=5)
+    assert _measure_behind_main(str(src), "v1.0.0") == 5
+
+
+def test_measure_behind_main_zero_for_tip_tag(tmp_path):
+    src = _source_repo(tmp_path / "src", ahead=0)
+    assert _measure_behind_main(str(src), "v1.0.0") == 0
+
+
+def test_measure_behind_main_unknown_for_missing_ref(tmp_path):
+    src = _source_repo(tmp_path / "src", ahead=2)
+    assert _measure_behind_main(str(src), "v9.9.9") is None
+
+
+def test_measure_behind_main_unknown_for_unreachable_source(tmp_path):
+    missing = tmp_path / "no-such-repo"
+    assert _measure_behind_main(str(missing), "v1.0.0") is None
+
+
+def test_measure_behind_main_unknown_when_source_has_no_main(tmp_path):
+    """A source without a ``main`` branch cannot define behindness — UNKNOWN,
+    never 0."""
+    src = tmp_path / "src"
+    src.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", "trunk"], cwd=src, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=src, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=src, check=True)
+    subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=src, check=True)
+    subprocess.run(["git", "tag", "v1.0.0"], cwd=src, check=True)
+    assert _measure_behind_main(str(src), "v1.0.0") is None
+
+
+# ---------------------------------------------------------------------------
+# Threshold configuration
+# ---------------------------------------------------------------------------
+
+def test_threshold_default_when_nothing_set(monkeypatch):
+    monkeypatch.delenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", raising=False)
+    monkeypatch.delenv("VNX_OVERRIDE_CUTOVER_MAX_BEHIND_COMMITS", raising=False)
+    assert _cutover_max_behind_commits() == DEFAULT_CUTOVER_MAX_BEHIND_COMMITS
+
+
+def test_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+    assert _cutover_max_behind_commits() == 2
+
+
+def test_threshold_invalid_value_falls_back_to_default_loudly(monkeypatch, capsys):
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "banana")
+    assert _cutover_max_behind_commits() == DEFAULT_CUTOVER_MAX_BEHIND_COMMITS
+    assert "VNX_CUTOVER_MAX_BEHIND_COMMITS" in capsys.readouterr().err
+
+
+def test_registry_entry_registered_with_description():
+    """The threshold lives in the config registry (requirement 4), with a
+    written-out description — not a bare number in code. The registry default
+    mirrors the code fallback, the registry's own contract."""
+    entry = cr.CONFIG_REGISTRY["VNX_CUTOVER_MAX_BEHIND_COMMITS"]
+    assert entry.default == str(DEFAULT_CUTOVER_MAX_BEHIND_COMMITS)
+    assert entry.type == "string"
+    assert len(entry.description) > 40
+    assert entry.subsystem
+    assert entry.status in cr.ALLOWED_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# The guard on the flip: under threshold proceeds and NAMES the count
+# ---------------------------------------------------------------------------
+
+def test_under_threshold_proceeds_and_names_count(
+    tmp_path, central_root, audit_log, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", ahead=3)
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "20")
+    target_dir = _flip_target(central_root, "v1.0.0")
+
+    out, _err = _flip(
+        central_root, target_dir, audit_log, behind_source=str(src)
+    )
+
+    # Positive control: the count is named even though the cutover succeeds.
+    assert "3 commits behind" in out
+    assert "v1.0.0" in out
+    assert (central_root / "current").resolve() == target_dir.resolve()
+    assert "Activated:" in out
+    events = _audit_events(audit_log)
+    checks = [e for e in events if e["event_type"] == "central_install_cutover_behind_check"]
+    assert len(checks) == 1
+    assert checks[0]["behind"] == 3
+    assert checks[0]["outcome"] == "proceed"
+    assert checks[0]["threshold"] == 20
+
+
+def test_over_threshold_refused_names_count_ref_and_way_out(
+    tmp_path, central_root, audit_log, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", ahead=5)
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+    target_dir = _flip_target(central_root, "v1.0.0")
+
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        with pytest.raises(CutoverRefusedError) as excinfo:
+            _atomic_symlink_flip(
+                central_root, target_dir, dry_run=False,
+                audit_log=audit_log, behind_source=str(src),
+            )
+
+    message = str(excinfo.value)
+    # The refusal names the count, the target ref, and the way out.
+    assert "5" in message
+    assert "v1.0.0" in message
+    assert "--cutover-reason" in message
+    # Negative control: the flip never happened — no symlink, no flip events.
+    assert not (central_root / "current").exists()
+    events = _audit_events(audit_log)
+    assert not [e for e in events if e["event_type"] == "central_install_update"]
+    checks = [e for e in events if e["event_type"] == "central_install_cutover_behind_check"]
+    assert len(checks) == 1
+    assert checks[0]["outcome"] == "refused"
+    assert checks[0]["behind"] == 5
+
+
+def test_over_threshold_with_reason_proceeds_and_records_reason(
+    tmp_path, central_root, audit_log, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", ahead=5)
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+    target_dir = _flip_target(central_root, "v1.0.0")
+    reason = "mission-control hotfix must ship before the next tag is cut"
+
+    out, _err = _flip(
+        central_root, target_dir, audit_log,
+        behind_source=str(src), cutover_reason=reason,
+    )
+
+    assert "5 commits behind" in out
+    assert reason in out
+    assert (central_root / "current").resolve() == target_dir.resolve()
+    checks = [
+        e for e in _audit_events(audit_log)
+        if e["event_type"] == "central_install_cutover_behind_check"
+    ]
+    assert len(checks) == 1
+    assert checks[0]["outcome"] == "override"
+    assert checks[0]["reason"] == reason
+
+
+@pytest.mark.parametrize("empty_reason", ["", "   "])
+def test_over_threshold_empty_reason_is_a_refusal(
+    tmp_path, central_root, audit_log, monkeypatch, empty_reason
+):
+    """The escape hatch demands an explicit reason — a blank one is refused."""
+    src = _source_repo(tmp_path / "src", ahead=5)
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+    target_dir = _flip_target(central_root, "v1.0.0")
+
+    with pytest.raises(CutoverRefusedError):
+        _atomic_symlink_flip(
+            central_root, target_dir, dry_run=False,
+            audit_log=audit_log, behind_source=str(src),
+            cutover_reason=empty_reason,
+        )
+
+    assert not (central_root / "current").exists()
+
+
+# ---------------------------------------------------------------------------
+# Third outcome: unmeasurable behindness is UNKNOWN, never silently 0
+# ---------------------------------------------------------------------------
+
+def test_unmeasurable_source_is_unknown_not_zero(
+    tmp_path, central_root, audit_log, monkeypatch, capsys
+):
+    missing = tmp_path / "no-such-repo"
+    target_dir = _flip_target(central_root, "v1.0.0")
+
+    out, err = _flip(
+        central_root, target_dir, audit_log, behind_source=str(missing)
+    )
+
+    combined = out + err
+    assert "UNKNOWN" in combined
+    # Negative control: unknown is never reported as a number, and never as 0.
+    assert "0 commits behind" not in combined
+    # Design decision: UNKNOWN proceeds loudly rather than blocking (a cutover
+    # is non-destructive; update/rollback are recovery tools that must keep
+    # working when the remote is unreachable).
+    assert (central_root / "current").resolve() == target_dir.resolve()
+    checks = [
+        e for e in _audit_events(audit_log)
+        if e["event_type"] == "central_install_cutover_behind_check"
+    ]
+    assert len(checks) == 1
+    assert checks[0]["outcome"] == "proceed_unknown"
+    assert checks[0]["behind"] is None
+
+
+def test_missing_ref_is_unknown_not_zero(
+    tmp_path, central_root, audit_log, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", ahead=2)
+    target_dir = _flip_target(central_root, "v9.9.9")
+
+    out, err = _flip(
+        central_root, target_dir, audit_log, behind_source=str(src)
+    )
+
+    assert "UNKNOWN" in (out + err)
+    assert (central_root / "current").resolve() == target_dir.resolve()
+
+
+def test_non_git_flip_target_with_no_source_is_unknown_without_network(
+    tmp_path, central_root, audit_log
+):
+    """A flip target that is not a git checkout (test stubs, hand-made dirs)
+    carries no origin to measure against — UNKNOWN, and crucially NO clone of
+    the canonical remote is attempted (the existing direct-flip tests must
+    stay offline)."""
+    target_dir = _flip_target(central_root, "v1.0.0")
+
+    out, err = _flip(central_root, target_dir, audit_log)
+
+    assert "UNKNOWN" in (out + err)
+    assert (central_root / "current").resolve() == target_dir.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Rollback: measured and named, never blocked
+# ---------------------------------------------------------------------------
+
+def test_rollback_reports_count_but_never_blocks(
+    tmp_path, central_root, audit_log, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", ahead=5)
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+
+    old = central_root / "versions" / "v1.0.0"
+    old.mkdir(parents=True)
+    # Give the rollback target an origin so the guard can measure it.
+    subprocess.run(["git", "init", "-q"], cwd=old, check=True)
+    _git(old, "remote", "add", "origin", str(src))
+    new = central_root / "versions" / "v1.0.1"
+    new.mkdir(parents=True)
+    import os
+    os.utime(old, (1_700_000_000, 1_700_000_000))
+    os.utime(new, (1_700_000_100, 1_700_000_100))
+    (central_root / "current").symlink_to(new)
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = _do_rollback(central_root, dry_run=False)
+
+    assert rc == 0
+    # The count is named on the rollback path too ...
+    assert "5 commits behind" in out.getvalue()
+    # ... but over-threshold does not refuse: rollback goes backwards by design.
+    assert (central_root / "current").resolve() == old.resolve()
+
+
+# ---------------------------------------------------------------------------
+# edge tracks main by definition: 0 behind, no clone attempted
+# ---------------------------------------------------------------------------
+
+def test_edge_reports_zero_without_touching_source(
+    tmp_path, central_root, audit_log
+):
+    target_dir = _flip_target(central_root, "edge")
+
+    out, _err = _flip(
+        central_root, target_dir, audit_log,
+        # A nonexistent source proves no measurement clone was attempted.
+        behind_source=str(tmp_path / "no-such-repo"),
+    )
+
+    assert "0 commits behind" in out
+    assert (central_root / "current").resolve() == target_dir.resolve()
+
+
+# ---------------------------------------------------------------------------
+# No cutover path passes without the measurement being named
+# ---------------------------------------------------------------------------
+
+def test_every_successful_flip_output_names_the_measurement(
+    tmp_path, central_root, audit_log, monkeypatch
+):
+    """Negative control for requirement 1: three different flip paths
+    (measured, override, unknown) all carry the behind-check line — no silent
+    cutover exists."""
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+
+    # measured + over threshold + reason
+    src = _source_repo(tmp_path / "src", ahead=5)
+    t1 = _flip_target(central_root, "v1.0.0")
+    out1, _ = _flip(
+        central_root, t1, audit_log,
+        behind_source=str(src), cutover_reason="deliberate pin",
+    )
+    assert "behind" in out1 and "5" in out1
+
+    # measured + under threshold
+    src2 = _source_repo(tmp_path / "src2", tag="v1.0.1", ahead=1)
+    t2 = _flip_target(central_root, "v1.0.1")
+    out2, _ = _flip(central_root, t2, audit_log, behind_source=str(src2))
+    assert "1 commits behind" in out2
+
+    # unknown
+    t3 = _flip_target(central_root, "v1.0.2")
+    out3, err3 = _flip(central_root, t3, audit_log)
+    assert "UNKNOWN" in (out3 + err3)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run announces the guard without measuring
+# ---------------------------------------------------------------------------
+
+def test_flip_dry_run_announces_behind_check(tmp_path, central_root):
+    target_dir = central_root / "versions" / "v1.0.0"
+    out = io.StringIO()
+    with redirect_stdout(out):
+        _atomic_symlink_flip(central_root, target_dir, dry_run=True)
+    assert "[dry-run]" in out.getvalue()
+    assert "behind" in out.getvalue()
+    assert not (central_root / "current").exists()
+
+
+def test_update_dry_run_announces_behind_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    args = Namespace(
+        to_version="v2.0.0", keep_last=3, dry_run=True,
+        rollback=False, protect_pins=None, cutover_reason=None,
+    )
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = vnx_update(args)
+    assert rc == 0
+    assert "behind" in out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Release publish --set-current: the guard rides the publish cutover too
+# ---------------------------------------------------------------------------
+
+STUB_INSTALL_CENTRAL = """#!/usr/bin/env bash
+set -euo pipefail
+VERSION=""
+TARGET=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --target)  TARGET="$2";  shift 2 ;;
+    --source)  shift 2 ;;
+    --materialize-only) shift ;;
+    *) echo "stub: unknown arg $1" >&2; exit 1 ;;
+  esac
+done
+[ -n "$VERSION" ] && [ -n "$TARGET" ]
+mkdir -p "${TARGET}/versions/${VERSION}"
+echo "stub-materialized ${VERSION}"
+"""
+
+
+@pytest.fixture
+def stub_install_central(tmp_path, monkeypatch):
+    stub = tmp_path / "install-central.sh"
+    stub.write_text(STUB_INSTALL_CENTRAL, encoding="utf-8")
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("VNX_INSTALL_CENTRAL_SCRIPT", str(stub))
+    return stub
+
+
+def _publish_args(*, tag, repo, dry_run=False, set_current=False, cutover_reason=None):
+    return Namespace(
+        tag=tag, repo=repo, dry_run=dry_run,
+        set_current=set_current, cutover_reason=cutover_reason,
+    )
+
+
+def test_release_set_current_refused_over_threshold(
+    tmp_path, central_root, stub_install_central, monkeypatch, capsys
+):
+    src = _source_repo(tmp_path / "src", tag="v1.3.1", ahead=5)
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+
+    rc = vnx_release_publish(
+        _publish_args(tag="v1.3.1", repo=str(src), set_current=True)
+    )
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "5" in captured.err
+    assert "v1.3.1" in captured.err
+    assert "--cutover-reason" in captured.err
+    # The publish itself succeeded; only the cutover was refused.
+    assert (central_root / "versions" / "v1.3.1").is_dir()
+    assert not (central_root / "current").exists()
+
+
+def test_release_set_current_with_reason_proceeds(
+    tmp_path, central_root, stub_install_central, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", tag="v1.3.1", ahead=5)
+    monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
+    reason = "staging cutover rehearsed against the old tag on purpose"
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = vnx_release_publish(
+            _publish_args(
+                tag="v1.3.1", repo=str(src), set_current=True,
+                cutover_reason=reason,
+            )
+        )
+
+    assert rc == 0
+    assert "5 commits behind" in out.getvalue()
+    current = central_root / "current"
+    assert current.is_symlink()
+    assert current.resolve() == (central_root / "versions" / "v1.3.1").resolve()
+    # The reason is on the audit trail.
+    log = central_root.parent / "vnx-data" / "events" / "central_install.ndjson"
+    events = _audit_events(log)
+    checks = [e for e in events if e["event_type"] == "central_install_cutover_behind_check"]
+    assert len(checks) == 1
+    assert checks[0]["outcome"] == "override"
+    assert checks[0]["reason"] == reason
+
+
+def test_release_set_current_under_threshold_names_count(
+    tmp_path, central_root, stub_install_central, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", tag="v1.3.1", ahead=1)
+    monkeypatch.delenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", raising=False)
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = vnx_release_publish(
+            _publish_args(tag="v1.3.1", repo=str(src), set_current=True)
+        )
+
+    assert rc == 0
+    assert "1 commits behind" in out.getvalue()
+    assert (central_root / "current").is_symlink()
+
+
+def test_release_dry_run_set_current_announces_behind_check(
+    tmp_path, central_root, monkeypatch
+):
+    src = _source_repo(tmp_path / "src", tag="v1.3.1", ahead=5)
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = vnx_release_publish(
+            _publish_args(tag="v1.3.1", repo=str(src), dry_run=True, set_current=True)
+        )
+    assert rc == 0
+    assert "behind" in out.getvalue()
+    assert not (central_root / "current").exists()

--- a/tests/test_oi1718_cutover_behind_guard.py
+++ b/tests/test_oi1718_cutover_behind_guard.py
@@ -45,12 +45,8 @@ if str(REPO_ROOT / "scripts" / "lib") not in sys.path:
 import config_registry as cr
 import vnx_cli.commands.update as update_module
 from vnx_cli.commands.update import (
-    CutoverRefusedError,
-    DEFAULT_CUTOVER_MAX_BEHIND_COMMITS,
     _atomic_symlink_flip,
-    _cutover_max_behind_commits,
     _do_rollback,
-    _measure_behind_main,
     vnx_update,
 )
 from vnx_cli.commands.release import vnx_release_publish
@@ -131,21 +127,29 @@ def _flip(root, target_dir, audit_log, **kwargs):
 # ---------------------------------------------------------------------------
 
 def test_measure_behind_main_counts_commits(tmp_path):
+    from vnx_cli.commands.update import _measure_behind_main
+
     src = _source_repo(tmp_path / "src", ahead=5)
     assert _measure_behind_main(str(src), "v1.0.0") == 5
 
 
 def test_measure_behind_main_zero_for_tip_tag(tmp_path):
+    from vnx_cli.commands.update import _measure_behind_main
+
     src = _source_repo(tmp_path / "src", ahead=0)
     assert _measure_behind_main(str(src), "v1.0.0") == 0
 
 
 def test_measure_behind_main_unknown_for_missing_ref(tmp_path):
+    from vnx_cli.commands.update import _measure_behind_main
+
     src = _source_repo(tmp_path / "src", ahead=2)
     assert _measure_behind_main(str(src), "v9.9.9") is None
 
 
 def test_measure_behind_main_unknown_for_unreachable_source(tmp_path):
+    from vnx_cli.commands.update import _measure_behind_main
+
     missing = tmp_path / "no-such-repo"
     assert _measure_behind_main(str(missing), "v1.0.0") is None
 
@@ -153,6 +157,8 @@ def test_measure_behind_main_unknown_for_unreachable_source(tmp_path):
 def test_measure_behind_main_unknown_when_source_has_no_main(tmp_path):
     """A source without a ``main`` branch cannot define behindness — UNKNOWN,
     never 0."""
+    from vnx_cli.commands.update import _measure_behind_main
+
     src = tmp_path / "src"
     src.mkdir(parents=True)
     subprocess.run(["git", "init", "-q", "-b", "trunk"], cwd=src, check=True)
@@ -168,17 +174,29 @@ def test_measure_behind_main_unknown_when_source_has_no_main(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_threshold_default_when_nothing_set(monkeypatch):
+    from vnx_cli.commands.update import (
+        DEFAULT_CUTOVER_MAX_BEHIND_COMMITS,
+        _cutover_max_behind_commits,
+    )
+
     monkeypatch.delenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", raising=False)
     monkeypatch.delenv("VNX_OVERRIDE_CUTOVER_MAX_BEHIND_COMMITS", raising=False)
     assert _cutover_max_behind_commits() == DEFAULT_CUTOVER_MAX_BEHIND_COMMITS
 
 
 def test_threshold_env_override(monkeypatch):
+    from vnx_cli.commands.update import _cutover_max_behind_commits
+
     monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
     assert _cutover_max_behind_commits() == 2
 
 
 def test_threshold_invalid_value_falls_back_to_default_loudly(monkeypatch, capsys):
+    from vnx_cli.commands.update import (
+        DEFAULT_CUTOVER_MAX_BEHIND_COMMITS,
+        _cutover_max_behind_commits,
+    )
+
     monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "banana")
     assert _cutover_max_behind_commits() == DEFAULT_CUTOVER_MAX_BEHIND_COMMITS
     assert "VNX_CUTOVER_MAX_BEHIND_COMMITS" in capsys.readouterr().err
@@ -188,6 +206,8 @@ def test_registry_entry_registered_with_description():
     """The threshold lives in the config registry (requirement 4), with a
     written-out description — not a bare number in code. The registry default
     mirrors the code fallback, the registry's own contract."""
+    from vnx_cli.commands.update import DEFAULT_CUTOVER_MAX_BEHIND_COMMITS
+
     entry = cr.CONFIG_REGISTRY["VNX_CUTOVER_MAX_BEHIND_COMMITS"]
     assert entry.default == str(DEFAULT_CUTOVER_MAX_BEHIND_COMMITS)
     assert entry.type == "string"
@@ -227,6 +247,8 @@ def test_under_threshold_proceeds_and_names_count(
 def test_over_threshold_refused_names_count_ref_and_way_out(
     tmp_path, central_root, audit_log, monkeypatch
 ):
+    from vnx_cli.commands.update import CutoverRefusedError
+
     src = _source_repo(tmp_path / "src", ahead=5)
     monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
     target_dir = _flip_target(central_root, "v1.0.0")
@@ -284,6 +306,8 @@ def test_over_threshold_empty_reason_is_a_refusal(
     tmp_path, central_root, audit_log, monkeypatch, empty_reason
 ):
     """The escape hatch demands an explicit reason — a blank one is refused."""
+    from vnx_cli.commands.update import CutoverRefusedError
+
     src = _source_repo(tmp_path / "src", ahead=5)
     monkeypatch.setenv("VNX_CUTOVER_MAX_BEHIND_COMMITS", "2")
     target_dir = _flip_target(central_root, "v1.0.0")

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -337,7 +337,13 @@ def test_symlink_flip_emits_audit_events(tmp_path):
     _atomic_symlink_flip(root, target_dir, dry_run=False, audit_log=audit_log)
 
     assert audit_log.exists()
-    lines = audit_log.read_text().strip().splitlines()
+    # OI-1718: the flip also emits a central_install_cutover_behind_check
+    # event; this test pins the flip's own before/after pair.
+    lines = [
+        line
+        for line in audit_log.read_text().strip().splitlines()
+        if json.loads(line)["event_type"] == "central_install_update"
+    ]
     assert len(lines) == 2
 
     before = json.loads(lines[0])

--- a/vnx_cli/commands/release.py
+++ b/vnx_cli/commands/release.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from vnx_cli.commands.update import (
     INSTALL_MODE_MARKER,
     VNX_GIT_REMOTE,
+    CutoverRefusedError,
     _atomic_symlink_flip,
     _current_target,
     _emit_audit_event,
@@ -219,6 +220,7 @@ def vnx_release_publish(args) -> int:
     tag: "str | None" = getattr(args, "tag", None)
     dry_run: bool = getattr(args, "dry_run", False)
     set_current: bool = getattr(args, "set_current", False)
+    cutover_reason: "str | None" = getattr(args, "cutover_reason", None)
 
     if not tag:
         print("Error: --tag <vX.Y.Z> is required.", file=sys.stderr)
@@ -300,6 +302,11 @@ def vnx_release_publish(args) -> int:
                 "(--set-current passed)"
             )
             print(
+                f"[dry-run] Would measure how far '{tag}' is behind main and "
+                "enforce the VNX_CUTOVER_MAX_BEHIND_COMMITS threshold before "
+                "flipping (OI-1718)"
+            )
+            print(
                 f"[dry-run] Would warn: consumers with a tracked .vnx-version "
                 f"pin must update their pin to {tag} (the pin does not follow "
                 f"`current`)"
@@ -327,7 +334,24 @@ def vnx_release_publish(args) -> int:
     print(f"Published: {target_dir}")
 
     if set_current:
-        _atomic_symlink_flip(root, target_dir, dry_run=False)
+        # OI-1718: the guard measures the tag's behindness against the repo
+        # being published from (the same source the tag came from) and refuses
+        # the cutover over the configured threshold without an explicit reason.
+        # A refusal leaves the publish itself intact — only the flip is denied.
+        try:
+            _atomic_symlink_flip(
+                root, target_dir, dry_run=False,
+                cutover_reason=cutover_reason, behind_source=repo,
+            )
+        except CutoverRefusedError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            print(
+                f"Note: '{tag}' was published to {target_dir}; only the cutover "
+                f"was refused. Cut over later with `vnx update --to {tag} "
+                "--cutover-reason \"...\"` once the reason exists.",
+                file=sys.stderr,
+            )
+            return 1
         print(_release_notes_hint(tag))
         print(_current_flip_warning(tag), file=sys.stderr)
     else:

--- a/vnx_cli/commands/release.py
+++ b/vnx_cli/commands/release.py
@@ -25,6 +25,7 @@ from vnx_cli.commands.update import (
     _current_target,
     _emit_audit_event,
     _git_toplevel,
+    _origin_url,
     _resolve_root,
     _validate_version_name,
     _write_install_marker,
@@ -140,8 +141,46 @@ def _materialize_from_tag(root: Path, repo: str, tag: str) -> Path:
         raise RuntimeError(
             f"materialization reported success but {target_dir} does not exist"
         )
+    _set_origin_remote(target_dir)
     _write_install_marker(target_dir)
     return target_dir
+
+
+def _set_origin_remote(version_dir: Path) -> None:
+    """Point a freshly published version dir's ``origin`` at the canonical remote.
+
+    install-central.sh clones from the temp checkout publish made of the
+    source repo, so the materialized dir's origin is a temp path that
+    publish deletes right after — every later git fetch/pull in that dir
+    would fail against a vanished origin (OI-1711 defect 1). Re-point origin
+    at ``VNX_GIT_REMOTE`` (the remote ``vnx update`` clones from and fetches
+    against) before the dir is considered published. Goes through the same
+    ``writeable_version_dir`` unlock/relock route ``vnx update`` uses — the
+    dir is already read-only at this point for pinned versions. A
+    materialized dir that is not a git checkout at all (test stubs that do
+    not clone) is skipped with a warning instead of failing the publish.
+    """
+    if _git_toplevel(version_dir) != version_dir:
+        print(f"[warn] {version_dir} is not a git checkout — origin left untouched")
+        return
+    from vnx_cli import _engine
+    _engine.ensure_engine_on_path()
+    from vnx_version_ro import writeable_version_dir
+    with writeable_version_dir(version_dir):
+        existing = _origin_url(version_dir)
+        if existing is None:
+            subprocess.run(
+                ["git", "-C", str(version_dir), "remote", "add", "origin", VNX_GIT_REMOTE],
+                check=True,
+            )
+        elif existing != VNX_GIT_REMOTE:
+            subprocess.run(
+                ["git", "-C", str(version_dir), "remote", "set-url", "origin", VNX_GIT_REMOTE],
+                check=True,
+            )
+        else:
+            return
+    print(f"Origin set: {version_dir} -> {VNX_GIT_REMOTE}")
 
 
 def _release_notes_hint(tag: str) -> str:

--- a/vnx_cli/commands/subsystems.py
+++ b/vnx_cli/commands/subsystems.py
@@ -94,6 +94,11 @@ SUBSYSTEM_DESCRIPTIONS: Dict[str, str] = {
         "N-slot serial lock protecting the shared Claude subscription session cap "
         "for the claude-tmux dispatch lane."
     ),
+    "central-install-cutover": (
+        "Cutover behind-guard: every central-install flip measures and names how "
+        "far the target lags main; over the threshold the flip needs an explicit "
+        "operator reason (OI-1718)."
+    ),
 }
 
 # Ledger row order (framework-status-audit-and-cockpit PR-3). Grouped by
@@ -133,6 +138,7 @@ _ROW_ORDER: List[str] = [
     "central-db-routing",
     "smart-router-staging",
     "claude-tmux-serialization",
+    "central-install-cutover",
     # SCOPE
     "plan-gate-panel",
     "plan-gate-task-class-scope",

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -150,6 +150,126 @@ def _current_target(root: Path):
     return None
 
 
+def _origin_url(version_dir: Path) -> "str | None":
+    """The fetch URL of ``origin`` in ``version_dir``, or None when absent/unreadable."""
+    result = subprocess.run(
+        ["git", "-C", str(version_dir), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _origin_usable(version_dir: Path) -> bool:
+    """True when origin exists and points somewhere a fetch can actually read.
+
+    A local-path origin whose directory vanished (exactly what a pre-OI-1711
+    publish left behind: the deleted temp checkout) counts as unusable. A
+    network URL is assumed usable — a real outage there surfaces from the
+    fetch/pull itself with its own error.
+    """
+    url = _origin_url(version_dir)
+    if not url:
+        return False
+    if "://" in url or url.startswith("git@"):
+        return True
+    local = Path(os.path.expanduser(url))
+    if not local.is_dir():
+        return False
+    probe = subprocess.run(
+        ["git", "-C", str(local), "rev-parse", "--git-dir"],
+        capture_output=True,
+    )
+    return probe.returncode == 0
+
+
+def _ensure_origin_remote(version_dir: Path) -> bool:
+    """Repair a missing or unusable ``origin`` back to ``VNX_GIT_REMOTE``.
+
+    ``vnx update`` clones from and fetches against ``VNX_GIT_REMOTE``; an
+    origin that is absent or points at a vanished path makes every fetch
+    fail with git's opaque "does not appear to be a git repository".
+    Re-pointing at the canonical remote is the repair. Returns True when a
+    repair was applied.
+    """
+    if _origin_usable(version_dir):
+        return False
+    old = _origin_url(version_dir)
+    if old is None:
+        subprocess.run(
+            ["git", "-C", str(version_dir), "remote", "add", "origin", VNX_GIT_REMOTE],
+            check=True,
+        )
+    else:
+        subprocess.run(
+            ["git", "-C", str(version_dir), "remote", "set-url", "origin", VNX_GIT_REMOTE],
+            check=True,
+        )
+    print(f"Repaired unusable origin ({old or 'none'}) -> {VNX_GIT_REMOTE}")
+    return True
+
+
+def _head_sha(version_dir: Path) -> "str | None":
+    """The commit HEAD points at, or None when it cannot be resolved."""
+    result = subprocess.run(
+        ["git", "-C", str(version_dir), "rev-parse", "--verify", "--quiet", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _head_branch(version_dir: Path) -> "str | None":
+    """The branch HEAD is attached to, or None for a detached HEAD."""
+    result = subprocess.run(
+        ["git", "-C", str(version_dir), "symbolic-ref", "-q", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _ref_sha(version_dir: Path, ref: str) -> "str | None":
+    """The commit of a local ref (e.g. ``refs/tags/v1.2.3``), or None."""
+    result = subprocess.run(
+        ["git", "-C", str(version_dir), "rev-parse", "--verify", "--quiet",
+         f"{ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _fetch_and_checkout_ref(version_dir: Path, target: str) -> None:
+    """Fetch ``target`` from origin and point HEAD at it explicitly.
+
+    The correct update move for a tag-pinned version dir: such a clone has a
+    detached HEAD with no upstream, so ``git pull --ff-only`` fails no matter
+    how healthy origin is (OI-1711 defect 2). Fetch the ref, then check it
+    out — detached again for a tag, re-attached to ``main`` for ``edge``.
+    """
+    if target == "edge":
+        refspec = "+refs/heads/main:refs/heads/main"
+        checkout = ["checkout", "main"]
+    else:
+        refspec = f"+refs/tags/{target}:refs/tags/{target}"
+        checkout = ["checkout", "--detach", target]
+    print(f"Fetching {target} from origin and checking it out in {version_dir}...")
+    subprocess.run(
+        ["git", "-C", str(version_dir), "fetch", "--depth", "1", "origin", refspec],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(version_dir), *checkout], check=True)
+
+
 def _fetch_version(
     root: Path, target: str, dry_run: bool, audit_log: "Path | None" = None
 ) -> Path:
@@ -166,15 +286,41 @@ def _fetch_version(
     versions_dir.mkdir(parents=True, exist_ok=True)
 
     if target_dir.is_dir():
-        print(f"Pulling {target} in {target_dir}...")
         from vnx_cli import _engine as _eng2
         _eng2.ensure_engine_on_path()
         from vnx_version_ro import writeable_version_dir as _wvd
         with _wvd(target_dir):
-            subprocess.run(
-                ["git", "-C", str(target_dir), "pull", "--ff-only"],
-                check=True,
-            )
+            # Test before touching anything: an origin left pointing at a
+            # vanished path (a pre-OI-1711 publish's deleted temp checkout)
+            # is repaired to the canonical remote first, so a later git
+            # failure is never the opaque "does not appear to be a git
+            # repository" against a path that no longer exists.
+            _ensure_origin_remote(target_dir)
+            if target == "edge":
+                if _head_branch(target_dir) is None:
+                    # Detached edge checkout: pull has no upstream to work
+                    # with — re-attach to a freshly fetched main instead.
+                    _fetch_and_checkout_ref(target_dir, target)
+                else:
+                    print(f"Pulling {target} in {target_dir}...")
+                    subprocess.run(
+                        ["git", "-C", str(target_dir), "pull", "--ff-only"],
+                        check=True,
+                    )
+            else:
+                head = _head_sha(target_dir)
+                tag_sha = _ref_sha(target_dir, f"refs/tags/{target}")
+                if head and tag_sha and head == tag_sha:
+                    # A tag-pinned dir already at the target tag is DONE, not
+                    # broken: no-op with a clear message — no pull (a detached
+                    # HEAD has no upstream, so pull could never work here),
+                    # no error.
+                    print(
+                        f"{target_dir} is already at {target} ({head[:12]}) — "
+                        "nothing to pull."
+                    )
+                else:
+                    _fetch_and_checkout_ref(target_dir, target)
             # Strip and marker happen inside the context so the dir is
             # writable for both.  _write_install_marker has its own inner
             # context manager that is a no-op when already writable.

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -27,6 +28,21 @@ VNX_GIT_REMOTE = "https://github.com/Vinix24/vnx-orchestration.git"
 DEFAULT_KEEP_LAST = 3
 DEFAULT_REGISTRY_PATH = Path.home() / ".vnx" / "projects.json"
 PROTECTED_VERSIONS_FILE = "protected-versions"
+
+# OI-1718: every cutover measures how far its target lags main and names that
+# number out loud before flipping `current`; over the threshold the flip is
+# refused unless the operator passes an explicit --cutover-reason. The
+# threshold is CONFIG, not a hardcoded gate: it is registered as
+# VNX_CUTOVER_MAX_BEHIND_COMMITS in scripts/lib/config_registry.py, whose
+# default mirrors this constant (the registry's own contract — "defaults
+# mirror the current code"). Default 20: the OI-1718 incident was a tag
+# measured 36 commits behind main at the start of an evening and 42 by its
+# end; a release cut the same week typically sits well under 20.
+CUTOVER_BEHIND_CONFIG_KEY = "VNX_CUTOVER_MAX_BEHIND_COMMITS"
+DEFAULT_CUTOVER_MAX_BEHIND_COMMITS = 20
+# Bounded so an unreachable remote cannot hang a cutover (or a rollback, which
+# measures best-effort and never blocks) for longer than this.
+_BEHIND_CLONE_TIMEOUT_SECONDS = 60
 
 # OI-1379: the fleet registry (source 1) only protects REGISTERED consumer
 # projects. A project that pins a version via ``.vnx-version`` but was never
@@ -61,6 +77,15 @@ _VERSION_RE = re.compile(r"^(edge|latest|v?\d+\.\d+\.\d+(?:-[\w.]+)?)$")
 # standalone dev checkout and collapses PROJECT_ROOT onto the shared code tree.
 INSTALL_MODE_MARKER = ".vnx-install-mode"
 INSTALL_MODE_VALUE = "central"
+
+
+class CutoverRefusedError(Exception):
+    """The cutover behind-guard refused the flip (OI-1718).
+
+    Raised before any filesystem mutation: the target was measured too far
+    behind main and no explicit operator reason was given. The message names
+    the count, the target ref, and the way out.
+    """
 
 
 class ProtectionSetUnavailable(Exception):
@@ -440,13 +465,261 @@ def _ensure_install_marker(
     print(f"Repaired missing install-mode marker: {marker}")
 
 
+def _cutover_max_behind_commits() -> int:
+    """The cutover behindness threshold, read from the config registry.
+
+    Read through ``config_registry.get()`` so the standard precedence chain
+    applies (``VNX_OVERRIDE_CUTOVER_MAX_BEHIND_COMMITS`` > DB >
+    ``VNX_CUTOVER_MAX_BEHIND_COMMITS`` env > registry default). Falls back to
+    ``DEFAULT_CUTOVER_MAX_BEHIND_COMMITS`` when the engine tree is not
+    importable (the pip CLI without scripts/lib on path) — the registry
+    default mirrors that constant exactly, and a test pins the two together.
+    An invalid configured value is loud and falls back to the default rather
+    than silently disabling or hardening the guard.
+    """
+    raw = None
+    try:
+        from vnx_cli import _engine
+        _engine.ensure_engine_on_path()
+        from config_registry import get as _config_get
+        raw = _config_get(CUTOVER_BEHIND_CONFIG_KEY)
+    except ImportError:
+        override_key = f"VNX_OVERRIDE_{CUTOVER_BEHIND_CONFIG_KEY[len('VNX_'):]}"
+        raw = os.environ.get(override_key) or os.environ.get(CUTOVER_BEHIND_CONFIG_KEY)
+    if raw is None or not str(raw).strip():
+        return DEFAULT_CUTOVER_MAX_BEHIND_COMMITS
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        value = -1
+    if value < 0:
+        print(
+            f"[warn] invalid {CUTOVER_BEHIND_CONFIG_KEY}={raw!r} "
+            f"(need a non-negative integer) — using default "
+            f"{DEFAULT_CUTOVER_MAX_BEHIND_COMMITS}",
+            file=sys.stderr,
+        )
+        return DEFAULT_CUTOVER_MAX_BEHIND_COMMITS
+    return value
+
+
+def _measure_behind_main(source: str, target_ref: str) -> "int | None":
+    """Commits on ``main`` that ``target_ref`` does not contain, or None.
+
+    Measured in a throwaway bare clone of ``source`` so no live checkout is
+    touched: installed version dirs are shallow (``--depth 1``) and read-only,
+    so counting there would either fail or silently under-count. A local-path
+    source clones with full history (hardlinked, cheap); a remote URL clones
+    the commit graph only (``--filter=tree:0``) — ``rev-list --count`` walks
+    commits, never trees.
+
+    None is a THIRD outcome, never a silent 0 (absence-is-loud, OI-1718):
+    unreachable source, a ref the source does not know, a source with no
+    ``main`` branch, or any git failure all land here, each with a named
+    warning on stderr.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="vnx-cutover-behind-"))
+    try:
+        clone_cmd = ["git", "clone", "--bare", "--quiet"]
+        if not Path(os.path.expanduser(source)).is_dir():
+            clone_cmd.append("--filter=tree:0")
+        clone_cmd += [source, str(tmp)]
+        try:
+            clone = subprocess.run(
+                clone_cmd, capture_output=True, text=True,
+                timeout=_BEHIND_CLONE_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            print(
+                f"[warn] cutover behind-check: cannot clone {source}: {exc}",
+                file=sys.stderr,
+            )
+            return None
+        if clone.returncode != 0:
+            lines = (clone.stderr or "").strip().splitlines()
+            detail = f": {lines[-1]}" if lines else ""
+            print(
+                f"[warn] cutover behind-check: clone of {source} failed{detail}",
+                file=sys.stderr,
+            )
+            return None
+        main_sha = _ref_sha(tmp, "refs/heads/main")
+        if main_sha is None:
+            print(
+                f"[warn] cutover behind-check: {source} has no main branch",
+                file=sys.stderr,
+            )
+            return None
+        target_sha = _ref_sha(tmp, target_ref)
+        if target_sha is None:
+            print(
+                f"[warn] cutover behind-check: ref {target_ref!r} not found in {source}",
+                file=sys.stderr,
+            )
+            return None
+        count = subprocess.run(
+            ["git", "-C", str(tmp), "rev-list", "--count", f"{target_sha}..{main_sha}"],
+            capture_output=True, text=True,
+        )
+        if count.returncode != 0:
+            print(
+                f"[warn] cutover behind-check: rev-list failed: "
+                f"{(count.stderr or '').strip()}",
+                file=sys.stderr,
+            )
+            return None
+        try:
+            return int(count.stdout.strip())
+        except ValueError:
+            print(
+                f"[warn] cutover behind-check: unparseable rev-list output "
+                f"{count.stdout!r}",
+                file=sys.stderr,
+            )
+            return None
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _derive_behind_source(target_dir: Path) -> "str | None":
+    """The git source to measure a flip target's behindness against.
+
+    The version dir being activated is a clone of the canonical remote in
+    every real install (``_ensure_origin_remote`` has repaired its origin by
+    the time the flip runs), so its own origin is the authoritative source.
+    A target that is not a git checkout carries no source: the caller reports
+    UNKNOWN without touching the network.
+    """
+    if _git_toplevel(target_dir) != target_dir:
+        return None
+    return _origin_url(target_dir)
+
+
+def _cutover_behind_guard(
+    to_name: str,
+    *,
+    target_dir: Path,
+    cutover_reason: "str | None",
+    enforce: bool,
+    behind_source: "str | None",
+    audit_log: "Path | None" = None,
+) -> None:
+    """Measure and NAME how far the cutover target lags main — before the flip.
+
+    Three outcomes, all loud and all audited as
+    ``central_install_cutover_behind_check`` events:
+
+    - measured, at or under the threshold: the count is printed and the
+      cutover proceeds (outcome ``proceed``). A silent successful cutover is
+      exactly the OI-1718 bug, so the number is named here too.
+    - measured, over the threshold: refused (outcome ``refused``, raises
+      ``CutoverRefusedError``) unless the operator passed an explicit
+      non-empty reason (outcome ``override``, the reason is printed and
+      recorded). A blank reason is a refusal.
+    - unmeasurable (no source, unreachable remote, unknown ref): reported as
+      UNKNOWN, never silently as 0 (outcome ``proceed_unknown``). UNKNOWN
+      proceeds loudly rather than blocking: a cutover is non-destructive, and
+      refusing every flip whenever the remote is unreachable would disable
+      ``update``/``rollback`` exactly when they are needed as recovery tools.
+
+    ``enforce=False`` is the rollback path: rolling back goes backwards by
+    design, so the count is measured and named but never refuses.
+    """
+    threshold = _cutover_max_behind_commits()
+    reason = (cutover_reason or "").strip()
+
+    def _audit(outcome: str, behind: "int | None") -> None:
+        fields = {
+            "to_version": to_name,
+            "behind": behind,
+            "threshold": threshold,
+            "enforced": enforce,
+            "outcome": outcome,
+        }
+        if reason:
+            fields["reason"] = reason
+        _emit_audit_event(
+            "central_install_cutover_behind_check", fields, audit_log=audit_log
+        )
+
+    if to_name == "edge":
+        # edge tracks main: the fetch/pull immediately before this flip put it
+        # at main's tip, so the count is 0 by construction — no clone needed.
+        print(
+            f"Cutover behind-check: 'edge' is 0 commits behind main "
+            f"(edge tracks main; threshold: {threshold})."
+        )
+        _audit("proceed", 0)
+        return
+
+    source = behind_source or _derive_behind_source(target_dir)
+    if source is None:
+        print(
+            f"[warn] cutover behind-check: no git source for '{to_name}' "
+            "(target dir is not a git checkout with an origin)",
+            file=sys.stderr,
+        )
+        behind = None
+    else:
+        behind = _measure_behind_main(source, to_name)
+
+    if behind is None:
+        print(
+            f"Cutover behind-check: behindness of '{to_name}' vs main is UNKNOWN "
+            "— proceeding with the flip, but the staleness of this target is "
+            "unverified. Unknown is not zero."
+        )
+        _audit("proceed_unknown", None)
+        return
+
+    print(
+        f"Cutover behind-check: '{to_name}' is {behind} commits behind main "
+        f"(threshold: {threshold})."
+    )
+
+    if behind <= threshold:
+        _audit("proceed", behind)
+        return
+
+    if not enforce:
+        print(
+            f"Cutover behind-check: {behind} exceeds threshold {threshold} — "
+            "reported, not blocked: a rollback goes backwards by design.",
+            file=sys.stderr,
+        )
+        _audit("proceed", behind)
+        return
+
+    if reason:
+        print(
+            f"Cutover behind-check: {behind} exceeds threshold {threshold} — "
+            f"proceeding on explicit operator reason: {reason!r}"
+        )
+        _audit("override", behind)
+        return
+
+    _audit("refused", behind)
+    raise CutoverRefusedError(
+        f"cutover refused: '{to_name}' is {behind} commits behind main "
+        f"(threshold: {threshold}). Cut a fresher release from main and target "
+        f"that, or re-run with --cutover-reason \"<why this stale target is "
+        f"intended>\" — an empty reason is itself a refusal."
+    )
+
+
 def _atomic_symlink_flip(
-    root: Path, target_dir: Path, dry_run: bool, audit_log: "Path | None" = None
+    root: Path, target_dir: Path, dry_run: bool, audit_log: "Path | None" = None,
+    cutover_reason: "str | None" = None, enforce_behind_guard: bool = True,
+    behind_source: "str | None" = None,
 ) -> None:
     current = root / "current"
 
     if dry_run:
         print(f"[dry-run] Would flip symlink: {current} -> {target_dir}")
+        print(
+            f"[dry-run] Would measure how far '{target_dir.name}' is behind main "
+            f"and enforce the {CUTOVER_BEHIND_CONFIG_KEY} threshold before flipping"
+        )
         return
 
     # Self-heal: whatever becomes active must carry the marker, even when this
@@ -457,6 +730,17 @@ def _atomic_symlink_flip(
     from_version = _current_target(root)
     from_name = from_version.name if from_version else None
     to_name = target_dir.name
+
+    # OI-1718: measure + name the target's behindness BEFORE any flip
+    # mutation. A refusal raises here, so `current` is never half-moved.
+    _cutover_behind_guard(
+        to_name,
+        target_dir=target_dir,
+        cutover_reason=cutover_reason,
+        enforce=enforce_behind_guard,
+        behind_source=behind_source,
+        audit_log=audit_log,
+    )
 
     root.mkdir(parents=True, exist_ok=True)
     tmp_link = root / "current.tmp"
@@ -965,7 +1249,7 @@ def _do_rollback(root: Path, dry_run: bool) -> int:
         print(f"[dry-run] Would rollback current -> {prev_dir}")
         return 0
 
-    _atomic_symlink_flip(root, prev_dir, dry_run=False)
+    _atomic_symlink_flip(root, prev_dir, dry_run=False, enforce_behind_guard=False)
     print(f"Rolled back to: {prev_dir.name}")
     return 0
 
@@ -976,6 +1260,7 @@ def vnx_update(args) -> int:
     dry_run: bool = getattr(args, "dry_run", False)
     rollback: bool = getattr(args, "rollback", False)
     protect_pins = getattr(args, "protect_pins", None)
+    cutover_reason = getattr(args, "cutover_reason", None)
 
     root = _resolve_root()
 
@@ -1003,10 +1288,15 @@ def vnx_update(args) -> int:
 
     try:
         target_dir = _fetch_version(root, target, dry_run=dry_run)
-        _atomic_symlink_flip(root, target_dir, dry_run=dry_run)
+        _atomic_symlink_flip(
+            root, target_dir, dry_run=dry_run, cutover_reason=cutover_reason
+        )
         _prune_old_versions(
             root, keep_last=keep_last, dry_run=dry_run, protect_pins=protect_pins
         )
+    except CutoverRefusedError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
     except FileNotFoundError:
         print("Error: git executable not found in PATH", file=sys.stderr)
         return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -336,6 +336,15 @@ def _register_update_subparser(subparsers: argparse.Action) -> None:
              "fleet .vnx-version pins (from ~/.vnx/projects.json) and the "
              "<root>/protected-versions file",
     )
+    update_parser.add_argument(
+        "--cutover-reason",
+        dest="cutover_reason",
+        default=None,
+        metavar="TEXT",
+        help="explicit reason required to cut over to a target measured more "
+             "than VNX_CUTOVER_MAX_BEHIND_COMMITS commits behind main "
+             "(OI-1718); an empty reason is refused",
+    )
 
 
 def _register_release_subparser(subparsers: argparse.Action) -> None:
@@ -373,6 +382,15 @@ def _register_release_subparser(subparsers: argparse.Action) -> None:
         dest="set_current",
         action="store_true",
         help="also flip current -> <tag> (default OFF: publish without cutover)",
+    )
+    publish_parser.add_argument(
+        "--cutover-reason",
+        dest="cutover_reason",
+        default=None,
+        metavar="TEXT",
+        help="explicit reason required for --set-current when the tag measures "
+             "more than VNX_CUTOVER_MAX_BEHIND_COMMITS commits behind main "
+             "(OI-1718); an empty reason is refused",
     )
 
 


### PR DESCRIPTION
## OI-1718 — een cutover noemt zijn achterstand hardop

A cutover could silently activate a target far behind `main`: tag `v1.6.1` pointed at a 6-day-old commit while `origin/main` had moved 36→42 commits ahead in a single evening, and nothing in `vnx update --to` / `vnx release publish --set-current` surfaced it. A consumer session spent the evening debugging symptoms whose cause was that behindness.

### What changed

`_atomic_symlink_flip` now runs a **behind-guard before any flip mutation**:

- **Always named** — the measured count (`git rev-list --count <target>..main`) is printed on every cutover, including successful and under-threshold ones. A silent successful cutover was the bug.
- **Over the threshold → refused** — the refusal names the count, the target ref, and the way out (`--cutover-reason`). `CutoverRefusedError` → exit 1, `current` untouched.
- **Escape = explicit reason, not a bare flag** — an empty/whitespace `--cutover-reason` is itself a refusal; a used reason is printed and recorded in the central-install audit log (`central_install_cutover_behind_check` event with count/threshold/outcome/reason).
- **Threshold is config, not code** — `VNX_CUTOVER_MAX_BEHIND_COMMITS` registered in `scripts/lib/config_registry.py` (default 20, mirroring the code fallback, override chain applies), cockpit ledger row added (`central-install-cutover`).
- **Unmeasurable = third outcome, never silent 0** — unreachable source, unknown ref, or missing `main` reports UNKNOWN loudly and proceeds (a cutover is non-destructive; `update`/`rollback` are recovery tools that must keep working when the remote is unreachable). Audited as `proceed_unknown`.
- **Rollback is exempt from refusal** — measured and named, never blocked: rolling back goes backwards by design; a guard firing there would trap the operator on a broken version.

Measurement runs in a throwaway bare clone of the relevant source (the publish repo for `--set-current`; the target dir's origin for `update`) — installed version dirs are shallow and read-only, so they are never trusted or mutated for the count. `edge` reports 0 by construction (it tracks main, freshly pulled).

### Which call sites got the guard, and why

| Call site | Measured | Refuses over threshold |
|---|---|---|
| `vnx release publish --set-current` (release.py) | yes, vs publish repo | yes (reason escape) |
| `vnx update --to <tag>` (update.py) | yes, vs target dir origin | yes (reason escape) |
| `vnx update --rollback` (update.py) | yes, named | **no — by design** |

### Verification

- RED (pre-fix): `pytest tests/test_oi1718_cutover_behind_guard.py` → collection ImportError (`CutoverRefusedError` absent) — no test can pass on the old code.
- GREEN: `pytest tests/test_oi1718_cutover_behind_guard.py tests/test_vnx_cli_update.py tests/test_vnx_release_publish.py tests/test_oi1711_publish_update_rerun.py tests/test_config_registry.py tests/vnx_cli/test_subsystems.py tests/test_subsystems_md_exists.py tests/test_cli_naamdrift.py tests/test_bin_vnx_command_loader.py tests/dashboard/test_api_subsystems.py tests/dashboard/test_api_health_subsystems.py tests/test_config_runtime.py -q` → **244 passed**.
- `python3 scripts/check_subsystems_drift.py` → OK (29 subsystems).
- One existing test updated: `test_symlink_flip_emits_audit_events` counted all audit lines (2); the guard adds a third event type, so it now filters to the flip's own `central_install_update` pair — intent preserved.

### Stacked on #1840

This branch is stacked on `dispatch/20260911-oi1711-publicatiepad-werkt-twee-keer` (PR #1840, OI-1711 — same two files). Base is `main`; mergeable after #1840 lands. Not rebased onto main on purpose — that would drop the OI-1711 base it builds on.

Dispatch-ID: 20260911-oi1718-cutover-noemt-zijn-achterstand
