### PR TITLE
feat(launchd): cleanup-reviewed-worktrees as a per-project job (OI-1629 deel c)

### DIFF
--- a/scripts/cleanup_reviewed_worktrees.py
+++ b/scripts/cleanup_reviewed_worktrees.py
@@ -1,0 +1,444 @@
+"""cleanup_reviewed_worktrees.py — release dispatch worktrees preserved for
+identity review, once that review is provably done (OI-1111).
+
+Background: ``vnx-orchestration``'s ``tmux_worktree.reap()`` classifies a
+worktree ``dirty`` — and preserves it forever via ``git worktree lock
+--reason "vnx preserve <ts>"`` — in two cases: (a) plain uncommitted tracked
+changes, or (b) OI-1124 BRANCH-IDENTITY DRIFT, where a fix-forward dispatch
+checked out an EXISTING branch (often naming a different dispatch id) instead
+of its own. Both are the right call at teardown time: reaping a dirty tree
+risks losing work. But nothing ever performs the second half — releasing the
+worktree once whatever it was preserved for has actually shipped. Measured
+17 august 2026 on this Mac: 32 of 61 ``.vnx-data/worktrees/dispatch-*``
+worktrees sit locked this way, three of them freed by hand overnight
+16/17-08 (dispatch-D-e6712386, dispatch-D-0c729d74, dispatch-D-06334377)
+because nothing else does it.
+
+"Reviewed" here means one specific, git-provable fact, never an age guess
+(``.claude/rules/rode-test-eigenschap-of-momentopname.md``): the worktree's
+checked-out branch has NO commit that isn't already captured somewhere safe,
+AND the working tree carries no uncommitted change. Two ways a branch counts
+as captured:
+
+1. Its HEAD is an ancestor of (or equal to) ``origin/main`` — the ordinary
+   merge/rebase-merge case.
+2. GitHub reports a MERGED pull request for that branch, and the worktree's
+   HEAD is an ancestor of (or equal to) that PR's ``headRefOid`` — the
+   squash-merge case, where main's integration commit has a different SHA
+   than anything the branch ever held, so (1) alone would never fire even
+   though the PR shipped everything the worktree has.
+
+Releasing under either proof can never discard work: every commit the
+worktree holds is already durably recorded elsewhere (in main's history, or
+as the head of a merged PR), and an empty ``git status --porcelain`` means
+there is nothing beyond those commits to lose.
+
+Dry-run by default — this script only ever WRITES when called with
+``--apply``. Even then it only touches ``git worktree``/``git branch``
+plumbing in the target repo; it never touches ``~/Library/LaunchAgents`` or
+any other machine state, and it always refuses to act on the worktree it is
+currently running from (via ``VNX_DISPATCH_ID``/``VNX_CURRENT_DISPATCH_ID``
+and via cwd).
+
+Usage::
+
+    python3 scripts/cleanup_reviewed_worktrees.py [--repo-root DIR]
+                                                    [--only DISPATCH_ID ...]
+                                                    [--apply] [--json]
+
+Exit 0 on a normal run (this is a maintenance report, not a CI gate) unless
+argument/repo resolution itself fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TypedDict
+
+REPO_ROOT_DEFAULT = Path(__file__).resolve().parent.parent
+LOCK_REASON_PREFIX = "vnx preserve"
+_DISPATCH_DIR_RE = re.compile(r"^dispatch-(?P<id>[A-Za-z0-9][A-Za-z0-9_-]*)$")
+
+
+def _run(args: list[str], cwd: Path | str | None = None, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    """Thin subprocess wrapper — no shell=True, mockable in tests."""
+    return subprocess.run(args, cwd=str(cwd) if cwd else None, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def run_git(args: list[str], cwd: Path | str | None = None) -> subprocess.CompletedProcess[str]:
+    return _run(["git", *args], cwd=cwd)
+
+
+def run_gh_pr_list(repo_slug: str, branch: str) -> str:
+    """stdout of ``gh pr list --state all --head <branch> --json ...``.
+
+    Thin wrapper so tests only monkeypatch this call, same pattern as
+    ``ci_launchd_inventory_check.run_launchctl_list``. Returns ``""`` (not
+    an exception) when ``gh`` itself is missing — callers treat that as
+    "cannot verify via PR", not as "no PR exists"."""
+    try:
+        proc = _run(
+            [
+                "gh", "pr", "list",
+                "--repo", repo_slug,
+                "--state", "all",
+                "--head", branch,
+                "--json", "number,state,mergedAt,headRefOid",
+            ],
+            timeout=30,
+        )
+    except FileNotFoundError:
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+@dataclass(frozen=True)
+class LockedWorktree:
+    path: Path
+    dispatch_dir_id: str | None
+    branch: str | None  # short form, e.g. "dispatch/D-030d7e66"; None when detached
+    head_sha: str | None
+    lock_reason: str | None
+
+
+@dataclass
+class Verdict:
+    safe: bool
+    reason: str
+
+
+@dataclass
+class ReleaseResult:
+    released: bool
+    errors: list[str] = field(default_factory=list)
+
+
+class WorktreePorcelainRecord(TypedDict, total=False):
+    """One ``git worktree list --porcelain`` block. Every key is optional —
+    presence tracks whether the corresponding line appeared at all."""
+
+    path: str
+    head: str
+    branch: str
+    locked: str
+    detached: bool
+    bare: bool
+    prunable: bool
+
+
+def parse_worktree_list_porcelain(text: str) -> list[WorktreePorcelainRecord]:
+    """Parse ``git worktree list --porcelain`` into one dict per worktree
+    block. Keys present only when the corresponding line was present:
+    ``path``, ``head``, ``branch``, ``locked`` (reason, possibly ""),
+    ``detached`` (bool)."""
+    records: list[WorktreePorcelainRecord] = []
+    current: WorktreePorcelainRecord = {}
+    for line in text.splitlines():
+        if not line.strip():
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        if line.startswith("worktree "):
+            current["path"] = line[len("worktree "):]
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD "):]
+        elif line.startswith("branch "):
+            current["branch"] = line[len("branch "):]
+        elif line == "detached":
+            current["detached"] = True
+        elif line == "locked":
+            current["locked"] = ""
+        elif line.startswith("locked "):
+            current["locked"] = line[len("locked "):]
+        elif line == "bare":
+            current["bare"] = True
+        elif line == "prunable" or line.startswith("prunable "):
+            current["prunable"] = True
+    if current:
+        records.append(current)
+    return records
+
+
+def discover_locked_dispatch_worktrees(repo_root: Path) -> list[LockedWorktree]:
+    """Every ``.vnx-data/worktrees/dispatch-*`` entry that is currently
+    ``git worktree lock``-ed with a ``vnx preserve`` reason. Anything locked
+    for a DIFFERENT reason (an operator's own manual lock) is left out —
+    this tool only ever acts on locks the engine itself created."""
+    proc = run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    if proc.returncode != 0:
+        return []
+    worktrees_dir = (repo_root / ".vnx-data" / "worktrees").resolve()
+    result: list[LockedWorktree] = []
+    for rec in parse_worktree_list_porcelain(proc.stdout):
+        raw_path = rec.get("path")
+        if not raw_path:
+            continue
+        path = Path(raw_path)
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if resolved.parent != worktrees_dir:
+            continue
+        m = _DISPATCH_DIR_RE.match(resolved.name)
+        if not m:
+            continue
+        lock_reason = rec.get("locked")
+        if lock_reason is None or not lock_reason.startswith(LOCK_REASON_PREFIX):
+            continue
+        branch_ref = rec.get("branch")
+        branch = branch_ref[len("refs/heads/"):] if branch_ref and branch_ref.startswith("refs/heads/") else branch_ref
+        result.append(
+            LockedWorktree(
+                path=resolved,
+                dispatch_dir_id=m.group("id"),
+                branch=branch,
+                head_sha=rec.get("head"),
+                lock_reason=lock_reason,
+            )
+        )
+    return result
+
+
+def is_current_worktree(wt: LockedWorktree) -> bool:
+    """Never act on the worktree this process is itself running from —
+    checked two ways so either signal alone is enough to protect it."""
+    dispatch_env = os.environ.get("VNX_DISPATCH_ID") or os.environ.get("VNX_CURRENT_DISPATCH_ID")
+    if dispatch_env and wt.dispatch_dir_id == dispatch_env:
+        return True
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return False
+    return cwd == wt.path or wt.path in cwd.parents
+
+
+def get_repo_slug(repo_root: Path) -> str | None:
+    proc = run_git(["remote", "get-url", "origin"], cwd=repo_root)
+    if proc.returncode != 0:
+        return None
+    url = proc.stdout.strip()
+    m = re.search(r"github\.com[:/]([^/]+/[^/]+?)(?:\.git)?$", url)
+    return m.group(1) if m else None
+
+
+def is_worktree_clean(wt_path: Path) -> bool:
+    proc = run_git(["status", "--porcelain"], cwd=wt_path)
+    return proc.returncode == 0 and proc.stdout.strip() == ""
+
+
+def is_ancestor(repo_root: Path, ancestor_sha: str, descendant_sha: str) -> bool:
+    proc = run_git(["merge-base", "--is-ancestor", ancestor_sha, descendant_sha], cwd=repo_root)
+    return proc.returncode == 0
+
+
+def object_available(repo_root: Path, sha: str) -> bool:
+    proc = run_git(["cat-file", "-e", sha], cwd=repo_root)
+    return proc.returncode == 0
+
+
+def try_fetch_sha(repo_root: Path, sha: str) -> bool:
+    """Best-effort: some remotes allow fetching an arbitrary reachable SHA
+    even after its branch was deleted (observed working against this repo's
+    origin for a squash-merged, branch-deleted PR). Never raises — a failed
+    fetch just means the PR-ancestor path can't be verified this round."""
+    if object_available(repo_root, sha):
+        return True
+    proc = run_git(["fetch", "origin", sha], cwd=repo_root)
+    return proc.returncode == 0 and object_available(repo_root, sha)
+
+
+def find_merged_pr_head(repo_slug: str, branch: str) -> str | None:
+    """The ``headRefOid`` of a MERGED pull request for *branch*, or
+    ``None`` if ``gh`` found none / isn't usable. Multiple PRs can share a
+    branch name over time; any MERGED entry is sufficient proof."""
+    raw = run_gh_pr_list(repo_slug, branch)
+    if not raw:
+        return None
+    try:
+        entries = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("state") == "MERGED" and entry.get("headRefOid"):
+            return str(entry["headRefOid"])
+    return None
+
+
+def evaluate_worktree(repo_root: Path, wt: LockedWorktree, repo_slug: str | None) -> Verdict:
+    if wt.branch is None:
+        return Verdict(False, "worktree staat op een detached HEAD — geen branch-identiteit om te verifiëren")
+    if wt.head_sha is None:
+        return Verdict(False, "kon HEAD-sha niet bepalen")
+    if not is_worktree_clean(wt.path):
+        return Verdict(False, "werkmap is niet schoon (ongecommitte tracked wijzigingen) — dataverlies-risico")
+
+    if is_ancestor(repo_root, wt.head_sha, "origin/main"):
+        return Verdict(True, f"HEAD ({wt.head_sha[:12]}) is ancestor van origin/main")
+
+    if repo_slug is None:
+        return Verdict(False, "HEAD zit niet in origin/main en de PR-status kon niet gecontroleerd worden (geen origin-remote herkend)")
+
+    pr_head = find_merged_pr_head(repo_slug, wt.branch)
+    if pr_head is None:
+        return Verdict(False, f"geen MERGED pull request gevonden voor branch {wt.branch!r} — werk is niet aantoonbaar afgerond")
+
+    if wt.head_sha == pr_head:
+        return Verdict(True, f"HEAD is exact de headRefOid van een MERGED PR voor {wt.branch!r}")
+
+    try_fetch_sha(repo_root, pr_head)
+    if is_ancestor(repo_root, wt.head_sha, pr_head):
+        return Verdict(True, f"HEAD is ancestor van de headRefOid ({pr_head[:12]}) van een MERGED PR voor {wt.branch!r}")
+
+    return Verdict(
+        False,
+        f"branch {wt.branch!r} heeft een MERGED PR, maar HEAD ({wt.head_sha[:12]}) bevat commits die niet in "
+        f"die PR ({pr_head[:12]}) terechtkwamen — mogelijk verder gewerkt na de laatste push vanuit deze worktree",
+    )
+
+
+@contextmanager
+def _flock_context(repo_root: Path) -> Iterator[None]:
+    git_dir_proc = run_git(["rev-parse", "--git-common-dir"], cwd=repo_root)
+    git_dir = Path(git_dir_proc.stdout.strip()) if git_dir_proc.returncode == 0 else (repo_root / ".git")
+    if not git_dir.is_absolute():
+        git_dir = (repo_root / git_dir).resolve()
+    lock_dir = git_dir / "worktrees"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / ".vnx-cleanup-lock"
+    with open(lock_path, "a") as lf:
+        fcntl.flock(lf, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+def release_worktree(repo_root: Path, wt: LockedWorktree) -> ReleaseResult:
+    errors: list[str] = []
+    with _flock_context(repo_root):
+        unlock = run_git(["worktree", "unlock", str(wt.path)], cwd=repo_root)
+        if unlock.returncode != 0:
+            errors.append(f"unlock failed: {(unlock.stderr or '').strip()}")
+            return ReleaseResult(released=False, errors=errors)
+
+        remove = run_git(["worktree", "remove", "--force", str(wt.path)], cwd=repo_root)
+        if remove.returncode != 0:
+            errors.append(f"worktree remove failed: {(remove.stderr or '').strip()}")
+            return ReleaseResult(released=False, errors=errors)
+
+        if wt.branch:
+            branch_delete = run_git(["branch", "-D", wt.branch], cwd=repo_root)
+            if branch_delete.returncode != 0:
+                errors.append(f"branch delete failed (worktree already removed): {(branch_delete.stderr or '').strip()}")
+
+    return ReleaseResult(released=True, errors=errors)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT_DEFAULT)
+    parser.add_argument(
+        "--only",
+        action="append",
+        default=None,
+        metavar="DISPATCH_ID",
+        help="beperk tot deze dispatch-id('s) (bv. D-4cbc8faf); mag meerdere keren opgegeven worden",
+    )
+    parser.add_argument("--apply", action="store_true", help="release SAFE_TO_RELEASE-worktrees echt (default: dry-run)")
+    parser.add_argument("--json", action="store_true", help="schrijf het rapport als JSON naar stdout")
+    return parser
+
+
+class WorktreeReportEntry(TypedDict):
+    """One row of the human/JSON report — always carries every key, unlike
+    :class:`WorktreePorcelainRecord` which is a partial parse."""
+
+    dispatch_id: str | None
+    path: str
+    branch: str | None
+    head_sha: str | None
+    lock_reason: str | None
+    safe_to_release: bool
+    reason: str
+    released: bool
+    errors: list[str]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
+    candidates = discover_locked_dispatch_worktrees(repo_root)
+    if args.only:
+        wanted = set(args.only)
+        candidates = [c for c in candidates if c.dispatch_dir_id in wanted]
+
+    repo_slug = get_repo_slug(repo_root)
+    if repo_slug is None:
+        print("WAARSCHUWING: kon geen github.com owner/repo herkennen uit origin — PR-gebaseerde verificatie (squash-merges) wordt overgeslagen, alleen ancestor-of-main telt.")
+
+    report: list[WorktreeReportEntry] = []
+    released = 0
+    skipped_self = 0
+    for wt in candidates:
+        if is_current_worktree(wt):
+            skipped_self += 1
+            continue
+        verdict = evaluate_worktree(repo_root, wt, repo_slug)
+        entry: WorktreeReportEntry = {
+            "dispatch_id": wt.dispatch_dir_id,
+            "path": str(wt.path),
+            "branch": wt.branch,
+            "head_sha": wt.head_sha,
+            "lock_reason": wt.lock_reason,
+            "safe_to_release": verdict.safe,
+            "reason": verdict.reason,
+            "released": False,
+            "errors": [],
+        }
+        if verdict.safe and args.apply:
+            result = release_worktree(repo_root, wt)
+            entry["released"] = result.released
+            entry["errors"] = result.errors
+            if result.released:
+                released += 1
+        report.append(entry)
+
+    if args.json:
+        print(json.dumps({"repo_root": str(repo_root), "candidates": report}, indent=2))
+    else:
+        print(f"cleanup_reviewed_worktrees: {len(candidates)} locked dispatch-worktree(s) gevonden ({skipped_self} eigen worktree overgeslagen)")
+        for entry in report:
+            verdict_label = "SAFE_TO_RELEASE" if entry["safe_to_release"] else "BLIJFT_STAAN"
+            action = ""
+            if entry["safe_to_release"]:
+                if args.apply:
+                    action = " -> RELEASED" if entry["released"] else f" -> RELEASE FAILED: {entry['errors']}"
+                else:
+                    action = " (dry-run, gebruik --apply om echt vrij te geven)"
+            print(f"  [{verdict_label}] {entry['dispatch_id']} ({entry['branch']}): {entry['reason']}{action}")
+        if args.apply:
+            print(f"cleanup_reviewed_worktrees: {released} worktree(s) vrijgegeven")
+        else:
+            safe_count = sum(1 for e in report if e["safe_to_release"])
+            print(f"cleanup_reviewed_worktrees: {safe_count} van {len(report)} zijn SAFE_TO_RELEASE (dry-run — geen --apply meegegeven)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/launchd/com.vnx.cleanup-reviewed-worktrees.plist
+++ b/scripts/launchd/com.vnx.cleanup-reviewed-worktrees.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.vnx.cleanup-reviewed-worktrees.${VNX_PROJECT_ID}</string>
+  <!--
+    OI-1629 deel c (2026-09-12): release dispatch worktrees preserved for
+    identity review, once that review is provably done, per project.
+
+    Before this template, the only launchd job running this script was
+    mission-control's hand-written plist, hard-targeted at that one repo
+    (REPO="$HOME/Development/mission-control"). Every other repo's
+    .vnx-data/worktrees/ grew unchecked while that job "succeeded" nightly on
+    the wrong checkout. The script itself (scripts/cleanup_reviewed_worktrees.py,
+    brought over verbatim) always had a repo-root flag; nothing per-project
+    used it.
+
+    Per-project from the start, same form as com.vnx.gate-obligation-runner
+    and com.vnx.receipt-processor: the Label carries ${VNX_PROJECT_ID}, so a
+    second project installing this template never collides with (or unloads)
+    the first project's job. See com.vnx.gate-obligation-runner.plist's
+    comment for the full collision history this pattern avoids.
+
+    The worktrees live under EACH PROJECT'S own checkout
+    (<checkout>/.vnx-data/worktrees/), not under the engine root. A central
+    install shares one engine across many projects, so the script must be told
+    which checkout to sweep. The repo-root argument is ${VNX_PROJECT_ROOT}:
+    the central shim exports it (the project's git root) when vnx init runs
+    inside the project; a standalone dev checkout has no shim, and there
+    _install_launchd_agent falls back to VNX_HOME, which IS the checkout. The
+    EnvironmentVariables entry below carries the same value for the script's
+    own resolution.
+
+    Applying the sweep is deliberate and safe: the script is dry-run by
+    construction and only ever releases a worktree whose work is provably
+    captured elsewhere (HEAD ancestor-of-origin/main, or HEAD equal/ancestor
+    of a MERGED PR's headRefOid, and the worktree is clean). Its judgment rule
+    is deliberately strict and is not changed here.
+
+    Installed by vnx init (_install_cleanup_reviewed_worktrees_runner in
+    vnx_cli/commands/init_cmd.py), or manually via reload_plist.sh:
+      bash scripts/launchd/reload_plist.sh com.vnx.cleanup-reviewed-worktrees
+  -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/cleanup_reviewed_worktrees.py --repo-root ${VNX_PROJECT_ROOT} --apply</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>4</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key><string>/tmp/vnx-cleanup-reviewed-worktrees-${VNX_PROJECT_ID}.log</string>
+  <key>StandardErrorPath</key><string>/tmp/vnx-cleanup-reviewed-worktrees-${VNX_PROJECT_ID}.err</string>
+  <key>WorkingDirectory</key><string>${VNX_HOME}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VNX_HOME</key>
+    <string>${VNX_HOME}</string>
+    <key>VNX_PROJECT_ID</key>
+    <string>${VNX_PROJECT_ID}</string>
+    <key>VNX_PROJECT_ROOT</key>
+    <string>${VNX_PROJECT_ROOT}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/launchd/launchd_project_scope.py
+++ b/scripts/launchd/launchd_project_scope.py
@@ -56,14 +56,19 @@ import vnx_paths  # noqa: E402
 # py/sh duplication.
 PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9-]{1,31}$")
 
-# The two daemon families OI-1509/OI-1510 name explicitly. Not derived
-# dynamically from whatever templates happen to exist under scripts/launchd/:
-# most templates in that directory (conversation-analyzer, dashboard-adjacent
-# jobs, etc.) are deliberately single-instance-per-machine, not per-project,
-# and must NOT be flagged just for lacking a ${VNX_PROJECT_ID} placeholder.
+# The daemon families that must be per-project. OI-1509/OI-1510 named the first
+# two; OI-1629 deel c adds the reviewed-worktree cleaner, which must run per
+# project (each project's .vnx-data/worktrees/ is its own) and was measured
+# hard-targeted at a single repo via its old mission-control launchd job. Not
+# derived dynamically from whatever templates happen to exist under
+# scripts/launchd/: most templates in that directory (conversation-analyzer,
+# dashboard-adjacent jobs, etc.) are deliberately single-instance-per-machine,
+# not per-project, and must NOT be flagged just for lacking a
+# ${VNX_PROJECT_ID} placeholder.
 REQUIRED_PER_PROJECT_FAMILIES: tuple = (
     "com.vnx.gate-obligation-runner",
     "com.vnx.receipt-processor",
+    "com.vnx.cleanup-reviewed-worktrees",
 )
 
 _PLACEHOLDER = "${VNX_PROJECT_ID}"
@@ -262,11 +267,11 @@ def _run_real_launchctl_list() -> str:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Fail-closed guard: exits non-zero when a per-project launchd "
-            "daemon (gate-obligation-runner, receipt-processor) is missing "
-            "this project's instance, or when a bare/malformed label is "
-            "loaded for it (OI-1509/OI-1510). Read-only: never installs, "
-            "loads, or unloads a launchd job."
+            "Fail-closed guard: exits non-zero when a required per-project "
+            "launchd daemon family is missing this project's instance, or when "
+            "a bare/malformed label is loaded for it (OI-1509/OI-1510, "
+            "OI-1629). Read-only: never installs, loads, or unloads a launchd "
+            "job."
         )
     )
     parser.add_argument(

--- a/scripts/launchd/reload_plist.sh
+++ b/scripts/launchd/reload_plist.sh
@@ -114,6 +114,16 @@ if printf '%s' "$RESOLVED" | grep -q '\${VNX_PROJECT_ID}'; then
     echo "Resolved project id: $PROJECT_ID"
 fi
 
+# OI-1629 deel c: point per-project worktree sweepers at the PROJECT checkout,
+# not the shared engine root. VNX_PROJECT_ROOT is the central shim's export for
+# the checkout vnx init ran inside; a standalone checkout has no shim and
+# VNX_HOME IS the checkout, so fall back to it.
+if printf '%s' "$RESOLVED" | grep -q '\${VNX_PROJECT_ROOT}'; then
+    PROJECT_ROOT="${VNX_PROJECT_ROOT:-$VNX_HOME}"
+    RESOLVED="$(printf '%s' "$RESOLVED" | sed "s|\${VNX_PROJECT_ROOT}|$PROJECT_ROOT|g")"
+    echo "Resolved project root: $PROJECT_ROOT"
+fi
+
 # Fail loud on any remaining unresolved ${...} placeholder rather than
 # install a plist that will confuse the daemon it starts.
 if printf '%s' "$RESOLVED" | grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*\}'; then

--- a/tests/test_cleanup_reviewed_worktrees_launchd.py
+++ b/tests/test_cleanup_reviewed_worktrees_launchd.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Tests for OI-1629 deel c — the reviewed-worktree cleaner as a per-project
+launchd job, wired through `vnx init`.
+
+Measured 12-09: ``~/Library/LaunchAgents/com.vnx.cleanup-reviewed-worktrees.plist``
+was hard-targeted at one repo (``REPO="$HOME/Development/mission-control"``) even
+though ``scripts/cleanup_reviewed_worktrees.py`` has a ``--repo-root`` flag. Every
+other repo's ``.vnx-data/worktrees/`` grew unchecked while the job "succeeded"
+nightly on the wrong checkout.
+
+This repo has had the per-project launchd machinery since #1830 (OI-1509/OI-1510):
+a ``REQUIRED_PER_PROJECT_FAMILIES`` registration, a ``${VNX_PROJECT_ID}``-scoped
+template, install via ``_install_launchd_agent`` (destination filename derived
+from the resolved Label, so two projects never overwrite each other), and a
+``vnx doctor`` FAIL on a missing instance. This module follows that same form for
+the ``com.vnx.cleanup-reviewed-worktrees`` family and never invents a second one.
+
+Mirrors ``tests/test_receipt_processor_launchd_init.py``'s pattern: fake engine
+root + fake home + monkeypatched ``subprocess.run``, exercising the REAL install
+path (``_install_launchd_agent`` / its per-family wrapper), never a
+reimplementation.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+LAUNCHD_DIR = VNX_ROOT / "scripts" / "launchd"
+sys.path.insert(0, str(VNX_ROOT))
+sys.path.insert(0, str(LAUNCHD_DIR))
+
+from vnx_cli.commands import init_cmd  # noqa: E402
+import launchd_project_scope as lps  # noqa: E402
+
+CLEANUP_WORKTREES = "com.vnx.cleanup-reviewed-worktrees"
+
+
+def _fake_engine_root(tmp_path: Path) -> Path:
+    """A fake engine root under tmp_path (never under .vnx-data/worktrees/,
+    which this suite's own real repo path is) so the OI-1117 worktree guard
+    in _install_launchd_agent does not fire and silently skip the install."""
+    real_engine = init_cmd._engine.engine_root()
+    fake_engine_root = tmp_path / "fake-vnx-engine"
+    fake_engine_root.mkdir()
+    (fake_engine_root / "scripts").symlink_to(real_engine / "scripts", target_is_directory=True)
+    return fake_engine_root
+
+
+def _patch_launchctl(monkeypatch, loaded_labels: "set[str]") -> None:
+    """Fake launchctl: 'load' registers the label (read from the just-written
+    plist file path, launchd-style — the label IS the destination basename),
+    'list' reports whatever is currently 'loaded'."""
+
+    def fake_run(cmd, **kwargs):
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = ""
+        if cmd[:2] == ["launchctl", "load"]:
+            dest = Path(cmd[-1])
+            loaded_labels.add(dest.stem)
+            m.stdout = ""
+        elif cmd[:2] == ["launchctl", "unload"]:
+            dest = Path(cmd[-1])
+            loaded_labels.discard(dest.stem)
+            m.stdout = ""
+        elif cmd == ["launchctl", "list"]:
+            m.stdout = "\n".join(loaded_labels)
+        else:
+            m.stdout = ""
+        return m
+
+    monkeypatch.setattr(init_cmd.subprocess, "run", fake_run)
+
+
+class TestCleanupWorktreesTemplateAndPerProjectInstall:
+    """The dispatch's required red test: the template must carry the
+    ``${VNX_PROJECT_ID}`` placeholder AND two projects installing it must land
+    on different destination files (OI-1510's collision must not regress)."""
+
+    def test_template_is_project_scoped_and_two_projects_get_separate_files(
+        self, tmp_path, monkeypatch
+    ):
+        # (1) Static contract: the real repo template's Label carries the
+        # ${VNX_PROJECT_ID} placeholder, so the family is genuinely per-project.
+        result = lps.check_template_contract(LAUNCHD_DIR)
+        assert result["ok"] is True, result["violations"]
+        labels = {c["family"]: c["label"] for c in result["checked"]}
+        assert labels[CLEANUP_WORKTREES] == f"{CLEANUP_WORKTREES}.${{VNX_PROJECT_ID}}"
+
+        # (2) Two projects installing the family resolve to two different
+        # destination files, and neither carries the other project's id.
+        fake_engine_root = _fake_engine_root(tmp_path)
+        monkeypatch.setattr(init_cmd._engine, "engine_root", lambda: fake_engine_root)
+        # Standalone-install semantics: no central shim -> project root falls
+        # back to VNX_HOME. Clear any ambient VNX_PROJECT_ROOT so the test does
+        # not measure whichever host happens to run it.
+        monkeypatch.delenv("VNX_PROJECT_ROOT", raising=False)
+
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        _patch_launchctl(monkeypatch, set())
+
+        assert init_cmd._install_cleanup_reviewed_worktrees_runner(
+            str(fake_engine_root), project_id="project-alpha"
+        )
+        assert init_cmd._install_cleanup_reviewed_worktrees_runner(
+            str(fake_engine_root), project_id="project-beta"
+        )
+
+        la_dir = fake_home / "Library" / "LaunchAgents"
+        alpha_dest = la_dir / f"{CLEANUP_WORKTREES}.project-alpha.plist"
+        beta_dest = la_dir / f"{CLEANUP_WORKTREES}.project-beta.plist"
+
+        assert alpha_dest.is_file(), "project-alpha's plist is missing — beta's install overwrote it"
+        assert beta_dest.is_file(), "project-beta's plist was never written"
+
+        alpha_content = alpha_dest.read_text(encoding="utf-8")
+        beta_content = beta_dest.read_text(encoding="utf-8")
+        assert "project-alpha" in alpha_content
+        assert "project-beta" not in alpha_content, (
+            "project-alpha's installed plist carries project-beta's id — "
+            "the second install overwrote the first project's file (OI-1510)"
+        )
+        assert "project-beta" in beta_content
+        assert "project-alpha" not in beta_content
+
+
+class TestCleanupWorktreesRunsAgainstTheProject:
+    """The template must run the script with ``--repo-root`` pointing at the
+    PROJECT's checkout, never at the engine root (a central install shares one
+    engine across many projects, and the worktrees live under each project's
+    own ``.vnx-data/worktrees/``)."""
+
+    def test_installed_plist_passes_repo_root_for_the_project(
+        self, tmp_path, monkeypatch
+    ):
+        fake_engine_root = _fake_engine_root(tmp_path)
+        monkeypatch.setattr(init_cmd._engine, "engine_root", lambda: fake_engine_root)
+        project_checkout = tmp_path / "project-checkout"
+        project_checkout.mkdir()
+        monkeypatch.setenv("VNX_PROJECT_ROOT", str(project_checkout))
+
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        _patch_launchctl(monkeypatch, set())
+
+        init_cmd._install_cleanup_reviewed_worktrees_runner(
+            str(fake_engine_root), project_id="project-alpha"
+        )
+
+        import plistlib
+
+        dest = fake_home / "Library" / "LaunchAgents" / f"{CLEANUP_WORKTREES}.project-alpha.plist"
+        data = plistlib.loads(dest.read_bytes())
+        program_args = data.get("ProgramArguments")
+        # /bin/bash -c "<command>" — the command is the last array element.
+        command = program_args[-1] if isinstance(program_args, list) and program_args else ""
+        assert f"--repo-root {project_checkout}" in command, (
+            f"installed ProgramArguments {command!r} does not pass --repo-root "
+            f"for the project checkout {project_checkout}"
+        )
+        env = data.get("EnvironmentVariables") or {}
+        assert env.get("VNX_PROJECT_ROOT") == str(project_checkout)
+
+
+class TestCleanupWorktreesInstalled:
+    """vnx init must install com.vnx.cleanup-reviewed-worktrees — not just
+    ship the template and the registration."""
+
+    def test_vnx_init_calls_cleanup_reviewed_worktrees_installer(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        monkeypatch.setattr(init_cmd, "_bootstrap_runtime_dbs", MagicMock(return_value=None))
+        spy = MagicMock(return_value=True)
+        monkeypatch.setattr(init_cmd, "_install_cleanup_reviewed_worktrees_runner", spy)
+
+        from vnx_cli.commands.init_cmd import vnx_init
+
+        ns = argparse.Namespace(
+            project_path=None,
+            project_dir=str(tmp_path),
+            project_id=None,
+            template="minimal",
+            force=False,
+            non_interactive=False,
+            set_version=None,
+        )
+        rc = vnx_init(ns)
+        assert rc == 0
+        assert spy.called, "vnx init did not call _install_cleanup_reviewed_worktrees_runner"
+        _, kwargs = spy.call_args
+        assert kwargs.get("project_id"), (
+            f"_install_cleanup_reviewed_worktrees_runner called without a project_id: "
+            f"{spy.call_args}"
+        )

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -860,7 +860,7 @@ class TestInitDoctorDataDirConsistency:
         assert rc == 0, "vnx init must succeed"
 
         # Isolate the launchd-agents check (golf C, C3) from this test's own
-        # concern (data-dir mismatch warnings): report both required jobs as
+        # concern (data-dir mismatch warnings): report all required jobs as
         # loaded for whatever project_id vnx_init resolved. Without this, a
         # worktree test run — where the OI-1117 guard always skips the real
         # launchd install — would FAIL doctor for a reason unrelated to what
@@ -878,6 +878,7 @@ class TestInitDoctorDataDirConsistency:
                 "PID\tStatus\tLabel\n"
                 f"-\t0\tcom.vnx.gate-obligation-runner.{resolved_project_id}\n"
                 f"-\t0\tcom.vnx.receipt-processor.{resolved_project_id}\n"
+                f"-\t0\tcom.vnx.cleanup-reviewed-worktrees.{resolved_project_id}\n"
             ),
         )
 

--- a/tests/test_doctor_launchd_agents.py
+++ b/tests/test_doctor_launchd_agents.py
@@ -33,6 +33,7 @@ import launchd_project_scope as lps  # noqa: E402
 
 RECEIPT_PROCESSOR = "com.vnx.receipt-processor"
 GATE_OBLIGATION = "com.vnx.gate-obligation-runner"
+CLEANUP_WORKTREES = "com.vnx.cleanup-reviewed-worktrees"
 
 
 def _write_marker(project_dir: Path, project_id: str) -> None:
@@ -83,13 +84,42 @@ class TestMissingJobIsLoud:
         assert f"{RECEIPT_PROCESSOR}.vnx-dev" in failed[f"launchd:{RECEIPT_PROCESSOR}"].detail
         assert f"{GATE_OBLIGATION}.vnx-dev" in failed[f"launchd:{GATE_OBLIGATION}"].detail
 
+    def test_missing_cleanup_reviewed_worktrees_fails_with_job_name(
+        self, tmp_path, monkeypatch
+    ):
+        """OI-1629 deel c red test: without the family registered, doctor
+        produces no ``launchd:com.vnx.cleanup-reviewed-worktrees`` check at all
+        (KeyError -> red); with the registration, a project with no cleanup
+        instance must FAIL and the failure must name the job."""
+        _write_marker(tmp_path, "vnx-dev")
+        # receipt-processor and gate-obligation-runner both loaded; the
+        # cleanup family has no instance at all.
+        _patch(
+            monkeypatch,
+            labels=[
+                f"{RECEIPT_PROCESSOR}.vnx-dev",
+                f"{GATE_OBLIGATION}.vnx-dev",
+            ],
+        )
+
+        checks = doctor._check_launchd_agents(tmp_path)
+        by_name = {c.name: c for c in checks}
+
+        cleanup_check = by_name[f"launchd:{CLEANUP_WORKTREES}"]
+        assert cleanup_check.status == doctor.FAIL, checks
+        assert f"{CLEANUP_WORKTREES}.vnx-dev" in cleanup_check.detail
+
 
 class TestCleanStateIsGreen:
-    def test_both_jobs_loaded_is_all_pass(self, tmp_path, monkeypatch):
+    def test_all_required_jobs_loaded_is_all_pass(self, tmp_path, monkeypatch):
         _write_marker(tmp_path, "vnx-dev")
         _patch(
             monkeypatch,
-            labels=[f"{RECEIPT_PROCESSOR}.vnx-dev", f"{GATE_OBLIGATION}.vnx-dev"],
+            labels=[
+                f"{RECEIPT_PROCESSOR}.vnx-dev",
+                f"{GATE_OBLIGATION}.vnx-dev",
+                f"{CLEANUP_WORKTREES}.vnx-dev",
+            ],
         )
 
         checks = doctor._check_launchd_agents(tmp_path)
@@ -97,6 +127,7 @@ class TestCleanStateIsGreen:
         by_name = {c.name: c for c in checks}
         assert by_name[f"launchd:{RECEIPT_PROCESSOR}"].status == doctor.PASS
         assert by_name[f"launchd:{GATE_OBLIGATION}"].status == doctor.PASS
+        assert by_name[f"launchd:{CLEANUP_WORKTREES}"].status == doctor.PASS
 
     def test_a_second_projects_own_scoped_job_never_counts_for_this_project(
         self, tmp_path, monkeypatch
@@ -109,6 +140,7 @@ class TestCleanStateIsGreen:
             labels=[
                 f"{RECEIPT_PROCESSOR}.mission-control",
                 f"{GATE_OBLIGATION}.mission-control",
+                f"{CLEANUP_WORKTREES}.mission-control",
             ],
         )
 
@@ -116,6 +148,7 @@ class TestCleanStateIsGreen:
         failed_names = {c.name for c in checks if c.status == doctor.FAIL}
         assert f"launchd:{RECEIPT_PROCESSOR}" in failed_names
         assert f"launchd:{GATE_OBLIGATION}" in failed_names
+        assert f"launchd:{CLEANUP_WORKTREES}" in failed_names
 
 
 class TestNonBehavioralGuards:
@@ -161,7 +194,7 @@ class TestWiredIntoVnxDoctor:
         import argparse
 
         _write_marker(tmp_path, "vnx-dev")
-        _patch(monkeypatch, labels=[])  # both families absent
+        _patch(monkeypatch, labels=[])  # all required families absent
 
         # Isolate from the real .vnx/.vnx-data resolution machinery — only
         # the launchd check's behavior is under test here.

--- a/tests/test_launchd_project_scope.py
+++ b/tests/test_launchd_project_scope.py
@@ -92,9 +92,10 @@ def _launchctl_text(entries: Iterable[Tuple[str, str, int]]) -> str:
 def test_required_families_constant_is_not_empty() -> None:
     # Nul-is-eerst-een-meetfout: every "ok" result below is only meaningful
     # if the family list actually has entries to check.
-    assert len(lps.REQUIRED_PER_PROJECT_FAMILIES) == 2
+    assert len(lps.REQUIRED_PER_PROJECT_FAMILIES) == 3
     assert "com.vnx.gate-obligation-runner" in lps.REQUIRED_PER_PROJECT_FAMILIES
     assert "com.vnx.receipt-processor" in lps.REQUIRED_PER_PROJECT_FAMILIES
+    assert "com.vnx.cleanup-reviewed-worktrees" in lps.REQUIRED_PER_PROJECT_FAMILIES
 
 
 def test_real_repo_launchd_templates_are_per_project_scoped() -> None:
@@ -103,6 +104,7 @@ def test_real_repo_launchd_templates_are_per_project_scoped() -> None:
     labels = {c["family"]: c["label"] for c in result["checked"]}
     assert labels["com.vnx.gate-obligation-runner"] == "com.vnx.gate-obligation-runner.${VNX_PROJECT_ID}"
     assert labels["com.vnx.receipt-processor"] == "com.vnx.receipt-processor.${VNX_PROJECT_ID}"
+    assert labels["com.vnx.cleanup-reviewed-worktrees"] == "com.vnx.cleanup-reviewed-worktrees.${VNX_PROJECT_ID}"
 
 
 def test_check_template_contract_flags_a_bare_label(tmp_path: Path) -> None:
@@ -145,6 +147,11 @@ def test_check_template_contract_clean_state_is_ok(tmp_path: Path) -> None:
     )
     _write_template(
         tmp_path, "com.vnx.receipt-processor", "com.vnx.receipt-processor.${VNX_PROJECT_ID}"
+    )
+    _write_template(
+        tmp_path,
+        "com.vnx.cleanup-reviewed-worktrees",
+        "com.vnx.cleanup-reviewed-worktrees.${VNX_PROJECT_ID}",
     )
     result = lps.check_template_contract(tmp_path)
     assert result["ok"] is True, result["violations"]
@@ -208,6 +215,8 @@ def test_check_installed_state_clean_multi_project_is_ok() -> None:
             ("com.vnx.gate-obligation-runner.mission-control", "-", 20),
             ("com.vnx.receipt-processor.vnx-dev", "1234", 0),
             ("com.vnx.receipt-processor.mission-control", "5678", 0),
+            ("com.vnx.cleanup-reviewed-worktrees.vnx-dev", "9012", 0),
+            ("com.vnx.cleanup-reviewed-worktrees.mission-control", "3456", 0),
         ]
     )
     result_vnx_dev = lps.check_installed_state(text, "vnx-dev")
@@ -265,6 +274,7 @@ def test_check_project_scope_real_templates_clean_installed_state_is_ok() -> Non
         [
             ("com.vnx.gate-obligation-runner.vnx-dev", "-", 11),
             ("com.vnx.receipt-processor.vnx-dev", "4321", 0),
+            ("com.vnx.cleanup-reviewed-worktrees.vnx-dev", "8765", 0),
         ]
     )
     result = lps.check_project_scope(LAUNCHD_DIR, "vnx-dev", text)
@@ -315,6 +325,7 @@ def test_main_json_mode_emits_parseable_json(monkeypatch, capsys) -> None:
             [
                 ("com.vnx.gate-obligation-runner.vnx-dev", "-", 11),
                 ("com.vnx.receipt-processor.vnx-dev", "1", 0),
+                ("com.vnx.cleanup-reviewed-worktrees.vnx-dev", "2", 0),
             ]
         ),
     )

--- a/tests/test_vnx_cli.py
+++ b/tests/test_vnx_cli.py
@@ -47,7 +47,7 @@ def _dispatch_agent_args(project_dir, agent, instruction, model="sonnet"):
 
 def _mock_launchd_agents_loaded(project_dir, monkeypatch):
     """Isolate doctor's launchd-agents check (golf C, C3) from tests whose
-    actual concern is unrelated: report both required jobs as loaded for
+    actual concern is unrelated: report all required jobs as loaded for
     whatever project_id `vnx init` resolved. Without this, a worktree test
     run — where the OI-1117 guard always skips the real launchd install —
     would FAIL doctor for a reason the test isn't checking."""
@@ -67,6 +67,7 @@ def _mock_launchd_agents_loaded(project_dir, monkeypatch):
             "PID\tStatus\tLabel\n"
             f"-\t0\tcom.vnx.gate-obligation-runner.{project_id}\n"
             f"-\t0\tcom.vnx.receipt-processor.{project_id}\n"
+            f"-\t0\tcom.vnx.cleanup-reviewed-worktrees.{project_id}\n"
         ),
     )
 

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -724,15 +724,20 @@ def vnx_init(args) -> int:
         return 1
 
 
-def _install_launchd_agent(vnx_home: str, plist_name: str, project_id: str = "") -> bool:
+def _install_launchd_agent(
+    vnx_home: str, plist_name: str, project_id: str = "", project_root: str = ""
+) -> bool:
     """Install a VNX launchd plist by name (OI-917, generalized for OI-1409).
 
     Reads the plist template from the engine root's scripts/launchd/ directory,
-    substitutes ``${VNX_HOME}`` with the resolved VNX home path and
+    substitutes ``${VNX_HOME}`` with the resolved VNX home path,
     ``${VNX_PROJECT_ID}`` with the project's id (OI-1253 fix-forward: a job
     identifies its project via VNX_PROJECT_ID, one instance per project, never
-    via a hardcoded store path), writes atomically to ``~/Library/LaunchAgents/``,
-    and loads via launchctl.
+    via a hardcoded store path), and ``${VNX_PROJECT_ROOT}`` with the project's
+    checkout path (OI-1629 deel c: a job that sweeps per-project worktrees must
+    be pointed at the PROJECT's checkout, not at the shared engine root — see
+    _install_cleanup_reviewed_worktrees_runner), writes atomically to
+    ``~/Library/LaunchAgents/``, and loads via launchctl.
 
     OI-1510 (golf C, C3): the destination filename is derived from the
     template's own RESOLVED Label, never from the ``plist_name`` argument.
@@ -789,6 +794,7 @@ def _install_launchd_agent(vnx_home: str, plist_name: str, project_id: str = "")
     content = template.read_text(encoding="utf-8")
     content = content.replace("${VNX_HOME}", vnx_home)
     content = content.replace("${VNX_PROJECT_ID}", project_id)
+    content = content.replace("${VNX_PROJECT_ROOT}", project_root)
 
     # OI-1510: destination filename comes from the RESOLVED Label, not the
     # plist_name argument — see the docstring above.
@@ -799,8 +805,9 @@ def _install_launchd_agent(vnx_home: str, plist_name: str, project_id: str = "")
     if not isinstance(resolved_label, str) or not resolved_label:
         raise RuntimeError(
             f"could not read a Label out of {plist_name}.plist after "
-            "${VNX_HOME}/${VNX_PROJECT_ID} substitution — refusing to install "
-            "under an unresolvable destination filename (OI-1510)"
+            "${VNX_HOME}/${VNX_PROJECT_ID}/${VNX_PROJECT_ROOT} substitution — "
+            "refusing to install under an unresolvable destination filename "
+            "(OI-1510)"
         )
     dest = dest_dir / f"{resolved_label}.plist"
 
@@ -890,6 +897,32 @@ def _install_receipt_processor_runner(vnx_home: str, project_id: str = "") -> bo
     """
     return _install_launchd_agent(
         vnx_home, "com.vnx.receipt-processor", project_id=project_id
+    )
+
+
+def _install_cleanup_reviewed_worktrees_runner(vnx_home: str, project_id: str = "") -> bool:
+    """Install the cleanup-reviewed-worktrees launchd plist (OI-1629 deel c).
+
+    Thin wrapper over ``_install_launchd_agent``, mirroring
+    ``_install_receipt_processor_runner`` — the same wiring, not a new
+    mechanism. Closes the gap the measured 12-09 launchd job left: that job
+    was hard-targeted at one repo (``REPO="$HOME/Development/mission-control"``)
+    even though ``scripts/cleanup_reviewed_worktrees.py`` has a ``--repo-root``
+    flag, so every other repo's ``.vnx-data/worktrees/`` grew unchecked.
+
+    The one thing this wrapper adds over the other runners is which checkout
+    to sweep. The worktrees live under each project's own checkout, not under
+    the engine root, and a central install shares one engine across many
+    projects. ``VNX_PROJECT_ROOT`` is the central shim's export for "the
+    project checkout vnx init is running inside"; a standalone dev checkout
+    has no shim, and there VNX_HOME IS the checkout, so fall back to it.
+    """
+    project_root = os.environ.get("VNX_PROJECT_ROOT") or vnx_home
+    return _install_launchd_agent(
+        vnx_home,
+        "com.vnx.cleanup-reviewed-worktrees",
+        project_id=project_id,
+        project_root=project_root,
     )
 
 
@@ -1039,6 +1072,16 @@ def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) ->
             print("  skipped receipt-processor (plist template not found)")
     except (OSError, RuntimeError) as exc:
         print(f"  warning: receipt-processor install failed: {exc}")
+
+    # --- OI-1629 deel c: install cleanup-reviewed-worktrees launchd agent ------
+    try:
+        installed = _install_cleanup_reviewed_worktrees_runner(
+            str(_engine.engine_root()), project_id=project_id
+        )
+        if not installed:
+            print("  skipped cleanup-reviewed-worktrees (plist template not found)")
+    except (OSError, RuntimeError) as exc:
+        print(f"  warning: cleanup-reviewed-worktrees install failed: {exc}")
 
     print()
     print(f"Runtime state: {data_root}")


### PR DESCRIPTION
## Wat

De gemeten 12-09 launchd-job `com.vnx.cleanup-reviewed-worktrees` draaide dagelijks hard-targeted op één repo, terwijl het script al een `--repo-root` vlag had. Elke andere repo's `.vnx-data/worktrees/` groeide ongecontroleerd terwijl die job "slaagde" op de verkeerde checkout.

Deze PR brengt dat in de bestaande per-project vorm van #1830 (OI-1509/OI-1510), geen tweede mechanisme:

- `scripts/cleanup_reviewed_worktrees.py` verbatim overgenomen uit mission-control (judgment rule bewust NIET aangepast).
- `com.vnx.cleanup-reviewed-worktrees` toegevoegd aan `REQUIRED_PER_PROJECT_FAMILIES` in `scripts/launchd/launchd_project_scope.py`.
- Nieuwe template `scripts/launchd/com.vnx.cleanup-reviewed-worktrees.plist` met `${VNX_PROJECT_ID}` in de Label, die het script draait met `--repo-root ${VNX_PROJECT_ROOT} --apply` om 04:00.
- `${VNX_PROJECT_ROOT}` substitutie toegevoegd aan `_install_launchd_agent` en `reload_plist.sh`. De centrale shim exporteert `VNX_PROJECT_ROOT` (de checkout van het project); standalone checkouts vallen terug op `VNX_HOME` (wat daar de checkout is).
- `vnx init` installeert de job via `_install_cleanup_reviewed_worktrees_runner` (bestandsnaam afgeleid van de resolved Label, dus twee projecten overschrijven elkaar nooit).
- `vnx doctor` FAALt op een ontbrekende instantie en noemt de jobnaam (`launchd:com.vnx.cleanup-reviewed-worktrees`).

## Tests

Twee verplichte rode tests eerst gedraaid (beide `KeyError` vóór registratie), daarna groen:

- `test_missing_cleanup_reviewed_worktrees_fails_with_job_name` — doctor FAALt met de jobnaam.
- `test_template_is_project_scoped_and_two_projects_get_separate_files` — template draagt `${VNX_PROJECT_ID}` én twee projecten krijgen aparte bestandsnamen.

Aangeraakte suite + directe buren: 108 passed.

## Niet gedaan

Niets geïnstalleerd/launchctl gedraaid, de bestaande mission-control job blijft staan, judgment rule van het script is ongewijzigd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)