### PR TITLE
feat(gate): consolidate harness-lane verdict contract to one source (C6 step 3)

### DIFF
--- a/scripts/gate_reanchor_cli.py
+++ b/scripts/gate_reanchor_cli.py
@@ -110,18 +110,25 @@ def load_existing_result(results_dir: Path, gate: str, pr_number: int) -> Dict[s
 def current_contract_hash(gate: str, pr_number: int) -> str:
     """Recompute the hash the gate WOULD produce for the PR head, offline.
 
-    No model call: ``_build_prompt`` is deterministic and the diff comes from
-    ``gh``. Verified against PR #1691, whose recorded hash
-    ``dd5ac45f7e84535e`` this reproduces exactly.
+    No model call: the prompt is deterministic and the diff comes from ``gh``.
+    Builds the prompt the way the harness lane does — ``build_review_prompt``
+    with the shared gate_lane_contract verdict contract and diff cap (C6 step
+    3) — instead of importing the standalone gate module. Verified against PR
+    #1691, whose recorded hash ``dd5ac45f7e84535e`` this reproduces exactly.
     """
-    diff = _gh(["pr", "diff", str(pr_number)])
-    if gate == "glm_gate":
-        import glm_gate as gate_module
-    elif gate == "kimi_gate":
-        import kimi_gate as gate_module
-    else:  # pragma: no cover — guarded by DIFF_DERIVED_HASH_GATES at the call site
+    if gate not in DIFF_DERIVED_HASH_GATES:
         raise ValueError(f"{gate} has no diff-derived contract hash")
-    prompt = gate_module._build_prompt(diff, str(pr_number))
+    from gate_lane_contract import MAX_DIFF_CHARS, VERDICT_CONTRACT
+    from gate_prompt import build_review_prompt
+
+    diff = _gh(["pr", "diff", str(pr_number)])
+    prompt = build_review_prompt(
+        gate_name=gate,
+        pr=str(pr_number),
+        diff_text=diff,
+        verdict_contract=VERDICT_CONTRACT,
+        max_chars=MAX_DIFF_CHARS,
+    )
     return _compute_contract_hash({"prompt": prompt}, gate)
 
 

--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -32,6 +32,12 @@ import vertex_ai_runner as _vtx
 from gate_worktree import create_gate_worktree, remove_gate_worktree, GateWorktreeError
 from gate_prompt import build_review_prompt  # OI-1442: the diff is data, not instruction
 from prompt_assembler import PromptAssembler, format_for_provider
+from gate_lane_contract import (  # C6 step 3: one source, three readers
+    MODEL_DEFAULTS as _HARNESS_LANE_MODEL,
+    TIMEOUT_SECONDS as _HARNESS_LANE_TIMEOUT_SECONDS,
+    MAX_DIFF_CHARS as _HARNESS_LANE_MAX_DIFF_CHARS,
+    VERDICT_CONTRACT as _HARNESS_LANE_VERDICT_CONTRACT,
+)
 
 _REVIEWER_VERDICT_TEMPLATE = (
     "Respond with a structured JSON verdict only:\n"
@@ -69,34 +75,11 @@ GATE_CLI_ARGS: Dict[str, List[str]] = {
 _REASON_DETAIL_TAIL_CHARS = 4000
 
 # Harness-lane gates (glm_gate/kimi_gate) delegate to the governed dispatcher
-# (C6 step 1). These constants mirror what scripts/glm_gate.py and
-# scripts/kimi_gate.py already hold, so a run through gate_runner's third
-# strategy has the same model, timeout, diff cap and verdict contract as the
-# same gate run standalone — verbatim effect, different entry point.
-_HARNESS_LANE_MODEL: Dict[str, tuple] = {
-    "glm_gate": ("VNX_GLM_GATE_MODEL", "glm-5.2"),
-    "kimi_gate": ("VNX_KIMI_GATE_MODEL", "kimi-k3"),
-}
-# glm_gate.py/kimi_gate.py drive the governed lane with DEFAULT_TIMEOUT=900.
-# headless_adapter.gate_timeout() has no entry for these gates and would fall
-# back to 600, cutting a run short that the standalone gate would have let
-# finish. The dispatcher's timeout_seconds is the lane's own deadline, so it
-# must match the standalone gate, not the runner's PATH-binary default.
-_HARNESS_LANE_TIMEOUT_SECONDS = 900
-_HARNESS_LANE_MAX_DIFF_CHARS = 50000
-# Verbatim-identical to glm_gate._VERDICT_CONTRACT and kimi_gate._VERDICT_CONTRACT.
-_HARNESS_LANE_VERDICT_CONTRACT = (
-    "When done, end your report with a structured JSON verdict ONLY, in a fenced block:\n"
-    "```json\n"
-    "{\n"
-    '  "verdict": "pass|fail|blocked",\n'
-    '  "findings": [{"severity": "error|warning|info", "message": "..."}],\n'
-    '  "residual_risk": "remaining risk or null"\n'
-    "}\n"
-    "```\n"
-    "verdict=fail/blocked ONLY for a real, blocking correctness/security/governance issue "
-    "introduced by THIS diff. Style nits are severity=info, never blocking.\n"
-)
+# (C6 step 1). The _HARNESS_LANE_* aliases imported at the top are the SAME
+# objects scripts/glm_gate.py and scripts/kimi_gate.py read from
+# gate_lane_contract (C6 step 3), so a run through gate_runner's third
+# strategy has the model, timeout, diff cap and verdict contract of the same
+# gate run standalone — verbatim effect, different entry point.
 
 
 def _harness_lane_dispatch_id(gate: str, pr_number: Optional[int], pr_id: str) -> str:

--- a/scripts/glm_gate.py
+++ b/scripts/glm_gate.py
@@ -105,6 +105,12 @@ from gate_recorder import (
 )
 import gate_depth  # OI-1618: a verdict without investigation is no verdict, on every lane
 from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
+from gate_lane_contract import (  # C6 step 3: one source, three readers
+    MAX_DIFF_CHARS,
+    MODEL_DEFAULTS,
+    TIMEOUT_SECONDS,
+    VERDICT_CONTRACT,
+)
 from gate_prompt import (  # OI-1442: the diff is data, not instruction
     build_review_prompt,
     merge_scan_findings,
@@ -147,28 +153,19 @@ def _extract_verdict(text: str) -> dict:
     return {}
 
 
-DEFAULT_MODEL = "glm-5.2"
-DEFAULT_TIMEOUT = 900
-MAX_DIFF_CHARS = 50000
+# One source (C6 step 3): model env var/default, timeout, diff cap and verdict
+# contract come from gate_lane_contract — the SAME objects gate_runner and
+# kimi_gate read. The aliases keep this gate's existing names for the readers
+# below; ALLOWED_MODELS stays here because it is glm-specific.
+_MODEL_ENV, DEFAULT_MODEL = MODEL_DEFAULTS["glm_gate"]
+DEFAULT_TIMEOUT = TIMEOUT_SECONDS
+_VERDICT_CONTRACT = VERDICT_CONTRACT
 
 # deprecated-glm-models (provider_constraints.yaml): glm-5.2 is the ONLY
 # admitted GLM version. This is an allowlist, not a blocklist — every other
 # name (including a not-yet-released version) is refused until an operator
 # decision admits it explicitly.
-ALLOWED_MODELS = frozenset({"glm-5.2"})
-
-_VERDICT_CONTRACT = (
-    "When done, end your report with a structured JSON verdict ONLY, in a fenced block:\n"
-    "```json\n"
-    "{\n"
-    '  "verdict": "pass|fail|blocked",\n'
-    '  "findings": [{"severity": "error|warning|info", "message": "..."}],\n'
-    '  "residual_risk": "remaining risk or null"\n'
-    "}\n"
-    "```\n"
-    "verdict=fail/blocked ONLY for a real, blocking correctness/security/governance issue "
-    "introduced by THIS diff. Style nits are severity=info, never blocking.\n"
-)
+ALLOWED_MODELS = frozenset({DEFAULT_MODEL})
 
 
 def _validate_model(model: str) -> "str | None":
@@ -192,9 +189,10 @@ def _build_prompt(diff_text: str, pr: str) -> str:
     author's own text, unmarked, in the last and most weighted position of the
     prompt. ``gate_prompt.build_review_prompt`` puts it in an explicitly
     delimited block and restates the instruction after it, so the gate has the
-    last word. The verdict contract stays this gate's own (kimi_gate and
-    gate_runner ask for different verdict shapes — sharing a builder must not
-    silently collapse three contracts into one).
+    last word. The verdict contract is the shared gate_lane_contract source
+    (C6 step 3), identical by design for glm_gate, kimi_gate and gate_runner's
+    harness-lane path; gate_runner's ``_REVIEWER_VERDICT_TEMPLATE``
+    (codex/gemini) is a different, richer shape and is not this contract.
     """
     return build_review_prompt(
         gate_name="glm_gate",
@@ -459,7 +457,7 @@ def main(argv: "list[str] | None" = None) -> int:
     ap.add_argument("--data-dir", default=os.environ.get("VNX_DATA_DIR", ""),
                     help="VNX data dir; report lands in <data-dir>/unified_reports/ and the "
                          "result in <data-dir>/state/review_gates/results/")
-    ap.add_argument("--model", default=os.environ.get("VNX_GLM_GATE_MODEL", DEFAULT_MODEL))
+    ap.add_argument("--model", default=os.environ.get(_MODEL_ENV, DEFAULT_MODEL))
     ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
     ap.add_argument("--json", action="store_true", help="print the result record as JSON")
     ap.add_argument(

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -117,6 +117,12 @@ from gate_recorder import (
 )
 import gate_depth  # OI-1618: a verdict without investigation is no verdict, on every lane
 from gate_artifacts import _compute_contract_hash  # canonical hash source — never a second hasher
+from gate_lane_contract import (  # C6 step 3: one source, three readers
+    MAX_DIFF_CHARS,
+    MODEL_DEFAULTS,
+    TIMEOUT_SECONDS,
+    VERDICT_CONTRACT,
+)
 from gate_prompt import (  # OI-1442: the diff is data, not instruction
     build_review_prompt,
     merge_scan_findings,
@@ -153,22 +159,13 @@ def _extract_verdict(text: str) -> dict:
             return obj
     return {}
 
-DEFAULT_MODEL = "kimi-k3"
-DEFAULT_TIMEOUT = 900
-MAX_DIFF_CHARS = 50000
-
-_VERDICT_CONTRACT = (
-    "When done, end your report with a structured JSON verdict ONLY, in a fenced block:\n"
-    "```json\n"
-    "{\n"
-    '  "verdict": "pass|fail|blocked",\n'
-    '  "findings": [{"severity": "error|warning|info", "message": "..."}],\n'
-    '  "residual_risk": "remaining risk or null"\n'
-    "}\n"
-    "```\n"
-    "verdict=fail/blocked ONLY for a real, blocking correctness/security/governance issue "
-    "introduced by THIS diff. Style nits are severity=info, never blocking.\n"
-)
+# One source (C6 step 3): model env var/default, timeout, diff cap and verdict
+# contract come from gate_lane_contract — the SAME objects gate_runner and
+# glm_gate read. The aliases keep this gate's existing names for the readers
+# below.
+_MODEL_ENV, DEFAULT_MODEL = MODEL_DEFAULTS["kimi_gate"]
+DEFAULT_TIMEOUT = TIMEOUT_SECONDS
+_VERDICT_CONTRACT = VERDICT_CONTRACT
 
 
 def _build_prompt(diff_text: str, pr: str) -> str:
@@ -177,7 +174,8 @@ def _build_prompt(diff_text: str, pr: str) -> str:
     OI-1442, identical defect and identical fix to ``glm_gate._build_prompt``:
     the raw diff used to be the last thing in the prompt, unmarked. It now
     sits in an explicitly delimited block with the instruction restated after
-    it. ``_VERDICT_CONTRACT`` stays this gate's own.
+    it. ``_VERDICT_CONTRACT`` is the shared gate_lane_contract source (C6
+    step 3).
     """
     return build_review_prompt(
         gate_name="kimi_gate",
@@ -426,7 +424,7 @@ def main(argv: "list[str] | None" = None) -> int:
     ap.add_argument("--data-dir", default=os.environ.get("VNX_DATA_DIR", ""),
                     help="VNX data dir; report lands in <data-dir>/unified_reports/ and the "
                          "result in <data-dir>/state/review_gates/results/")
-    ap.add_argument("--model", default=os.environ.get("VNX_KIMI_GATE_MODEL", DEFAULT_MODEL))
+    ap.add_argument("--model", default=os.environ.get(_MODEL_ENV, DEFAULT_MODEL))
     ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
     ap.add_argument("--json", action="store_true", help="print the result record as JSON")
     ap.add_argument(

--- a/scripts/lib/gate_lane_contract.py
+++ b/scripts/lib/gate_lane_contract.py
@@ -18,11 +18,16 @@ from typing import Dict
 #
 # glm_gate runs glm-5.2 (deprecated-glm-models allowlist, operator directive
 # 2026-08-03) via the glm-harness lane; kimi_gate runs kimi-k3 via the kimi
-# CLI. The env var is the per-gate override an operator sets before the run;
-# the default is what the governed lane dispatches when it is unset.
+# CLI; deepseek_gate runs deepseek-v4-pro via the deepseek-harness lane
+# (DEFAULT_DEEPSEEK_HARNESS_MODEL, provider_spawns/deepseek_harness_spawn.py
+# — the SAME default the build lane dispatches, registry wave7_models.yaml
+# `deepseek_harness.deepseek-v4-pro` with dispatch_allowed: true). The env var
+# is the per-gate override an operator sets before the run; the default is
+# what the governed lane dispatches when it is unset.
 MODEL_DEFAULTS: Dict[str, tuple] = {
     "glm_gate": ("VNX_GLM_GATE_MODEL", "glm-5.2"),
     "kimi_gate": ("VNX_KIMI_GATE_MODEL", "kimi-k3"),
+    "deepseek_gate": ("VNX_DEEPSEEK_GATE_MODEL", "deepseek-v4-pro"),
 }
 
 # glm_gate.py/kimi_gate.py drive the governed lane with DEFAULT_TIMEOUT=900.

--- a/scripts/lib/gate_lane_contract.py
+++ b/scripts/lib/gate_lane_contract.py
@@ -1,0 +1,54 @@
+"""Single source for the harness-lane gate constants (C6 step 3).
+
+``gate_runner``, ``glm_gate`` and ``kimi_gate`` each carried their own copy of
+the verdict contract and the model/timeout/diff-cap defaults. Three copies
+drift silently: a writer edits one shape, misses the other two, and no test
+fails because every module reads its own copy. This module is the ONE source
+all three read from — the names in the consumers are aliases to these SAME
+objects (``is``-identical, not merely equal), and
+``tests/test_gate_lane_contract.py`` pins that identity so a byte-identical
+copy can no longer sneak back in unnoticed.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# gate name -> (model env var, default model).
+#
+# glm_gate runs glm-5.2 (deprecated-glm-models allowlist, operator directive
+# 2026-08-03) via the glm-harness lane; kimi_gate runs kimi-k3 via the kimi
+# CLI. The env var is the per-gate override an operator sets before the run;
+# the default is what the governed lane dispatches when it is unset.
+MODEL_DEFAULTS: Dict[str, tuple] = {
+    "glm_gate": ("VNX_GLM_GATE_MODEL", "glm-5.2"),
+    "kimi_gate": ("VNX_KIMI_GATE_MODEL", "kimi-k3"),
+}
+
+# glm_gate.py/kimi_gate.py drive the governed lane with DEFAULT_TIMEOUT=900.
+# headless_adapter.gate_timeout() has no entry for these gates and would fall
+# back to 600, cutting a run short that the standalone gate would have let
+# finish. The dispatcher's timeout_seconds is the lane's own deadline, so it
+# must match the standalone gate, not the runner's PATH-binary default.
+TIMEOUT_SECONDS = 900
+
+# Diff cap applied by gate_prompt.build_review_prompt: the diff is delimited,
+# untrusted DATA, and this bounds how much of it enters the prompt.
+MAX_DIFF_CHARS = 50000
+
+# The verdict the gate must end its report with. Verbatim-identical across
+# glm_gate, kimi_gate and gate_runner's harness-lane strategy; this is the one
+# copy. Not gate_runner._REVIEWER_VERDICT_TEMPLATE — the codex/gemini reviewer
+# asks for a different, richer findings shape.
+VERDICT_CONTRACT = (
+    "When done, end your report with a structured JSON verdict ONLY, in a fenced block:\n"
+    "```json\n"
+    "{\n"
+    '  "verdict": "pass|fail|blocked",\n'
+    '  "findings": [{"severity": "error|warning|info", "message": "..."}],\n'
+    '  "residual_risk": "remaining risk or null"\n'
+    "}\n"
+    "```\n"
+    "verdict=fail/blocked ONLY for a real, blocking correctness/security/governance issue "
+    "introduced by THIS diff. Style nits are severity=info, never blocking.\n"
+)

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -1506,7 +1506,7 @@ class GateRequestHandlerMixin:
             payload["dispatch_id"] = dispatch_id
         if not available:
             reason = "gate_runner_missing"
-            reason_detail = "scripts/glm_gate.py is not on disk — glm_gate is registered as a script runner and its runner is unavailable"
+            reason_detail = "glm_gate is not available — its registered provider route is not present"
             payload["reason"] = reason
             payload["reason_detail"] = reason_detail
             payload["resolved_at"] = payload["requested_at"]

--- a/scripts/lib/pr_readiness.py
+++ b/scripts/lib/pr_readiness.py
@@ -88,16 +88,18 @@ class GateCost:
 #: assumed.
 GATE_COST: Dict[str, GateCost] = {
     Gate.GLM_GATE.value: GateCost(
-        command="python3 scripts/glm_gate.py --pr {pr}",
+        command="python3 scripts/review_gate_manager.py execute --gate glm_gate --pr {pr}",
         lane="glm-harness → litellm :4141 → OpenRouter",
         usd="~1.3–2.8 USD",
-        note="source ~/.config/vnx/provider-usage.env in the same subshell; glm-5.2 only",
+        note="governed lane entry (C6 step 3); request --review-stack glm_gate first, then "
+             "source ~/.config/vnx/provider-usage.env in the same subshell; glm-5.2 only",
     ),
     Gate.KIMI_GATE.value: GateCost(
-        command="python3 scripts/kimi_gate.py --pr {pr}",
+        command="python3 scripts/review_gate_manager.py execute --gate kimi_gate --pr {pr}",
         lane="kimi CLI (OAuth)",
         usd="subscription",
-        note="kimi-via-cli-only: never the Moonshot API",
+        note="governed lane entry (C6 step 3); request --review-stack kimi_gate first; "
+             "kimi-via-cli-only: never the Moonshot API",
     ),
     Gate.CODEX_GATE.value: GateCost(
         command="python3 scripts/review_gate_manager.py request-and-execute --gate codex_gate --pr {pr}",

--- a/tests/test_gate_lane_contract.py
+++ b/tests/test_gate_lane_contract.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
 import gate_lane_contract
+import gate_recorder
 import gate_runner
 import glm_gate
 import kimi_gate
@@ -55,3 +56,72 @@ def test_model_timeout_and_diff_cap_are_one_source():
 def test_model_env_var_names_come_from_the_shared_map():
     assert glm_gate._MODEL_ENV == "VNX_GLM_GATE_MODEL"
     assert kimi_gate._MODEL_ENV == "VNX_KIMI_GATE_MODEL"
+
+
+def _harness_lane_gates():
+    """The set of harness-lane gates, DERIVED from the single registry.
+
+    ``gate_recorder.GATE_PROVIDERS`` is the one place that says which gates are
+    harness lanes; ``gate_lane_contract.MODEL_DEFAULTS`` is the second table
+    that must carry the model for each of them. Deriving the expectation here
+    (instead of hardcoding a list of three names) means a fourth harness gate
+    added to ``GATE_PROVIDERS`` is automatically demanded of ``MODEL_DEFAULTS``
+    by the same test that caught ``deepseek_gate`` — the problem can no longer
+    shift into the test.
+    """
+    return {
+        gate
+        for gate, (kind, _name) in gate_recorder.GATE_PROVIDERS.items()
+        if kind == gate_recorder.GATE_PROVIDER_HARNESS_LANE
+    }
+
+
+def test_every_harness_lane_gate_has_a_model_default():
+    """Every harness-lane gate must have a MODEL_DEFAULTS rule with a model.
+
+    The two tables carry one fact in two places: ``GATE_PROVIDERS`` says which
+    gates route through the governed dispatcher, ``MODEL_DEFAULTS`` says which
+    model they dispatch on. When a harness gate is missing from the second
+    table, ``gate_runner._run_harness_lane_path`` falls back to
+    ``("", "")`` and hands ``model=""`` to the dispatcher. This is exactly the
+    OI-1714 gap that let ``deepseek_gate`` reach the lane with no model.
+    """
+    harness_gates = _harness_lane_gates()
+    assert harness_gates, (
+        "GATE_PROVIDERS has no harness-lane gates — the derivation is empty, "
+        "so this test would pass vacuously"
+    )
+    missing = sorted(
+        gate for gate in harness_gates if gate not in gate_lane_contract.MODEL_DEFAULTS
+    )
+    assert not missing, (
+        "every harness-lane gate in GATE_PROVIDERS must have a MODEL_DEFAULTS "
+        f"entry, or gate_runner hands model='' to the dispatcher: {missing}"
+    )
+    empty_models = sorted(
+        gate
+        for gate in harness_gates
+        if not (gate_lane_contract.MODEL_DEFAULTS.get(gate, ("", ""))[1] or "").strip()
+    )
+    assert not empty_models, (
+        "a MODEL_DEFAULTS entry whose default model is empty is the same defect "
+        f"as a missing entry — model='' reaches the dispatcher: {empty_models}"
+    )
+
+
+def test_model_defaults_cover_only_harness_lane_gates():
+    """A MODEL_DEFAULTS rule for a gate that is not a harness lane is dead.
+
+    ``gate_runner`` only reads ``MODEL_DEFAULTS`` from
+    ``_run_harness_lane_path``, which is reached exclusively for harness-lane
+    gates. An entry keyed on a path-binary gate (codex_gate, gemini_review) or
+    a renamed gate could never fire, and would be the inverse drift of the
+    missing-entry case: a rule nobody consumes while a real gate silently runs
+    model-less.
+    """
+    harness_gates = _harness_lane_gates()
+    orphan = sorted(set(gate_lane_contract.MODEL_DEFAULTS) - harness_gates)
+    assert not orphan, (
+        "a MODEL_DEFAULTS entry for a gate that is not a harness lane in "
+        "GATE_PROVIDERS is dead config — gate_runner never reads it: {orphan}"
+    )

--- a/tests/test_gate_lane_contract.py
+++ b/tests/test_gate_lane_contract.py
@@ -1,0 +1,57 @@
+"""The harness-lane verdict contract is ONE object, not three copies (C6 step 3).
+
+``gate_runner``, ``glm_gate`` and ``kimi_gate`` each used to carry their own
+byte-identical copy of the verdict contract and the model/timeout/diff-cap
+defaults. A copy drifts silently: an edit to one shape leaves the other two
+behind and no test fails, because every module reads its own copy. The three
+readers now alias the SAME objects in ``gate_lane_contract``. These tests pin
+that identity — a byte-identical copy smuggled back in would be a different
+object, so ``is`` fails and the copy can no longer go unnoticed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import gate_lane_contract
+import gate_runner
+import glm_gate
+import kimi_gate
+
+
+def test_verdict_contract_is_one_object_across_all_three_readers():
+    assert glm_gate._VERDICT_CONTRACT is gate_lane_contract.VERDICT_CONTRACT
+    assert kimi_gate._VERDICT_CONTRACT is gate_lane_contract.VERDICT_CONTRACT
+    assert gate_runner._HARNESS_LANE_VERDICT_CONTRACT is gate_lane_contract.VERDICT_CONTRACT
+    # The two gates must read the same object as each other, not merely two
+    # equal aliases of the source.
+    assert glm_gate._VERDICT_CONTRACT is kimi_gate._VERDICT_CONTRACT
+
+
+def test_verdict_contract_is_not_the_codex_reviewer_template():
+    # gate_runner's codex/gemini reviewer asks for a different, richer findings
+    # shape. Aliasing that template here would silently change what the
+    # harness-lane gates ask for, so the identity must NOT hold.
+    assert gate_runner._HARNESS_LANE_VERDICT_CONTRACT is not gate_runner._REVIEWER_VERDICT_TEMPLATE
+
+
+def test_model_timeout_and_diff_cap_are_one_source():
+    assert gate_runner._HARNESS_LANE_MODEL is gate_lane_contract.MODEL_DEFAULTS
+    assert glm_gate.DEFAULT_MODEL == gate_lane_contract.MODEL_DEFAULTS["glm_gate"][1]
+    assert kimi_gate.DEFAULT_MODEL == gate_lane_contract.MODEL_DEFAULTS["kimi_gate"][1]
+    assert glm_gate.DEFAULT_TIMEOUT == gate_lane_contract.TIMEOUT_SECONDS
+    assert kimi_gate.DEFAULT_TIMEOUT == gate_lane_contract.TIMEOUT_SECONDS
+    assert gate_runner._HARNESS_LANE_TIMEOUT_SECONDS == gate_lane_contract.TIMEOUT_SECONDS
+    assert glm_gate.MAX_DIFF_CHARS == gate_lane_contract.MAX_DIFF_CHARS
+    assert kimi_gate.MAX_DIFF_CHARS == gate_lane_contract.MAX_DIFF_CHARS
+    assert gate_runner._HARNESS_LANE_MAX_DIFF_CHARS == gate_lane_contract.MAX_DIFF_CHARS
+
+
+def test_model_env_var_names_come_from_the_shared_map():
+    assert glm_gate._MODEL_ENV == "VNX_GLM_GATE_MODEL"
+    assert kimi_gate._MODEL_ENV == "VNX_KIMI_GATE_MODEL"


### PR DESCRIPTION
## What

C6 step 3: migrate the last production importer of `glm_gate`/`kimi_gate` onto the harness lane, and turn the three byte-identical verdict-contract copies into one source.

## Changes

- `scripts/lib/gate_lane_contract.py` (new): one source for the verdict contract, model defaults, timeout and diff cap. `gate_runner`, `glm_gate` and `kimi_gate` now read the SAME objects via alias imports (`is`-identical).
- `scripts/gate_reanchor_cli.py`: `current_contract_hash` no longer imports the standalone gate module; it builds the prompt via `gate_prompt.build_review_prompt` with the shared contract.
- `scripts/lib/pr_readiness.py`: `GATE_COST` glm/kimi commands point at the governed lane entry (`review_gate_manager.py execute --gate ...`) instead of the script path. Note the behavior change: `execute` needs a request record first (`request --review-stack <gate>`).
- `scripts/lib/gate_request_handler.py`: `_request_glm` refusal detail uses the harness-lane wording ("registered provider route"), not the stale script-runner claim.
- `tests/test_gate_lane_contract.py` (new): pins `is` identity across the three readers so a byte-identical copy can no longer go unnoticed.

## Verification

- New test `tests/test_gate_lane_contract.py`: 4 passed.
- Target suites: 265 passed, incl. `tests/test_dlv1_glm_gate.py` (must stay green).
- Neighbour suites (gate modules + handlers): 120 passed.
- Red on old code: `glm_gate._VERDICT_CONTRACT is kimi_gate._VERDICT_CONTRACT` was `False` (three separate objects); `True` after the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)