### PR TITLE
fix(gate): reopen terminally parked obligations with missing evidence (OI-1721)

### DIFF
--- a/scripts/gate_obligation_reopen_stale_evidence.py
+++ b/scripts/gate_obligation_reopen_stale_evidence.py
@@ -52,6 +52,13 @@ comparison is needed (or possible). That is the strongest reopen case there
 is, and this script used to refuse exactly it (measured: ``REFUSED: evidence
 file does not exist on disk: .../pr-1840-kimi_gate.json``).
 
+OI-1721 (2026-09-12): the same "absence IS the proof" branch now also admits
+a terminally-parked obligation — ``status=not_executable``,
+``reason=gate_parked_timeout``, evidence file missing. The gate never ran (it
+was parked and escalated to terminal), so its terminal state is a temporary
+refusal that exhausted its retry bound, not a verdict; the missing evidence
+file proves exactly that. Every OTHER not_executable reason stays refused.
+
 Usage:
     python3 scripts/gate_obligation_reopen_stale_evidence.py \\
         --dispatch-id 20260830-133000-oi1453-noemer-is-pass        # dry run
@@ -75,8 +82,10 @@ for _p in (SCRIPT_DIR / "lib", SCRIPT_DIR):
         sys.path.insert(0, str(_p))
 
 from gate_obligations import (  # noqa: E402
+    REASON_GATE_PARKED_TIMEOUT,
     STATUS_FAILED,
     STATUS_FULFILLED,
+    STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
     obligation_path,
     update_obligation,
@@ -100,8 +109,13 @@ def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
     writes. Raises :class:`ReopenRefused` (never returns a half-verified
     result) when the misstand cannot be established.
 
-    Two provable misstands are recognized:
+    Three provable misstands are recognized:
 
+      - OI-1721: the obligation is terminally ``not_executable`` with
+        ``reason=REASON_GATE_PARKED_TIMEOUT`` (the gate was parked and
+        escalated to terminal without ever running) AND its evidence file
+        does NOT exist on disk. Same branch and same returned shape as
+        OI-1726 — the absence IS the proof that no verdict exists.
       - OI-1726: the evidence file does NOT exist on disk. The obligation
         claims fulfilment/failure off a file that provably does not exist, so
         the claim is false by construction. Returned with
@@ -117,7 +131,17 @@ def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
     record = json.loads(path.read_text(encoding="utf-8"))
 
     status = record.get("status")
-    if status not in (STATUS_FULFILLED, STATUS_FAILED):
+    # OI-1721: a terminally-parked obligation is the ONE not_executable shape
+    # that is reopenable — its gate never ran, so "not_executable" here is a
+    # temporary refusal that exhausted its retry bound, not a verdict about
+    # the code. Every other not_executable reason (required_failure,
+    # stay_pending_timeout, ...) stays refused: the terminal state IS the
+    # honest end of a real decision, and this script must not reopen it.
+    parked_timeout = (
+        status == STATUS_NOT_EXECUTABLE
+        and record.get("reason") == REASON_GATE_PARKED_TIMEOUT
+    )
+    if status not in (STATUS_FULFILLED, STATUS_FAILED) and not parked_timeout:
         raise ReopenRefused(
             f"obligation status is {status!r}, not fulfilled/failed — nothing to reopen"
         )
@@ -127,13 +151,14 @@ def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
         raise ReopenRefused("obligation carries no evidence_result_path/result_path to verify")
     evidence_path = Path(evidence_path_str)
     if not evidence_path.exists():
-        # OI-1726: a MISSING evidence file is the strongest possible reopen
-        # reason — the obligation claims fulfilment/failure off a file that
-        # provably does not exist, so the claim is false by construction. The
-        # absence IS the proof; there is no PR head to resolve and no sha to
-        # compare (the stale-evidence path below only fires when the file
-        # EXISTS). A present-but-unreadable file (corrupt) is deliberately
-        # NOT this case and still refuses below.
+        # OI-1726 + OI-1721: a MISSING evidence file is the strongest possible
+        # reopen reason — the obligation claims fulfilment/failure (or, for
+        # OI-1721, a terminal verdict) off a file that provably does not
+        # exist, so the claim is false by construction. The absence IS the
+        # proof; there is no PR head to resolve and no sha to compare (the
+        # stale-evidence path below only fires when the file EXISTS). A
+        # present-but-unreadable file (corrupt) is deliberately NOT this case
+        # and still refuses below.
         return {
             "path": path,
             "record": record,
@@ -142,8 +167,21 @@ def verify_stale_evidence(state_dir: Path, dispatch_id: str) -> Dict[str, Any]:
             "evidence_sha": "",
             "evidence_path": str(evidence_path),
             "evidence_missing": True,
+            "parked_timeout": parked_timeout,
             "resolved_by_gate": record.get("resolved_by_gate") or record.get("fulfilled_by") or record.get("gate"),
         }
+    if parked_timeout:
+        # OI-1721: the parked-timeout reopen ground is DEFINED by the absence
+        # of the evidence file — the gate never ran, so there is nothing to
+        # bind against. An existing file means the absence is not provable,
+        # and a parked gate's result is not a code verdict: refuse rather
+        # than fall through to the sha-binding check, which would compare
+        # shas of a verdict that never existed.
+        raise ReopenRefused(
+            "obligation is parked-timeout but its evidence file still exists "
+            f"on disk ({evidence_path}) — the absence is not provable, so "
+            "there is nothing to reopen"
+        )
     try:
         evidence_record = json.loads(evidence_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -189,7 +227,20 @@ def reopen_obligation(
     """
     proof = verify_stale_evidence(state_dir, dispatch_id)
     record = proof["record"]
-    if proof.get("evidence_missing"):
+    if proof.get("parked_timeout"):
+        reopen_reason = "reopened_parked_timeout"
+        reason_detail = (
+            f"reopened by gate_obligation_reopen_stale_evidence.py (OI-1721): "
+            f"the obligation was booked {record.get('status')!r} with "
+            f"reason={record.get('reason')!r} — the gate was parked (provider "
+            "missing / config flag disabled) and escalated to terminal without "
+            f"ever running, and its evidence at {proof['evidence_path']} does "
+            "not exist on disk — there is no verdict to bind against, so the "
+            "runner must re-resolve the obligation now that the gate may be "
+            f"unparked/installed. Operator reason: {operator_reason}"
+        )
+    elif proof.get("evidence_missing"):
+        reopen_reason = "reopened_stale_takeover_evidence"
         reason_detail = (
             f"reopened by gate_obligation_reopen_stale_evidence.py (OI-1726): "
             f"the obligation was booked {record.get('status')!r} via "
@@ -200,6 +251,7 @@ def reopen_obligation(
             f"Operator reason: {operator_reason}"
         )
     else:
+        reopen_reason = "reopened_stale_takeover_evidence"
         reason_detail = (
             f"reopened by gate_obligation_reopen_stale_evidence.py (OI-1571 tak 3): "
             f"the obligation was booked {record.get('status')!r} via "
@@ -256,7 +308,7 @@ def reopen_obligation(
         fulfilled_by=None,
         takeover_gate=None,
         evidence_result_path=None,
-        reason="reopened_stale_takeover_evidence",
+        reason=reopen_reason,
         reason_detail=reason_detail,
     )
     outcome["action"] = "reopened"

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -177,6 +177,8 @@ from gate_obligations import (  # noqa: E402
     NO_GATE_KEY,
     REASON_FAILED_BY_TAKEOVER,
     REASON_FULFILLED_BY_TAKEOVER,
+    REASON_GATE_PARKED,
+    REASON_GATE_PARKED_TIMEOUT,
     REASON_NO_PR_BRANCH_GONE,
     REASON_NO_PR_BRANCH_GONE_LIVE,
     REASON_NO_PR_BRANCH_GONE_UNMEASURED,
@@ -2533,7 +2535,7 @@ def fulfill_obligation(
                 "not a failure; will be re-attempted on the next run"
             )
         elif result_status == STATUS_NOT_EXECUTABLE and result_reason in _TEMPORARY_NOT_EXECUTABLE_REASONS:
-            temp_reason = "gate_parked"
+            temp_reason = REASON_GATE_PARKED
             if result_reason == "provider_not_installed":
                 temp_cause = "the provider binary is not on PATH in this environment yet"
             else:
@@ -2602,6 +2604,15 @@ def fulfill_obligation(
                     f"{attempts} attempts (last status={result_status!r}, "
                     f"reason={result_reason!r}) — escalating to a loud terminal failure"
                 )
+                # OI-1721: the parked case must read the shared composed
+                # constant so the reopen script and this writer can never
+                # drift on the literal string; the other temporary refusals
+                # keep the generic "<temp_reason>_timeout" composition.
+                escalation_reason = (
+                    REASON_GATE_PARKED_TIMEOUT
+                    if temp_reason == REASON_GATE_PARKED
+                    else f"{temp_reason}_timeout"
+                )
                 update_obligation(
                     path,
                     status=STATUS_NOT_EXECUTABLE,
@@ -2612,7 +2623,7 @@ def fulfill_obligation(
                     resolved_at=utc_now_iso(),
                     request_path=str(manager._request_path(gate, pr_number)),
                     result_path=str(result_file),
-                    reason=f"{temp_reason}_timeout",
+                    reason=escalation_reason,
                     reason_detail=escalation_detail,
                 )
                 outcome["action"] = "not_executable"

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -121,6 +121,21 @@ REASON_NO_PR_BRANCH_GONE_UNMEASURED = "no_pr_branch_gone_unmeasured"
 REASON_FULFILLED_BY_TAKEOVER = "fulfilled_by_takeover_evidence"
 REASON_FAILED_BY_TAKEOVER = "failed_by_takeover_evidence"
 
+# OI-1721 (2026-09-12): a gate that could not run because it was PARKED
+# (provider binary missing / config flag disabled — the runner's
+# ``_TEMPORARY_NOT_EXECUTABLE_REASONS`` set) stays pending under a bounded
+# retry term, then escalates to the loud terminal ``not_executable`` with
+# reason "<parked-reason>_timeout". The runner composes that string (writer:
+# scripts/gate_obligation_runner.py, the temporary-refusal escalation branch)
+# and scripts/gate_obligation_reopen_stale_evidence.py reads it back to decide
+# whether a terminal not_executable obligation was terminally parked. Both
+# constants live here so writer and readers can never drift on the literal
+# string — the same discipline as REASON_FULFILLED_BY_TAKEOVER above. The
+# timeout form is DERIVED from the base, so a rename of the base cannot
+# silently strand the reader.
+REASON_GATE_PARKED = "gate_parked"
+REASON_GATE_PARKED_TIMEOUT = f"{REASON_GATE_PARKED}_timeout"
+
 # Distinct sentinel gate key for explicit no-gate records (dispatch
 # 20260816-gate-never-skippable). Deliberately NOT a member of the Gate enum: a
 # no-gate dispatch is not declaring any gate, but the freshness scanner needs a
@@ -516,6 +531,8 @@ __all__ = [
     "REASON_NO_PR_BRANCH_GONE_UNMEASURED",
     "REASON_FULFILLED_BY_TAKEOVER",
     "REASON_FAILED_BY_TAKEOVER",
+    "REASON_GATE_PARKED",
+    "REASON_GATE_PARKED_TIMEOUT",
     "TERMINAL_STATUSES",
     "NO_GATE_KEY",
     "obligations_dir",

--- a/tests/test_gate_obligation_reopen_stale_evidence.py
+++ b/tests/test_gate_obligation_reopen_stale_evidence.py
@@ -27,6 +27,7 @@ for p in (ROOT / "scripts" / "lib", ROOT / "scripts", ROOT):
 import gate_obligation_reopen_stale_evidence as reopener  # noqa: E402
 from gate_obligations import (  # noqa: E402
     STATUS_FULFILLED,
+    STATUS_NOT_EXECUTABLE,
     STATUS_PENDING,
     obligation_path,
     register_obligation,
@@ -219,6 +220,141 @@ class TestMissingEvidence:
 
         record = json.loads(path.read_text(encoding="utf-8"))
         assert record["status"] == STATUS_FULFILLED, "a corrupt-evidence refusal must never mutate"
+
+
+class TestParkedTimeoutReopen:
+    """OI-1721 (2026-09-12): a terminally-parked obligation —
+    status=not_executable, reason=gate_parked_timeout, evidence file missing —
+    is reopenable because its gate never ran. The missing evidence file IS the
+    proof that no verdict exists (the same "absence is the proof" branch as
+    OI-1726). Every OTHER not_executable reason stays refused, and so does a
+    parked-timeout obligation whose evidence file still exists on disk."""
+
+    def _seed_parked_timeout_obligation(self, state_dir, dispatch_id, *, gate="codex_gate", pr_number=1832, evidence_exists=False):
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate=gate,
+            project_id="vnx-dev", pr_number=pr_number,
+        )
+        evidence = state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+        if evidence_exists:
+            evidence.write_text(
+                json.dumps({
+                    "gate": gate, "pr_number": pr_number, "status": "not_executable",
+                    "commit_sha": _STALE_SHA, "recorded_at": "2026-09-10T10:00:00Z",
+                }),
+                encoding="utf-8",
+            )
+        update_obligation(
+            path,
+            status=STATUS_NOT_EXECUTABLE,
+            resolved_at="2026-09-10T10:00:00Z",
+            result_path=str(evidence),
+            evidence_result_path=str(evidence),
+            # The literal string the runner actually writes to disk (OI-1721:
+            # REASON_GATE_PARKED_TIMEOUT) — a literal here, not the constant,
+            # so this test proves the reader matches the writer's real output.
+            reason="gate_parked_timeout",
+            reason_detail="codex_gate stayed temporarily unavailable (gate_parked) — escalating",
+        )
+        return path, evidence
+
+    def _seed_not_executable_obligation(self, state_dir, dispatch_id, *, gate="codex_gate", pr_number=1830, reason=None):
+        path = register_obligation(
+            state_dir, dispatch_id=dispatch_id, gate=gate,
+            project_id="vnx-dev", pr_number=pr_number,
+        )
+        # The referenced result file is never written — exactly the shape of
+        # the old not_executable records (no reason, or required_failure)
+        # whose evidence is also missing. They must NOT become reopenable.
+        evidence = state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+        fields = {
+            "status": STATUS_NOT_EXECUTABLE,
+            "resolved_at": "2026-09-10T10:00:00Z",
+            "result_path": str(evidence),
+            "evidence_result_path": str(evidence),
+        }
+        if reason is not None:
+            fields["reason"] = reason
+        update_obligation(path, **fields)
+        return path, evidence
+
+    def test_parked_timeout_with_missing_evidence_is_reopenable(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        _path, evidence = self._seed_parked_timeout_obligation(state_dir, "d-parked-missing")
+        # The absence is itself the proof — a PR-head resolution attempt here
+        # would be a bug (there is no evidence sha to bind against).
+        monkeypatch.setattr(
+            reopener, "_get_pr_head_sha_for_gate",
+            lambda pr_number: pytest.fail("parked-timeout reopen must not resolve a PR head"),
+        )
+
+        proof = reopener.verify_stale_evidence(state_dir, "d-parked-missing")
+
+        assert proof.get("evidence_missing") is True
+        assert proof.get("parked_timeout") is True
+        assert proof["evidence_path"] == str(evidence)
+        assert proof["head_sha"] == ""
+        assert proof["evidence_sha"] == ""
+
+    def test_parked_timeout_with_existing_evidence_is_refused(self, tmp_path):
+        """A parked-timeout obligation whose evidence file STILL EXISTS has no
+        provable absence — the reopen ground is defined by the missing file.
+        It must refuse rather than fall through to the sha-binding check,
+        which would compare shas of a verdict that never existed."""
+        state_dir = _make_state_dir(tmp_path)
+        path, _evidence = self._seed_parked_timeout_obligation(
+            state_dir, "d-parked-existing", evidence_exists=True,
+        )
+
+        with pytest.raises(reopener.ReopenRefused, match="still exists"):
+            reopener.verify_stale_evidence(state_dir, "d-parked-existing")
+
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_NOT_EXECUTABLE, "a refusal must never mutate"
+
+    def test_parked_timeout_without_result_path_is_refused(self, tmp_path):
+        state_dir = _make_state_dir(tmp_path)
+        path = register_obligation(
+            state_dir, dispatch_id="d-parked-nopath", gate="codex_gate",
+            project_id="vnx-dev", pr_number=1830,
+        )
+        update_obligation(
+            path, status=STATUS_NOT_EXECUTABLE, reason="gate_parked_timeout",
+        )
+
+        with pytest.raises(reopener.ReopenRefused, match="no evidence_result_path/result_path"):
+            reopener.verify_stale_evidence(state_dir, "d-parked-nopath")
+
+    @pytest.mark.parametrize("reason", [None, "required_failure", "stay_pending_timeout"])
+    def test_other_not_executable_reasons_are_not_reopenable(self, tmp_path, reason):
+        """Scope guard (OI-1721): the ledger holds 49 not_executable records
+        without a reason and 3 with required_failure whose evidence is also
+        missing — none of them may become reopenable. Only the parked-timeout
+        reason is admitted."""
+        state_dir = _make_state_dir(tmp_path)
+        self._seed_not_executable_obligation(state_dir, "d-ne-other", reason=reason)
+
+        with pytest.raises(reopener.ReopenRefused, match="not fulfilled/failed"):
+            reopener.verify_stale_evidence(state_dir, "d-ne-other")
+
+    def test_write_reopens_a_parked_timeout_obligation(self, tmp_path, monkeypatch):
+        state_dir = _make_state_dir(tmp_path)
+        path, _vanished = self._seed_parked_timeout_obligation(state_dir, "d-parked-write")
+
+        with patch("review_gate_manager.emit_governance_receipt") as mock_emit:
+            outcome = reopener.reopen_obligation(
+                state_dir, "d-parked-write", operator_reason="OI-1721 parked gate", write=True,
+            )
+
+        assert outcome["action"] == "reopened"
+        assert mock_emit.called, "the ledger event must be emitted before the mutation (ADR-005)"
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["status"] == STATUS_PENDING
+        assert record["reason"] == "reopened_parked_timeout"
+        assert record["result_path"] is None
+        assert record["evidence_result_path"] is None
+        assert "OI-1721 parked gate" in record["reason_detail"]
+        assert "without ever running" in record["reason_detail"]
 
 
 class TestRunnerRebooksReopenedObligation:


### PR DESCRIPTION
## Wat er mis was

Vier verplichtingen hangen terminaal op `status=not_executable`, `reason=gate_parked_timeout`, met een `result_path` dat niet op schijf bestaat. `gate_obligation_reopen_stale_evidence.py` weigerde ze: de status moest in `(fulfilled, failed)` zitten. Daardoor zijn #1830 en #1832 sinds 10-09 niet te mergen.

Het bewijsbestand bestaat niet OMDAT de poort nooit heeft gedraaid (geparkeerd, over het retry-plafond geëscaleerd naar terminaal). Er is dus niets beoordeeld. Dat is dezelfde "afwezigheid is het bewijs"-redenering als OI-1726, een status ernaast.

## Wat er verandert

1. `verify_stale_evidence` erkent nu `not_executable` + `reason=gate_parked_timeout` met een ontbrekend bewijsbestand als heropenbare grond. Hergebruikt de OI-1726-tak: geen PR-head-resolutie, geen sha-vergelijking. Een parked-timeout verplichting met een bestaand bewijsbestand wordt geweigerd (de afwezigheid is dan niet bewijsbaar).
2. `REASON_GATE_PARKED` en `REASON_GATE_PARKED_TIMEOUT` leven nu in `scripts/lib/gate_obligations.py`. De runner schrijft en het reopen-script leest uit dezelfde constanten; `REASON_GATE_PARKED_TIMEOUT` is afgeleid van `REASON_GATE_PARKED`.
3. Alle andere weigeringsgronden blijven: pending, andere `not_executable`-redenen (`required_failure`, `stay_pending_timeout`), corrupt bewijs, onbekende dispatch, sha-binding onverifieerbaar, sha-match.

## Scope-bewijs (opnieuw gemeten, read-only, 2026-09-12)

Over 738 verplichtingen in `~/.vnx-data/vnx-dev/state/review_gates/obligations/`:

| reason | totaal | bewijs ontbreekt |
|---|---|---|
| required_failure | 68 | 3 |
| (geen reason) | 49 | 46 |
| stay_pending_timeout | 11 | 11 |
| gate_parked_timeout | 4 | 4 |

Alleen de 4 `gate_parked_timeout`-records worden heropenbaar. De 3 `required_failure` en de no-reason/`stay_pending_timeout`-records blijven geweigerd. De `stay_pending_timeout`-meting verschilt van de dispatch-nota (11/0): die records hebben `result_path=None` en geen `evidence_result_path`, en worden sowieso geweigerd (niet de parked-timeout-reason én geen result_path).

## Verificatie

- Rode run (nieuwe tests op oude code): 4 fail (`test_parked_timeout_with_missing_evidence_is_reopenable`, `test_parked_timeout_with_existing_evidence_is_refused`, `test_parked_timeout_without_result_path_is_refused`, `test_write_reopens_a_parked_timeout_obligation`) — alle op `ReopenRefused`, geen ImportError/collectiefout. 3 groene regression-guards.
- Groene run: `pytest tests/test_gate_obligation_reopen_stale_evidence.py tests/test_gate_obligation_runner.py tests/test_gate_obligations.py -q` → **144 passed**.
- Live dry-run (read-only): het echte record `20260909-golfc-c2a-beacon-lezers` retourneert nu `action=would_reopen` (exit 0); een echt `required_failure`-record met ontbrekend bewijs blijft `REFUSED` (exit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)