### PR TITLE
fix(gate): reset review-gate dispatch worktree at teardown (OI-1629b)

### DIFF
--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -869,6 +869,7 @@ def remove_dispatch_worktree(
     *,
     project_root: Optional[Path] = None,
     terminal_id: str = "",
+    review_only: bool = False,
 ) -> None:
     """Remove the ephemeral dispatch worktree.  Idempotent.
 
@@ -879,6 +880,20 @@ def remove_dispatch_worktree(
     → entire worktree locked).  A failed remote check (ls-remote timeout,
     network error) is fail-closed: the classification falls back to
     ``committed`` and the branch survives.
+
+    **OI-1629b (review-gate teardown):** when *review_only* is True, the
+    worktree's index and working tree are reset to the recorded base BEFORE
+    classification.  A review-gate worker may materialize the PR diff into
+    the worktree (``git checkout origin/<branch> -- <file>``) to run tests
+    against the checked-out tree; that staged reproduction is disposable —
+    the gate's verdict is captured as an inline report, not as files, and the
+    worker is dispatched with ``--no-auto-commit``.  The reset only fires
+    when HEAD still equals the recorded base (no local commits were made),
+    so real work is never discarded: if the worker committed anything, or the
+    base is unresolvable, teardown degrades to normal classification and the
+    worktree is preserved exactly as a normal dirty/committed dispatch would
+    be.  The default ``review_only=False`` keeps the normal build-dispatch
+    salvage rule (dirty → lock forever) untouched.
 
     When *terminal_id* is provided, a ``provider_teardown_worktree`` event is
     emitted via ``EventStore`` with the same metadata fields
@@ -984,6 +999,55 @@ def remove_dispatch_worktree(
                 _claim_base_ref, dispatch_id,
             )
             _claim_base_sha = ""
+
+    # ── OI-1629b: review-gate teardown resets the disposable PR reproduction ─
+    # A review-gate worker may have materialized the PR diff into the worktree
+    # (``git checkout origin/<branch> -- <file>`` stages the PR's file content)
+    # so it can run tests against the checked-out tree.  That staged state is
+    # not real work — the gate's verdict is captured inline, and the worker is
+    # dispatched with --no-auto-commit — so teardown discards it before
+    # classification.  The reset only fires when HEAD still equals the recorded
+    # base: a local commit means the worker produced real work, and teardown
+    # degrades to normal classification (which preserves it).  Best-effort:
+    # any git failure also degrades to normal classification.
+    if review_only and _claim_base_sha:
+        try:
+            _head_result = subprocess.run(
+                ["git", "-C", str(wt_path), "rev-parse", "HEAD"],
+                check=True, capture_output=True, text=True,
+            )
+            _wt_head = _head_result.stdout.strip()
+        except subprocess.CalledProcessError:
+            _wt_head = ""
+
+        if _wt_head and _wt_head == _claim_base_sha:
+            try:
+                subprocess.run(
+                    ["git", "-C", str(wt_path), "reset", "--hard", _claim_base_sha],
+                    check=True, capture_output=True, text=True,
+                )
+                subprocess.run(
+                    ["git", "-C", str(wt_path), "clean", "-fd"],
+                    check=True, capture_output=True, text=True,
+                )
+                log.info(
+                    "remove_dispatch_worktree: review_only reset %s to base %s "
+                    "(no local commits — disposable PR reproduction discarded)",
+                    dispatch_id, _claim_base_sha[:8],
+                )
+            except subprocess.CalledProcessError as _reset_exc:
+                log.warning(
+                    "remove_dispatch_worktree: review_only reset failed for %s: %s — "
+                    "degrading to normal classification (worktree may be preserved)",
+                    dispatch_id, _reset_exc,
+                )
+        else:
+            log.info(
+                "remove_dispatch_worktree: review_only skip reset for %s "
+                "(HEAD=%s base=%s) — local commits present, degrading to normal "
+                "classification so real work is never discarded",
+                dispatch_id, (_wt_head or "?")[:8], _claim_base_sha[:8],
+            )
 
     from tmux_worktree import WorktreeHandle, classify, reap  # noqa: PLC0415
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1766,7 +1766,12 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
         # dispatch (archive -> receipt -> clear) instead of straggling into
         # the live ring buffer after the clear.  None marks it reaped so the
         # finally path does not remove it twice.
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         isolation_worktree = None
 
         if result.error or result.timed_out:
@@ -1794,7 +1799,12 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
         # buffer ends empty even when an unexpected exception bypassed
         # _emit_governance.  Both calls are no-ops after a normal emit (the
         # worktree was already reaped above; the live file is truncated).
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         _event_store_safety_net(event_store, args)
 
 
@@ -1878,7 +1888,12 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
         return 0 if ok else 1
     finally:
         _set_active_worktree(None)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
 
 
 def _create_provider_worktree(dispatch_id: str, base_ref: Optional[str] = None) -> Path:
@@ -1957,7 +1972,9 @@ def _prepare_provider_workdir(
     return isolation_worktree, worker_cwd
 
 
-def _remove_provider_worktree(dispatch_id: str, *, terminal_id: str = "") -> None:
+def _remove_provider_worktree(
+    dispatch_id: str, *, terminal_id: str = "", review_only: bool = False
+) -> None:
     """Remove the isolated worktree for a provider dispatch.  Best-effort; idempotent.
 
     Resolves the same consumer project_root as _create_provider_worktree —
@@ -1966,6 +1983,10 @@ def _remove_provider_worktree(dispatch_id: str, *, terminal_id: str = "") -> Non
 
     When *terminal_id* is provided, a ``provider_teardown_worktree`` event is
     emitted via EventStore (L3 provider-lane reap).
+
+    *review_only* forwards to ``remove_dispatch_worktree`` so a review-gate
+    dispatch (OI-1629b) resets its disposable PR reproduction instead of
+    locking the worktree as dirty.
     """
     try:
         from dispatch_worktree_isolation import (  # noqa: PLC0415
@@ -1976,6 +1997,7 @@ def _remove_provider_worktree(dispatch_id: str, *, terminal_id: str = "") -> Non
             dispatch_id,
             project_root=resolve_consumer_project_root(),
             terminal_id=terminal_id,
+            review_only=review_only,
         )
         logger.info("provider isolation: worktree removed (dispatch=%s)", dispatch_id)
     except Exception as exc:
@@ -1990,6 +2012,7 @@ def _finish_provider_worktree(
     isolation_worktree: Optional[Path],
     *,
     terminal_id: str = "",
+    review_only: bool = False,
 ) -> None:
     """Remove normal provider worktrees while preserving benchmark output."""
     if isolation_worktree is None:
@@ -2001,7 +2024,9 @@ def _finish_provider_worktree(
             dispatch_id,
         )
         return
-    _remove_provider_worktree(dispatch_id, terminal_id=terminal_id)
+    _remove_provider_worktree(
+        dispatch_id, terminal_id=terminal_id, review_only=review_only
+    )
 
 
 def _dispatch_codex(args: argparse.Namespace) -> int:
@@ -2061,7 +2086,12 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         # dispatch (archive -> receipt -> clear) instead of straggling into
         # the live ring buffer after the clear.  None marks it reaped so the
         # finally path does not remove it twice.
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         isolation_worktree = None
 
         if result.error:
@@ -2090,7 +2120,12 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         # buffer ends empty even when an unexpected exception bypassed
         # _emit_governance.  Both calls are no-ops after a normal emit (the
         # worktree was already reaped above; the live file is truncated).
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         _event_store_safety_net(event_store, args)
 
 
@@ -2535,7 +2570,12 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         # dispatch (archive -> receipt -> clear) instead of straggling into
         # the live ring buffer after the clear.  None marks it reaped so the
         # finally path does not remove it twice.
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         isolation_worktree = None
 
         if result.error:
@@ -2564,7 +2604,12 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         # buffer ends empty even when an unexpected exception bypassed
         # _emit_governance.  Both calls are no-ops after a normal emit (the
         # worktree was already reaped above; the live file is truncated).
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         _event_store_safety_net(event_store, args)
 
 
@@ -2650,7 +2695,12 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         # dispatch (archive -> receipt -> clear) instead of straggling into
         # the live ring buffer after the clear.  None marks it reaped so the
         # finally path does not remove it twice.
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         isolation_worktree = None
 
         if result.error:
@@ -2679,7 +2729,12 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         # buffer ends empty even when an unexpected exception bypassed
         # _emit_governance.  Both calls are no-ops after a normal emit (the
         # worktree was already reaped above; the live file is truncated).
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         _event_store_safety_net(event_store, args)
 
 
@@ -2779,7 +2834,12 @@ def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
         # dispatch (archive -> receipt -> clear) instead of straggling into
         # the live ring buffer after the clear.  None marks it reaped so the
         # finally path does not remove it twice.
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         isolation_worktree = None
 
         if result.error:
@@ -2801,7 +2861,12 @@ def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
         # buffer ends empty even when an unexpected exception bypassed
         # _emit_governance.  Both calls are no-ops after a normal emit (the
         # worktree was already reaped above; the live file is truncated).
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         _event_store_safety_net(event_store, args)
 
 
@@ -2855,7 +2920,12 @@ def _dispatch_glm_harness(args: argparse.Namespace) -> int:
         # dispatch (archive -> receipt -> clear) instead of straggling into
         # the live ring buffer after the clear.  None marks it reaped so the
         # finally path does not remove it twice.
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         isolation_worktree = None
 
         if result.error:
@@ -2877,7 +2947,12 @@ def _dispatch_glm_harness(args: argparse.Namespace) -> int:
         # buffer ends empty even when an unexpected exception bypassed
         # _emit_governance.  Both calls are no-ops after a normal emit (the
         # worktree was already reaped above; the live file is truncated).
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         _event_store_safety_net(event_store, args)
 
 
@@ -2936,7 +3011,12 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         # dispatch (archive -> receipt -> clear) instead of straggling into
         # the live ring buffer after the clear.  None marks it reaped so the
         # finally path does not remove it twice.
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         isolation_worktree = None
 
         if result.error:
@@ -2965,7 +3045,12 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         # buffer ends empty even when an unexpected exception bypassed
         # _emit_governance.  Both calls are no-ops after a normal emit (the
         # worktree was already reaped above; the live file is truncated).
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _finish_provider_worktree(
+            args.dispatch_id,
+            isolation_worktree,
+            terminal_id=args.terminal_id,
+            review_only=getattr(args, "role", None) == "review-gate",
+        )
         _event_store_safety_net(event_store, args)
 
 

--- a/tests/test_provider_dispatch_worktree_isolation.py
+++ b/tests/test_provider_dispatch_worktree_isolation.py
@@ -123,7 +123,7 @@ class TestCodexIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-codex-001", base_ref=None)
-        mock_remove.assert_called_once_with("iso-codex-001", terminal_id="T1")
+        mock_remove.assert_called_once_with("iso-codex-001", terminal_id="T1", review_only=False)
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_isolation_without_env_var(self):
@@ -154,7 +154,7 @@ class TestCodexIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("default-iso-codex", base_ref=None)
-        mock_remove.assert_called_once_with("default-iso-codex", terminal_id="T1")
+        mock_remove.assert_called_once_with("default-iso-codex", terminal_id="T1", review_only=False)
         assert captured.get("cwd") == _FAKE_WT_PATH
 
     def test_worktree_removed_on_spawn_failure(self):
@@ -176,7 +176,7 @@ class TestCodexIsolation:
                 with pytest.raises(RuntimeError, match="simulated"):
                     provider_dispatch._dispatch_codex(args)
 
-        mock_remove.assert_called_once_with("fail-codex", terminal_id="T1")
+        mock_remove.assert_called_once_with("fail-codex", terminal_id="T1", review_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +209,7 @@ class TestGeminiIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-gemini-001", base_ref=None)
-        mock_remove.assert_called_once_with("iso-gemini-001", terminal_id="T1")
+        mock_remove.assert_called_once_with("iso-gemini-001", terminal_id="T1", review_only=False)
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_isolation_without_env_var(self):
@@ -238,7 +238,7 @@ class TestGeminiIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("default-iso-gemini", base_ref=None)
-        mock_remove.assert_called_once_with("default-iso-gemini", terminal_id="T1")
+        mock_remove.assert_called_once_with("default-iso-gemini", terminal_id="T1", review_only=False)
         assert captured.get("cwd") == _FAKE_WT_PATH
 
 
@@ -273,7 +273,7 @@ class TestKimiIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-kimi-001", base_ref=None)
-        mock_remove.assert_called_once_with("iso-kimi-001", terminal_id="T1")
+        mock_remove.assert_called_once_with("iso-kimi-001", terminal_id="T1", review_only=False)
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_isolation_without_env_var(self):
@@ -303,7 +303,7 @@ class TestKimiIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("default-iso-kimi", base_ref=None)
-        mock_remove.assert_called_once_with("default-iso-kimi", terminal_id="T1")
+        mock_remove.assert_called_once_with("default-iso-kimi", terminal_id="T1", review_only=False)
         assert captured.get("cwd") == _FAKE_WT_PATH
 
 
@@ -343,7 +343,7 @@ class TestLiteLLMIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-litellm-001", base_ref=None)
-        mock_remove.assert_called_once_with("iso-litellm-001", terminal_id="T1")
+        mock_remove.assert_called_once_with("iso-litellm-001", terminal_id="T1", review_only=False)
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_isolation_without_env_var(self):
@@ -378,7 +378,7 @@ class TestLiteLLMIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("default-iso-litellm", base_ref=None)
-        mock_remove.assert_called_once_with("default-iso-litellm", terminal_id="T1")
+        mock_remove.assert_called_once_with("default-iso-litellm", terminal_id="T1", review_only=False)
         assert captured.get("cwd") == _FAKE_WT_PATH
 
 
@@ -412,7 +412,12 @@ class TestProviderWorktreeHelpers:
         with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=consumer_root), \
              patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove:
             provider_dispatch._remove_provider_worktree("remove-ok-test")
-        mock_remove.assert_called_once_with("remove-ok-test", project_root=consumer_root, terminal_id="")
+        mock_remove.assert_called_once_with(
+            "remove-ok-test",
+            project_root=consumer_root,
+            terminal_id="",
+            review_only=False,
+        )
 
     def test_remove_best_effort_when_resolver_raises(self):
         """A resolver failure must also be swallowed — remove is best-effort end-to-end."""
@@ -975,6 +980,147 @@ class TestProviderLaneReapClassification:
         ).strip()
         assert branch_name in branches, (
             "L3 FAIL: branch was deleted — missing base_sha must fail-closed"
+        )
+
+
+# ---------------------------------------------------------------------------
+# OI-1629b: a review-gate dispatch must not leave its dispatch worktree dirty.
+# The gate worker materializes the PR diff into the worktree (git checkout
+# origin/<branch> -- <file>) to run tests, leaving a staged change. Teardown
+# with review_only=True resets that disposable reproduction before
+# classification, so the worktree is removed instead of locked forever.
+# The default (review_only=False) salvage rule for normal build dispatches is
+# untouched — a dirty build dispatch is still preserved.
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGateTeardownResetsReproduction:
+    """review_only teardown: forced gate-dispatch state ending with a staged
+    change must NOT classify dirty afterward."""
+
+    def _stage_diff(self, wt_path: Path) -> None:
+        """Reproduce the review-gate writer: a staged change to a tracked file
+        (the worker's ``git checkout origin/<branch> -- <file>`` leaves exactly
+        this state)."""
+        (wt_path / "README.md").write_text("pr diff content\n")
+        subprocess.run(
+            ["git", "-C", str(wt_path), "add", "README.md"],
+            check=True, capture_output=True,
+        )
+
+    def test_review_only_removes_worktree_with_staged_diff(
+        self, tmp_path, monkeypatch
+    ):
+        """A gate dispatch ending with a staged change is removed, not locked.
+
+        Fails on old code: remove_dispatch_worktree had no review_only keyword,
+        so this call raises TypeError instead of cleaning the worktree.
+        """
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "glm-gate-pr1847-1789228202"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+        self._stage_diff(wt_path)
+
+        remove_dispatch_worktree(
+            dispatch_id,
+            project_root=local,
+            terminal_id="T1",
+            review_only=True,
+        )
+
+        # The worktree must be gone — not classified dirty, not locked.
+        assert not wt_path.exists(), (
+            "OI-1629b FAIL: review-gate worktree with a staged diff was "
+            "preserved as dirty instead of removed"
+        )
+        # Clean removal also deletes the branch.
+        branch_name = f"dispatch/{dispatch_id}"
+        branches = subprocess.check_output(
+            ["git", "-C", str(local), "branch", "--list", branch_name],
+            text=True,
+        ).strip()
+        assert branches == ""
+
+    def test_default_preserves_dirty_build_dispatch(self, tmp_path, monkeypatch):
+        """The hard boundary: without review_only, a staged change is still
+        dirty → worktree locked (salvage rule untouched)."""
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "build-dispatch-dirty-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+        self._stage_diff(wt_path)
+
+        remove_dispatch_worktree(
+            dispatch_id,
+            project_root=local,
+            terminal_id="T1",
+        )
+
+        assert wt_path.is_dir(), (
+            "OI-1629b FAIL: normal build dispatch with a staged change was "
+            "removed — the dirty salvage rule must stay untouched"
+        )
+
+    def test_review_only_never_discards_local_commits(self, tmp_path, monkeypatch):
+        """review_only teardown only resets when HEAD still equals base. A
+        committed change degrades to normal classification (committed → branch
+        kept), so real work is never thrown away."""
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "glm-gate-pr9999-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        (wt_path / "work.txt").write_text("committed real work\n")
+        subprocess.run(
+            ["git", "-C", str(wt_path), "add", "work.txt"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wt_path), "commit", "-m", "worker commit"],
+            check=True, capture_output=True,
+        )
+
+        remove_dispatch_worktree(
+            dispatch_id,
+            project_root=local,
+            terminal_id="T1",
+            review_only=True,
+        )
+
+        # Disk removed (committed), branch kept — the commit survived.
+        assert not wt_path.exists()
+        branch_name = f"dispatch/{dispatch_id}"
+        branches = subprocess.check_output(
+            ["git", "-C", str(local), "branch", "--list", branch_name],
+            text=True,
+        ).strip()
+        assert branch_name in branches, (
+            "OI-1629b FAIL: review_only teardown discarded a local commit"
         )
 
 


### PR DESCRIPTION
## OI-1629 deel b: een poortrun laat zijn dispatch-worktree vuil achter

A review-gate dispatch materializes the PR diff into its dispatch worktree
(`git checkout origin/<branch> -- <file>`) so it can run pytest against the
checked-out tree. That leaves a staged change, and at teardown
`remove_dispatch_worktree` classified the worktree `dirty`, locking it with
`git worktree lock --reason "vnx preserve ..."` forever (8 of 12 locked
worktrees were `dispatch-glm-gate-pr<N>-<ts>`).

### Writer

The staged diff is not written by deterministic repo code. It is produced by
the autonomous review-gate worker (spawned into the dispatch worktree by the
glm-harness lane) when it runs `git checkout origin/<branch> -- <file>` to
materialize the PR. The writer is therefore the harness worker's own PR
materialization step, observed in the worker transcript for PR 1847.

### Fix

Add a `review_only` flag to `remove_dispatch_worktree`. When true, before
classification teardown resets the index and working tree to the recorded
base (`git reset --hard <base_sha>` + `git clean -fd`) and only fires when
HEAD still equals base (no local commits). Real work is never discarded: a
committed change degrades to normal classification and is preserved. The
default `review_only=False` leaves the normal build-dispatch dirty salvage
rule untouched.

`review_only` is threaded through
`_finish_provider_worktree` -> `_remove_provider_worktree` in
provider_dispatch.py, computed as `role == "review-gate"`.

### Test

`TestReviewGateTeardownResetsReproduction` forces the gate-dispatch state
(staged diff) and asserts the worktree is removed, not locked. Fails on old
code: `remove_dispatch_worktree` had no `review_only` keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
