### PR TITLE
fix(envelope): thread spawn-layer diagnosis into unified report (OI-1716)

### DIFF
--- a/scripts/lib/envelope_govern.py
+++ b/scripts/lib/envelope_govern.py
@@ -258,6 +258,12 @@ def _govern(
             findings=None,
             duration_seconds=duration,
             data_dir=spec.data_dir,
+            # OI-1716: thread the spawn-layer diagnosis into the report so an
+            # empty response never falls back to "(no response captured)" when
+            # the spawn layer already knows why it produced nothing (proxy
+            # unreachable, harness refused to start). Same form as the provider
+            # lane (#1834, provider_dispatch._emit_governance).
+            spawn_error=getattr(adapter_result, "error", None),
             preserve_partial=adapter_result.status != "success",
         )
     except Exception as exc:

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -2,28 +2,28 @@
   "couplings": [
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 933,
+      "line": 952,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 936,
+      "line": 955,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_door_row.py",
-      "line": 574,
+      "line": 564,
       "mechanism": "direct-call",
       "module_target": "envelope_types",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_door_row.py",
-      "line": 579,
+      "line": 569,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
@@ -724,6 +724,48 @@
     {
       "file": "tests/test_envelope_govern_report_adoption.py",
       "line": 117,
+      "mechanism": "patch-string",
+      "module_target": "envelope_govern",
+      "symbol": "_receipt_exists_for_dispatch"
+    },
+    {
+      "file": "tests/test_envelope_govern_spawn_error.py",
+      "line": 29,
+      "mechanism": "direct-call",
+      "module_target": "envelope_govern",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_envelope_govern_spawn_error.py",
+      "line": 30,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_envelope_govern_spawn_error.py",
+      "line": 30,
+      "mechanism": "direct-call",
+      "module_target": "envelope_types",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_envelope_govern_spawn_error.py",
+      "line": 67,
+      "mechanism": "patch-string",
+      "module_target": "envelope_govern",
+      "symbol": "_archive_dispatch_events"
+    },
+    {
+      "file": "tests/test_envelope_govern_spawn_error.py",
+      "line": 69,
+      "mechanism": "patch-string",
+      "module_target": "envelope_govern",
+      "symbol": "_clear_dispatch_events"
+    },
+    {
+      "file": "tests/test_envelope_govern_spawn_error.py",
+      "line": 71,
       "mechanism": "patch-string",
       "module_target": "envelope_govern",
       "symbol": "_receipt_exists_for_dispatch"

--- a/tests/test_envelope_govern_spawn_error.py
+++ b/tests/test_envelope_govern_spawn_error.py
@@ -1,0 +1,118 @@
+"""tests/test_envelope_govern_spawn_error.py — OI-1716: the envelope path must
+thread the spawn-layer diagnosis (adapter_result.error) into the unified report,
+so an empty completion never falls back to "(no response captured)" when the
+spawn layer already knows why it produced nothing.
+
+The provider lane already does this (#1834, provider_dispatch._emit_governance
+passes ``spawn_error=getattr(result, "error", None)``); envelope_govern._govern
+is a second entrance to the same emitter and inherited nothing from it.
+
+The test asserts on the WRITTEN report's behavior, not on the source: with an
+empty completion_text and a filled error, the report body must carry the
+spawn-error diagnosis (the error text, under the emitter's spawn-error label)
+instead of the contentless placeholder. RED against the pre-fix envelope_govern
+(the error text never reaches the report; the body falls back to
+"(no response captured)").
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from envelope_govern import _govern
+from envelope_types import EnvelopeSpec, _AdapterResult
+
+_SPAWN_ERROR = "litellm proxy unreachable at http://127.0.0.1:1 (start the proxy first)"
+
+
+@pytest.fixture()
+def spec(tmp_path):
+    data_dir = tmp_path / "data"
+    state_dir = tmp_path / "state"
+    data_dir.mkdir()
+    state_dir.mkdir()
+    return EnvelopeSpec(
+        dispatch_id="oi1716-spawn-error-001",
+        terminal_id="T1",
+        provider="glm-harness",
+        model="glm-5.2",
+        instruction="do the thing",
+        role="backend-developer",
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+
+def _run_govern_with_real_report_emit(spec, result):
+    """Run _govern() letting the REAL emit_unified_report write the report.
+
+    emit_dispatch_receipt and the filesystem/event dependencies are mocked so
+    the receipt half does not touch external state — but the report half runs
+    the real emitter, so the written .md is the observable artifact the test
+    asserts on.
+    """
+    receipt_path = spec.state_dir / "t0_receipts.ndjson"
+    receipt_path.write_text("")
+
+    mock_emit_receipt = MagicMock(return_value=receipt_path)
+
+    with patch(
+        "envelope_govern._archive_dispatch_events", return_value=("", True)
+    ), patch(
+        "envelope_govern._clear_dispatch_events"
+    ), patch(
+        "envelope_govern._receipt_exists_for_dispatch", return_value=False
+    ), patch(
+        "governance_emit.emit_dispatch_receipt", mock_emit_receipt
+    ):
+        _govern(
+            spec,
+            result,
+            start_time=datetime(2026, 9, 12, 12, 0, 0),
+            end_time=datetime(2026, 9, 12, 12, 1, 0),
+        )
+
+    return mock_emit_receipt
+
+
+def test_empty_completion_with_error_surfaces_spawn_error_in_report(spec):
+    """An empty completion_text plus a filled adapter error must put the
+    spawn-layer diagnosis into the written report, not "(no response captured)".
+
+    Forces the state actively: the adapter result is constructed with an empty
+    completion and a concrete error. The report written to disk must carry that
+    error under the emitter's spawn-error label (the distinctive "spawn error"
+    phrasing, not the lane-log lift) and must not fall back to the placeholder.
+    """
+    result = _AdapterResult(
+        returncode=1,
+        completion_text="",
+        status="failure",
+        error=_SPAWN_ERROR,
+    )
+
+    _run_govern_with_real_report_emit(spec, result)
+
+    report_path = spec.data_dir / "unified_reports" / f"{spec.dispatch_id}.md"
+    content = report_path.read_text(encoding="utf-8")
+
+    assert _SPAWN_ERROR in content, (
+        "the written report must carry the spawn-layer diagnosis verbatim, "
+        f"not fall back to '(no response captured)': {content!r}"
+    )
+    assert "(no response captured)" not in content, (
+        "an empty response with a known spawn error must never degrade to the "
+        "contentless placeholder"
+    )
+    assert "spawn error" in content, (
+        "the diagnosis must be labeled as a spawn error (not a model reply, "
+        "not a lane-log lift) so readers never misread it as model output"
+    )


### PR DESCRIPTION
## OI-1716 — geef adapter_result.error door als spawn_error in de envelope-weg

De envelope-weg (`scripts/lib/envelope_govern.py`) riep `emit_unified_report()` aan zonder `spawn_error`. Is de completion leeg en weet de adapter waarom, dan viel het rapport terug op "(no response captured)" en verdween de diagnose. De provider-lane had precies deze fix al (#1834).

### Fix
`envelope_govern.py:249` geeft nu `spawn_error=getattr(adapter_result, "error", None)` mee, zelfde vorm als `provider_dispatch.py:1309`.

### Test
`tests/test_envelope_govern_spawn_error.py` construeert een `_AdapterResult` met lege `completion_text` en gevulde `error` en toetst op het GEDRAG van het geschreven rapport: de errortekst staat erin, "(no response captured)" staat er niet in, en de diagnose draagt het "spawn error"-label.

Red/green:
- Tegen de ONGEWIJZIGDE `envelope_govern.py`: **1 failed** — rapport valt terug op `(no response captured)`.
- Met de fix: **1 passed**.

### Open Items (meldplicht: de tweede plek)
De twee `dispatch_govern.py`-aanroepsites verliezen NIET dezelfde diagnose:
- `scripts/lib/dispatch_govern.py:549` (error-handler-synthese) en `:893` (govern-synthese) geven allebei een NIET-lege `response_text` mee (`f"Lane: {lane}. Error."` resp. `f"Lane: {lane}. Status: {status}."`). Daardoor wordt de empty-response/spawn_error-branch van de emitter nooit bereikt.
- Beide dragen een `body_override` mee (549: `error_body` met `Error: {exc}`; 893: `emit_body` + `frontmatter`). De body komt dus niet uit de empty-response-fallback.
- Beide hebben geen `adapter_result`/`result`-object met een `.error`-veld om te verliezen. De diagnose-klasse (lege completion + spawn-error → "(no response captured)") geldt alleen voor de adapter-lanes, niet voor deze synthese-paden. Repareren is hier niet aan de orde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)