### PR TITLE
fix(gate): heropen verplichting met verdwenen bewijsbestand als geldige reden (OI-1726)

### DIFF
--- a/scripts/gate_obligation_reopen_stale_evidence.py
+++ b/scripts/gate_obligation_reopen_stale_evidence.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """gate_obligation_reopen_stale_evidence.py — audited reopen of an obligation
-that was booked fulfilled/failed off evidence about a DIFFERENT commit
-(OI-1571 tak 3).
+that was booked fulfilled/failed off evidence that can no longer stand: either
+about a DIFFERENT commit (OI-1571 tak 3), or off a file that no longer exists
+at all (OI-1726).
 
 The gate obligation runner used to book an obligation fulfilled off any
 complete-evidence decided verdict for the same dispatch_id/PR+gate,
@@ -26,19 +27,30 @@ the time this script was written is 64df9933f6b3fed46070d597965f4415acca83e.
 ``vnx pr-ready 1719`` independently confirmed the same fact
 ("glm_gate NOT on head").
 
-Safety: this script VERIFIES the mismatch itself before writing anything —
+Safety: this script VERIFIES the misstand itself before writing anything —
 it never trusts an operator's claim on faith. It refuses (no write, exit 2)
 when:
   - the obligation is not in a terminal fulfilled/failed state (nothing to
     reopen),
-  - the obligation's own ``evidence_result_path``/``result_path`` cannot be
-    read,
+  - the obligation carries no ``evidence_result_path``/``result_path`` at
+    all,
+  - the evidence file EXISTS but cannot be parsed (corrupt JSON) — a
+    present-but-unreadable file cannot be PROVEN stale, so it is refused
+    rather than reopened on an unverified claim,
   - the PR's current head sha cannot be resolved (``gh`` unavailable) — the
     mismatch cannot be PROVEN, so nothing is reopened on an unverified claim
     (the same "third branch, never guess" discipline the runner's own sha
     check applies),
   - the evidence's own commit_sha turns out to MATCH the current head after
     all (there is genuinely nothing to correct).
+
+OI-1726 (2026-09-12): the ONE ground that flips from refusal to reason is an
+evidence file that does NOT exist on disk. An obligation that claims
+fulfilment/failure off a file that provably does not exist is false by
+construction — the absence IS the proof, so no PR-head resolution or sha
+comparison is needed (or possible). That is the strongest reopen case there
+is, and this script used to refuse exactly it (measured: ``REFUSED: evidence
+file does not exist on disk: .../pr-1840-kimi_gate.json``).
 
 Usage:
     python3 scripts/gate_obligation_reopen_stale_evidence.py \\
@@ -84,10 +96,20 @@ class ReopenRefused(RuntimeError):
 
 
 def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
-    """Read the obligation and PROVE its evidence is about a different
-    commit than the PR's current head. Never writes. Raises
-    :class:`ReopenRefused` (never returns a half-verified result) when the
-    mismatch cannot be established.
+    """Read the obligation and PROVE its evidence can no longer stand. Never
+    writes. Raises :class:`ReopenRefused` (never returns a half-verified
+    result) when the misstand cannot be established.
+
+    Two provable misstands are recognized:
+
+      - OI-1726: the evidence file does NOT exist on disk. The obligation
+        claims fulfilment/failure off a file that provably does not exist, so
+        the claim is false by construction. Returned with
+        ``evidence_missing=True`` and empty shas — there is no PR-head
+        resolution or sha comparison because the absence IS the proof.
+      - OI-1571 tak 3: the evidence file EXISTS and is readable, but its own
+        ``commit_sha`` binds to a DIFFERENT commit than the PR's current
+        head. Returned with ``evidence_missing=False`` and both shas.
     """
     path = obligation_path(state_dir, dispatch_id)
     if not path.exists():
@@ -105,7 +127,23 @@ def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
         raise ReopenRefused("obligation carries no evidence_result_path/result_path to verify")
     evidence_path = Path(evidence_path_str)
     if not evidence_path.exists():
-        raise ReopenRefused(f"evidence file does not exist on disk: {evidence_path}")
+        # OI-1726: a MISSING evidence file is the strongest possible reopen
+        # reason — the obligation claims fulfilment/failure off a file that
+        # provably does not exist, so the claim is false by construction. The
+        # absence IS the proof; there is no PR head to resolve and no sha to
+        # compare (the stale-evidence path below only fires when the file
+        # EXISTS). A present-but-unreadable file (corrupt) is deliberately
+        # NOT this case and still refuses below.
+        return {
+            "path": path,
+            "record": record,
+            "pr_number": record.get("pr_number"),
+            "head_sha": "",
+            "evidence_sha": "",
+            "evidence_path": str(evidence_path),
+            "evidence_missing": True,
+            "resolved_by_gate": record.get("resolved_by_gate") or record.get("fulfilled_by") or record.get("gate"),
+        }
     try:
         evidence_record = json.loads(evidence_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -137,6 +175,7 @@ def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
         "head_sha": head_sha,
         "evidence_sha": evidence_sha,
         "evidence_path": str(evidence_path),
+        "evidence_missing": False,
         "resolved_by_gate": record.get("resolved_by_gate") or record.get("fulfilled_by") or record.get("gate"),
     }
 
@@ -150,16 +189,27 @@ def reopen_obligation(
     """
     proof = verify_stale_evidence(state_dir, dispatch_id)
     record = proof["record"]
-    reason_detail = (
-        f"reopened by gate_obligation_reopen_stale_evidence.py (OI-1571 tak 3): "
-        f"the obligation was booked {record.get('status')!r} via "
-        f"{proof['resolved_by_gate']!r} off evidence at {proof['evidence_path']} "
-        f"(commit_sha={proof['evidence_sha'][:12]!r}), which is a DIFFERENT "
-        f"commit than PR #{proof['pr_number']}'s current head "
-        f"({proof['head_sha'][:12]!r}) — the gate obligation runner's own "
-        "sha-binding check (this same dispatch) would now refuse this "
-        f"evidence outright. Operator reason: {operator_reason}"
-    )
+    if proof.get("evidence_missing"):
+        reason_detail = (
+            f"reopened by gate_obligation_reopen_stale_evidence.py (OI-1726): "
+            f"the obligation was booked {record.get('status')!r} via "
+            f"{proof['resolved_by_gate']!r} off evidence at {proof['evidence_path']} "
+            "which no longer exists on disk — the claimed evidence is provably "
+            "gone, so the fulfilment/failure cannot stand and the runner must "
+            f"re-resolve the obligation against whatever real evidence exists. "
+            f"Operator reason: {operator_reason}"
+        )
+    else:
+        reason_detail = (
+            f"reopened by gate_obligation_reopen_stale_evidence.py (OI-1571 tak 3): "
+            f"the obligation was booked {record.get('status')!r} via "
+            f"{proof['resolved_by_gate']!r} off evidence at {proof['evidence_path']} "
+            f"(commit_sha={proof['evidence_sha'][:12]!r}), which is a DIFFERENT "
+            f"commit than PR #{proof['pr_number']}'s current head "
+            f"({proof['head_sha'][:12]!r}) — the gate obligation runner's own "
+            "sha-binding check (this same dispatch) would now refuse this "
+            f"evidence outright. Operator reason: {operator_reason}"
+        )
     outcome: Dict[str, Any] = {
         "dispatch_id": dispatch_id,
         "path": str(proof["path"]),
@@ -190,6 +240,7 @@ def reopen_obligation(
         previous_resolved_by_gate=proof["resolved_by_gate"],
         evidence_commit_sha=proof["evidence_sha"],
         pr_head_sha=proof["head_sha"],
+        evidence_missing=bool(proof.get("evidence_missing")),
         reason_detail=reason_detail,
     )
     update_obligation(

--- a/tests/test_gate_obligation_reopen_stale_evidence.py
+++ b/tests/test_gate_obligation_reopen_stale_evidence.py
@@ -120,6 +120,172 @@ class TestVerifyStaleEvidence:
         assert proof["resolved_by_gate"] == "glm_gate"
 
 
+class TestMissingEvidence:
+    """OI-1726 (2026-09-12): an obligation booked fulfilled/failed off an
+    evidence file that no longer exists on disk is the STRONGEST possible
+    reopen case — the claim is false by construction, not merely stale. This
+    script used to refuse exactly that (measured live: ``REFUSED: evidence
+    file does not exist on disk: .../pr-1840-kimi_gate.json``), which left the
+    poisoned-purge victim terminal with no way forward.
+
+    The absence IS the proof, so the missing-evidence path must NOT resolve a
+    PR head or compare shas — there is nothing to compare against."""
+
+    def _seed_missing_evidence_obligation(self, state_dir, dispatch_id, *, gate="kimi_gate", pr_number=1840):
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate=gate,
+            project_id="vnx-dev", pr_number=pr_number,
+        )
+        # The vanished record: referenced by the obligation, never written —
+        # exactly the shape a purge victim leaves behind.
+        vanished = state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+        update_obligation(
+            path,
+            status=STATUS_FULFILLED,
+            resolved_at="2026-09-11T10:00:00Z",
+            result_path=str(vanished),
+            evidence_result_path=str(vanished),
+            resolved_by_gate=gate,
+            fulfilled_by=gate,
+            takeover_gate=gate,
+            reason="fulfilled_by_takeover_evidence",
+        )
+        return path, vanished
+
+    def test_missing_evidence_is_a_valid_reopen_reason(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        _path, vanished = self._seed_missing_evidence_obligation(state_dir, "d-missing-evidence")
+        # The absence is itself the proof — a PR-head resolution attempt here
+        # would be a bug (there is no evidence sha to bind against).
+        monkeypatch.setattr(
+            reopener, "_get_pr_head_sha_for_gate",
+            lambda pr_number: pytest.fail("missing-evidence reopen must not resolve a PR head"),
+        )
+
+        proof = reopener.verify_stale_evidence(state_dir, "d-missing-evidence")
+
+        assert proof.get("evidence_missing") is True
+        assert proof["evidence_path"] == str(vanished)
+        assert proof["head_sha"] == ""
+        assert proof["evidence_sha"] == ""
+
+    def test_write_reopens_a_missing_evidence_obligation(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        path, _vanished = self._seed_missing_evidence_obligation(state_dir, "d-missing-write")
+
+        with patch("review_gate_manager.emit_governance_receipt") as mock_emit:
+            outcome = reopener.reopen_obligation(
+                state_dir, "d-missing-write", operator_reason="OI-1726 purged record", write=True,
+            )
+
+        assert outcome["action"] == "reopened"
+        assert mock_emit.called, "the ledger event must be emitted before the mutation (ADR-005)"
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_PENDING
+        assert record["attempts"] == 0
+        assert record["result_path"] is None
+        assert record["evidence_result_path"] is None
+        assert record["resolved_by_gate"] is None
+        assert record["fulfilled_by"] is None
+        assert "OI-1726 purged record" in record["reason_detail"]
+        assert "no longer exists on disk" in record["reason_detail"]
+
+    def test_corrupt_evidence_is_still_refused(self, tmp_path):
+        """A present-but-unparseable file is NOT the missing-evidence case.
+        Its stale-ness cannot be PROVEN (no commit_sha is readable), so the
+        script must refuse (no write) and leave the obligation untouched —
+        the same verify-before-write discipline, applied to the ambiguous
+        branch. Chosen deliberately over reopening: reopening an obligation
+        whose evidence might be current would risk losing a valid review."""
+        state_dir = _make_state_dir(tmp_path)
+        evidence = state_dir / "review_gates" / "results" / "pr-1719-codex_gate.json"
+        evidence.write_text('{"gate": "codex_gate", "commit_sha": "8101fd', encoding="utf-8")  # torn JSON
+        path = register_obligation(
+            state_dir, dispatch_id="d-corrupt", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1719,
+        )
+        update_obligation(
+            path,
+            status=STATUS_FULFILLED,
+            resolved_at="2026-09-11T10:00:00Z",
+            result_path=str(evidence),
+            evidence_result_path=str(evidence),
+            resolved_by_gate="codex_gate",
+            reason="fulfilled_by_takeover_evidence",
+        )
+
+        with pytest.raises(reopener.ReopenRefused, match="unreadable"):
+            reopener.verify_stale_evidence(state_dir, "d-corrupt")
+
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_FULFILLED, "a corrupt-evidence refusal must never mutate"
+
+
+class TestRunnerRebooksReopenedObligation:
+    """MOET (OI-1726): once a vanished-evidence obligation is reopened to
+    pending, the obligation-runner re-books it on the REAL evidence that
+    exists on disk — never the purged record. The reopen is the missing half;
+    the runner's own fulfilment-on-existing-evidence is pre-existing."""
+
+    def test_runner_rebooks_reopened_obligation_on_real_evidence(self, tmp_path, monkeypatch):
+        import gate_obligation_runner as runner
+
+        state_dir = _make_state_dir(tmp_path)
+        results = state_dir / "review_gates" / "results"
+
+        # The real, still-current evidence for the declared gate.
+        report = state_dir / "unified_reports" / "glm-pr1840.md"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text("# glm_gate verdict for PR 1840\n", encoding="utf-8")
+        real = results / "pr-1840-glm_gate.json"
+        real.write_text(
+            json.dumps({
+                "gate": "glm_gate", "pr_number": 1840, "status": "pass",
+                "verdict": "pass", "contract_hash": "sha256:real",
+                "report_path": str(report), "commit_sha": _HEAD_SHA,
+                "recorded_at": "2026-09-11T11:00:00Z",
+            }),
+            encoding="utf-8",
+        )
+
+        # The obligation: declared glm_gate, booked fulfilled off a record that
+        # no longer exists (the purged poison), then reopened to pending.
+        vanished = results / "pr-1840-kimi_gate.json"  # never written — gone
+        path = register_obligation(
+            state_dir, dispatch_id="d-rebook", gate="glm_gate",
+            project_id="vnx-dev", pr_number=1840,
+        )
+        update_obligation(
+            path,
+            status=STATUS_FULFILLED,
+            resolved_at="2026-09-11T10:00:00Z",
+            result_path=str(vanished),
+            evidence_result_path=str(vanished),
+            resolved_by_gate="glm_gate",
+            fulfilled_by="glm_gate",
+            reason="fulfilled_by_takeover_evidence",
+        )
+
+        monkeypatch.setattr(reopener, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+        with patch("review_gate_manager.emit_governance_receipt"):
+            reopened = reopener.reopen_obligation(
+                state_dir, "d-rebook", operator_reason="OI-1726", write=True,
+            )
+        assert reopened["action"] == "reopened"
+
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_PENDING
+
+        # The runner now picks the reopened obligation back up.
+        monkeypatch.setattr(runner, "_get_pr_head_sha_for_gate", lambda pr_number: _HEAD_SHA)
+        outcome = runner.fulfill_obligation(state_dir, path, record)
+
+        assert outcome["action"] == STATUS_FULFILLED
+        final = json.loads(path.read_text(encoding="utf-8"))
+        assert final["status"] == STATUS_FULFILLED
+        assert final["result_path"] == str(real), "re-booked on the real evidence, not the vanished record"
+
+
 class TestReopenObligation:
     def test_dry_run_never_writes(self, tmp_path, monkeypatch):
         state_dir = _make_state_dir(tmp_path)


### PR DESCRIPTION
## Wat er mis was

`scripts/gate_obligation_reopen_stale_evidence.py` weigerde een verplichting waarvan het `result_path` niet meer op schijf bestond:

```
REFUSED: evidence file does not exist on disk: .../pr-1840-kimi_gate.json
```

Dat is achterstevoren. Een verplichting die vervulling claimt op een bestand dat aantoonbaar niet bestaat is juist het sterkst denkbare heropen-geval: dat bewijs kan per definitie niet meer kloppen. De weigering beschermde niets en blokkeerde alles.

## Wat er verandert

Alleen de ontbrekend-grond draait om van weigering naar geldige reden. De afwezigheid IS het bewijs, dus de missing-evidence-pad lost geen PR-hoofd op en vergelijkt geen shas.

Drie gronden blijven weigeren, ongewijzigd:
- niet-terminale verplichting (niets te heropenen)
- PR-hoofd dat niet te bepalen is (misstand niet bewijsbaar)
- bewijs dat juist WEL met de huidige kop overeenkomt (niets te corrigeren)

Een bewijsbestand dat **bestaat maar corrupt is** blijft weigeren. Dat is bewust iets anders dan afwezig: bij een corrupt bestand is de misstand niet bewijsbaar (de commit_sha is niet leesbaar), dus heropenen zou een mogelijk geldige review kunnen weggooien.

## Toetsen

- MOET: verplichting die naar een verdwenen record wijst wordt heropend (pending, lege `result_path`/`evidence_result_path`/`resolved_by_gate`), en de obligation-runner herboekt hem daarna op het echte bewijs dat wel bestaat.
- MAG NIET: verplichting waarvan het bewijs bestaat en op de huidige kop staat wordt aangeraakt.

Rood eerst: `ReopenRefused: evidence file does not exist on disk` (assertie, geen import-/collectiefout). Groen na fix: `14 passed` in `tests/test_gate_obligation_reopen_stale_evidence.py`. Buren groen: `tests/test_gate_obligations.py` + `tests/test_gate_dispatch_identity_purge.py` (81 passed), `tests/test_gate_obligation_runner.py` (53 passed).

Het script is opgeleverd, niet gedraaid tegen de echte store. Test op een fixture-store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)